### PR TITLE
fix: use NuGet bot username for OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,7 +347,7 @@ jobs:
         id: login
         uses: NuGet/login@v1
         with:
-          user: ${{ secrets.NUGET_USER }}
+          user: ${{ secrets.NUGET_BOT_USERNAME }}
 
       - name: Push nupkgs
         shell: pwsh


### PR DESCRIPTION
Updates the release workflow to pass the configured `NUGET_BOT_USERNAME` secret to `NuGet/login`, aligning the OIDC login identity with the NuGet trusted publisher configuration.