### PR TITLE
fix: restore PowerShell module artifact layout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,9 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: unsigned-powershell-module
-          path: artifacts/powershell-modules
+          # upload-artifact strips the module directory because its path ends
+          # in /**. Restore that directory before signing and re-uploading it.
+          path: artifacts/powershell-modules/Devolutions.Ahtola.Sqlite
 
       - name: Determine signing mode
         id: sign_plan


### PR DESCRIPTION
## Summary
- restore the module directory when downloading the unsigned signing artifact
- allow the signing job's existing upload path to find the signed module

## Validation
- `pwsh ./build.ps1 pack-powershell -Configuration Release -PackageVersion 1.2.3`