### PR TITLE
fix: prevent unsigned release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       dry_run:
-        description: Build, sign, and validate release artifacts without creating a release or publishing
+        description: Build and validate unsigned release artifacts without creating a release or publishing
         default: false
         required: false
         type: boolean
@@ -118,7 +118,7 @@ jobs:
           if-no-files-found: error
 
   sign_powershell_module:
-    name: Sign PowerShell module with Azure Artifact Signing
+    name: Prepare PowerShell module for release
     needs:
       - preflight
       - pack
@@ -229,6 +229,7 @@ jobs:
           }
 
           foreach ($target in $targets) {
+            $unsignedHash = (Get-FileHash -LiteralPath $target.FullName -Algorithm SHA256).Hash
             psign-tool --mode portable --verbose sign `
               --artifact-signing-endpoint "$env:TRUSTED_SIGNING_ENDPOINT" `
               --artifact-signing-account-name "$env:TRUSTED_SIGNING_ACCOUNT_NAME" `
@@ -242,9 +243,15 @@ jobs:
             if ($LASTEXITCODE -ne 0) {
               throw "PSign failed to sign $($target.FullName)."
             }
+
+            $signedHash = (Get-FileHash -LiteralPath $target.FullName -Algorithm SHA256).Hash
+            if ($unsignedHash -eq $signedHash) {
+              throw "PSign reported success but did not modify $($target.FullName)."
+            }
           }
 
       - name: Archive signed PowerShell module
+        if: steps.sign_plan.outputs.should_sign == 'true'
         shell: pwsh
         env:
           RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
@@ -262,6 +269,7 @@ jobs:
           Compress-Archive -LiteralPath $moduleRoot -DestinationPath "$archiveRoot/Devolutions.Ahtola.Sqlite.$env:RELEASE_VERSION.zip" -Force
 
       - name: Upload signed PowerShell module
+        if: steps.sign_plan.outputs.should_sign == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: signed-powershell-module
@@ -269,6 +277,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload signed PowerShell module archive
+        if: steps.sign_plan.outputs.should_sign == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: signed-powershell-module-archive

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,12 @@ on:
         required: true
         type: string
       dry_run:
-        description: Build and validate unsigned release artifacts without creating a release or publishing
+        description: Build, sign, and validate artifacts without creating a release or publishing; choose test signing with github_env=test
         default: false
         required: false
         type: boolean
       github_env:
-        description: Protected GitHub environment that owns publishing credentials
+        description: Protected GitHub environment that owns signing and publishing credentials; select test for test signing
         default: auto
         required: false
         type: choice
@@ -118,7 +118,7 @@ jobs:
           if-no-files-found: error
 
   sign_powershell_module:
-    name: Prepare PowerShell module for release
+    name: Sign PowerShell module with Azure Artifact Signing
     needs:
       - preflight
       - pack
@@ -146,11 +146,9 @@ jobs:
           # in /**. Restore that directory before signing and re-uploading it.
           path: artifacts/powershell-modules/Devolutions.Ahtola.Sqlite
 
-      - name: Determine signing mode
+      - name: Validate signing configuration
         id: sign_plan
         shell: pwsh
-        env:
-          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           $required = @(
             'AZURE_CLIENT_ID',
@@ -161,16 +159,13 @@ jobs:
             'TRUSTED_SIGNING_PROFILE_NAME'
           )
           $missing = $required | Where-Object { [string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($_)) }
-          $shouldSign = $env:DRY_RUN -eq 'false'
-
-          if ($shouldSign -and $missing.Count -gt 0) {
+          if ($missing.Count -gt 0) {
             throw "Azure Artifact Signing requires: $($missing -join ', ')"
           }
 
-          "should_sign=$($shouldSign.ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
+          'should_sign=true' >> $env:GITHUB_OUTPUT
 
       - name: Download released PSign executable
-        if: steps.sign_plan.outputs.should_sign == 'true'
         shell: pwsh
         run: |
           $archive = Join-Path $env:RUNNER_TEMP 'psign-tool-linux-x64.zip'
@@ -194,7 +189,6 @@ jobs:
           & $toolPath --version
 
       - name: Azure login
-        if: steps.sign_plan.outputs.should_sign == 'true'
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -202,7 +196,6 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Sign PowerShell scripts
-        if: steps.sign_plan.outputs.should_sign == 'true'
         shell: pwsh
         run: |
           $accessToken = az account get-access-token `
@@ -251,7 +244,6 @@ jobs:
           }
 
       - name: Archive signed PowerShell module
-        if: steps.sign_plan.outputs.should_sign == 'true'
         shell: pwsh
         env:
           RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
@@ -269,7 +261,6 @@ jobs:
           Compress-Archive -LiteralPath $moduleRoot -DestinationPath "$archiveRoot/Devolutions.Ahtola.Sqlite.$env:RELEASE_VERSION.zip" -Force
 
       - name: Upload signed PowerShell module
-        if: steps.sign_plan.outputs.should_sign == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: signed-powershell-module
@@ -277,7 +268,6 @@ jobs:
           if-no-files-found: error
 
       - name: Upload signed PowerShell module archive
-        if: steps.sign_plan.outputs.should_sign == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: signed-powershell-module-archive


### PR DESCRIPTION
## Summary
- execute the full Azure Artifact Signing path for both dry-run and production releases
- use `github_env=test` to sign dry-run artifacts with the test environment and avoid production approvals
- require signing credentials and fail if PSign reports success without modifying a target script
- keep GitHub Release, NuGet.org, and PowerShell Gallery publishing disabled for dry runs

## Validation
- parsed `.github/workflows/release.yml`
- checked signing and publishing workflow invariants