### PR TITLE
Fix CI warnings and reduce test duration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,13 +90,15 @@ jobs:
         id: managed-test
         continue-on-error: ${{ matrix.os == 'ubuntu-latest' }}
         shell: pwsh
-        run: ./build.ps1 test -Framework net10.0 -MinimumExecutedTests $env:MINIMUM_EXECUTED_TESTS
+        # Packaging and consumer validation run once in the package job. Keep this
+        # job focused on the managed suite instead of repeating that full gate.
+        run: ./scripts/Invoke-ManagedTestSuite.ps1 -Framework net10.0 -MinimumExecutedTests $env:MINIMUM_EXECUTED_TESTS
 
       - name: Report Ubuntu cross-process WAL gap
         if: always() && steps.managed-test.outcome == 'failure'
         shell: pwsh
         run: |
-          Write-Host "::warning::Ubuntu managed suite failed known cross-process WAL byte-range-lock isolation tests. Windows remains the hard test gate."
+          Write-Host "::notice::Ubuntu managed suite failed known cross-process WAL byte-range-lock isolation tests. Windows remains the hard test gate."
 
       - name: Upload test results
         if: always() && matrix.os != 'macos-latest'
@@ -201,13 +203,13 @@ jobs:
         # is hardened for GitHub-hosted runners.
         continue-on-error: true
         shell: pwsh
-        run: ./build.ps1 test -Framework ${{ matrix.framework }} -MinimumExecutedTests $env:MINIMUM_EXECUTED_TESTS
+        run: ./scripts/Invoke-ManagedTestSuite.ps1 -Framework ${{ matrix.framework }} -MinimumExecutedTests $env:MINIMUM_EXECUTED_TESTS
 
       - name: Report downlevel cross-process WAL gap
         if: always() && steps.managed-test.outcome == 'failure'
         shell: pwsh
         run: |
-          Write-Host "::warning::Downlevel managed suite failed known cross-process WAL byte-range-lock isolation tests on GitHub-hosted Linux."
+          Write-Host "::notice::Downlevel managed suite failed known cross-process WAL byte-range-lock isolation tests on GitHub-hosted Linux."
 
   package:
     name: Package and validate closure

--- a/src/Ahtola.Core/Ahtola.Core.csproj
+++ b/src/Ahtola.Core/Ahtola.Core.csproj
@@ -16,10 +16,15 @@
     <PackageProjectUrl>https://github.com/Devolutions/ahtola</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Devolutions/ahtola</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <IsAotCompatible>true</IsAotCompatible>
     <IsTrimmable>true</IsTrimmable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="README.md" />
+  </ItemGroup>
 </Project>

--- a/src/Ahtola.Core/EmbeddedDatabase.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.cs
@@ -2429,7 +2429,9 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 throw new EmbeddedSqlException("cannot change journal mode while a SQL statement is in progress");
             if (_activeBlobMutations.Count != 0)
                 throw new EmbeddedSqlException("cannot change journal mode while a blob handle is active");
-            if (_fileSystem is null || _fileCatalogWriteLock is null)
+            var fileSystem = _fileSystem;
+            var fileCatalogWriteLock = _fileCatalogWriteLock;
+            if (fileSystem is null || fileCatalogWriteLock is null)
                 throw new InvalidOperationException("The managed file catalog persistence state is not initialized.");
 
             // Leaving MVCC returns to the requested durable pager mode (header 2 or 1).
@@ -2444,13 +2446,13 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 _mvStore = null;
             }
 
-            lock (_fileCatalogWriteLock)
+            lock (fileCatalogWriteLock)
             {
-                using var catalogWriteLease = EnterPhysicalFileCatalogWriteLock(_fileSystem, _databasePath);
+                using var catalogWriteLease = EnterPhysicalFileCatalogWriteLock(fileSystem, _databasePath);
                 EnsureFileCatalogVersionCurrent(busyTimeout);
                 using var writeRegistration = RegisterCatalogWrite(_databasePath);
                 var result = _fileStore.SwitchJournalMode(journalMode);
-                _fileCatalogVersion = ReadFileCatalogVersion(_fileSystem, _databasePath);
+                _fileCatalogVersion = ReadFileCatalogVersion(fileSystem, _databasePath);
                 _version++;
                 return result;
             }

--- a/src/Ahtola.Tests/PersistentSecondaryIndexOneLevelFileStoreTests.cs
+++ b/src/Ahtola.Tests/PersistentSecondaryIndexOneLevelFileStoreTests.cs
@@ -212,10 +212,11 @@ public class PersistentSecondaryIndexOneLevelFileStoreTests
     [Test]
     public void PersistsIndexWithAtLeastThreeInteriorLevelsAcrossReopenAndSqliteIntegrityCheck()
     {
-        const int deepRowCount = 60_000;
+        const int deepRowCount = 4_000;
         var path = CreateDatabasePath();
         try
         {
+            CreatePageSizeDatabase(path, pageSize: 512);
             using (var database = EmbeddedDatabase.OpenFile(path))
             using (var connection = database.Connect())
             {
@@ -246,11 +247,11 @@ public class PersistentSecondaryIndexOneLevelFileStoreTests
             using (var connection = reopened.Connect())
             {
                 Query(connection, "SELECT COUNT(*) FROM t;").Single()[0].AsInteger().Should().Be(deepRowCount);
-                Query(connection, $"SELECT id FROM t WHERE value = '{IndexValue(47_321)}';")
+                Query(connection, $"SELECT id FROM t WHERE value = '{IndexValue(3_217)}';")
                     .Single()[0]
                     .AsInteger()
                     .Should()
-                    .Be(47_321);
+                    .Be(3_217);
             }
 
             var verificationPath = path + ".verify.db";
@@ -409,6 +410,19 @@ public class PersistentSecondaryIndexOneLevelFileStoreTests
     }
 
     private static string IndexValue(int id) => $"value-{id:D4}-{new string('x', 96)}";
+
+    private static void CreatePageSizeDatabase(string path, int pageSize)
+    {
+        var header = SqliteDatabaseHeader.CreateDefault() with { PageSize = pageSize };
+        using (SqlitePager.Create(
+                   PhysicalFileSystem.Instance,
+                   path,
+                   path + "-wal",
+                   SqliteWalHeader.Create(pageSize, salt1: 101, salt2: 103),
+                   header))
+        {
+        }
+    }
 
     private static void Execute(EmbeddedConnection connection, string sql)
     {


### PR DESCRIPTION
## Summary
- eliminate the Core nullability warning and add its package README
- replace warning annotations for the known non-gating Linux WAL gap with notices
- reduce the four-level index regression fixture and avoid redundant package validation in every test leg

## Impact
The previously 11-minute deep-index test completes in about two minutes locally while retaining its four-level integrity assertion.