### PR TITLE
Add managed Turso Cloud replicas

### DIFF
--- a/.github/workflows/cloud-runtime-qualification.yml
+++ b/.github/workflows/cloud-runtime-qualification.yml
@@ -1,0 +1,43 @@
+name: Cloud runtime qualification
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  qualify:
+    name: Packed consumer runtime qualification
+    runs-on: windows-latest
+    environment: cloud-runtime-qualification
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Validate packaged trim and NativeAOT consumers
+        shell: pwsh
+        run: ./build.ps1 validate-runtime -Framework net10.0
+
+      - name: Run opt-in live cloud smoke
+        shell: pwsh
+        env:
+          AHTOLA_RUN_CLOUD_SMOKE: "1"
+          TURSO_REMOTE_URL: ${{ secrets.TURSO_REMOTE_URL }}
+          TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:TURSO_REMOTE_URL) -or
+              [string]::IsNullOrWhiteSpace($env:TURSO_AUTH_TOKEN)) {
+            Write-Host "Live cloud smoke skipped because its protected environment secrets are unavailable."
+            exit 0
+          }
+
+          ./build.ps1 cloud-smoke -Framework net10.0

--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ Requires the .NET SDK and PowerShell 7+:
 ./build.ps1 test
 ./build.ps1 pack              # -> ./artifacts/managed-packages
 ./build.ps1 pack-powershell   # -> ./artifacts/powershell-modules
+./build.ps1 validate-runtime  # packed consumer trim + NativeAOT publish
 ```
 
 Contributor details — the full task list, validation gates, conformance suite,

--- a/build.ps1
+++ b/build.ps1
@@ -25,6 +25,8 @@ param(
                 'pack-powershell',
                 'test-powershell',
                 'validate-package',
+                'validate-runtime',
+                'cloud-smoke',
                 'validate-project-closure',
                 'validate-packed-closure',
                 'format-check'
@@ -350,6 +352,94 @@ function Invoke-ValidatePackage {
     }
 }
 
+function Invoke-ValidateRuntime {
+    Invoke-ValidatePackage
+
+    if ($Framework -ne 'net10.0') {
+        Write-Step "Skipping NativeAOT consumer publish because $Framework is not net10.0"
+        return
+    }
+
+    $localVersion = '0.0.0-managed-local'
+    $packageOutputAbsolute = Get-AbsolutePath $PackageOutput
+    $consumerNugetConfigAbsolute = Get-AbsolutePath $ConsumerNugetConfig
+    $consumerProjectAbsolute = Get-AbsolutePath $ConsumerProject
+    $globalPackages = Join-Path $packageOutputAbsolute '.nuget-packages'
+    $runtimeOutputRoot = Get-AbsolutePath './artifacts/managed-package-runtime'
+    $trimmedOutput = Join-Path $runtimeOutputRoot 'trimmed'
+    $nativeAotOutput = Join-Path $runtimeOutputRoot 'nativeaot'
+    $runtimeIdentifier = if ($IsWindows) { 'win-x64' } elseif ($IsLinux) { 'linux-x64' } elseif ($IsMacOS) { 'osx-x64' } else {
+        throw "NativeAOT consumer publish is not configured for this host OS."
+    }
+
+    Remove-PathIfExists $trimmedOutput
+    Remove-PathIfExists $nativeAotOutput
+
+    Write-Step "Publishing trimmed packed consumer ($Framework)"
+    Invoke-DotNet @(
+        'restore', $ConsumerProject,
+        '--configfile', $consumerNugetConfigAbsolute,
+        '--packages', $globalPackages,
+        "-p:AhtolaPackageVersion=$localVersion",
+        "-p:AhtolaConsumerTargetFramework=$Framework",
+        '-p:PublishTrimmed=true'
+    )
+    Invoke-DotNet @(
+        'publish',
+        '--configuration', 'Release',
+        '--no-restore',
+        '--framework', $Framework,
+        '--output', $trimmedOutput,
+        $ConsumerProject,
+        "-p:AhtolaPackageVersion=$localVersion",
+        "-p:AhtolaConsumerTargetFramework=$Framework",
+        '-p:PublishTrimmed=true'
+    )
+    Invoke-PwshScript -Path $ClosureValidator -Arguments @(
+        '-PublishOutput', $trimmedOutput
+    )
+
+    Write-Step "Publishing NativeAOT packed consumer ($Framework/$runtimeIdentifier)"
+    Invoke-DotNet @(
+        'restore', $ConsumerProject,
+        '--runtime', $runtimeIdentifier,
+        '--configfile', $consumerNugetConfigAbsolute,
+        '--packages', $globalPackages,
+        "-p:AhtolaPackageVersion=$localVersion",
+        "-p:AhtolaConsumerTargetFramework=$Framework",
+        '-p:PublishAot=true'
+    )
+    Invoke-DotNet @(
+        'publish',
+        '--configuration', 'Release',
+        '--no-restore',
+        '--framework', $Framework,
+        '--runtime', $runtimeIdentifier,
+        '--output', $nativeAotOutput,
+        $ConsumerProject,
+        "-p:AhtolaPackageVersion=$localVersion",
+        "-p:AhtolaConsumerTargetFramework=$Framework",
+        '-p:PublishAot=true'
+    )
+    Invoke-PwshScript -Path $ClosureValidator -Arguments @(
+        '-PublishOutput', $nativeAotOutput,
+        '-NativeAot'
+    )
+}
+
+function Invoke-CloudSmoke {
+    if ($env:AHTOLA_RUN_CLOUD_SMOKE -ne '1') {
+        throw 'Cloud smoke requires AHTOLA_RUN_CLOUD_SMOKE=1.'
+    }
+    foreach ($name in 'TURSO_REMOTE_URL', 'TURSO_AUTH_TOKEN') {
+        if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($name))) {
+            throw "Cloud smoke requires $name."
+        }
+    }
+
+    Invoke-ValidatePackage
+}
+
 function Invoke-Test {
     Invoke-ValidatePackage
     Write-Step "Running managed test suite ($Framework)"
@@ -375,6 +465,8 @@ switch ($Task) {
         'validate-project-closure' { Assert-ManagedProjectClosure }
         'validate-packed-closure' { Invoke-ValidatePackedClosure }
         'validate-package' { Invoke-ValidatePackage }
+        'validate-runtime' { Invoke-ValidateRuntime }
+        'cloud-smoke' { Invoke-CloudSmoke }
         'test' { Invoke-Test }
         'format-check' { Invoke-FormatCheck }
         default { throw "Unknown task '$Task'" }

--- a/docs/turso-gap-analysis.md
+++ b/docs/turso-gap-analysis.md
@@ -717,6 +717,35 @@ resolution, CDC capture — including `vdbe-cdc-opcode`'s `InitCdcVersion`) are
 but filed as `missing`/s2 since they are unshipped rather than rejected).
 2 `extension` entries cover Ahtola-only provider conveniences.
 
+### 9.1 Managed Cloud replica support matrix (Turso v0.7.2)
+
+This matrix applies only to the pure-managed `ManagedReplicaConnectionHost`
+fallback reached by `AhtolaConnection.CreateReplica`, not to an explicitly
+registered companion factory. It is deliberately narrower than both the
+general Hrana remote client and Turso's sync engine. Unsupported settings are
+rejected while validating the managed replica open request, before the path is
+opened or bootstrap state is created. Unsupported wire responses are rejected
+while staged, before either the database or its replica metadata is published.
+
+| Capability / option | Status | Managed behavior |
+| --- | --- | --- |
+| Complete raw 4 KiB page stream, legacy/unspecified or v1 `Pages` protocol | **Qualified** | The bootstrapper requests raw pages, requires every 4 KiB `PageData` chunk exactly once, stages and validates the SQLite image, then atomically publishes it. Incremental raw page sets follow the same staged path. |
+| Remote encryption (`RemoteEncryption`) | **Explicitly rejected** | No encrypted page decoder or encrypted local image support is present in the managed replica. This is distinct from encrypted **remote SQL** connections. |
+| Partial prefix bootstrap, query bootstrap, lazy loading (`PartialBootstrap`) | **Explicitly rejected** | The managed replica has neither the server page selector/query protocol nor lazy page storage. |
+| Chunked bootstrap (`PullBytesThreshold`) | **Explicitly rejected** | A complete initial image is the only bootstrap shape; a multi-request page-selection bootstrap is not implemented. |
+| zstd/compressed page sets | **Explicitly rejected** | The response must declare raw encoding and each page payload must be exactly 4 KiB. |
+| MVCC logical streams / `MvccLogical` protocol | **Explicitly rejected** | There is no managed portable logical-log decoder or replay path. |
+| Local divergence before an incremental pull | **Explicitly rejected** | A changed fingerprint or local WAL/journal state aborts synchronization before any HTTP pull or file replacement. A managed replica never overwrites unproven local state. |
+| Non-4 KiB Cloud page streams | **Unknown/deferred — rejected by the gate** | Turso v0.7.2's physical sync protocol uses `PAGE_SIZE = 4096` (`sync/engine/src/database_sync_operations.rs`); the managed decoder intentionally has the same fixed 4 KiB stream boundary. Ahtola's local SQLite engine can use other database page sizes, but that does not qualify them for Cloud replica streaming. |
+
+Turso v0.7.2 exposes the broader option surface in
+`sync/engine/src/database_sync_engine.rs` (`DatabaseSyncEngineOpts`) and
+defines partial strategies and physical/logical stream kinds in
+`sync/engine/src/types.rs` and `sync/engine/src/server_proto.rs`. Its logical
+mode also rejects partial sync and remote encryption
+(`ensure_logical_mvcc_pull_supported`). Those upstream capabilities are not
+claimed by the managed replica.
+
 | ID | Kind | Severity | Effort | Mapped fails | Cited | Summary |
 | --- | --- | --- | --- | ---: | ---: | --- |
 | `sync-no-cdc-capture-pragma` | missing | s2-capability | L | 1 | 0 | Turso captures local writes into a `turso_cdc` change-data-capture table (via a CDC pragma) so they can be diffed and pushed to the remote and replayed against a revert/s… |

--- a/samples/ManagedPackageConsumer/Program.cs
+++ b/samples/ManagedPackageConsumer/Program.cs
@@ -106,6 +106,7 @@ try
     EnsureNoNativeCompanionWasRestored();
     await VerifyEntityFrameworkIntegrationAsync(connection);
     VerifySourceFreeReplicaOptions();
+    await VerifyOptionalCloudRuntimeAsync();
 
     Console.WriteLine(
         $"Managed package consumer succeeded on {AppContext.TargetFrameworkName} with EF Core {typeof(DbContext).Assembly.GetName().Version}.");
@@ -172,17 +173,110 @@ static void VerifySourceFreeReplicaOptions()
         PullBytesThreshold = 1024 * 1024,
     };
     using var replica = AhtolaConnection.CreateReplica(options);
-    try
-    {
-        replica.Open();
-    }
-    catch (NotSupportedException exception) when (
-        exception.Message.Contains("Turso.Data.Sqlite.Sync", StringComparison.Ordinal))
+    if (!replica.Capabilities.SupportsSync)
+        throw new InvalidOperationException("The managed package did not expose managed embedded replica synchronization.");
+}
+
+static async Task VerifyOptionalCloudRuntimeAsync()
+{
+    if (!string.Equals(
+            Environment.GetEnvironmentVariable("AHTOLA_RUN_CLOUD_SMOKE"),
+            "1",
+            StringComparison.Ordinal))
     {
         return;
     }
 
-    throw new InvalidOperationException("The managed package unexpectedly activated embedded replica Sync.");
+    var remoteUrl = Environment.GetEnvironmentVariable("TURSO_REMOTE_URL");
+    var authToken = Environment.GetEnvironmentVariable("TURSO_AUTH_TOKEN");
+    if (string.IsNullOrWhiteSpace(remoteUrl) || string.IsNullOrWhiteSpace(authToken))
+    {
+        throw new InvalidOperationException(
+            "The opt-in cloud smoke requires TURSO_REMOTE_URL and TURSO_AUTH_TOKEN.");
+    }
+
+    var replicaPath = Path.GetFullPath($"managed-package-cloud-replica-{Guid.NewGuid():N}.db");
+    var tableName = $"ahtola_package_smoke_{Guid.NewGuid():N}";
+    var stage = "direct remote query";
+    try
+    {
+        var directConnectionString = new AhtolaConnectionStringBuilder
+        {
+            DataSource = remoteUrl,
+            AuthToken = authToken,
+            ReadYourWrites = false,
+        }.ConnectionString;
+
+        using (var direct = new AhtolaConnection(directConnectionString))
+        {
+            await direct.OpenAsync(CancellationToken.None);
+            if (await ExecuteOneAsync(direct) != 1)
+                throw new InvalidOperationException("Direct remote query returned an unexpected result.");
+        }
+
+        var replicaOptions = new AhtolaReplicaOptions(
+            replicaPath,
+            new Uri(remoteUrl, UriKind.Absolute),
+            authToken,
+            bootstrapIfEmpty: true);
+        using (var replica = AhtolaConnection.CreateReplica(replicaOptions))
+        {
+            stage = "embedded replica open";
+            await replica.OpenAsync(CancellationToken.None);
+            stage = "embedded replica query";
+            if (await ExecuteOneAsync(replica) != 1)
+                throw new InvalidOperationException("Embedded replica query returned an unexpected result.");
+
+            replica.ExecuteNonQuery($"CREATE TABLE {tableName}(value INTEGER NOT NULL);");
+            replica.ExecuteNonQuery($"INSERT INTO {tableName} VALUES (1);");
+            stage = "embedded replica sync";
+            _ = await replica.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
+        }
+
+        stage = "remote cleanup";
+        using (var cleanup = new AhtolaConnection(directConnectionString))
+        {
+            await cleanup.OpenAsync(CancellationToken.None);
+            cleanup.ExecuteNonQuery($"DROP TABLE {tableName};");
+        }
+
+        Console.WriteLine("Opt-in cloud smoke succeeded.");
+    }
+    catch (Exception exception)
+    {
+        // Do not surface remote URLs, bearer tokens, or server response bodies in CI logs.
+        throw new InvalidOperationException(
+        $"The opt-in cloud smoke failed during {stage} ({exception.GetType().Name}).");
+    }
+    finally
+    {
+        DeleteReplicaFiles(replicaPath);
+    }
+}
+
+static async Task<long> ExecuteOneAsync(AhtolaConnection connection)
+{
+    using var command = connection.CreateCommand();
+    command.CommandText = "SELECT 1;";
+    return Convert.ToInt64(
+        await command.ExecuteScalarAsync(CancellationToken.None),
+        System.Globalization.CultureInfo.InvariantCulture);
+}
+
+static void DeleteReplicaFiles(string path)
+{
+    foreach (var suffix in new[]
+             {
+                 string.Empty,
+                 "-wal",
+                 "-shm",
+                 "-journal",
+                 ".ahtola-replica-meta",
+                 ".ahtola-replica-journal",
+             })
+    {
+        File.Delete(path + suffix);
+    }
 }
 
 static void VerifyPublicCapabilityContract()

--- a/src/Ahtola.Data/AhtolaCommand.cs
+++ b/src/Ahtola.Data/AhtolaCommand.cs
@@ -192,6 +192,12 @@ public class AhtolaCommand : DbCommand
 
     public override void Prepare()
     {
+        using var replicaOperation = _connection?.EnterManagedReplicaOperation(CancellationToken.None);
+        PrepareCore();
+    }
+
+    private void PrepareCore()
+    {
         if (_connection is null)
             throw new InvalidOperationException("Connection must be set before preparing a command.");
         if (string.IsNullOrWhiteSpace(CommandText))
@@ -209,6 +215,9 @@ public class AhtolaCommand : DbCommand
             try
             {
                 var sql = RewriteFacadePragmas(CommandText, _connection);
+                _connection.ManagedConnection.BusyTimeout = CommandTimeout == 0
+                    ? Timeout.InfiniteTimeSpan
+                    : TimeSpan.FromSeconds(CommandTimeout);
                 managedStatement = _connection.ManagedConnection.Prepare(sql);
                 BindManagedParameters(managedStatement);
                 _ = managedStatement.ResultMetadata.ColumnCount;
@@ -401,23 +410,47 @@ public class AhtolaCommand : DbCommand
         if (_connection.IsRemote)
             return ExecuteRemoteAsync(behavior, cancellationToken).GetAwaiter().GetResult();
 
-        Prepare();
-        cancellationToken.ThrowIfCancellationRequested();
+        IDisposable? replicaOperation = null;
+        var beganManagedReplicaTransaction = false;
+        try
+        {
+            beganManagedReplicaTransaction =
+                _connection.BeginManagedReplicaSqlTransaction(CommandText, cancellationToken);
+            replicaOperation = _connection.EnterManagedReplicaOperation(cancellationToken);
+            Prepare();
+            cancellationToken.ThrowIfCancellationRequested();
 
-        var nativeStatement = _nativeStatement;
-        var managedStatement = _managedStatement;
-        if (managedStatement is null && nativeStatement is null)
-            throw new InvalidOperationException("Command was not prepared.");
-        _nativeStatement = null;
-        _managedStatement = null;
-        var transactionCompletion = SqlTransactionControl.GetCompletion(CommandText);
-        var reader = new AhtolaDataReader(
-            this,
-            nativeStatement,
-            managedStatement,
-            behavior,
-            () => MarkTransactionCompletedExternally(transactionCompletion));
-        return reader;
+            var nativeStatement = _nativeStatement;
+            var managedStatement = _managedStatement;
+            if (managedStatement is null && nativeStatement is null)
+                throw new InvalidOperationException("Command was not prepared.");
+            _nativeStatement = null;
+            _managedStatement = null;
+            var transactionCompletion = SqlTransactionControl.GetCompletion(CommandText);
+            _connection.ManagedReplicaStatementStarted(CommandText);
+            var reader = new AhtolaDataReader(
+                this,
+                nativeStatement,
+                managedStatement,
+                behavior,
+                () =>
+                {
+                    MarkTransactionCompletedExternally(transactionCompletion);
+                    _connection.ManagedReplicaStatementCompleted(CommandText);
+                },
+                _connection.ManagedReplicaStatementFailed,
+                _connection.ManagedReplicaStatementClosed,
+                replicaOperation);
+            replicaOperation = null;
+            return reader;
+        }
+        catch
+        {
+            replicaOperation?.Dispose();
+            if (beganManagedReplicaTransaction)
+                _connection.ManagedReplicaStatementFailed();
+            throw;
+        }
     }
 
     internal T RunOperation<T>(

--- a/src/Ahtola.Data/AhtolaConnection.cs
+++ b/src/Ahtola.Data/AhtolaConnection.cs
@@ -8,8 +8,11 @@ namespace Ahtola;
 
 public class AhtolaConnection : DbConnection, ILocalReaderConnection
 {
+    internal const int AutomaticSyncMaximumAttempts = 3;
+
     private AhtolaNativeDatabase? _nativeDatabase;
     private AhtolaReplicaDatabase? _replicaDatabase;
+    private ManagedReplicaConnectionHost? _managedReplicaHost;
     private IManagedDatabaseAdapter? _managedDatabase;
     private ManagedConnectionPoolLease? _managedPoolLease;
     private ManagedConnectionPoolKey? _managedPoolKey;
@@ -17,6 +20,9 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
     private AhtolaConnectionOptions _connectionOptions;
     private AhtolaReplicaOptions? _replicaOptions;
     private HttpMessageHandler? _ownedReplicaHttpHandler;
+    private readonly object _automaticSyncLock = new();
+    private CancellationTokenSource? _automaticSyncCancellation;
+    private Task? _automaticSyncTask;
     private AhtolaEncryptionFileSystem? _managedEncryptionFileSystem;
     private AhtolaPageCodecFileSystem? _managedPageCodecFileSystem;
     private IPageCodec? _pageCodec;
@@ -28,6 +34,7 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
     private readonly HashSet<IConnectionOwnedReader> _openReaders = [];
     private readonly object _readerLock = new();
     private readonly HashSet<AhtolaCommand> _openCommands = [];
+    private readonly object _commandLock = new();
     private AhtolaTransaction? _transaction;
 
     [AllowNull]
@@ -56,7 +63,9 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
         : ConnectionState.Closed;
 
     public AhtolaConnectionCapabilities Capabilities
-        => AhtolaConnectionCapabilities.ForAhtola(_connectionOptions);
+        => AhtolaConnectionCapabilities.ForAhtola(
+            _connectionOptions,
+            replicaSupportsSync: _connectionOptions.IsReplica);
 
     public override bool CanCreateBatch => Capabilities.CanCreateBatch;
 
@@ -121,7 +130,6 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
         if (_connectionOptions.IsRemote && _connectionOptions.IsReplica)
         {
             ValidateCanOpen();
-            ValidateReplicaLocalProvider();
             return OpenRemoteReplicaAsync(GetReplicaOptions(), cancellationToken);
         }
 
@@ -154,6 +162,7 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
     public override void Close()
     {
         _replicaOptions?.ThrowIfApplicationHttpReentrant(closing: true);
+        var automaticSyncError = StopAutomaticManagedReplicaSync();
         if (_remoteClient is not null)
         {
             try
@@ -165,6 +174,8 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
                 CloseRemote();
                 _transaction = null;
             }
+            if (automaticSyncError is not null)
+                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(automaticSyncError).Throw();
             return;
         }
 
@@ -173,6 +184,7 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
         try
         {
             var nativeDatabase = _nativeDatabase;
+            var managedReplicaHost = _managedReplicaHost;
             var managedDatabase = _managedDatabase;
             var managedPoolLease = _managedPoolLease;
             var managedEncryptionFileSystem = _managedEncryptionFileSystem;
@@ -189,6 +201,7 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
             {
                 _nativeDatabase = null;
                 _replicaDatabase = null;
+                _managedReplicaHost = null;
                 _managedDatabase = null;
                 _managedPoolLease = null;
                 _managedEncryptionFileSystem = null;
@@ -203,6 +216,11 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
                     {
                         if (managedPoolLease is not null)
                             managedPoolLease.Release(reusable);
+                        else if (managedReplicaHost is not null)
+                        {
+                            managedReplicaHost.DetachConnection(this);
+                            managedReplicaHost.Dispose();
+                        }
                         else
                             managedDatabase?.Dispose();
                     }
@@ -218,14 +236,28 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
                 }
             }
         }
-        catch (Exception cleanupError) when (cancellationError is not null)
+        catch (Exception cleanupError) when (cancellationError is not null || automaticSyncError is not null)
         {
+            var errors = new List<Exception>();
+            if (automaticSyncError is not null)
+                errors.Add(automaticSyncError);
+            if (cancellationError is not null)
+                errors.Add(cancellationError);
+            errors.Add(cleanupError);
             throw new AggregateException(
-                "Embedded replica cancellation and connection cleanup both failed.",
-                cancellationError,
-                cleanupError);
+                "Embedded replica background synchronization, cancellation, and connection cleanup failed.",
+                errors);
         }
 
+        if (automaticSyncError is not null && cancellationError is not null)
+        {
+            throw new AggregateException(
+                "Embedded replica background synchronization and cancellation both failed.",
+                automaticSyncError,
+                cancellationError);
+        }
+        if (automaticSyncError is not null)
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(automaticSyncError).Throw();
         if (cancellationError is not null)
             System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(cancellationError).Throw();
     }
@@ -339,6 +371,8 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
             return Task.FromCanceled(cancellationToken);
         if (State != ConnectionState.Open)
             throw new InvalidOperationException("Ahtola database is closed.");
+        if (_managedReplicaHost is { } managedReplicaHost)
+            return SyncManagedReplicaAsync(managedReplicaHost, new AhtolaSyncOptions(), cancellationToken);
         if (!Capabilities.SupportsSync)
             throw new NotSupportedException("Sync requires an embedded replica connection.");
 
@@ -357,11 +391,55 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
             return Task.FromCanceled<AhtolaSyncResult>(cancellationToken);
         if (State != ConnectionState.Open)
             throw new InvalidOperationException("Ahtola database is closed.");
+        if (_managedReplicaHost is { } managedReplicaHost)
+            return SyncManagedReplicaAsync(managedReplicaHost, options, cancellationToken);
         if (!Capabilities.SupportsSync)
             throw new NotSupportedException("Sync requires an embedded replica connection.");
 
         return (_replicaDatabase ?? throw new InvalidOperationException("Ahtola database is closed."))
             .SyncAsync(options, cancellationToken);
+    }
+
+    internal async Task QuiesceManagedReplicaAsync(
+        Func<CancellationToken, Task> stagedOperation,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(stagedOperation);
+        if (_managedReplicaHost is not { } host || State != ConnectionState.Open)
+            throw new InvalidOperationException("Ahtola database is closed.");
+        if (_transaction is not null)
+            throw new InvalidOperationException("Managed embedded replica sync cannot run while a transaction is active.");
+        lock (_readerLock)
+        {
+            if (_openReaders.Count != 0)
+                throw new InvalidOperationException("Managed embedded replica sync cannot run while a data reader is active.");
+        }
+
+        await host.QuiesceAndReopenAsync(stagedOperation, cancellationToken).ConfigureAwait(false);
+        _managedDatabase = host.Database;
+    }
+
+    private async Task<AhtolaSyncResult> SyncManagedReplicaAsync(
+        ManagedReplicaConnectionHost host,
+        AhtolaSyncOptions options,
+        CancellationToken cancellationToken)
+    {
+        if (_transaction is not null)
+            throw new InvalidOperationException("Managed embedded replica sync cannot run while a transaction is active.");
+        lock (_readerLock)
+        {
+            if (_openReaders.Count != 0)
+                throw new InvalidOperationException("Managed embedded replica sync cannot run while a data reader is active.");
+        }
+
+        try
+        {
+            return await host.SyncAsync(options, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _managedDatabase = host.Database;
+        }
     }
 
     public override void ChangeDatabase(string databaseName)
@@ -401,7 +479,7 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
 
     internal bool IsManagedReadOnly => _managedReadOnly;
 
-    internal bool IsManaged => _managedDatabase is not null;
+    internal bool IsManaged => _managedReplicaHost is not null || _managedDatabase is not null;
 
     internal AhtolaTransaction? Transaction => _transaction;
 
@@ -427,7 +505,58 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
     }
 
     internal IManagedConnectionAdapter ManagedConnection
-        => _managedDatabase?.Connection ?? throw new InvalidOperationException("Ahtola database is closed.");
+        => _managedReplicaHost?.Database.Connection
+           ?? _managedDatabase?.Connection
+           ?? throw new InvalidOperationException("Ahtola database is closed.");
+
+    internal IDisposable? EnterManagedReplicaOperation(CancellationToken cancellationToken)
+    {
+        if (_managedReplicaHost is not { } host)
+            return null;
+
+        // The transaction owns the path lease until it completes, so commands in that
+        // transaction must be allowed to finish after a sync has begun waiting.
+        if (_transaction is { IsCompleted: false } || host.HasSqlTransactionOperation)
+            return null;
+
+        return host.EnterLocalOperation(cancellationToken);
+    }
+
+    internal IDisposable? EnterManagedReplicaTransaction()
+        => _managedReplicaHost?.EnterLocalOperation(CancellationToken.None);
+
+    internal void ManagedReplicaStatementStarted(string sql)
+        => _managedReplicaHost?.StatementStarted(sql);
+
+    internal bool BeginManagedReplicaSqlTransaction(string sql, CancellationToken cancellationToken)
+    {
+        if (SqlTransactionControl.GetFirstKeyword(sql)?.Equals("BEGIN", StringComparison.OrdinalIgnoreCase) != true
+            || _managedReplicaHost is not { } host)
+        {
+            return false;
+        }
+
+        host.BeginSqlTransaction(cancellationToken);
+        return true;
+    }
+
+    internal void ManagedReplicaStatementCompleted(string sql)
+        => _managedReplicaHost?.StatementCompleted(sql);
+
+    internal void ManagedReplicaStatementFailed()
+        => _managedReplicaHost?.StatementFailed();
+
+    internal void ManagedReplicaStatementClosed()
+        => _managedReplicaHost?.StatementClosed();
+
+    /// <summary>
+    /// Returns committed local replica changes at a durable, exclusive watermark boundary.
+    /// This is an internal hand-off to the following push implementation; it performs no network I/O.
+    /// </summary>
+    internal ReplicaLocalChangeBatch ReadManagedReplicaLocalChanges(int maximumChanges)
+        => (_managedReplicaHost ?? throw new InvalidOperationException(
+                "Local replica changes are available only for managed embedded replica connections."))
+            .ReadLocalChanges(maximumChanges);
 
     void ILocalReaderConnection.ReaderOpened(IConnectionOwnedReader reader)
     {
@@ -441,9 +570,19 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
             _openReaders.Remove(reader);
     }
 
-    internal void CommandOpened(AhtolaCommand command) => _openCommands.Add(command);
+    internal void CommandOpened(AhtolaCommand command)
+    {
+        lock (_commandLock)
+            _openCommands.Add(command);
+    }
 
-    internal void CommandClosed(AhtolaCommand command) => _openCommands.Remove(command);
+    internal void CommandClosed(AhtolaCommand command)
+    {
+        lock (_commandLock)
+            _openCommands.Remove(command);
+    }
+
+    internal void ResetManagedReplicaCommandsForPublication() => ResetOpenCommands();
 
     internal void TransactionCompleted(AhtolaTransaction transaction)
     {
@@ -711,14 +850,13 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
 
     private void OpenRemote()
     {
-        ValidateReplicaLocalProvider();
-
         if (_connectionOptions.IsReplica)
         {
-            SetReplicaDatabase(AhtolaReplicaProvider.OpenReplica(GetReplicaOptions()));
+            OpenReplica(GetReplicaOptions());
             return;
         }
 
+        ValidateDirectRemoteLocalProvider();
         _remoteClient = new AhtolaRemoteClient(
             _connectionOptions.GetRemoteUri(),
             _connectionOptions.AuthToken,
@@ -729,16 +867,66 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
         AhtolaReplicaOptions options,
         CancellationToken cancellationToken)
     {
-        var ValidateRemoteLocalProvider = await AhtolaReplicaProvider
-            .OpenReplicaAsync(options, cancellationToken)
+        if (!AhtolaReplicaProvider.HasRegisteredFactory)
+        {
+            await OpenManagedReplicaAsync(options, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        var replicaDatabase = await AhtolaReplicaProvider
+            .OpenRegisteredReplicaAsync(options, cancellationToken)
             .ConfigureAwait(false);
-        SetReplicaDatabase(ValidateRemoteLocalProvider);
+        SetReplicaDatabase(replicaDatabase);
     }
 
-    private void ValidateReplicaLocalProvider()
+    private void OpenReplica(AhtolaReplicaOptions options)
+    {
+        if (AhtolaReplicaProvider.HasRegisteredFactory)
+        {
+            SetReplicaDatabase(AhtolaReplicaProvider.OpenRegisteredReplica(options));
+            return;
+        }
+
+        OpenManagedReplica(options);
+    }
+
+    private void OpenManagedReplica(AhtolaReplicaOptions options)
+    {
+        var replicaHost = ManagedReplicaConnectionHost.Open(options);
+        try
+        {
+            SetManagedReplicaHost(replicaHost);
+            StartAutomaticManagedReplicaSync(replicaHost);
+        }
+        catch
+        {
+            replicaHost.Dispose();
+            throw;
+        }
+    }
+
+    private async Task OpenManagedReplicaAsync(AhtolaReplicaOptions options, CancellationToken cancellationToken)
+    {
+        var replicaHost = await ManagedReplicaConnectionHost.OpenAsync(options, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            SetManagedReplicaHost(replicaHost);
+            StartAutomaticManagedReplicaSync(replicaHost);
+        }
+        catch
+        {
+            replicaHost.Dispose();
+            throw;
+        }
+    }
+
+    private void ValidateDirectRemoteLocalProvider()
     {
         if (_connectionOptions.LocalProvider == AhtolaLocalProvider.Managed)
-            throw new NotSupportedException("Local Provider=Managed is supported only for local database connections.");
+        {
+            throw new NotSupportedException(
+                "Local Provider=Managed is supported only for local database and embedded replica connections.");
+        }
     }
 
     private AhtolaReplicaOptions GetReplicaOptions()
@@ -768,11 +956,24 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
         _nativeDatabase = replicaDatabase;
     }
 
+    private void SetManagedReplicaHost(ManagedReplicaConnectionHost replicaHost)
+    {
+        if (_disposed)
+        {
+            replicaHost.Dispose();
+            throw new ObjectDisposedException(nameof(AhtolaConnection));
+        }
+
+        _managedReplicaHost = replicaHost;
+        _managedDatabase = replicaHost.Database;
+        replicaHost.AttachConnection(this);
+    }
+
     private void ValidateCanOpen()
     {
         _replicaOptions?.ThrowIfApplicationHttpReentrant(closing: false);
         ObjectDisposedException.ThrowIf(_disposed, this);
-        if (_nativeDatabase is not null || _managedDatabase is not null || _remoteClient is not null)
+        if (_nativeDatabase is not null || _managedReplicaHost is not null || _managedDatabase is not null || _remoteClient is not null)
             throw new InvalidOperationException("The connection is already open.");
         ValidateAutomaticSyncPolicy();
                 if (!string.IsNullOrWhiteSpace(_connectionOptions["Password"]))
@@ -791,7 +992,7 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
     private void ValidateCanBeginTransaction()
     {
         _replicaOptions?.ThrowIfApplicationHttpReentrant(closing: false);
-        if (_nativeDatabase is null && _managedDatabase is null && _remoteClient is null)
+        if (_nativeDatabase is null && _managedReplicaHost is null && _managedDatabase is null && _remoteClient is null)
             throw new InvalidOperationException("Ahtola database is closed.");
         if (_transaction is not null)
             throw new InvalidOperationException("Parallel transactions are not supported.");
@@ -829,10 +1030,127 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
                 "Sync Interval cannot be negative.");
         }
 
-        if (syncInterval > 0)
+        if (syncInterval > 0
+            && (!_connectionOptions.IsReplica
+                || _connectionOptions.LocalProvider != AhtolaLocalProvider.Managed
+                || AhtolaReplicaProvider.HasRegisteredFactory))
         {
             throw new NotSupportedException(
-                "Automatic synchronization is not supported. Sync Interval must be 0. Call Sync or SyncAsync explicitly.");
+                "Sync Interval requires a managed embedded replica connection.");
+        }
+    }
+
+    private void StartAutomaticManagedReplicaSync(ManagedReplicaConnectionHost replicaHost)
+    {
+        var syncInterval = _connectionOptions.SyncInterval;
+        if (syncInterval <= 0 || !replicaHost.SupportsSync)
+            return;
+
+        var cancellation = new CancellationTokenSource();
+        lock (_automaticSyncLock)
+        {
+            if (_automaticSyncTask is not null)
+            {
+                cancellation.Dispose();
+                throw new InvalidOperationException("Automatic managed replica synchronization is already running.");
+            }
+
+            _automaticSyncCancellation = cancellation;
+            _automaticSyncTask = RunAutomaticManagedReplicaSyncAsync(
+                replicaHost,
+                TimeSpan.FromSeconds(syncInterval),
+                cancellation.Token);
+        }
+    }
+
+    private static async Task RunAutomaticManagedReplicaSyncAsync(
+        ManagedReplicaConnectionHost replicaHost,
+        TimeSpan interval,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            await Task.Delay(interval, cancellationToken).ConfigureAwait(false);
+            await SynchronizeManagedReplicaWithRetryAsync(replicaHost, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task SynchronizeManagedReplicaWithRetryAsync(
+        ManagedReplicaConnectionHost replicaHost,
+        CancellationToken cancellationToken)
+    {
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                _ = await replicaHost.SyncAsync(new AhtolaSyncOptions(), cancellationToken).ConfigureAwait(false);
+                return;
+            }
+            catch (Exception exception) when (
+                attempt < AutomaticSyncMaximumAttempts
+                && IsTransientAutomaticSyncFailure(exception, cancellationToken))
+            {
+                await Task.Delay(GetAutomaticSyncRetryDelay(attempt - 1), cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    internal static TimeSpan GetAutomaticSyncRetryDelay(int retryIndex)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(retryIndex);
+        return TimeSpan.FromMilliseconds(50 * (1 << Math.Min(retryIndex, 2)));
+    }
+
+    internal static bool IsTransientAutomaticSyncFailure(Exception exception, CancellationToken cancellationToken)
+    {
+        if (exception is AhtolaReplicaConflictException || cancellationToken.IsCancellationRequested)
+            return false;
+
+        return exception switch
+        {
+            AhtolaException ahtolaException => ahtolaException.IsTransientRemoteHttpFailure,
+            HttpRequestException requestException => requestException.StatusCode is null
+                or System.Net.HttpStatusCode.RequestTimeout
+                or System.Net.HttpStatusCode.TooManyRequests
+                || requestException.StatusCode is { } status
+                && (int)status is >= 500 and <= 599,
+            TaskCanceledException => true,
+            _ => false,
+        };
+    }
+
+    private Exception? StopAutomaticManagedReplicaSync()
+    {
+        CancellationTokenSource? cancellation;
+        Task? syncTask;
+        lock (_automaticSyncLock)
+        {
+            cancellation = _automaticSyncCancellation;
+            syncTask = _automaticSyncTask;
+            _automaticSyncCancellation = null;
+            _automaticSyncTask = null;
+        }
+
+        if (cancellation is null || syncTask is null)
+            return null;
+
+        try
+        {
+            cancellation.Cancel();
+            syncTask.GetAwaiter().GetResult();
+            return null;
+        }
+        catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+        {
+            return null;
+        }
+        catch (Exception exception)
+        {
+            return exception;
+        }
+        finally
+        {
+            cancellation.Dispose();
         }
     }
 
@@ -1076,7 +1394,10 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
 
     private void ResetOpenCommands()
     {
-        foreach (var command in _openCommands.ToArray())
+        AhtolaCommand[] commands;
+        lock (_commandLock)
+            commands = _openCommands.ToArray();
+        foreach (var command in commands)
             command.ResetFromConnection();
     }
 }

--- a/src/Ahtola.Data/AhtolaConnectionCapabilities.cs
+++ b/src/Ahtola.Data/AhtolaConnectionCapabilities.cs
@@ -52,7 +52,15 @@ public sealed class AhtolaConnectionCapabilities
         supportsTransactions: true,
         supportsSavepoints: true);
 
-    private static readonly AhtolaConnectionCapabilities AhtolaEmbeddedReplica = new(
+    private static readonly AhtolaConnectionCapabilities AhtolaManagedEmbeddedReplica = new(
+        AhtolaConnectionFacade.AhtolaData,
+        AhtolaConnectionMode.EmbeddedReplica,
+        canCreateBatch: false,
+        supportsAsyncOperations: true,
+        supportsTransactions: true,
+        supportsSavepoints: true);
+
+    private static readonly AhtolaConnectionCapabilities AhtolaSyncEmbeddedReplica = new(
         AhtolaConnectionFacade.AhtolaData,
         AhtolaConnectionMode.EmbeddedReplica,
         canCreateBatch: false,
@@ -155,10 +163,14 @@ public sealed class AhtolaConnectionCapabilities
 
     public bool SupportsSync { get; }
 
-    internal static AhtolaConnectionCapabilities ForAhtola(AhtolaConnectionOptions options)
+    internal static AhtolaConnectionCapabilities ForAhtola(
+        AhtolaConnectionOptions options,
+        bool replicaSupportsSync = false)
     {
         if (options.IsReplica)
-            return AhtolaEmbeddedReplica;
+            return replicaSupportsSync
+                ? AhtolaSyncEmbeddedReplica
+                : AhtolaManagedEmbeddedReplica;
         if (options.IsRemote)
             return AhtolaRemoteHrana;
         return options.LocalProvider == AhtolaLocalProvider.Managed

--- a/src/Ahtola.Data/AhtolaConnectionOptions.cs
+++ b/src/Ahtola.Data/AhtolaConnectionOptions.cs
@@ -227,10 +227,11 @@ public class AhtolaConnectionOptions
         {
             DataSource = options.RemoteUri.AbsoluteUri,
             ReplicaPath = options.Path,
-            LocalProvider = AhtolaLocalProvider.Native,
+            LocalProvider = AhtolaLocalProvider.Managed,
         };
         if (!string.IsNullOrWhiteSpace(options.AuthToken))
             builder.AuthToken = options.AuthToken;
+        builder.SyncInterval = options.SyncInterval;
         return new AhtolaConnectionOptions(builder);
     }
 

--- a/src/Ahtola.Data/AhtolaConnectionStringBuilder.cs
+++ b/src/Ahtola.Data/AhtolaConnectionStringBuilder.cs
@@ -157,11 +157,11 @@ public sealed class AhtolaConnectionStringBuilder : DbConnectionStringBuilder
     }
 
     /// <summary>
-    /// Gets or sets the reserved automatic synchronization interval.
+    /// Gets or sets the managed embedded-replica automatic synchronization interval.
     /// </summary>
     /// <remarks>
-    /// Only zero is supported. Positive values are preserved for connection-string
-    /// compatibility but are rejected when the connection opens.
+    /// Positive values are measured in seconds and are supported only by managed
+    /// embedded replica connections.
     /// </remarks>
     public int SyncInterval
     {

--- a/src/Ahtola.Data/AhtolaDataReader.cs
+++ b/src/Ahtola.Data/AhtolaDataReader.cs
@@ -16,6 +16,9 @@ public class AhtolaDataReader : DbDataReader, IConnectionOwnedReader
     private readonly IManagedStatementAdapter? _managedStatement;
     private readonly CommandBehavior _behavior;
     private readonly Action _completionCallback;
+    private readonly Action _failureCallback;
+    private readonly Action _closeCallback;
+    private IDisposable? _replicaOperation;
     private string?[]? _declaredColumnTypes;
     private bool _isClosed;
     private bool _hasCurrentRow;
@@ -87,7 +90,7 @@ public class AhtolaDataReader : DbDataReader, IConnectionOwnedReader
         AhtolaNativeStatement? nativeStatement,
         IManagedStatementAdapter? managedStatement,
         CommandBehavior behavior)
-        : this(command, nativeStatement, managedStatement, behavior, static () => { })
+        : this(command, nativeStatement, managedStatement, behavior, static () => { }, static () => { }, static () => { }, null)
     {
     }
 
@@ -96,7 +99,10 @@ public class AhtolaDataReader : DbDataReader, IConnectionOwnedReader
         AhtolaNativeStatement? nativeStatement,
         IManagedStatementAdapter? managedStatement,
         CommandBehavior behavior,
-        Action completionCallback)
+        Action completionCallback,
+        Action failureCallback,
+        Action closeCallback,
+        IDisposable? replicaOperation = null)
     {
         if ((nativeStatement is null) == (managedStatement is null))
             throw new ArgumentException("A reader requires exactly one statement implementation.");
@@ -108,6 +114,9 @@ public class AhtolaDataReader : DbDataReader, IConnectionOwnedReader
         _managedStatement = managedStatement;
         _behavior = behavior;
         _completionCallback = completionCallback;
+        _failureCallback = failureCallback;
+        _closeCallback = closeCallback;
+        _replicaOperation = replicaOperation;
         ((ILocalReaderConnection)_connection).ReaderOpened(this);
     }
 
@@ -363,13 +372,21 @@ public class AhtolaDataReader : DbDataReader, IConnectionOwnedReader
     private bool NextResultCore(CancellationToken cancellationToken)
     {
         EnsureOpen();
-        while (Step(cancellationToken))
+        try
         {
-        }
+            while (Step(cancellationToken))
+            {
+            }
 
-        _hasCurrentRow = false;
-        NotifyCompletion();
-        return false;
+            _hasCurrentRow = false;
+            NotifyCompletion();
+            return false;
+        }
+        catch
+        {
+            NotifyFailure();
+            throw;
+        }
     }
 
     public override Task<bool> NextResultAsync(CancellationToken cancellationToken)
@@ -393,10 +410,18 @@ public class AhtolaDataReader : DbDataReader, IConnectionOwnedReader
     private bool ReadCore(CancellationToken cancellationToken)
     {
         EnsureOpen();
-        _hasCurrentRow = Step(cancellationToken);
-        if (!_hasCurrentRow)
-            NotifyCompletion();
-        return _hasCurrentRow;
+        try
+        {
+            _hasCurrentRow = Step(cancellationToken);
+            if (!_hasCurrentRow)
+                NotifyCompletion();
+            return _hasCurrentRow;
+        }
+        catch
+        {
+            NotifyFailure();
+            throw;
+        }
     }
 
     public override Task<bool> ReadAsync(CancellationToken cancellationToken)
@@ -626,6 +651,15 @@ public class AhtolaDataReader : DbDataReader, IConnectionOwnedReader
         _completionCallback();
     }
 
+    private void NotifyFailure()
+    {
+        if (_completionNotified)
+            return;
+
+        _completionNotified = true;
+        _failureCallback();
+    }
+
     private void CloseCore(bool closeConnection)
     {
         if (_isClosed)
@@ -634,6 +668,7 @@ public class AhtolaDataReader : DbDataReader, IConnectionOwnedReader
         _command.Cancel();
         try
         {
+            NotifyFailure();
             _nativeStatement?.Dispose();
             _managedStatement?.Dispose();
         }
@@ -642,6 +677,8 @@ public class AhtolaDataReader : DbDataReader, IConnectionOwnedReader
             _hasCurrentRow = false;
             _isClosed = true;
             ((ILocalReaderConnection)_connection).ReaderClosed(this);
+            Interlocked.Exchange(ref _replicaOperation, null)?.Dispose();
+            _closeCallback();
             if (closeConnection && (_behavior & CommandBehavior.CloseConnection) == CommandBehavior.CloseConnection)
                 _connection.Close();
         }

--- a/src/Ahtola.Data/AhtolaException.cs
+++ b/src/Ahtola.Data/AhtolaException.cs
@@ -8,6 +8,20 @@ public class AhtolaException : Exception
     {
     }
 
+    internal AhtolaException(string message, System.Net.HttpStatusCode remoteStatusCode)
+        : base(message)
+    {
+        RemoteStatusCode = remoteStatusCode;
+    }
+
+    internal System.Net.HttpStatusCode? RemoteStatusCode { get; }
+
+    internal bool IsTransientRemoteHttpFailure
+        => RemoteStatusCode is System.Net.HttpStatusCode.RequestTimeout
+            or System.Net.HttpStatusCode.TooManyRequests
+            || RemoteStatusCode is { } status
+            && (int)status is >= 500 and <= 599;
+
     internal AhtolaException(string message, Exception innerException) : base(message, innerException)
     {
     }

--- a/src/Ahtola.Data/AhtolaRemoteClient.cs
+++ b/src/Ahtola.Data/AhtolaRemoteClient.cs
@@ -6,14 +6,9 @@ using System.Text.Json.Serialization;
 
 namespace Ahtola;
 
-internal sealed class AhtolaRemoteClient : IDisposable
+internal sealed partial class AhtolaRemoteClient : IDisposable
 {
     private const string EncryptionKeyHeaderName = "x-turso-encryption-key";
-
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-    };
 
     private readonly HttpClient _httpClient;
     private readonly string? _authToken;
@@ -122,6 +117,118 @@ internal sealed class AhtolaRemoteClient : IDisposable
         return ExtractBatchResults(response, commands.Count, stepSucceeded);
     }
 
+    /// <summary>
+    /// Replays a durably captured managed-replica batch using the same guarded Hrana batch
+    /// shape as Turso v0.7.2's <c>send_push_batch</c>. A caller acknowledges its local journal
+    /// only after this method returns successfully.
+    /// </summary>
+    internal async Task PushReplicaChangesAsync(
+        ReplicaLocalChangeBatch changes,
+        string clientId,
+        long sourcePullGeneration,
+        int commandTimeout,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(clientId);
+        if (changes.Changes.Count == 0)
+            return;
+
+        var guarded = new RemoteBatchCondition
+        {
+            Type = "not",
+            Condition = new RemoteBatchCondition { Type = "is_autocommit" },
+        };
+        var steps = new List<RemoteBatchStep>(checked(changes.Changes.Count + 4))
+        {
+            new()
+            {
+                Statement = BuildStatement("BEGIN IMMEDIATE", new AhtolaParameterCollection(), wantRows: false),
+            },
+            new()
+            {
+                Condition = guarded,
+                Statement = BuildStatement(
+                    "CREATE TABLE IF NOT EXISTS turso_sync_last_change_id (client_id TEXT PRIMARY KEY, pull_gen INTEGER, change_id INTEGER)",
+                    new AhtolaParameterCollection(),
+                    wantRows: false),
+            },
+        };
+
+        var replayedChangeSteps = new List<int>(changes.Changes.Count);
+        var replayedChangeContexts = new Dictionary<int, ReplicaPushConflictContext>();
+        foreach (var change in changes.Changes)
+        {
+            // A multi-row statement is represented by more than one update hook record. Only
+            // its first record carries SQL, while all of its records advance together on ACK.
+            if (string.IsNullOrWhiteSpace(change.Sql))
+                continue;
+
+            var step = steps.Count;
+            replayedChangeSteps.Add(step);
+            replayedChangeContexts.Add(
+                step,
+                new ReplicaPushConflictContext(
+                    change.Kind == ReplicaLocalChangeKind.Schema
+                        ? AhtolaReplicaConflictKind.SchemaChange
+                        : AhtolaReplicaConflictKind.RowWrite,
+                    change.Sequence));
+            steps.Add(new RemoteBatchStep
+            {
+                Condition = guarded,
+                Statement = BuildStatement(change.Sql, new AhtolaParameterCollection(), wantRows: false),
+            });
+        }
+
+        if (replayedChangeSteps.Count == 0)
+            throw new InvalidDataException("Managed replica journal batch has no replayable SQL.");
+
+        var watermarkStep = steps.Count;
+        var watermarkStatement = BuildStatement(
+            "INSERT INTO turso_sync_last_change_id(client_id, pull_gen, change_id) VALUES (?, ?, ?) ON CONFLICT(client_id) DO UPDATE SET pull_gen=excluded.pull_gen, change_id=excluded.change_id",
+            new AhtolaParameterCollection(),
+            wantRows: false);
+        watermarkStatement.Args.Add(new RemoteRequestValue { Type = "text", Value = clientId });
+        watermarkStatement.Args.Add(new RemoteRequestValue
+        {
+            Type = "integer",
+            Value = sourcePullGeneration.ToString(CultureInfo.InvariantCulture),
+        });
+        watermarkStatement.Args.Add(new RemoteRequestValue
+        {
+            Type = "integer",
+            Value = changes.Changes[^1].Sequence.ToString(CultureInfo.InvariantCulture),
+        });
+        steps.Add(new RemoteBatchStep { Condition = guarded, Statement = watermarkStatement });
+
+        var commitStep = steps.Count;
+        steps.Add(new RemoteBatchStep
+        {
+            Statement = BuildStatement("COMMIT", new AhtolaParameterCollection(), wantRows: false),
+        });
+
+        var request = new RemotePipelineRequest
+        {
+            Requests = [RemoteStreamRequest.Batch(new RemoteBatch { Steps = steps })],
+        };
+        var response = await SendPipelineAsync(request, commandTimeout, cancellationToken).ConfigureAwait(false);
+        UpdateSession(response, closeAfter: false);
+
+        var succeeded = new bool[steps.Count];
+        _ = ExtractBatchResults(
+            response,
+            steps.Count,
+            step => succeeded[step] = true,
+            replicaPush: true,
+            replayedChangeContexts: replayedChangeContexts);
+        foreach (var step in replayedChangeSteps)
+        {
+            if (!succeeded[step])
+                throw new AhtolaException("Remote replica push skipped a local change.");
+        }
+        if (!succeeded[watermarkStep] || !succeeded[commitStep])
+            throw new AhtolaException("Remote replica push did not commit its acknowledgement watermark.");
+    }
+
     public async Task CloseAsync(int commandTimeout, CancellationToken cancellationToken)
     {
         if (_baton is null)
@@ -153,7 +260,9 @@ internal sealed class AhtolaRemoteClient : IDisposable
         using var timeout = CreateTimeout(commandTimeout, cancellationToken);
         var effectiveCancellationToken = timeout?.Token ?? cancellationToken;
 
-        var json = JsonSerializer.Serialize(request, JsonOptions);
+        var json = JsonSerializer.Serialize(
+            request,
+            AhtolaRemoteJsonContext.Default.RemotePipelineRequest);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
         using var httpRequest = new HttpRequestMessage(HttpMethod.Post, _pipelineUri)
         {
@@ -172,13 +281,19 @@ internal sealed class AhtolaRemoteClient : IDisposable
         var body = await response.Content.ReadAsStringAsync(effectiveCancellationToken).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
         {
+            if (response.StatusCode == System.Net.HttpStatusCode.Conflict)
+                throw new AhtolaReplicaConflictException(
+                    $"Remote replica push conflicted with HTTP {(int)response.StatusCode} {response.ReasonPhrase}: {body}");
             throw new AhtolaException(
-                $"Remote request failed with HTTP {(int)response.StatusCode} {response.ReasonPhrase}: {body}");
+                $"Remote request failed with HTTP {(int)response.StatusCode} {response.ReasonPhrase}: {body}",
+                response.StatusCode);
         }
 
         try
         {
-            return JsonSerializer.Deserialize<RemotePipelineResponse>(body, JsonOptions)
+            return JsonSerializer.Deserialize(
+                       body,
+                       AhtolaRemoteJsonContext.Default.RemotePipelineResponse)
                    ?? throw new AhtolaException("Remote request returned an empty response.");
         }
         catch (JsonException ex)
@@ -195,6 +310,19 @@ internal sealed class AhtolaRemoteClient : IDisposable
         var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         timeout.CancelAfter(TimeSpan.FromSeconds(commandTimeout));
         return timeout;
+    }
+
+    internal static T DeserializeRemoteResult<T>(JsonElement result)
+    {
+        try
+        {
+            return result.Deserialize<T>(AhtolaRemoteJsonContext.Default.Options)
+                   ?? throw new AhtolaException("Remote response returned an empty result.");
+        }
+        catch (JsonException ex)
+        {
+            throw new AhtolaException($"Unable to parse remote response: {ex.Message}");
+        }
     }
 
     private static void ValidateAuthTokenTransport(Uri endpoint, string? authToken)
@@ -286,7 +414,9 @@ internal sealed class AhtolaRemoteClient : IDisposable
     private IReadOnlyList<RemoteStatementResult> ExtractBatchResults(
         RemotePipelineResponse response,
         int expectedCount,
-        Action<int>? stepSucceeded)
+        Action<int>? stepSucceeded,
+        bool replicaPush = false,
+        IReadOnlyDictionary<int, ReplicaPushConflictContext>? replayedChangeContexts = null)
     {
         if (response.Results.Count == 0)
             throw new AhtolaException("Remote batch returned no results.");
@@ -309,11 +439,16 @@ internal sealed class AhtolaRemoteClient : IDisposable
                         UpdateReplicationIndex(statementResult.ReplicationIndex);
                 }
 
-                statementResults = ExtractBatchStepResults(batch, expectedCount, stepSucceeded);
+                statementResults = ExtractBatchStepResults(
+                    batch,
+                    expectedCount,
+                    stepSucceeded,
+                    replicaPush,
+                    replayedChangeContexts);
                 break;
 
             case "error":
-                throw CreateRemoteError(result.Error);
+                throw CreateRemoteError(result.Error, replicaPush);
 
             default:
                 throw new AhtolaException($"Remote batch returned unexpected result type: {result.Type}");
@@ -328,12 +463,24 @@ internal sealed class AhtolaRemoteClient : IDisposable
         if (encodedIndex.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null)
             return;
 
-        if (encodedIndex.ValueKind is not JsonValueKind.String
-            || !ulong.TryParse(
+        ulong index;
+        if (encodedIndex.ValueKind == JsonValueKind.String)
+        {
+            if (!ulong.TryParse(
                 encodedIndex.GetString(),
                 NumberStyles.None,
                 CultureInfo.InvariantCulture,
-                out var index))
+                out index))
+            {
+                throw new AhtolaException("Remote response returned an invalid replication_index.");
+            }
+        }
+        else if (encodedIndex.ValueKind == JsonValueKind.Number)
+        {
+            if (!encodedIndex.TryGetUInt64(out index))
+                throw new AhtolaException("Remote response returned an invalid replication_index.");
+        }
+        else
         {
             throw new AhtolaException("Remote response returned an invalid replication_index.");
         }
@@ -368,7 +515,9 @@ internal sealed class AhtolaRemoteClient : IDisposable
     private static List<RemoteStatementResult> ExtractBatchStepResults(
         RemoteBatchResult batch,
         int expectedCount,
-        Action<int>? stepSucceeded)
+        Action<int>? stepSucceeded,
+        bool replicaPush,
+        IReadOnlyDictionary<int, ReplicaPushConflictContext>? replayedChangeContexts)
     {
         if (batch.StepErrors.Count != expectedCount || batch.StepResults.Count != expectedCount)
         {
@@ -385,7 +534,17 @@ internal sealed class AhtolaRemoteClient : IDisposable
         for (var i = 0; i < batch.StepErrors.Count; i++)
         {
             if (batch.StepErrors[i] is { } error)
-                throw CreateRemoteError(error);
+            {
+                var context = replayedChangeContexts is not null
+                    && replayedChangeContexts.TryGetValue(i, out var value)
+                    ? value
+                    : default;
+                throw CreateRemoteError(
+                    error,
+                    replicaPush,
+                    context.Kind,
+                    context.LocalChangeSequence);
+            }
         }
 
         var statementResults = new List<RemoteStatementResult>(expectedCount);
@@ -419,15 +578,37 @@ internal sealed class AhtolaRemoteClient : IDisposable
         }
     }
 
-    private static AhtolaException CreateRemoteError(RemoteError? error)
+    private static AhtolaException CreateRemoteError(
+        RemoteError? error,
+        bool replicaPush = false,
+        AhtolaReplicaConflictKind conflictKind = AhtolaReplicaConflictKind.Unknown,
+        long? localChangeSequence = null)
     {
         if (error is null)
             return new AhtolaRemoteSqlException("Remote SQL execution failed.");
+
+        if (replicaPush && IsConflict(error))
+        {
+            return new AhtolaReplicaConflictException(
+                $"Remote replica push conflicted: {error.Message}",
+                error.Code,
+                conflictKind,
+                localChangeSequence);
+        }
 
         return string.IsNullOrWhiteSpace(error.Code)
             ? new AhtolaRemoteSqlException($"Remote SQL execution failed: {error.Message}")
             : new AhtolaRemoteSqlException($"Remote SQL execution failed: {error.Message} ({error.Code})");
     }
+
+    private static bool IsConflict(RemoteError error)
+        => error.Code?.Contains("CONSTRAINT", StringComparison.OrdinalIgnoreCase) == true
+           || error.Code?.Contains("CONFLICT", StringComparison.OrdinalIgnoreCase) == true
+           || error.Message.Contains("conflict", StringComparison.OrdinalIgnoreCase);
+
+    private readonly record struct ReplicaPushConflictContext(
+        AhtolaReplicaConflictKind Kind,
+        long? LocalChangeSequence);
 
     private void UpdateSession(RemotePipelineResponse response, bool closeAfter)
     {
@@ -611,6 +792,13 @@ internal sealed class AhtolaRemoteClient : IDisposable
             };
         }
     }
+
+    [JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonSerializable(typeof(RemotePipelineRequest))]
+    [JsonSerializable(typeof(RemotePipelineResponse))]
+    [JsonSerializable(typeof(RemoteBatchResult))]
+    [JsonSerializable(typeof(RemoteStatementResult))]
+    private sealed partial class AhtolaRemoteJsonContext : JsonSerializerContext;
 }
 
 internal sealed class RemotePipelineResponse
@@ -650,15 +838,7 @@ internal sealed class RemoteStreamResponse
         if (Result.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null)
             throw new AhtolaException($"Remote response {Type} did not include a result.");
 
-        try
-        {
-            return Result.Deserialize<T>()
-                   ?? throw new AhtolaException($"Remote response {Type} returned an empty result.");
-        }
-        catch (JsonException ex)
-        {
-            throw new AhtolaException($"Unable to parse remote {Type} response: {ex.Message}");
-        }
+        return AhtolaRemoteClient.DeserializeRemoteResult<T>(Result);
     }
 }
 

--- a/src/Ahtola.Data/AhtolaReplicaConflictException.cs
+++ b/src/Ahtola.Data/AhtolaReplicaConflictException.cs
@@ -1,0 +1,61 @@
+namespace Ahtola;
+
+/// <summary>
+/// Describes the local replica operation that the remote server rejected.
+/// </summary>
+public enum AhtolaReplicaConflictKind
+{
+    /// <summary>
+    /// The remote response could not be associated with a replayed local operation.
+    /// </summary>
+    Unknown,
+
+    /// <summary>
+    /// A replayed row insert, update, or delete conflicted.
+    /// </summary>
+    RowWrite,
+
+    /// <summary>
+    /// A replayed schema-changing statement conflicted.
+    /// </summary>
+    SchemaChange,
+}
+
+/// <summary>
+/// Indicates that the server rejected a managed replica push because its state conflicts with
+/// locally committed journal changes. The journal is retained so the application can resolve
+/// the conflict explicitly; synchronization never rebases changes automatically.
+/// </summary>
+public sealed class AhtolaReplicaConflictException : AhtolaException
+{
+    /// <summary>
+    /// Initializes a conflict exception reported by the remote server.
+    /// </summary>
+    public AhtolaReplicaConflictException(
+        string message,
+        string? remoteErrorCode = null,
+        AhtolaReplicaConflictKind conflictKind = AhtolaReplicaConflictKind.Unknown,
+        long? localChangeSequence = null)
+        : base(message)
+    {
+        RemoteErrorCode = remoteErrorCode;
+        ConflictKind = conflictKind;
+        LocalChangeSequence = localChangeSequence;
+    }
+
+    /// <summary>
+    /// Gets the optional Hrana error code reported by the server.
+    /// </summary>
+    public string? RemoteErrorCode { get; }
+
+    /// <summary>
+    /// Gets the kind of local operation associated with the conflicting replay step.
+    /// </summary>
+    public AhtolaReplicaConflictKind ConflictKind { get; }
+
+    /// <summary>
+    /// Gets the durable local journal sequence associated with the conflicting replay step,
+    /// when the server reported a step-specific batch error.
+    /// </summary>
+    public long? LocalChangeSequence { get; }
+}

--- a/src/Ahtola.Data/AhtolaReplicaProvider.cs
+++ b/src/Ahtola.Data/AhtolaReplicaProvider.cs
@@ -1,6 +1,3 @@
-using System.Reflection;
-using System.Runtime.Loader;
-
 namespace Ahtola;
 
 /// <summary>
@@ -8,31 +5,31 @@ namespace Ahtola;
 /// </summary>
 public static class AhtolaReplicaProvider
 {
-    private const string ReplicaProviderAssemblyName = "Turso.Data.Sync";
-    private const string ReplicaProviderRegistrationTypeName = "Turso.Data.Sync.ReplicaProviderRegistration";
     private static AhtolaReplicaProviderFactory? s_factory;
 
     /// <summary>
-    /// Registers the embedded-replica factory supplied by the optional companion assembly.
+    /// Registers an explicitly supplied embedded-replica factory.
     /// </summary>
     public static void Register(AhtolaReplicaProviderFactory factory)
     {
         ArgumentNullException.ThrowIfNull(factory);
 
         var registeredFactory = Interlocked.CompareExchange(ref s_factory, factory, null);
-        if (registeredFactory is not null && registeredFactory.GetType() != factory.GetType())
+        if (registeredFactory is not null && !ReferenceEquals(registeredFactory, factory))
         {
             throw new InvalidOperationException(
-                $"An embedded replica provider factory of type {registeredFactory.GetType().FullName} is already registered.");
+                "An embedded replica provider factory is already registered.");
         }
     }
 
-    internal static AhtolaReplicaDatabase OpenReplica(AhtolaReplicaOptions options)
+    internal static bool HasRegisteredFactory => Volatile.Read(ref s_factory) is not null;
+
+    internal static AhtolaReplicaDatabase OpenRegisteredReplica(AhtolaReplicaOptions options)
     {
         return GetFactory().OpenReplica(options);
     }
 
-    internal static Task<AhtolaReplicaDatabase> OpenReplicaAsync(
+    internal static Task<AhtolaReplicaDatabase> OpenRegisteredReplicaAsync(
         AhtolaReplicaOptions options,
         CancellationToken cancellationToken)
     {
@@ -41,36 +38,9 @@ public static class AhtolaReplicaProvider
 
     private static AhtolaReplicaProviderFactory GetFactory()
     {
-        var factory = Volatile.Read(ref s_factory);
-        if (factory is null)
-        {
-            TryRegisterCompanion();
-            factory = Volatile.Read(ref s_factory);
-        }
-
-        return factory
+        return Volatile.Read(ref s_factory)
             ?? throw new NotSupportedException(
-                "Embedded replica connections are not supported yet by the .NET provider. " +
-                "Add the matching Turso.Data.Sqlite.Sync companion package to enable them.");
-    }
-
-    private static void TryRegisterCompanion()
-    {
-        try
-        {
-            var loadContext = AssemblyLoadContext.GetLoadContext(typeof(AhtolaReplicaProvider).Assembly);
-            var assembly = loadContext?.LoadFromAssemblyName(new AssemblyName(ReplicaProviderAssemblyName))
-                ?? Assembly.Load(new AssemblyName(ReplicaProviderAssemblyName));
-            var registrationType = assembly.GetType(ReplicaProviderRegistrationTypeName, throwOnError: true)!;
-            var register = registrationType.GetMethod(
-                "Register",
-                BindingFlags.Public | BindingFlags.Static)
-                ?? throw new MissingMethodException(ReplicaProviderRegistrationTypeName, "Register");
-            register.Invoke(null, null);
-        }
-        catch (FileNotFoundException)
-        {
-        }
+                "No embedded replica factory has been registered.");
     }
 }
 
@@ -105,7 +75,7 @@ public sealed class AhtolaReplicaOptions
         ArgumentNullException.ThrowIfNull(remoteUri);
 
         Path = path;
-        RemoteUri = remoteUri;
+        RemoteUri = NormalizeRemoteUri(remoteUri);
         AuthToken = authToken;
         BootstrapIfEmpty = bootstrapIfEmpty;
     }
@@ -156,19 +126,18 @@ public sealed class AhtolaReplicaOptions
     public long? PullBytesThreshold { get; init; }
 
     /// <summary>
+    /// Gets or initializes the managed embedded-replica synchronization interval in seconds.
+    /// A positive value starts a background synchronization loop after the connection opens.
+    /// </summary>
+    public int SyncInterval { get; init; }
+
+    /// <summary>
     /// Gets or initializes the HTTP transport policy.
     /// </summary>
     public AhtolaSyncHttpPolicy HttpPolicy { get; init; } = new();
 
     internal void Validate()
     {
-        if (!RemoteUri.IsAbsoluteUri
-            || (!RemoteUri.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
-                && !RemoteUri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)))
-        {
-            throw new ArgumentException("Embedded replica remote URLs must use HTTP or HTTPS.", nameof(RemoteUri));
-        }
-
         if (LongPollTimeout is { } longPollTimeout
             && (longPollTimeout < TimeSpan.FromMilliseconds(1)
                 || longPollTimeout.TotalMilliseconds > int.MaxValue))
@@ -181,6 +150,7 @@ public sealed class AhtolaReplicaOptions
 
         ValidateNativeSize(PushOperationsThreshold, nameof(PushOperationsThreshold));
         ValidateNativeSize(PullBytesThreshold, nameof(PullBytesThreshold));
+        ArgumentOutOfRangeException.ThrowIfNegative(SyncInterval);
         if (PartialBootstrap?.SegmentSize is { } segmentSize)
             ValidateNativeSize(segmentSize, nameof(AhtolaPartialBootstrapOptions.SegmentSize));
 
@@ -201,8 +171,34 @@ public sealed class AhtolaReplicaOptions
             throw new InvalidOperationException(
                 "PullBytesThreshold cannot be combined with query partial bootstrap because the server selects the query page set.");
         }
-
         ArgumentNullException.ThrowIfNull(HttpPolicy);
+        ArgumentNullException.ThrowIfNull(HttpPolicy);
+    }
+
+    private static Uri NormalizeRemoteUri(Uri remoteUri)
+    {
+        if (!remoteUri.IsAbsoluteUri)
+            throw new ArgumentException("Embedded replica remote URLs must be absolute.", nameof(remoteUri));
+
+        if (remoteUri.Scheme.Equals("libsql", StringComparison.OrdinalIgnoreCase))
+        {
+            var builder = new UriBuilder(remoteUri)
+            {
+                Scheme = Uri.UriSchemeHttps,
+                Port = remoteUri.IsDefaultPort ? -1 : remoteUri.Port,
+                UserName = string.Empty,
+                Password = string.Empty,
+            };
+            return builder.Uri;
+        }
+
+        if (remoteUri.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+            || remoteUri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            return remoteUri;
+        }
+
+        throw new ArgumentException("Embedded replica remote URLs must use libsql, HTTP, or HTTPS.", nameof(remoteUri));
     }
 
     internal IDisposable EnterApplicationHttpScope()
@@ -222,6 +218,7 @@ public sealed class AhtolaReplicaOptions
             RemoteEncryption = RemoteEncryption,
             PushOperationsThreshold = PushOperationsThreshold,
             PullBytesThreshold = PullBytesThreshold,
+            SyncInterval = SyncInterval,
             HttpPolicy = HttpPolicy,
         };
     }

--- a/src/Ahtola.Data/AhtolaTransaction.cs
+++ b/src/Ahtola.Data/AhtolaTransaction.cs
@@ -8,6 +8,7 @@ public class AhtolaTransaction : DbTransaction
     private AhtolaConnection? _connection;
     private readonly IsolationLevel _isolationLevel;
     private readonly bool _supportsSavepoints;
+    private IDisposable? _managedReplicaOperation;
     private bool _completed;
 
     public AhtolaTransaction(AhtolaConnection connection, IsolationLevel isolationLevel)
@@ -27,12 +28,23 @@ public class AhtolaTransaction : DbTransaction
         if (_isolationLevel == IsolationLevel.ReadUncommitted)
             connection.ReadUncommitted = true;
 
-        if (beginTransaction)
+        try
         {
-            if (connection.IsRemote)
-                connection.BeginRemoteTransaction(_isolationLevel);
-            else
-                connection.ExecuteNonQuery("BEGIN");
+            if (beginTransaction)
+            {
+                if (connection.IsRemote)
+                    connection.BeginRemoteTransaction(_isolationLevel);
+                else
+                    connection.ExecuteNonQuery("BEGIN");
+            }
+
+            _managedReplicaOperation = connection.EnterManagedReplicaTransaction();
+        }
+        catch
+        {
+            _managedReplicaOperation?.Dispose();
+            _managedReplicaOperation = null;
+            throw;
         }
     }
 
@@ -60,6 +72,7 @@ public class AhtolaTransaction : DbTransaction
                     .ConfigureAwait(false);
             }
 
+            transaction._managedReplicaOperation = connection.EnterManagedReplicaTransaction();
             return transaction;
         }
         catch
@@ -274,6 +287,7 @@ public class AhtolaTransaction : DbTransaction
         _completed = true;
         _connection = null;
         connection.TransactionCompleted(this);
+        Interlocked.Exchange(ref _managedReplicaOperation, null)?.Dispose();
     }
 
     private void ThrowIfCompleted()

--- a/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
+++ b/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
@@ -1,0 +1,777 @@
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using Ahtola.Core;
+
+namespace Ahtola;
+
+internal static class ManagedReplicaBootstrapper
+{
+    private const int PageSize = 4096;
+    private const int MaxHeaderLength = 64 * 1024;
+    private const int MaxPageMessageLength = PageSize + 1024;
+    private const string MetadataSuffix = ".ahtola-replica-meta";
+    private static readonly byte[] SqliteHeader = "SQLite format 3\0"u8.ToArray();
+    private static readonly UTF8Encoding StrictUtf8 = new(false, true);
+
+    public static async Task BootstrapAsync(AhtolaReplicaOptions options, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        cancellationToken.ThrowIfCancellationRequested();
+        ManagedReplicaSupportMatrix.ValidateOptions(options);
+
+        if (File.Exists(options.Path))
+        {
+            throw new NotSupportedException(
+                "Managed embedded replica bootstrap only installs a database at a missing replica path.");
+        }
+
+        if (!options.BootstrapIfEmpty)
+        {
+            throw new NotSupportedException(
+                "Managed embedded replica bootstrap is disabled and the replica path does not contain an initialized managed database.");
+        }
+
+        var metadataPath = options.Path + MetadataSuffix;
+        if (File.Exists(metadataPath))
+        {
+            throw new InvalidOperationException(
+                "Managed embedded replica metadata exists while the replica database is missing.");
+        }
+
+        var directory = Path.GetDirectoryName(Path.GetFullPath(options.Path))!;
+        var stagingPath = Path.Combine(
+            directory,
+            $".{Path.GetFileName(options.Path)}.bootstrap-{Guid.NewGuid():N}.tmp");
+        var metadataStagingPath = Path.Combine(
+            directory,
+            $".{Path.GetFileName(metadataPath)}.bootstrap-{Guid.NewGuid():N}.tmp");
+
+        var databaseInstalled = false;
+        try
+        {
+            var revision = await DownloadDatabaseAsync(options, stagingPath, cancellationToken).ConfigureAwait(false);
+            ValidateStagedDatabase(stagingPath);
+
+            ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.BootstrapStagedDatabase);
+            cancellationToken.ThrowIfCancellationRequested();
+            File.Move(stagingPath, options.Path, overwrite: false);
+            databaseInstalled = true;
+
+            ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.BootstrapDatabasePublished);
+            cancellationToken.ThrowIfCancellationRequested();
+            await WriteMetadataAsync(
+                metadataStagingPath,
+                metadataPath,
+                revision,
+                ComputeDatabaseFingerprint(options.Path),
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // A bootstrap image is not usable as a replica until its matching revision
+            // metadata is durable. Roll it back so the next open can bootstrap cleanly.
+            if (databaseInstalled && !File.Exists(metadataPath))
+                DeleteIfExists(options.Path);
+            throw;
+        }
+        finally
+        {
+            DeleteIfExists(stagingPath);
+            DeleteStagingSidecars(stagingPath);
+            DeleteIfExists(metadataStagingPath);
+        }
+    }
+
+    public static ManagedReplicaMetadata? LoadMetadata(string databasePath)
+    {
+        var path = databasePath + MetadataSuffix;
+        if (!File.Exists(path))
+            return null;
+        if (new FileInfo(path).Length is <= 0 or > 8192)
+            throw new InvalidDataException("Managed embedded replica metadata has an invalid size.");
+
+        var values = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var line in StrictUtf8.GetString(File.ReadAllBytes(path)).Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var separator = line.IndexOf('=');
+            if (separator <= 0 || !values.TryAdd(line[..separator], line[(separator + 1)..]))
+                throw new InvalidDataException("Managed embedded replica metadata is malformed.");
+        }
+
+        if (!values.TryGetValue("version", out var version) || version != "2"
+            || !values.TryGetValue("server_revision_base64", out var encodedRevision)
+            || !values.TryGetValue("database_sha256", out var fingerprint)
+            || !values.TryGetValue("client_id", out var clientId) || values.Count != 4)
+            throw new InvalidDataException("Managed embedded replica metadata is incomplete.");
+        try
+        {
+            var revision = StrictUtf8.GetString(Convert.FromBase64String(encodedRevision));
+            if (revision.Length == 0 || !Guid.TryParseExact(clientId, "N", out _))
+                throw new InvalidDataException("Managed embedded replica metadata is invalid.");
+            if (!IsSha256Hex(fingerprint))
+                throw new InvalidDataException("Managed embedded replica metadata is invalid.");
+            return new ManagedReplicaMetadata(revision, fingerprint, clientId);
+        }
+        catch (FormatException exception)
+        {
+            throw new InvalidDataException("Managed embedded replica metadata is invalid.", exception);
+        }
+    }
+
+    public static async Task<AhtolaSyncResult> CheckForUpdatesAsync(
+        AhtolaReplicaOptions options, ManagedReplicaMetadata metadata, AhtolaSyncOptions syncOptions,
+        CancellationToken cancellationToken)
+    {
+        ManagedReplicaSupportMatrix.ValidateOptions(options);
+        EnsureNoLocalDivergence(options.Path, metadata);
+        syncOptions.Progress?.Report(new AhtolaSyncProgress(AhtolaSyncProgressStage.Pulling));
+        var payload = CreatePullRequest(metadata.Revision, options.LongPollTimeout);
+        using var timeout = CreateTimeout(options.HttpPolicy.RequestTimeout, cancellationToken);
+        using var scope = options.EnterApplicationHttpScope();
+        using var client = options.HttpPolicy.MessageHandler is { } handler ? new HttpClient(handler, false) : new HttpClient();
+        client.Timeout = Timeout.InfiniteTimeSpan;
+        using var request = new HttpRequestMessage(HttpMethod.Post, CreatePullUpdatesUri(options.RemoteUri))
+        {
+            Content = new ByteArrayContent(payload),
+        };
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/protobuf");
+        request.Headers.TryAddWithoutValidation("Accept-Encoding", "application/protobuf");
+        var token = string.IsNullOrWhiteSpace(options.AuthToken) ? null : options.AuthToken;
+        ValidateAuthTokenTransport(request.RequestUri!, token);
+        if (token is not null)
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var effectiveToken = timeout?.Token ?? cancellationToken;
+        using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, effectiveToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+        await using var stream = await response.Content.ReadAsStreamAsync(effectiveToken).ConfigureAwait(false);
+        var reader = new DelimitedProtobufReader(stream);
+        var message = await reader.ReadAsync(MaxHeaderLength, effectiveToken).ConfigureAwait(false)
+            ?? throw new InvalidDataException("The pull-updates response did not contain a protobuf header.");
+        var header = ParseHeader(message);
+        var pages = new List<PullPage>();
+        while (await reader.ReadAsync(MaxPageMessageLength, effectiveToken).ConfigureAwait(false) is { } page)
+        {
+            pages.Add(ParsePage(page));
+        }
+        if (pages.Count == 0 && string.Equals(header.Revision, metadata.Revision, StringComparison.Ordinal))
+        {
+            syncOptions.Progress?.Report(new AhtolaSyncProgress(AhtolaSyncProgressStage.Completed));
+            return new AhtolaSyncResult(AhtolaSyncOutcome.UpToDate,
+                new AhtolaSyncStatistics(0, 0, 0, DateTimeOffset.UtcNow, null, payload.Length, reader.BytesRead, metadata.Revision));
+        }
+
+        if (pages.Count == 0)
+            throw new InvalidDataException("The pull-updates response changed revision without returning page data.");
+        if (string.Equals(header.Revision, metadata.Revision, StringComparison.Ordinal))
+            throw new InvalidDataException("The pull-updates response returned page data without changing revision.");
+
+        await ApplyIncrementalPagesAsync(options, header, pages, metadata.ClientId, effectiveToken).ConfigureAwait(false);
+        syncOptions.Progress?.Report(new AhtolaSyncProgress(AhtolaSyncProgressStage.Applying));
+        syncOptions.Progress?.Report(new AhtolaSyncProgress(AhtolaSyncProgressStage.Completed));
+        return new AhtolaSyncResult(AhtolaSyncOutcome.RemoteChangesApplied,
+            new AhtolaSyncStatistics(0, 0, 0, DateTimeOffset.UtcNow, null, payload.Length, reader.BytesRead, header.Revision));
+    }
+
+    /// <summary>
+    /// Records the local image that was just acknowledged by a committed remote push. This
+    /// preserves the client identity and lets the subsequent pull retain its divergence guard.
+    /// </summary>
+    public static async Task<ManagedReplicaMetadata> RecordLocalPushAsync(
+        AhtolaReplicaOptions options,
+        ManagedReplicaMetadata metadata,
+        CancellationToken cancellationToken)
+    {
+        var metadataPath = options.Path + MetadataSuffix;
+        var directory = Path.GetDirectoryName(Path.GetFullPath(metadataPath))!;
+        var stagingPath = Path.Combine(
+            directory,
+            $".{Path.GetFileName(metadataPath)}.push-{Guid.NewGuid():N}.tmp");
+        try
+        {
+            var fingerprint = ComputeDatabaseFingerprint(options.Path);
+            await WriteMetadataAsync(
+                    stagingPath,
+                    metadataPath,
+                    metadata.Revision,
+                    fingerprint,
+                    cancellationToken,
+                    replaceExisting: true,
+                    clientId: metadata.ClientId)
+                .ConfigureAwait(false);
+            return metadata with { DatabaseSha256 = fingerprint };
+        }
+        finally
+        {
+            DeleteIfExists(stagingPath);
+        }
+    }
+
+    private static async Task ApplyIncrementalPagesAsync(
+        AhtolaReplicaOptions options,
+        PullHeader header,
+        IReadOnlyList<PullPage> pages,
+        string clientId,
+        CancellationToken cancellationToken)
+    {
+        var directory = Path.GetDirectoryName(Path.GetFullPath(options.Path))!;
+        var stagingPath = Path.Combine(directory, $".{Path.GetFileName(options.Path)}.apply-{Guid.NewGuid():N}.tmp");
+        var backupPath = Path.Combine(directory, $".{Path.GetFileName(options.Path)}.apply-{Guid.NewGuid():N}.bak");
+        var metadataPath = options.Path + MetadataSuffix;
+        var metadataStagingPath = Path.Combine(
+            directory,
+            $".{Path.GetFileName(metadataPath)}.apply-{Guid.NewGuid():N}.tmp");
+        var databaseInstalled = false;
+        var metadataInstalled = false;
+        try
+        {
+            File.Copy(options.Path, stagingPath, overwrite: false);
+            var pageIds = new HashSet<ulong>();
+            await using (var staging = new FileStream(
+                stagingPath,
+                FileMode.Open,
+                FileAccess.ReadWrite,
+                FileShare.None,
+                bufferSize: PageSize,
+                FileOptions.Asynchronous | FileOptions.WriteThrough))
+            {
+                staging.SetLength(checked((long)header.DatabasePages * PageSize));
+                foreach (var page in pages)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (page.PageId >= header.DatabasePages || !pageIds.Add(page.PageId))
+                        throw new InvalidDataException("The pull-updates response contains an invalid incremental page set.");
+
+                    staging.Position = checked((long)page.PageId * PageSize);
+                    await staging.WriteAsync(page.Data, cancellationToken).ConfigureAwait(false);
+                }
+
+                await staging.FlushAsync(cancellationToken).ConfigureAwait(false);
+                staging.Flush(flushToDisk: true);
+            }
+
+            ValidateStagedDatabase(stagingPath);
+            ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.IncrementalApplyStagedDatabase);
+            cancellationToken.ThrowIfCancellationRequested();
+            File.Replace(stagingPath, options.Path, backupPath, ignoreMetadataErrors: false);
+            databaseInstalled = true;
+            ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.IncrementalApplyDatabasePublished);
+            cancellationToken.ThrowIfCancellationRequested();
+            await WriteMetadataAsync(
+                    metadataStagingPath,
+                    metadataPath,
+                    header.Revision,
+                    ComputeDatabaseFingerprint(options.Path),
+                    cancellationToken,
+                    replaceExisting: true,
+                    clientId: clientId)
+                .ConfigureAwait(false);
+            metadataInstalled = true;
+            ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.IncrementalApplyMetadataPublished);
+            cancellationToken.ThrowIfCancellationRequested();
+            DeleteIfExists(backupPath);
+        }
+        catch
+        {
+            // Once metadata is durable it fingerprints the installed image. A later
+            // interruption must preserve that matched pair rather than restore only DB.
+            if (databaseInstalled && !metadataInstalled && File.Exists(backupPath))
+                File.Replace(backupPath, options.Path, destinationBackupFileName: null, ignoreMetadataErrors: false);
+            throw;
+        }
+        finally
+        {
+            DeleteIfExists(stagingPath);
+            DeleteStagingSidecars(stagingPath);
+            DeleteIfExists(metadataStagingPath);
+            DeleteIfExists(backupPath);
+        }
+    }
+
+    private static async Task<string> DownloadDatabaseAsync(
+        AhtolaReplicaOptions options,
+        string stagingPath,
+        CancellationToken cancellationToken)
+    {
+        using var timeout = CreateTimeout(options.HttpPolicy.RequestTimeout, cancellationToken);
+        var effectiveCancellationToken = timeout?.Token ?? cancellationToken;
+        using var scope = options.EnterApplicationHttpScope();
+        using var client = options.HttpPolicy.MessageHandler is { } handler
+            ? new HttpClient(handler, disposeHandler: false)
+            : new HttpClient();
+        client.Timeout = Timeout.InfiniteTimeSpan;
+        using var request = new HttpRequestMessage(HttpMethod.Post, CreatePullUpdatesUri(options.RemoteUri));
+        request.Content = new ByteArrayContent(CreateInitialPullRequest(options.LongPollTimeout));
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/protobuf");
+        request.Headers.TryAddWithoutValidation("Accept-Encoding", "application/protobuf");
+
+        var authToken = string.IsNullOrWhiteSpace(options.AuthToken) ? null : options.AuthToken;
+        ValidateAuthTokenTransport(request.RequestUri!, authToken);
+        if (authToken is not null)
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", authToken);
+
+        using var response = await client.SendAsync(
+            request,
+            HttpCompletionOption.ResponseHeadersRead,
+            effectiveCancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        await using var stream = await response.Content.ReadAsStreamAsync(effectiveCancellationToken).ConfigureAwait(false);
+        var reader = new DelimitedProtobufReader(stream);
+        var headerPayload = await reader.ReadAsync(MaxHeaderLength, effectiveCancellationToken).ConfigureAwait(false)
+            ?? throw new InvalidDataException("The pull-updates response did not contain a protobuf header.");
+        var header = ParseHeader(headerPayload);
+
+        var databaseLength = checked((long)header.DatabasePages * PageSize);
+        var receivedPages = new HashSet<ulong>();
+        await using (var staging = new FileStream(
+            stagingPath,
+            FileMode.CreateNew,
+            FileAccess.ReadWrite,
+            FileShare.None,
+            bufferSize: PageSize,
+            FileOptions.Asynchronous | FileOptions.WriteThrough))
+        {
+            staging.SetLength(databaseLength);
+            while (await reader.ReadAsync(MaxPageMessageLength, effectiveCancellationToken).ConfigureAwait(false) is { } pagePayload)
+            {
+                var page = ParsePage(pagePayload);
+                if (page.PageId >= header.DatabasePages)
+                    throw new InvalidDataException("The pull-updates response contains a page outside the declared database size.");
+                if (!receivedPages.Add(page.PageId))
+                    throw new InvalidDataException("The pull-updates response contains a duplicate page.");
+
+                staging.Position = checked((long)page.PageId * PageSize);
+                await staging.WriteAsync(page.Data, effectiveCancellationToken).ConfigureAwait(false);
+            }
+
+            if ((ulong)receivedPages.Count != header.DatabasePages)
+                throw new InvalidDataException("The pull-updates response did not contain every database page exactly once.");
+
+            await staging.FlushAsync(effectiveCancellationToken).ConfigureAwait(false);
+            staging.Flush(flushToDisk: true);
+        }
+
+        return header.Revision;
+    }
+
+    private static void ValidateStagedDatabase(string stagingPath)
+    {
+        using (var stream = new FileStream(stagingPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+        {
+            Span<byte> header = stackalloc byte[SqliteHeader.Length];
+            stream.ReadExactly(header);
+            if (!header.SequenceEqual(SqliteHeader))
+                throw new InvalidDataException("The bootstrapped page stream does not contain a SQLite database header.");
+        }
+
+        using var database = ManagedDatabaseAdapter.Open(stagingPath);
+        _ = database.Connect();
+    }
+
+    private static async Task WriteMetadataAsync(
+        string stagingPath,
+        string metadataPath,
+        string revision,
+        string fingerprint,
+        CancellationToken cancellationToken,
+        bool replaceExisting = false,
+        string? clientId = null)
+    {
+        var metadata = string.Concat(
+            "version=2\n",
+            "server_revision_base64=", Convert.ToBase64String(StrictUtf8.GetBytes(revision)), "\n",
+            "database_sha256=", fingerprint, "\n",
+            "client_id=", clientId ?? Guid.NewGuid().ToString("N"), "\n");
+        await using (var stream = new FileStream(
+            stagingPath,
+            FileMode.CreateNew,
+            FileAccess.Write,
+            FileShare.None,
+            bufferSize: 1024,
+            FileOptions.Asynchronous | FileOptions.WriteThrough))
+        {
+            await stream.WriteAsync(Encoding.UTF8.GetBytes(metadata), cancellationToken).ConfigureAwait(false);
+            await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+            stream.Flush(flushToDisk: true);
+        }
+
+        if (replaceExisting && File.Exists(metadataPath))
+            File.Replace(stagingPath, metadataPath, destinationBackupFileName: null, ignoreMetadataErrors: false);
+        else
+            File.Move(stagingPath, metadataPath, overwrite: false);
+    }
+
+    private static PullHeader ParseHeader(byte[] payload)
+    {
+        var reader = new ProtobufFieldReader(payload);
+        string? revision = null;
+        ulong? databasePages = null;
+        var rawEncoding = false;
+        var zstdEncoding = false;
+        ulong? streamKind = null;
+        ulong? applyMode = null;
+        ulong? protocol = null;
+
+        while (reader.TryReadField(out var field, out var wireType))
+        {
+            switch (field)
+            {
+                case 1:
+                    revision = ReadSingleString(ref reader, wireType, revision, "server revision");
+                    break;
+                case 2:
+                    databasePages = ReadSingleVarint(ref reader, wireType, databasePages, "database size");
+                    break;
+                case 3:
+                    ReadEmptyMessage(ref reader, wireType, "raw encoding");
+                    if (rawEncoding)
+                        throw new InvalidDataException("The pull-updates header contains raw encoding more than once.");
+                    rawEncoding = true;
+                    break;
+                case 4:
+                    reader.SkipField(wireType);
+                    zstdEncoding = true;
+                    break;
+                case 5:
+                    streamKind = ReadSingleVarint(ref reader, wireType, streamKind, "stream kind");
+                    break;
+                case 6:
+                    applyMode = ReadSingleVarint(ref reader, wireType, applyMode, "apply mode");
+                    break;
+                case 7:
+                    throw new InvalidDataException("Managed embedded replica bootstrap does not support logical update streams.");
+                case 8:
+                    protocol = ReadSingleVarint(ref reader, wireType, protocol, "protocol");
+                    break;
+                default:
+                    reader.SkipField(wireType);
+                    break;
+            }
+        }
+
+        if (!rawEncoding || zstdEncoding)
+            throw new InvalidDataException("Managed embedded replica bootstrap requires a raw, non-zstd page stream.");
+        if (revision is null || revision.Length == 0)
+            throw new InvalidDataException("The pull-updates response did not provide a server revision.");
+        if (databasePages is not { } pageCount || pageCount == 0 || pageCount > (ulong)(long.MaxValue / PageSize))
+            throw new InvalidDataException("The pull-updates response has an invalid database size.");
+        if (streamKind is > 0)
+            throw new InvalidDataException("Managed embedded replica bootstrap supports only page streams.");
+        if (applyMode is > 1)
+            throw new InvalidDataException("The pull-updates response has an unsupported apply mode.");
+        if (protocol is > 1)
+            throw new InvalidDataException("Managed embedded replica bootstrap does not support logical pull protocols.");
+
+        return new PullHeader(revision, pageCount);
+    }
+
+    private static PullPage ParsePage(byte[] payload)
+    {
+        var reader = new ProtobufFieldReader(payload);
+        ulong? pageId = null;
+        byte[]? pageData = null;
+
+        while (reader.TryReadField(out var field, out var wireType))
+        {
+            switch (field)
+            {
+                case 1:
+                    pageId = ReadSingleVarint(ref reader, wireType, pageId, "page id");
+                    break;
+                case 2:
+                    if (pageData is not null)
+                        throw new InvalidDataException("A page message contains page data more than once.");
+                    pageData = reader.ReadLengthDelimited(wireType, "page data");
+                    break;
+                default:
+                    reader.SkipField(wireType);
+                    break;
+            }
+        }
+
+        if (pageData is null || pageData.Length != PageSize)
+            throw new InvalidDataException("The pull-updates response contains an invalid raw database page.");
+
+        // Protobuf omits scalar fields at their default value. Turso's page-zero
+        // messages therefore carry only encoded_page (server_proto.rs::PageData).
+        return new PullPage(pageId ?? 0, pageData);
+    }
+
+    private static string ReadSingleString(
+        ref ProtobufFieldReader reader,
+        int wireType,
+        string? currentValue,
+        string name)
+    {
+        if (currentValue is not null)
+            throw new InvalidDataException($"The pull-updates response contains {name} more than once.");
+        return StrictUtf8.GetString(reader.ReadLengthDelimited(wireType, name));
+    }
+
+    private static ulong ReadSingleVarint(
+        ref ProtobufFieldReader reader,
+        int wireType,
+        ulong? currentValue,
+        string name)
+    {
+        if (currentValue is not null)
+            throw new InvalidDataException($"The pull-updates response contains {name} more than once.");
+        return reader.ReadVarint(wireType, name);
+    }
+
+    private static void ReadEmptyMessage(ref ProtobufFieldReader reader, int wireType, string name)
+    {
+        if (reader.ReadLengthDelimited(wireType, name).Length != 0)
+            throw new InvalidDataException($"The pull-updates response has an unsupported {name} payload.");
+    }
+
+    private static byte[] CreateInitialPullRequest(TimeSpan? longPollTimeout)
+        => CreatePullRequest(clientRevision: null, longPollTimeout);
+
+    private static byte[] CreatePullRequest(string? clientRevision, TimeSpan? longPollTimeout)
+    {
+        // Raw, Pages, and empty revisions are Prost defaults. A configured
+        // timeout alone is non-default and uses PullUpdatesReqProtoBody tag 4.
+        if (longPollTimeout is null)
+            return [];
+
+        var request = new List<byte>(clientRevision is null ? 6 : clientRevision.Length + 12);
+        if (!string.IsNullOrEmpty(clientRevision))
+        {
+            var revision = StrictUtf8.GetBytes(clientRevision);
+            WriteVarint(request, 3u << 3 | 2);
+            WriteVarint(request, checked((ulong)revision.Length));
+            request.AddRange(revision);
+        }
+        if (longPollTimeout is { } timeout)
+        {
+            WriteVarint(request, 4u << 3);
+            WriteVarint(request, checked((ulong)timeout.TotalMilliseconds));
+        }
+        return request.ToArray();
+    }
+
+    private static Uri CreatePullUpdatesUri(Uri endpoint)
+    {
+        var builder = new UriBuilder(endpoint)
+        {
+            Query = string.Empty,
+            Fragment = string.Empty,
+        };
+        var path = builder.Path;
+        builder.Path = string.IsNullOrEmpty(path) || path == "/"
+            ? "/pull-updates"
+            : path.TrimEnd('/').EndsWith("/pull-updates", StringComparison.OrdinalIgnoreCase)
+                ? path
+                : path.TrimEnd('/') + "/pull-updates";
+        return builder.Uri;
+    }
+
+    private static CancellationTokenSource? CreateTimeout(TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        if (timeout == Timeout.InfiniteTimeSpan)
+            return null;
+
+        var source = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        source.CancelAfter(timeout);
+        return source;
+    }
+
+    private static void ValidateAuthTokenTransport(Uri endpoint, string? authToken)
+    {
+        if (authToken is null
+            || endpoint.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+            || endpoint.IsLoopback)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException("Auth Token requires an HTTPS remote Ahtola URL unless the host is localhost or loopback.");
+    }
+
+    private static void DeleteIfExists(string path)
+    {
+        if (File.Exists(path))
+            File.Delete(path);
+    }
+
+    private static void DeleteStagingSidecars(string path)
+    {
+        DeleteIfExists(path + "-wal");
+        DeleteIfExists(path + "-shm");
+        DeleteIfExists(path + "-journal");
+    }
+
+    private static void WriteVarint(List<byte> destination, ulong value)
+    {
+        while (value >= 0x80)
+        {
+            destination.Add((byte)((value & 0x7f) | 0x80));
+            value >>= 7;
+        }
+        destination.Add((byte)value);
+    }
+
+    public static void EnsureNoLocalDivergence(string databasePath, ManagedReplicaMetadata metadata)
+    {
+        // Opening the managed pager may create an empty 32-byte WAL header; frames
+        // beyond that header are local state and cannot be replaced safely.
+        if ((File.Exists(databasePath + "-wal") && new FileInfo(databasePath + "-wal").Length > 32)
+            || (File.Exists(databasePath + "-journal") && new FileInfo(databasePath + "-journal").Length > 0))
+            throw new NotSupportedException("Managed embedded replica local divergence was detected; incremental pull cannot replace local changes.");
+        if (!string.Equals(ComputeDatabaseFingerprint(databasePath), metadata.DatabaseSha256, StringComparison.Ordinal))
+            throw new NotSupportedException("Managed embedded replica local divergence was detected; incremental pull cannot replace local changes.");
+    }
+
+    private static string ComputeDatabaseFingerprint(string path)
+        => Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(path)));
+
+    private static bool IsSha256Hex(string value)
+        => value.Length == 64 && value.All(static c => c is >= '0' and <= '9' or >= 'A' and <= 'F');
+
+    public readonly record struct ManagedReplicaMetadata(string Revision, string DatabaseSha256, string ClientId);
+    private readonly record struct PullHeader(string Revision, ulong DatabasePages);
+    private readonly record struct PullPage(ulong PageId, byte[] Data);
+
+    private sealed class DelimitedProtobufReader(Stream stream)
+    {
+        private readonly byte[] _singleByte = new byte[1];
+        public long BytesRead { get; private set; }
+
+        public async Task<byte[]?> ReadAsync(int maximumLength, CancellationToken cancellationToken)
+        {
+            var next = await ReadByteAsync(cancellationToken).ConfigureAwait(false);
+            if (next < 0)
+                return null;
+
+            ulong length = 0;
+            for (var byteIndex = 0; byteIndex < 10; byteIndex++)
+            {
+                if (byteIndex == 9 && (next & 0xfe) != 0)
+                    throw new InvalidDataException("The protobuf message length is invalid.");
+                length |= (ulong)(next & 0x7f) << (byteIndex * 7);
+                if ((next & 0x80) == 0)
+                    break;
+                if (byteIndex == 9)
+                    throw new InvalidDataException("The protobuf message length is invalid.");
+                next = await ReadByteAsync(cancellationToken).ConfigureAwait(false);
+                if (next < 0)
+                    throw new InvalidDataException("The protobuf message ended inside its length prefix.");
+            }
+
+            if (length > (ulong)maximumLength)
+                throw new InvalidDataException("The protobuf message exceeds the supported size.");
+
+            var payload = new byte[(int)length];
+            var offset = 0;
+            while (offset < payload.Length)
+            {
+                var read = await stream.ReadAsync(payload.AsMemory(offset), cancellationToken).ConfigureAwait(false);
+                if (read == 0)
+                    throw new InvalidDataException("The protobuf message ended before its declared length.");
+                offset += read;
+                BytesRead += read;
+            }
+            return payload;
+        }
+
+        private async Task<int> ReadByteAsync(CancellationToken cancellationToken)
+        {
+            var read = await stream.ReadAsync(_singleByte.AsMemory(), cancellationToken).ConfigureAwait(false);
+            if (read != 0)
+                BytesRead++;
+            return read == 0 ? -1 : _singleByte[0];
+        }
+    }
+
+    private ref struct ProtobufFieldReader(ReadOnlySpan<byte> payload)
+    {
+        private ReadOnlySpan<byte> _payload = payload;
+        private int _offset;
+
+        public bool TryReadField(out int fieldNumber, out int wireType)
+        {
+            if (_offset == _payload.Length)
+            {
+                fieldNumber = 0;
+                wireType = 0;
+                return false;
+            }
+
+            var key = ReadRawVarint();
+            fieldNumber = checked((int)(key >> 3));
+            wireType = checked((int)(key & 7));
+            if (fieldNumber == 0)
+                throw new InvalidDataException("The protobuf message contains an invalid field number.");
+            return true;
+        }
+
+        public ulong ReadVarint(int wireType, string name)
+        {
+            if (wireType != 0)
+                throw new InvalidDataException($"The protobuf {name} field has an invalid wire type.");
+            return ReadRawVarint();
+        }
+
+        public byte[] ReadLengthDelimited(int wireType, string name)
+        {
+            if (wireType != 2)
+                throw new InvalidDataException($"The protobuf {name} field has an invalid wire type.");
+            var length = ReadRawVarint();
+            if (length > (ulong)(_payload.Length - _offset))
+                throw new InvalidDataException($"The protobuf {name} field exceeds its message.");
+            var value = _payload.Slice(_offset, (int)length).ToArray();
+            _offset += value.Length;
+            return value;
+        }
+
+        public void SkipField(int wireType)
+        {
+            switch (wireType)
+            {
+                case 0:
+                    _ = ReadRawVarint();
+                    break;
+                case 1:
+                    Skip(8);
+                    break;
+                case 2:
+                    var length = ReadRawVarint();
+                    if (length > int.MaxValue)
+                        throw new InvalidDataException("The protobuf field is too large.");
+                    Skip((int)length);
+                    break;
+                case 5:
+                    Skip(4);
+                    break;
+                default:
+                    throw new InvalidDataException("The protobuf message contains an unsupported wire type.");
+            }
+        }
+
+        private ulong ReadRawVarint()
+        {
+            ulong value = 0;
+            for (var byteIndex = 0; byteIndex < 10; byteIndex++)
+            {
+                if (_offset == _payload.Length)
+                    throw new InvalidDataException("The protobuf message ended inside a varint.");
+                var next = _payload[_offset++];
+                if (byteIndex == 9 && (next & 0xfe) != 0)
+                    throw new InvalidDataException("The protobuf message contains an invalid varint.");
+                value |= (ulong)(next & 0x7f) << (byteIndex * 7);
+                if ((next & 0x80) == 0)
+                    return value;
+            }
+            throw new InvalidDataException("The protobuf message contains an invalid varint.");
+        }
+
+        private void Skip(int length)
+        {
+            if (length < 0 || length > _payload.Length - _offset)
+                throw new InvalidDataException("The protobuf field exceeds its message.");
+            _offset += length;
+        }
+    }
+}

--- a/src/Ahtola.Data/ManagedReplicaChangeJournal.cs
+++ b/src/Ahtola.Data/ManagedReplicaChangeJournal.cs
@@ -1,0 +1,293 @@
+using System.Text;
+using Ahtola.Core;
+
+namespace Ahtola;
+
+/// <summary>
+/// The kind of durable operation captured from a managed embedded replica.
+/// </summary>
+internal enum ReplicaLocalChangeKind : byte
+{
+    Row = 1,
+    Schema = 2,
+}
+
+/// <summary>
+/// A committed operation awaiting a future managed-replica push implementation.
+/// </summary>
+internal readonly record struct ReplicaLocalChange(
+    long Sequence,
+    ReplicaLocalChangeKind Kind,
+    SqliteChangeOperation Operation,
+    string Database,
+    string Table,
+    long RowId,
+    string Sql)
+{
+    public static ReplicaLocalChange Row(
+        SqliteChangeOperation operation,
+        string database,
+        string table,
+        long rowId)
+        => new(0, ReplicaLocalChangeKind.Row, operation, database, table, rowId, string.Empty);
+
+    public static ReplicaLocalChange Schema(string sql)
+        => new(0, ReplicaLocalChangeKind.Schema, default, string.Empty, string.Empty, 0, sql);
+}
+
+/// <summary>
+/// An ordered, bounded view of locally committed replica operations. <see cref="Watermark"/>
+/// is the exclusive sequence boundary a successful push may acknowledge.
+/// </summary>
+internal readonly record struct ReplicaLocalChangeBatch(
+    long FirstSequence,
+    long Watermark,
+    IReadOnlyList<ReplicaLocalChange> Changes);
+
+/// <summary>
+/// Replica-private, crash-safe journal. It deliberately lives outside the SQLite file so a
+/// remote raw-page replacement never becomes a locally captured mutation.
+/// </summary>
+internal sealed class ManagedReplicaChangeJournal
+{
+    internal const string Suffix = ".ahtola-replica-journal";
+
+    private const ulong Magic = 0x4C_4E_52_4A_4C_4F_54_41; // "ATOLJRNL"
+    private const int Version = 3;
+    private const int MaxStringBytes = 1024 * 1024;
+
+    private readonly object _gate = new();
+    private readonly string _path;
+    private readonly List<ReplicaLocalChange> _changes;
+    private long _sequence;
+    private long _watermark;
+
+    private ManagedReplicaChangeJournal(
+        string path,
+        long sequence,
+        long watermark,
+        List<ReplicaLocalChange> changes)
+    {
+        _path = path;
+        _sequence = sequence;
+        _watermark = watermark;
+        _changes = changes;
+    }
+
+    public static ManagedReplicaChangeJournal Open(string databasePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(databasePath);
+        var path = databasePath + Suffix;
+        if (!File.Exists(path))
+            return new ManagedReplicaChangeJournal(path, 0, 1, []);
+
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+        using var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: false);
+        if (reader.ReadUInt64() != Magic)
+            throw new InvalidDataException("Managed replica change journal has an unsupported format.");
+        var formatVersion = reader.ReadInt32();
+        if (formatVersion is not (1 or 2 or Version))
+            throw new InvalidDataException("Managed replica change journal has an unsupported format.");
+
+        var sequence = reader.ReadInt64();
+        var persistedWatermark = reader.ReadInt64();
+        var count = reader.ReadInt32();
+        if (sequence < 0
+            || (formatVersion == 1
+                ? persistedWatermark != checked(sequence + 1)
+                : persistedWatermark < 1 || persistedWatermark > checked(sequence + 1))
+            || count < 0)
+            throw new InvalidDataException("Managed replica change journal has invalid state.");
+        if (count > (stream.Length - stream.Position) / 13)
+            throw new InvalidDataException("Managed replica change journal has an invalid entry count.");
+
+        var changes = new List<ReplicaLocalChange>(count);
+        long previous = 0;
+        for (var i = 0; i < count; i++)
+        {
+            var change = ReadChange(reader, formatVersion);
+            if (change.Sequence <= previous
+                || (formatVersion != 1 && change.Sequence < persistedWatermark)
+                || change.Sequence > sequence)
+                throw new InvalidDataException("Managed replica change journal is not ordered.");
+            changes.Add(change);
+            previous = change.Sequence;
+        }
+
+        if (stream.Position != stream.Length || (count != 0 && previous != sequence))
+            throw new InvalidDataException("Managed replica change journal is malformed.");
+        var watermark = formatVersion == 1 && changes.Count != 0
+            ? changes[0].Sequence
+            : persistedWatermark;
+        return new ManagedReplicaChangeJournal(path, sequence, watermark, changes);
+    }
+
+    public ReplicaLocalChangeBatch ReadBatch(int maximumChanges)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumChanges);
+        lock (_gate)
+        {
+            var count = Math.Min(maximumChanges, _changes.Count);
+            if (count == 0)
+                return new ReplicaLocalChangeBatch(_watermark, _watermark, []);
+
+            var batch = _changes.Take(count).ToArray();
+            var watermark = batch[^1].Sequence + 1;
+            return new ReplicaLocalChangeBatch(batch[0].Sequence, watermark, batch);
+        }
+    }
+
+    public void AppendCommitted(IReadOnlyList<ReplicaLocalChange> changes)
+    {
+        ArgumentNullException.ThrowIfNull(changes);
+        if (changes.Count == 0)
+            return;
+
+        lock (_gate)
+        {
+            var first = checked(_sequence + 1);
+            var assigned = new ReplicaLocalChange[changes.Count];
+            for (var i = 0; i < changes.Count; i++)
+            {
+                var change = changes[i];
+                assigned[i] = change with { Sequence = checked(first + i) };
+            }
+
+            var nextSequence = assigned[^1].Sequence;
+            Persist(nextSequence, _watermark, _changes.Concat(assigned).ToArray());
+            ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.JournalAppendPersisted);
+            _changes.AddRange(assigned);
+            _sequence = nextSequence;
+        }
+    }
+
+    /// <summary>
+    /// Durably discards changes below an exclusive watermark after their enclosing remote
+    /// transaction has committed. Failed, cancelled, and conflicting pushes never call this.
+    /// </summary>
+    public void Acknowledge(long watermark)
+    {
+        lock (_gate)
+        {
+            if (watermark < _watermark || watermark > checked(_sequence + 1))
+                throw new ArgumentOutOfRangeException(nameof(watermark));
+
+            if (watermark == _watermark)
+                return;
+
+            var retained = _changes.Where(change => change.Sequence >= watermark).ToArray();
+            Persist(_sequence, watermark, retained);
+            ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.JournalAcknowledgementPersisted);
+            _changes.RemoveAll(change => change.Sequence < watermark);
+            _watermark = watermark;
+        }
+    }
+
+    private void Persist(long sequence, long watermark, IReadOnlyList<ReplicaLocalChange> changes)
+    {
+        var directory = Path.GetDirectoryName(Path.GetFullPath(_path))!;
+        var stagingPath = Path.Combine(
+            directory,
+            $".{Path.GetFileName(_path)}.{Guid.NewGuid():N}.tmp");
+        try
+        {
+            using (var stream = new FileStream(
+                       stagingPath,
+                       FileMode.CreateNew,
+                       FileAccess.Write,
+                       FileShare.None,
+                       bufferSize: 4096,
+                       FileOptions.WriteThrough))
+            using (var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true))
+            {
+                writer.Write(Magic);
+                writer.Write(Version);
+                writer.Write(sequence);
+                writer.Write(watermark);
+                writer.Write(changes.Count);
+                foreach (var change in changes)
+                    WriteChange(writer, change);
+                writer.Flush();
+                stream.Flush(flushToDisk: true);
+            }
+
+            if (File.Exists(_path))
+                File.Replace(stagingPath, _path, destinationBackupFileName: null, ignoreMetadataErrors: false);
+            else
+                File.Move(stagingPath, _path, overwrite: false);
+        }
+        finally
+        {
+            if (File.Exists(stagingPath))
+                File.Delete(stagingPath);
+        }
+    }
+
+    private static void WriteChange(BinaryWriter writer, ReplicaLocalChange change)
+    {
+        writer.Write(change.Sequence);
+        writer.Write((byte)change.Kind);
+        switch (change.Kind)
+        {
+            case ReplicaLocalChangeKind.Row:
+                writer.Write((int)change.Operation);
+                WriteString(writer, change.Database);
+                WriteString(writer, change.Table);
+                writer.Write(change.RowId);
+                WriteString(writer, change.Sql);
+                break;
+            case ReplicaLocalChangeKind.Schema:
+                WriteString(writer, change.Sql);
+                break;
+            default:
+                throw new InvalidDataException("Managed replica change journal has an unknown change kind.");
+        }
+    }
+
+    private static ReplicaLocalChange ReadChange(BinaryReader reader, int formatVersion)
+    {
+        var sequence = reader.ReadInt64();
+        var kind = (ReplicaLocalChangeKind)reader.ReadByte();
+        return kind switch
+        {
+            ReplicaLocalChangeKind.Row => new ReplicaLocalChange(
+                sequence,
+                kind,
+                (SqliteChangeOperation)reader.ReadInt32(),
+                ReadString(reader),
+                ReadString(reader),
+                reader.ReadInt64(),
+                formatVersion >= 3 ? ReadString(reader) : string.Empty),
+            ReplicaLocalChangeKind.Schema => ReplicaLocalChange.Schema(ReadString(reader)) with { Sequence = sequence },
+            _ => throw new InvalidDataException("Managed replica change journal has an unknown change kind."),
+        };
+    }
+
+    private static void WriteString(BinaryWriter writer, string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        var bytes = Encoding.UTF8.GetBytes(value);
+        if (bytes.Length > MaxStringBytes)
+            throw new InvalidDataException("Managed replica change journal entry is too large.");
+        writer.Write(bytes.Length);
+        writer.Write(bytes);
+    }
+
+    private static string ReadString(BinaryReader reader)
+    {
+        var length = reader.ReadInt32();
+        if (length < 0 || length > MaxStringBytes)
+            throw new InvalidDataException("Managed replica change journal contains an invalid string.");
+        var bytes = reader.ReadBytes(length);
+        if (bytes.Length != length)
+            throw new EndOfStreamException("Managed replica change journal is truncated.");
+        try
+        {
+            return new UTF8Encoding(false, true).GetString(bytes);
+        }
+        catch (DecoderFallbackException exception)
+        {
+            throw new InvalidDataException("Managed replica change journal contains invalid UTF-8.", exception);
+        }
+    }
+}

--- a/src/Ahtola.Data/ManagedReplicaConnectionHost.cs
+++ b/src/Ahtola.Data/ManagedReplicaConnectionHost.cs
@@ -1,0 +1,514 @@
+using Ahtola.Core;
+
+namespace Ahtola;
+
+/// <summary>
+/// Owns a managed local database used by an embedded replica connection.
+/// Initial raw-page bootstrap is intentionally separate from later incremental
+/// pull and push synchronization.
+/// </summary>
+internal sealed class ManagedReplicaConnectionHost : IDisposable
+{
+    private IManagedDatabaseAdapter? _database;
+    private ManagedReplicaBootstrapper.ManagedReplicaMetadata? _metadata;
+    private readonly AhtolaReplicaOptions _options;
+    private readonly ManagedReplicaSyncRegistry.Entry _syncEntry;
+    private volatile ManagedReplicaChangeJournal _changeJournal;
+    private readonly object _changeGate = new();
+    private readonly List<ReplicaLocalChange> _statementChanges = [];
+    private readonly List<ReplicaLocalChange> _transactionChanges = [];
+    private AhtolaConnection? _connection;
+    private bool _localTransactionActive;
+    private IDisposable? _sqlTransactionOperation;
+    private bool _sqlTransactionBeginPending;
+    private bool _sqlTransactionCompletionPending;
+
+    private ManagedReplicaConnectionHost(
+        IManagedDatabaseAdapter database,
+        ManagedReplicaBootstrapper.ManagedReplicaMetadata? metadata,
+        AhtolaReplicaOptions options,
+        ManagedReplicaChangeJournal changeJournal,
+        ManagedReplicaSyncRegistry.Entry syncEntry)
+    {
+        _database = database;
+        _metadata = metadata;
+        _options = options;
+        _changeJournal = changeJournal;
+        _syncEntry = syncEntry;
+        InstallChangeCapture(database.Connection);
+        _syncEntry.Register(this);
+    }
+
+    public IManagedDatabaseAdapter Database
+        => _database ?? throw new ObjectDisposedException(nameof(ManagedReplicaConnectionHost));
+
+    public bool SupportsSync => _metadata is not null;
+
+    public IDisposable EnterLocalOperation(CancellationToken cancellationToken)
+        => _syncEntry.EnterLocalOperation(cancellationToken);
+
+    public bool HasSqlTransactionOperation
+    {
+        get
+        {
+            lock (_changeGate)
+                return _sqlTransactionOperation is not null;
+        }
+    }
+
+    public void BeginSqlTransaction(CancellationToken cancellationToken)
+    {
+        lock (_changeGate)
+        {
+            if (_sqlTransactionOperation is not null)
+                return;
+        }
+
+        var operation = EnterLocalOperation(cancellationToken);
+        lock (_changeGate)
+        {
+            if (_sqlTransactionOperation is null)
+            {
+                _sqlTransactionOperation = operation;
+                _sqlTransactionBeginPending = true;
+                return;
+            }
+        }
+
+        operation.Dispose();
+    }
+
+    public void AttachConnection(AhtolaConnection connection)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        if (Interlocked.CompareExchange(ref _connection, connection, null) is { } existing
+            && !ReferenceEquals(existing, connection))
+        {
+            throw new InvalidOperationException("Managed embedded replica host is already attached to a connection.");
+        }
+    }
+
+    public void DetachConnection(AhtolaConnection connection)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        Interlocked.CompareExchange(ref _connection, null, connection);
+    }
+
+    public ReplicaLocalChangeBatch ReadLocalChanges(int maximumChanges)
+        => _changeJournal.ReadBatch(maximumChanges);
+
+    public void AcknowledgeLocalChanges(long watermark)
+        => _changeJournal.Acknowledge(watermark);
+
+    public void StatementStarted(string sql)
+    {
+        ArgumentNullException.ThrowIfNull(sql);
+        lock (_changeGate)
+        {
+            // A previous reader that was abandoned before completion must not make its
+            // unproven changes eligible for push.
+            _statementChanges.Clear();
+        }
+    }
+
+    public void StatementCompleted(string sql)
+    {
+        ArgumentNullException.ThrowIfNull(sql);
+        lock (_changeGate)
+        {
+            var keyword = SqlTransactionControl.GetFirstKeyword(sql);
+            if (IsSchemaMutation(keyword) && _statementChanges.Count == 0)
+                _statementChanges.Add(ReplicaLocalChange.Schema(sql));
+
+            if (_statementChanges.Count > 0
+                && !string.IsNullOrWhiteSpace(sql)
+                && _statementChanges[0].Kind == ReplicaLocalChangeKind.Row)
+            {
+                // One SQL statement can invoke the update hook for many rows. Replay the
+                // statement once; the remaining journal rows advance with that statement.
+                _statementChanges[0] = _statementChanges[0] with { Sql = sql };
+            }
+
+            if (keyword is not null && keyword.Equals("BEGIN", StringComparison.OrdinalIgnoreCase))
+            {
+                _statementChanges.Clear();
+                _localTransactionActive = true;
+                _sqlTransactionBeginPending = false;
+                return;
+            }
+
+            var completion = SqlTransactionControl.GetCompletion(sql);
+            if (completion == SqlTransactionCompletion.Rollback)
+            {
+                _statementChanges.Clear();
+                _transactionChanges.Clear();
+                _localTransactionActive = false;
+                _sqlTransactionCompletionPending = true;
+                return;
+            }
+
+            if (completion == SqlTransactionCompletion.Commit)
+            {
+                _transactionChanges.AddRange(_statementChanges);
+                _statementChanges.Clear();
+                _changeJournal.AppendCommitted(_transactionChanges);
+                _transactionChanges.Clear();
+                _localTransactionActive = false;
+                _sqlTransactionCompletionPending = true;
+                return;
+            }
+
+            if (_localTransactionActive)
+            {
+                _transactionChanges.AddRange(_statementChanges);
+                _statementChanges.Clear();
+            }
+            else
+            {
+                _changeJournal.AppendCommitted(_statementChanges);
+                _statementChanges.Clear();
+            }
+        }
+    }
+
+    public void StatementFailed()
+    {
+        IDisposable? transactionOperation = null;
+        lock (_changeGate)
+        {
+            _statementChanges.Clear();
+            if (_sqlTransactionBeginPending)
+            {
+                transactionOperation = _sqlTransactionOperation;
+                _sqlTransactionOperation = null;
+                _sqlTransactionBeginPending = false;
+            }
+        }
+
+        transactionOperation?.Dispose();
+    }
+
+    public void StatementClosed()
+    {
+        IDisposable? transactionOperation = null;
+        lock (_changeGate)
+        {
+            if (_sqlTransactionCompletionPending)
+            {
+                transactionOperation = _sqlTransactionOperation;
+                _sqlTransactionOperation = null;
+                _sqlTransactionCompletionPending = false;
+            }
+        }
+
+        transactionOperation?.Dispose();
+    }
+
+    public async Task QuiesceAndReopenAsync(
+        Func<CancellationToken, Task> stagedOperation,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(stagedOperation);
+        await _syncEntry.PublishAsync(stagedOperation, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<T> QuiesceAndReopenAsync<T>(
+        Func<CancellationToken, Task<T>> stagedOperation,
+        CancellationToken cancellationToken)
+    {
+        T? result = default;
+        await QuiesceAndReopenAsync(
+                (Func<CancellationToken, Task>)(async token => result = await stagedOperation(token).ConfigureAwait(false)),
+                cancellationToken)
+            .ConfigureAwait(false);
+        return result!;
+    }
+
+    public static ManagedReplicaConnectionHost Open(AhtolaReplicaOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ManagedReplicaSupportMatrix.ValidateOptions(options);
+        var syncEntry = ManagedReplicaSyncRegistry.Acquire(options.Path);
+        try
+        {
+            using var operation = syncEntry.EnterLocalOperation(CancellationToken.None);
+            EnsureReplicaAvailableAsync(options, CancellationToken.None).GetAwaiter().GetResult();
+            return OpenExisting(options, syncEntry);
+        }
+        catch
+        {
+            syncEntry.ReleaseReference();
+            throw;
+        }
+    }
+
+    public static async Task<ManagedReplicaConnectionHost> OpenAsync(
+        AhtolaReplicaOptions options,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ManagedReplicaSupportMatrix.ValidateOptions(options);
+        var syncEntry = ManagedReplicaSyncRegistry.Acquire(options.Path);
+        try
+        {
+            using var operation = await syncEntry.EnterLocalOperationAsync(cancellationToken).ConfigureAwait(false);
+            await EnsureReplicaAvailableAsync(options, cancellationToken).ConfigureAwait(false);
+            return OpenExisting(options, syncEntry);
+        }
+        catch
+        {
+            syncEntry.ReleaseReference();
+            throw;
+        }
+    }
+
+    private static ManagedReplicaConnectionHost OpenExisting(
+        AhtolaReplicaOptions options,
+        ManagedReplicaSyncRegistry.Entry syncEntry)
+    {
+        var database = OpenDatabase(options.Path);
+        try
+        {
+            _ = database.Connect();
+            return new ManagedReplicaConnectionHost(
+                database,
+                ManagedReplicaBootstrapper.LoadMetadata(options.Path),
+                options,
+                ManagedReplicaChangeJournal.Open(options.Path),
+                syncEntry);
+        }
+
+        catch
+        {
+            database.Dispose();
+            throw;
+        }
+    }
+
+    private static IManagedDatabaseAdapter OpenDatabase(string path)
+    {
+        var database = ManagedDatabaseAdapter.Open(path);
+        try
+        {
+            _ = database.Connect();
+            return database;
+        }
+        catch
+        {
+            database.Dispose();
+            throw;
+        }
+    }
+
+    private static async Task EnsureReplicaAvailableAsync(AhtolaReplicaOptions options, CancellationToken cancellationToken)
+    {
+        if (File.Exists(options.Path) && new FileInfo(options.Path).Length > 0)
+            return;
+
+        if (File.Exists(options.Path))
+        {
+            throw new NotSupportedException(
+                "Managed embedded replica bootstrap only installs a database at a missing replica path.");
+        }
+
+        await ManagedReplicaBootstrapper.BootstrapAsync(options, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task SyncAsync(CancellationToken cancellationToken)
+    {
+        _ = await SyncAsync(new AhtolaSyncOptions(), cancellationToken).ConfigureAwait(false);
+    }
+
+    public Task<AhtolaSyncResult> SyncAsync(
+        AhtolaSyncOptions options,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (_metadata is null)
+        {
+            return Task.FromException<AhtolaSyncResult>(
+                new NotSupportedException(
+                    "Managed embedded replica synchronization requires bootstrap metadata."));
+        }
+
+        return _syncEntry.SynchronizeAsync(
+            this,
+            token =>
+            {
+                var metadata = ManagedReplicaBootstrapper.LoadMetadata(_options.Path)
+                    ?? throw new NotSupportedException(
+                        "Managed embedded replica synchronization requires bootstrap metadata.");
+                _metadata = metadata;
+                return SynchronizeAsync(_options, metadata, options, token);
+            },
+            cancellationToken);
+    }
+
+    private async Task<AhtolaSyncResult> SynchronizeAsync(
+        AhtolaReplicaOptions replicaOptions,
+        ManagedReplicaBootstrapper.ManagedReplicaMetadata metadata,
+        AhtolaSyncOptions syncOptions,
+        CancellationToken cancellationToken)
+    {
+        var push = await PushLocalChangesAsync(replicaOptions, metadata, syncOptions, cancellationToken)
+            .ConfigureAwait(false);
+        metadata = push.Metadata;
+        var result = await ManagedReplicaBootstrapper.CheckForUpdatesAsync(
+                replicaOptions,
+                metadata,
+                syncOptions,
+                cancellationToken)
+            .ConfigureAwait(false);
+        _metadata = ManagedReplicaBootstrapper.LoadMetadata(replicaOptions.Path);
+        return result with
+        {
+            Statistics = result.Statistics with
+            {
+                CdcOperations = checked(result.Statistics.CdcOperations + push.ChangeCount),
+                LastPush = push.ChangeCount == 0 ? result.Statistics.LastPush : DateTimeOffset.UtcNow,
+            },
+        };
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            using var operation = EnterLocalOperation(CancellationToken.None);
+            _syncEntry.Unregister(this);
+            Interlocked.Exchange(ref _connection, null);
+            ReleaseSqlTransactionOperation();
+            var database = Interlocked.Exchange(ref _database, null);
+            database?.Dispose();
+        }
+        finally
+        {
+            _syncEntry.ReleaseReference();
+        }
+    }
+
+    internal void CloseForPublication()
+    {
+        Volatile.Read(ref _connection)?.ResetManagedReplicaCommandsForPublication();
+        var database = Interlocked.Exchange(ref _database, null)
+            ?? throw new ObjectDisposedException(nameof(ManagedReplicaConnectionHost));
+        database.Dispose();
+    }
+
+    internal void ReopenAfterPublication()
+    {
+        var database = OpenDatabase(_options.Path);
+        try
+        {
+            var changeJournal = ManagedReplicaChangeJournal.Open(_options.Path);
+            InstallChangeCapture(database.Connection);
+            if (Interlocked.CompareExchange(ref _database, database, null) is not null)
+                throw new InvalidOperationException("Managed embedded replica host reopened more than once.");
+            _changeJournal = changeJournal;
+            database = null!;
+        }
+        finally
+        {
+            database?.Dispose();
+        }
+    }
+
+    private void InstallChangeCapture(IManagedConnectionAdapter connection)
+    {
+        var hooks = connection.Hooks;
+        hooks.UpdateHook = change =>
+        {
+            if (!change.Database.Equals("main", StringComparison.OrdinalIgnoreCase))
+                return;
+            lock (_changeGate)
+            {
+                _statementChanges.Add(
+                    ReplicaLocalChange.Row(change.Operation, change.Database, change.Table, change.RowId));
+            }
+        };
+        hooks.RollbackHook = () =>
+        {
+            lock (_changeGate)
+            {
+                _statementChanges.Clear();
+                _transactionChanges.Clear();
+                _localTransactionActive = false;
+                if (_sqlTransactionOperation is not null)
+                {
+                    _sqlTransactionBeginPending = false;
+                    _sqlTransactionCompletionPending = true;
+                }
+            }
+        };
+    }
+
+    private static bool IsSchemaMutation(string? keyword)
+        => keyword is not null
+           && (keyword.Equals("CREATE", StringComparison.OrdinalIgnoreCase)
+               || keyword.Equals("ALTER", StringComparison.OrdinalIgnoreCase)
+               || keyword.Equals("DROP", StringComparison.OrdinalIgnoreCase)
+               || keyword.Equals("REINDEX", StringComparison.OrdinalIgnoreCase)
+               || keyword.Equals("VACUUM", StringComparison.OrdinalIgnoreCase));
+
+    private void ReleaseSqlTransactionOperation()
+    {
+        IDisposable? transactionOperation;
+        lock (_changeGate)
+        {
+            transactionOperation = _sqlTransactionOperation;
+            _sqlTransactionOperation = null;
+            _sqlTransactionBeginPending = false;
+            _sqlTransactionCompletionPending = false;
+        }
+
+        transactionOperation?.Dispose();
+    }
+
+    private async Task<LocalPushResult> PushLocalChangesAsync(
+        AhtolaReplicaOptions replicaOptions,
+        ManagedReplicaBootstrapper.ManagedReplicaMetadata metadata,
+        AhtolaSyncOptions syncOptions,
+        CancellationToken cancellationToken)
+    {
+        var maximumChanges = replicaOptions.PushOperationsThreshold is { } threshold
+            ? checked((int)Math.Min(threshold, int.MaxValue))
+            : 1000;
+        var batch = _changeJournal.ReadBatch(maximumChanges);
+        if (batch.Changes.Count == 0)
+            return new LocalPushResult(0, metadata);
+
+        syncOptions.Progress?.Report(new AhtolaSyncProgress(AhtolaSyncProgressStage.Pushing));
+        using var client = replicaOptions.HttpPolicy.MessageHandler is { } handler
+            ? new HttpClient(handler, disposeHandler: false)
+            : new HttpClient();
+        client.Timeout = Timeout.InfiniteTimeSpan;
+        using var remote = new AhtolaRemoteClient(
+            client,
+            replicaOptions.RemoteUri,
+            replicaOptions.AuthToken,
+            replicaOptions.RemoteEncryption,
+            disposeHttpClient: false);
+
+        await remote.PushReplicaChangesAsync(
+                batch,
+                metadata.ClientId,
+                sourcePullGeneration: 0,
+                ToCommandTimeoutSeconds(replicaOptions.HttpPolicy.RequestTimeout),
+                cancellationToken)
+            .ConfigureAwait(false);
+        var updatedMetadata = await ManagedReplicaBootstrapper
+            .RecordLocalPushAsync(replicaOptions, metadata, cancellationToken)
+            .ConfigureAwait(false);
+        _changeJournal.Acknowledge(batch.Watermark);
+        return new LocalPushResult(batch.Changes.Count, updatedMetadata);
+    }
+
+    private static int ToCommandTimeoutSeconds(TimeSpan timeout)
+    {
+        if (timeout == Timeout.InfiniteTimeSpan)
+            return 0;
+        return checked((int)Math.Max(1, Math.Ceiling(timeout.TotalSeconds)));
+    }
+
+    private readonly record struct LocalPushResult(long ChangeCount, ManagedReplicaBootstrapper.ManagedReplicaMetadata Metadata);
+}

--- a/src/Ahtola.Data/ManagedReplicaFaultInjection.cs
+++ b/src/Ahtola.Data/ManagedReplicaFaultInjection.cs
@@ -1,0 +1,47 @@
+namespace Ahtola;
+
+/// <summary>
+/// Durable publication points that tests may interrupt to verify replica recovery.
+/// </summary>
+internal enum ManagedReplicaDurableBoundary
+{
+    BootstrapStagedDatabase,
+    BootstrapDatabasePublished,
+    IncrementalApplyStagedDatabase,
+    IncrementalApplyDatabasePublished,
+    IncrementalApplyMetadataPublished,
+    JournalAppendPersisted,
+    JournalAcknowledgementPersisted,
+}
+
+/// <summary>
+/// Async-flow-local fault injection for deterministic managed replica durability tests.
+/// </summary>
+internal static class ManagedReplicaFaultInjection
+{
+    private static readonly AsyncLocal<Action<ManagedReplicaDurableBoundary>?> Callback = new();
+
+    internal static IDisposable Push(Action<ManagedReplicaDurableBoundary> callback)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        var previous = Callback.Value;
+        Callback.Value = callback;
+        return new Scope(previous);
+    }
+
+    internal static void Hit(ManagedReplicaDurableBoundary boundary)
+        => Callback.Value?.Invoke(boundary);
+
+    private sealed class Scope(Action<ManagedReplicaDurableBoundary>? previous) : IDisposable
+    {
+        private Action<ManagedReplicaDurableBoundary>? _previous = previous;
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _previous, null) is { } previous)
+                Callback.Value = previous;
+            else
+                Callback.Value = null;
+        }
+    }
+}

--- a/src/Ahtola.Data/ManagedReplicaSupportMatrix.cs
+++ b/src/Ahtola.Data/ManagedReplicaSupportMatrix.cs
@@ -1,0 +1,30 @@
+namespace Ahtola;
+
+/// <summary>
+/// Enforces the managed Cloud-replica support boundary before a local replica is opened.
+/// </summary>
+internal static class ManagedReplicaSupportMatrix
+{
+    public static void ValidateOptions(AhtolaReplicaOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (options.PartialBootstrap is not null)
+        {
+            throw new NotSupportedException(
+                "Managed embedded replicas support only a complete raw 4 KiB page bootstrap; partial, query, and lazy bootstrap are not supported.");
+        }
+
+        if (options.PullBytesThreshold is not null)
+        {
+            throw new NotSupportedException(
+                "Managed embedded replicas support only a single complete raw 4 KiB page bootstrap; chunked bootstrap is not supported.");
+        }
+
+        if (options.RemoteEncryption is not null)
+        {
+            throw new NotSupportedException(
+                "Managed embedded replicas do not support encrypted remote page streams.");
+        }
+    }
+}

--- a/src/Ahtola.Data/ManagedReplicaSyncRegistry.cs
+++ b/src/Ahtola.Data/ManagedReplicaSyncRegistry.cs
@@ -1,0 +1,345 @@
+using System.Collections.Concurrent;
+
+namespace Ahtola;
+
+/// <summary>
+/// Coordinates managed embedded-replica publication for one normalized database path.
+/// Local work holds a shared lease; publication waits for those leases and then closes
+/// and reopens every registered host while no local work can begin.
+/// </summary>
+internal static class ManagedReplicaSyncRegistry
+{
+    private static readonly ConcurrentDictionary<string, Entry> Entries =
+        new(PathComparer);
+
+    private static StringComparer PathComparer =>
+        OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+
+    public static Entry Acquire(string path)
+    {
+        var normalizedPath = NormalizePath(path);
+        while (true)
+        {
+            var entry = Entries.GetOrAdd(normalizedPath, static key => new Entry(key));
+            if (entry.TryAddReference())
+                return entry;
+        }
+    }
+
+    private static string NormalizePath(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        return Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+    }
+
+    internal sealed class Entry
+    {
+        private readonly object _gate = new();
+        private readonly string _path;
+        private readonly HashSet<ManagedReplicaConnectionHost> _hosts = [];
+        private TaskCompletionSource _stateChanged = NewStateChangedSource();
+        private Task<AhtolaSyncResult>? _inFlightSync;
+        private int _references;
+        private int _activeLocalOperations;
+        private bool _publicationPending;
+        private bool _publicationActive;
+        private bool _retired;
+
+        internal Entry(string path)
+        {
+            _path = path;
+        }
+
+        internal bool TryAddReference()
+        {
+            lock (_gate)
+            {
+                if (_retired)
+                    return false;
+
+                _references++;
+                return true;
+            }
+        }
+
+        public void ReleaseReference()
+        {
+            lock (_gate)
+            {
+                if (_references == 0)
+                    return;
+
+                _references--;
+                RetireIfUnusedNoLock();
+            }
+        }
+
+        public void Register(ManagedReplicaConnectionHost host)
+        {
+            ArgumentNullException.ThrowIfNull(host);
+            lock (_gate)
+                _hosts.Add(host);
+        }
+
+        public void Unregister(ManagedReplicaConnectionHost host)
+        {
+            ArgumentNullException.ThrowIfNull(host);
+            lock (_gate)
+            {
+                _hosts.Remove(host);
+                RetireIfUnusedNoLock();
+            }
+        }
+
+        public IDisposable EnterLocalOperation(CancellationToken cancellationToken)
+            => EnterLocalOperationAsync(cancellationToken).AsTask().GetAwaiter().GetResult();
+
+        public async ValueTask<IDisposable> EnterLocalOperationAsync(CancellationToken cancellationToken)
+        {
+            while (true)
+            {
+                Task stateChanged;
+                lock (_gate)
+                {
+                    if (!_publicationPending && !_publicationActive)
+                    {
+                        _activeLocalOperations++;
+                        return new LocalOperationLease(this);
+                    }
+
+                    stateChanged = _stateChanged.Task;
+                }
+
+                await stateChanged.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        public Task<AhtolaSyncResult> SynchronizeAsync(
+            ManagedReplicaConnectionHost initiator,
+            Func<CancellationToken, Task<AhtolaSyncResult>> stagedOperation,
+            CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(initiator);
+            ArgumentNullException.ThrowIfNull(stagedOperation);
+
+            Task<AhtolaSyncResult> syncTask;
+            lock (_gate)
+            {
+                if (_inFlightSync is null)
+                {
+                    var completion = new TaskCompletionSource<AhtolaSyncResult>(
+                        TaskCreationOptions.RunContinuationsAsynchronously);
+                    _inFlightSync = completion.Task;
+                    syncTask = completion.Task;
+                    _ = CompleteSyncAsync(completion, stagedOperation, cancellationToken);
+                }
+                else
+                {
+                    syncTask = _inFlightSync;
+                }
+            }
+
+            return WaitForSynchronizationAsync(syncTask, cancellationToken);
+        }
+
+        private static async Task<AhtolaSyncResult> WaitForSynchronizationAsync(
+            Task<AhtolaSyncResult> syncTask,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                return await syncTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Publication temporarily closes every host. A cancelled observer must
+                // wait for its finally block to reopen them before its caller resumes.
+                try
+                {
+                    await syncTask.ConfigureAwait(false);
+                }
+                catch
+                {
+                    // The caller observes cancellation below; publication's result has
+                    // served its purpose by completing all reopen work.
+                }
+
+                throw;
+            }
+        }
+
+        private async Task CompleteSyncAsync(
+            TaskCompletionSource<AhtolaSyncResult> completion,
+            Func<CancellationToken, Task<AhtolaSyncResult>> stagedOperation,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                completion.TrySetResult(
+                    await PublishAsync(stagedOperation, cancellationToken, clearInFlightSync: true)
+                        .ConfigureAwait(false));
+            }
+            catch (OperationCanceledException exception) when (exception.CancellationToken == cancellationToken)
+            {
+                completion.TrySetCanceled(cancellationToken);
+            }
+            catch (Exception exception)
+            {
+                completion.TrySetException(exception);
+            }
+        }
+
+        public Task PublishAsync(
+            Func<CancellationToken, Task> stagedOperation,
+            CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(stagedOperation);
+            return PublishAsync(
+                async token =>
+                {
+                    await stagedOperation(token).ConfigureAwait(false);
+                    return true;
+                },
+                cancellationToken,
+                clearInFlightSync: false);
+        }
+
+        private async Task<T> PublishAsync<T>(
+            Func<CancellationToken, Task<T>> stagedOperation,
+            CancellationToken cancellationToken,
+            bool clearInFlightSync)
+        {
+            var request = new PublicationRequest();
+            try
+            {
+                await EnterPublicationAsync(request, cancellationToken).ConfigureAwait(false);
+                ManagedReplicaConnectionHost[] hosts;
+                lock (_gate)
+                    hosts = _hosts.ToArray();
+
+                foreach (var host in hosts)
+                    host.CloseForPublication();
+
+                try
+                {
+                    return await stagedOperation(cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    Exception? reopenError = null;
+                    foreach (var host in hosts)
+                    {
+                        try
+                        {
+                            host.ReopenAfterPublication();
+                        }
+                        catch (Exception exception)
+                        {
+                            reopenError ??= exception;
+                        }
+                    }
+
+                    if (reopenError is not null)
+                        throw reopenError;
+                }
+            }
+            finally
+            {
+                if (request.OwnsPublication)
+                {
+                    lock (_gate)
+                    {
+                        _publicationActive = false;
+                        _publicationPending = false;
+                        if (clearInFlightSync)
+                            _inFlightSync = null;
+                        SignalStateChangedNoLock();
+                        RetireIfUnusedNoLock();
+                    }
+                }
+            }
+        }
+
+        private async Task EnterPublicationAsync(
+            PublicationRequest request,
+            CancellationToken cancellationToken)
+        {
+            while (true)
+            {
+                Task stateChanged;
+                lock (_gate)
+                {
+                    if (!request.OwnsPublication && !_publicationPending && !_publicationActive)
+                    {
+                        _publicationPending = true;
+                        request.OwnsPublication = true;
+                        SignalStateChangedNoLock();
+                    }
+
+                    if (request.OwnsPublication && _activeLocalOperations == 0 && !_publicationActive)
+                    {
+                        _publicationActive = true;
+                        return;
+                    }
+
+                    stateChanged = _stateChanged.Task;
+                }
+
+                await stateChanged.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private void ExitLocalOperation()
+        {
+            lock (_gate)
+            {
+                _activeLocalOperations--;
+                SignalStateChangedNoLock();
+                RetireIfUnusedNoLock();
+            }
+        }
+
+        private void RetireIfUnusedNoLock()
+        {
+            if (_retired
+                || _references != 0
+                || _hosts.Count != 0
+                || _activeLocalOperations != 0
+                || _publicationPending
+                || _publicationActive)
+            {
+                return;
+            }
+
+            _retired = true;
+            if (Entries.TryGetValue(_path, out var current) && ReferenceEquals(current, this))
+                Entries.TryRemove(_path, out _);
+        }
+
+        private void SignalStateChangedNoLock()
+        {
+            var previous = _stateChanged;
+            _stateChanged = NewStateChangedSource();
+            previous.TrySetResult();
+        }
+
+        private static TaskCompletionSource NewStateChangedSource()
+            => new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private sealed class LocalOperationLease(Entry entry) : IDisposable
+        {
+            private Entry? _entry = entry;
+
+            public void Dispose()
+            {
+                var entry = Interlocked.Exchange(ref _entry, null);
+                entry?.ExitLocalOperation();
+            }
+        }
+
+        private sealed class PublicationRequest
+        {
+            public bool OwnsPublication { get; set; }
+        }
+    }
+}

--- a/src/Ahtola.EntityFrameworkCore.Sqlite/AhtolaDbContextOptionsBuilderExtensions.cs
+++ b/src/Ahtola.EntityFrameworkCore.Sqlite/AhtolaDbContextOptionsBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Query;
@@ -75,6 +76,16 @@ public static class AhtolaDbContextOptionsBuilderExtensions
         where TContext : DbContext
         => (DbContextOptionsBuilder<TContext>)UseAhtola((DbContextOptionsBuilder)optionsBuilder, connection, contextOwnsConnection, sqliteOptionsAction);
 
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(AhtolaSqliteRelationalConnection))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(AhtolaSqliteDatabaseCreator))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(AhtolaSqliteQuerySqlGeneratorFactory))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(AhtolaSqliteUpdateSqlGenerator))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(AhtolaManagedSqliteQuerySqlGeneratorFactory))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(AhtolaManagedSqliteQueryableMethodTranslatingExpressionVisitorFactory))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(AhtolaManagedSqliteHistoryRepository))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(AhtolaManagedSqliteMigrationsSqlGenerator))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(AhtolaSqliteParameterBasedSqlProcessorFactory))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(AhtolaSqliteQueryableMethodTranslatingExpressionVisitorFactory))]
     private static DbContextOptionsBuilder UseAhtolaServices(
         DbContextOptionsBuilder optionsBuilder,
         bool usesManagedLocalProvider)

--- a/src/Ahtola.Tests/CloudTransportQualificationTests.cs
+++ b/src/Ahtola.Tests/CloudTransportQualificationTests.cs
@@ -1,0 +1,111 @@
+using System.Net;
+using System.Text;
+using AwesomeAssertions;
+
+namespace Ahtola.Tests;
+
+public sealed class CloudTransportQualificationTests
+{
+    [TestCase(HttpStatusCode.Unauthorized, false)]
+    [TestCase(HttpStatusCode.Forbidden, false)]
+    [TestCase(HttpStatusCode.Conflict, false)]
+    [TestCase(HttpStatusCode.RequestTimeout, true)]
+    [TestCase(HttpStatusCode.TooManyRequests, true)]
+    [TestCase(HttpStatusCode.InternalServerError, true)]
+    [TestCase((HttpStatusCode)599, true)]
+    [TestCase((HttpStatusCode)600, false)]
+    public void AutomaticReplicaRetryClassifiesOnlyTransientHttpFailures(
+        HttpStatusCode statusCode,
+        bool expectedTransient)
+    {
+        var exception = new AhtolaException("HTTP failure", statusCode);
+
+        AhtolaConnection.IsTransientAutomaticSyncFailure(exception, CancellationToken.None)
+            .Should().Be(expectedTransient);
+        AhtolaConnection.IsTransientAutomaticSyncFailure(
+                new HttpRequestException("HTTP failure", inner: null, statusCode),
+                CancellationToken.None)
+            .Should().Be(expectedTransient);
+    }
+
+    [Test]
+    public void AutomaticReplicaRetryDoesNotRetryProtocolOrCallerCancellation()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        AhtolaConnection.IsTransientAutomaticSyncFailure(
+                new InvalidDataException("malformed pull stream"),
+                CancellationToken.None)
+            .Should().BeFalse();
+        AhtolaConnection.IsTransientAutomaticSyncFailure(
+                new AhtolaReplicaConflictException("conflict"),
+                CancellationToken.None)
+            .Should().BeFalse();
+        AhtolaConnection.IsTransientAutomaticSyncFailure(
+                new TaskCanceledException(),
+                cancellation.Token)
+            .Should().BeFalse();
+    }
+
+    [Test]
+    public void AutomaticReplicaRetryBackoffIsBounded()
+    {
+        AhtolaConnection.AutomaticSyncMaximumAttempts.Should().Be(3);
+        AhtolaConnection.GetAutomaticSyncRetryDelay(0).Should().Be(TimeSpan.FromMilliseconds(50));
+        AhtolaConnection.GetAutomaticSyncRetryDelay(1).Should().Be(TimeSpan.FromMilliseconds(100));
+        AhtolaConnection.GetAutomaticSyncRetryDelay(2).Should().Be(TimeSpan.FromMilliseconds(200));
+        AhtolaConnection.GetAutomaticSyncRetryDelay(20).Should().Be(TimeSpan.FromMilliseconds(200));
+    }
+
+    [Test]
+    public async Task RemotePipelineHonorsAResponseBaseUrl()
+    {
+        using var handler = new BaseUrlHandler();
+        using var httpClient = new HttpClient(handler);
+        using var client = new AhtolaRemoteClient(
+            httpClient,
+            new Uri("https://example.test/cluster"),
+            authToken: null);
+
+        await client.ExecuteAsync(
+            "SELECT 1",
+            new AhtolaParameterCollection(),
+            wantRows: true,
+            commandTimeout: 30,
+            closeAfter: false,
+            CancellationToken.None);
+        await client.ExecuteAsync(
+            "SELECT 2",
+            new AhtolaParameterCollection(),
+            wantRows: true,
+            commandTimeout: 30,
+            closeAfter: true,
+            CancellationToken.None);
+
+        handler.Paths.Should().Equal("/cluster/v2/pipeline", "/redirected/v2/pipeline");
+    }
+
+    private sealed class BaseUrlHandler : HttpMessageHandler
+    {
+        public List<string> Paths { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Paths.Add(request.RequestUri!.AbsolutePath);
+            var response = Paths.Count == 1
+                ? """
+                  {"baton":"baton-1","base_url":"/redirected","results":[{"type":"ok","response":{"type":"execute","result":{"cols":[],"rows":[],"affected_row_count":0}}}]}
+                  """
+                : """
+                  {"results":[{"type":"ok","response":{"type":"execute","result":{"cols":[],"rows":[],"affected_row_count":0}}}]}
+                  """;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(response, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+}

--- a/src/Ahtola.Tests/ManagedEmbeddedReplicaConnectionTests.cs
+++ b/src/Ahtola.Tests/ManagedEmbeddedReplicaConnectionTests.cs
@@ -1,0 +1,2084 @@
+using AwesomeAssertions;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Ahtola.Core;
+
+namespace Ahtola.Tests;
+
+public sealed class ManagedEmbeddedReplicaConnectionTests
+{
+    private const int BootstrapStagedDatabaseBoundary = (int)ManagedReplicaDurableBoundary.BootstrapStagedDatabase;
+    private const int BootstrapDatabasePublishedBoundary = (int)ManagedReplicaDurableBoundary.BootstrapDatabasePublished;
+    private const int IncrementalApplyStagedDatabaseBoundary = (int)ManagedReplicaDurableBoundary.IncrementalApplyStagedDatabase;
+    private const int IncrementalApplyDatabasePublishedBoundary = (int)ManagedReplicaDurableBoundary.IncrementalApplyDatabasePublished;
+    private const int IncrementalApplyMetadataPublishedBoundary = (int)ManagedReplicaDurableBoundary.IncrementalApplyMetadataPublished;
+
+    [Test]
+    public void ReplicaOptionsNormalizeLibsqlUrlsToHttps()
+    {
+        var options = new AhtolaReplicaOptions(
+            "replica.db",
+            new Uri("libsql://example.test/cluster"),
+            authToken: null);
+
+        options.RemoteUri.Should().Be(new Uri("https://example.test/cluster"));
+    }
+
+    [Test]
+    public void ManagedReplicaJournalCapturesCommittedAutocommitMutation()
+    {
+        var path = NewReplicaPath("managed-replica-journal-autocommit");
+        try
+        {
+            CreateJournalDatabase(path);
+            using var connection = AhtolaConnection.CreateReplica(
+                new AhtolaReplicaOptions(path, new Uri("https://example.test"), authToken: null));
+            connection.Open();
+
+            connection.ExecuteNonQuery("INSERT INTO journal_events VALUES (10);");
+
+            var batch = connection.ReadManagedReplicaLocalChanges(10);
+            batch.FirstSequence.Should().Be(1);
+            batch.Watermark.Should().Be(2);
+            batch.Changes.Should().ContainSingle();
+            var change = batch.Changes[0];
+            change.Sequence.Should().Be(1);
+            change.Kind.Should().Be(ReplicaLocalChangeKind.Row);
+            change.Operation.Should().Be(SqliteChangeOperation.Insert);
+            change.Database.Should().Be("main");
+            change.Table.Should().Be("journal_events");
+            change.RowId.Should().Be(1);
+            File.Exists(path + ManagedReplicaChangeJournal.Suffix).Should().BeTrue();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public void ManagedReplicaJournalCapturesOnlyCommittedTransactionMutations()
+    {
+        var path = NewReplicaPath("managed-replica-journal-commit");
+        try
+        {
+            CreateJournalDatabase(path);
+            using var connection = AhtolaConnection.CreateReplica(
+                new AhtolaReplicaOptions(path, new Uri("https://example.test"), authToken: null));
+            connection.Open();
+
+            using (var transaction = connection.BeginTransaction())
+            {
+                connection.ExecuteNonQuery("INSERT INTO journal_events VALUES (10);");
+                connection.ExecuteNonQuery("INSERT INTO journal_events VALUES (20);");
+                connection.ReadManagedReplicaLocalChanges(10).Changes.Should().BeEmpty();
+                transaction.Commit();
+            }
+
+            var batch = connection.ReadManagedReplicaLocalChanges(10);
+            batch.Changes.Select(change => change.Sequence).Should().Equal(1, 2);
+            batch.Changes.Select(change => change.RowId).Should().Equal(1, 2);
+            batch.Watermark.Should().Be(3);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public void ManagedReplicaJournalLeavesRolledBackTransactionOutOfBatch()
+    {
+        var path = NewReplicaPath("managed-replica-journal-rollback");
+        try
+        {
+            CreateJournalDatabase(path);
+            using var connection = AhtolaConnection.CreateReplica(
+                new AhtolaReplicaOptions(path, new Uri("https://example.test"), authToken: null));
+            connection.Open();
+
+            using (var transaction = connection.BeginTransaction())
+            {
+                connection.ExecuteNonQuery("INSERT INTO journal_events VALUES (10);");
+                transaction.Rollback();
+            }
+
+            connection.ReadManagedReplicaLocalChanges(10).Changes.Should().BeEmpty();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public void ManagedReplicaJournalPreservesCommitOrderAcrossTransactions()
+    {
+        var path = NewReplicaPath("managed-replica-journal-order");
+        try
+        {
+            CreateJournalDatabase(path);
+            using var connection = AhtolaConnection.CreateReplica(
+                new AhtolaReplicaOptions(path, new Uri("https://example.test"), authToken: null));
+            connection.Open();
+
+            connection.ExecuteNonQuery("INSERT INTO journal_events VALUES (10);");
+            using (var transaction = connection.BeginTransaction())
+            {
+                connection.ExecuteNonQuery("INSERT INTO journal_events VALUES (20);");
+                connection.ExecuteNonQuery("INSERT INTO journal_events VALUES (30);");
+                transaction.Commit();
+            }
+            connection.ExecuteNonQuery("INSERT INTO journal_events VALUES (40);");
+
+            var batch = connection.ReadManagedReplicaLocalChanges(10);
+            batch.Changes.Select(change => change.Sequence).Should().Equal(1, 2, 3, 4);
+            batch.Changes.Select(change => change.RowId).Should().Equal(1, 2, 3, 4);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public void ManagedReplicaJournalSurvivesReopen()
+    {
+        var path = NewReplicaPath("managed-replica-journal-reopen");
+        try
+        {
+            CreateJournalDatabase(path);
+            var options = new AhtolaReplicaOptions(path, new Uri("https://example.test"), authToken: null);
+            using (var connection = AhtolaConnection.CreateReplica(options))
+            {
+                connection.Open();
+                connection.ExecuteNonQuery("INSERT INTO journal_events VALUES (10);");
+            }
+
+            using var reopened = AhtolaConnection.CreateReplica(options);
+            reopened.Open();
+            var batch = reopened.ReadManagedReplicaLocalChanges(10);
+            batch.Changes.Should().ContainSingle();
+            batch.Changes[0].Sequence.Should().Be(1);
+            batch.Changes[0].Operation.Should().Be(SqliteChangeOperation.Insert);
+            batch.Watermark.Should().Be(2);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public void CreateReplicaUsesManagedLocalSqlAndPersistsCommittedTransactions()
+    {
+        var path = Path.Combine(
+            TestContext.CurrentContext.WorkDirectory,
+            $"managed-embedded-replica-{Guid.NewGuid():N}.db");
+        var options = new AhtolaReplicaOptions(
+            path,
+            new Uri("https://example.com"),
+            authToken: null);
+
+        try
+        {
+            CreateInitializedDatabase(path);
+
+            using (var connection = AhtolaConnection.CreateReplica(options))
+            {
+                connection.Open();
+                connection.State.Should().Be(System.Data.ConnectionState.Open);
+                connection.Capabilities.Mode.Should().Be(AhtolaConnectionMode.EmbeddedReplica);
+                connection.Capabilities.SupportsSync.Should().BeTrue();
+                Assert.Throws<NotSupportedException>(() => connection.Sync())!.Message.Should()
+                    .Be("Managed embedded replica synchronization requires bootstrap metadata.");
+
+                connection.ExecuteNonQuery("CREATE TABLE events(value INTEGER NOT NULL);");
+                using (var transaction = connection.BeginTransaction())
+                {
+                    using var insert = connection.CreateCommand();
+                    insert.Transaction = transaction;
+                    insert.CommandText = "INSERT INTO events VALUES (41);";
+                    insert.ExecuteNonQuery();
+                    transaction.Commit();
+                }
+
+                using (var transaction = connection.BeginTransaction())
+                {
+                    using var insert = connection.CreateCommand();
+                    insert.Transaction = transaction;
+                    insert.CommandText = "INSERT INTO events VALUES (99);";
+                    insert.ExecuteNonQuery();
+                    transaction.Rollback();
+                }
+
+                using (var timeout = connection.CreateCommand())
+                {
+                    timeout.CommandText = "PRAGMA busy_timeout;";
+                    timeout.CommandTimeout = 1;
+                    timeout.ExecuteScalar().Should().Be(1000L);
+                }
+            }
+
+            using var reopened = AhtolaConnection.CreateReplica(options);
+            reopened.Open();
+            using var reader = reopened.CreateCommand();
+            reader.CommandText = "SELECT value FROM events;";
+            using var rows = reader.ExecuteReader();
+            rows.Read().Should().BeTrue();
+            rows.GetInt64(0).Should().Be(41);
+            rows.Read().Should().BeFalse();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public void CreateReplicaBootstrapsRawPagesAndSendsThePullUpdatesRequest()
+    {
+        var path = Path.Combine(
+            TestContext.CurrentContext.WorkDirectory,
+            $"managed-embedded-replica-bootstrap-{Guid.NewGuid():N}.db");
+        var sourcePath = path + ".source";
+        byte[] databaseImage;
+        try
+        {
+            CreateInitializedDatabase(sourcePath);
+            databaseImage = File.ReadAllBytes(sourcePath);
+        }
+
+        finally
+        {
+            DeleteReplicaFiles(sourcePath);
+        }
+
+        var response = CreatePullResponse("revision-42", databaseImage);
+        var handler = new PullUpdatesHandler(response, request =>
+        {
+            request.Method.Should().Be(HttpMethod.Post);
+            request.RequestUri!.AbsolutePath.Should().Be("/cluster/pull-updates");
+            request.Headers.Authorization.Should().Be(new AuthenticationHeaderValue("Bearer", "token-42"));
+            request.Headers.TryGetValues("Accept-Encoding", out var acceptEncoding).Should().BeTrue();
+            acceptEncoding.Should().ContainSingle().Which.Should().Be("application/protobuf");
+            request.Content!.Headers.ContentType!.MediaType.Should().Be("application/protobuf");
+
+            var fields = ReadVarintFields(request.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult());
+            fields.Should().ContainSingle();
+            fields[4].Should().Be(3000);
+        });
+        var options = new AhtolaReplicaOptions(
+            path,
+            new Uri("https://example.test/cluster"),
+            authToken: "token-42",
+            bootstrapIfEmpty: true)
+        {
+            LongPollTimeout = TimeSpan.FromSeconds(3),
+            HttpPolicy = new AhtolaSyncHttpPolicy(handler),
+        };
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(options);
+            connection.Open();
+            using var command = connection.CreateCommand();
+            command.CommandText = "SELECT value FROM bootstrap_marker;";
+            command.ExecuteScalar().Should().Be(42L);
+            handler.CallCount.Should().Be(1);
+            File.Exists(path).Should().BeTrue();
+            File.ReadAllText(path + ".ahtola-replica-meta").Should().Contain("server_revision_base64=cmV2aXNpb24tNDI=");
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task ManagedReplicaAcceptsRawLegacyAndV1PageStreams()
+    {
+        var path = NewReplicaPath("managed-replica-raw-legacy-v1");
+        var initialImage = CreateDatabaseImageWithMarker(path + ".initial", 42);
+        var updatedImage = CreateDatabaseImageWithMarker(path + ".updated", 84);
+        var handler = new PullUpdatesHandler([
+            CreatePullResponse("legacy-revision", initialImage, protocol: null),
+            CreatePullResponse("v1-revision", updatedImage, protocol: 1),
+        ]);
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            connection.Open();
+            ReadBootstrapMarker(connection).Should().Be(42);
+
+            var result = await connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
+
+            result.Outcome.Should().Be(AhtolaSyncOutcome.RemoteChangesApplied);
+            ReadBootstrapMarker(connection).Should().Be(84);
+            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.Revision.Should().Be("v1-revision");
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task ManagedReplicaJournalDoesNotCaptureRemotePageApply()
+    {
+        var path = NewReplicaPath("managed-replica-journal-remote-apply");
+        var image = CreateDatabaseImage(path + ".source");
+        var handler = new PullUpdatesHandler([
+            CreatePullResponse("revision-42", image),
+            CreatePullResponse("revision-43", image),
+        ]);
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            connection.Open();
+
+            _ = await connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
+
+            connection.ReadManagedReplicaLocalChanges(10).Changes.Should().BeEmpty();
+            File.Exists(path + ManagedReplicaChangeJournal.Suffix).Should().BeFalse();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task SyncAsyncPushesJournalInGuardedHranaTransactionAndDurablyAcknowledgesIt()
+    {
+        var path = NewReplicaPath("managed-replica-push");
+        var image = CreateJournalDatabaseImage(path + ".source");
+        JsonDocument? push = null;
+        var handler = new ReplicaPushHandler(
+            [
+                CreatePullResponse("revision-42", image),
+                CreatePullResponse("revision-42", [], declaredPages: 1),
+            ],
+            request =>
+            {
+                request.Method.Should().Be(HttpMethod.Post);
+                request.RequestUri!.AbsolutePath.Should().Be("/cluster/v2/pipeline");
+                request.Headers.Authorization.Should().Be(new AuthenticationHeaderValue("Bearer", "token-42"));
+                push = JsonDocument.Parse(request.Content!.ReadAsStringAsync().GetAwaiter().GetResult());
+                return ReplicaPushHandler.SuccessfulBatchResponse(5);
+            });
+        try
+        {
+            var options = CreateOptions(path, handler);
+            using (var connection = AhtolaConnection.CreateReplica(options))
+            {
+                connection.Open();
+                connection.ExecuteNonQuery("INSERT INTO journal_events VALUES (10);");
+
+                var result = await connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
+                result.Statistics.CdcOperations.Should().Be(1);
+                result.Statistics.LastPush.Should().NotBeNull();
+                connection.ReadManagedReplicaLocalChanges(10).Changes.Should().BeEmpty();
+            }
+
+            using (var reopened = AhtolaConnection.CreateReplica(options))
+            {
+                reopened.Open();
+                reopened.ReadManagedReplicaLocalChanges(10).Changes.Should().BeEmpty();
+                reopened.ExecuteNonQuery("INSERT INTO journal_events VALUES (20);");
+                reopened.ReadManagedReplicaLocalChanges(10).FirstSequence.Should().Be(2);
+            }
+
+            push.Should().NotBeNull();
+            var steps = push!.RootElement.GetProperty("requests")[0].GetProperty("batch").GetProperty("steps");
+            steps.GetArrayLength().Should().Be(5);
+            steps[0].GetProperty("stmt").GetProperty("sql").GetString().Should().Be("BEGIN IMMEDIATE");
+            steps[1].GetProperty("stmt").GetProperty("sql").GetString().Should()
+                .Be("CREATE TABLE IF NOT EXISTS turso_sync_last_change_id (client_id TEXT PRIMARY KEY, pull_gen INTEGER, change_id INTEGER)");
+            steps[2].GetProperty("stmt").GetProperty("sql").GetString().Should().Be("INSERT INTO journal_events VALUES (10);");
+            steps[3].GetProperty("stmt").GetProperty("sql").GetString().Should()
+                .StartWith("INSERT INTO turso_sync_last_change_id");
+            steps[4].GetProperty("stmt").GetProperty("sql").GetString().Should().Be("COMMIT");
+            foreach (var index in new[] { 1, 2, 3 })
+            {
+                steps[index].GetProperty("condition").GetProperty("type").GetString().Should().Be("not");
+                steps[index].GetProperty("condition").GetProperty("cond").GetProperty("type").GetString()
+                    .Should().Be("is_autocommit");
+            }
+            steps[3].GetProperty("stmt").GetProperty("args")[1].GetProperty("value").GetString().Should().Be("0");
+            steps[3].GetProperty("stmt").GetProperty("args")[2].GetProperty("value").GetString().Should().Be("1");
+        }
+        finally
+        {
+            push?.Dispose();
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task SyncAsyncRetainsJournalWhenPushHttpRequestFails()
+    {
+        var path = NewReplicaPath("managed-replica-push-http-failure");
+        var image = CreateJournalDatabaseImage(path + ".source");
+        var handler = new ReplicaPushHandler(
+            [CreatePullResponse("revision-42", image)],
+            _ => new HttpResponseMessage(HttpStatusCode.InternalServerError)
+            {
+                Content = new StringContent("unavailable"),
+            });
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            connection.Open();
+            connection.ExecuteNonQuery("INSERT INTO journal_events VALUES (10);");
+
+            Assert.ThrowsAsync<AhtolaException>(() => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+            connection.ReadManagedReplicaLocalChanges(10).Changes.Should().ContainSingle();
+            handler.PullCallCount.Should().Be(1);
+            handler.PushCallCount.Should().Be(1);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task SyncAsyncSurfacesSameRowWriteConflictWithDurableMetadataAndRetainsJournal()
+    {
+        var path = NewReplicaPath("managed-replica-push-conflict");
+        var image = CreateJournalDatabaseImage(path + ".source");
+        var handler = new ReplicaPushHandler(
+            [CreatePullResponse("revision-42", image)],
+            _ => ReplicaPushHandler.BatchErrorResponse(5, 2, "conflicting local change", "SQLITE_CONSTRAINT"));
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            connection.Open();
+            connection.ExecuteNonQuery("INSERT INTO journal_events VALUES (10);");
+
+            var exception = Assert.ThrowsAsync<AhtolaReplicaConflictException>(
+                () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+            exception!.RemoteErrorCode.Should().Be("SQLITE_CONSTRAINT");
+            exception.ConflictKind.Should().Be(AhtolaReplicaConflictKind.RowWrite);
+            exception.LocalChangeSequence.Should().Be(1);
+            connection.ReadManagedReplicaLocalChanges(10).Changes.Should().ContainSingle();
+            handler.PullCallCount.Should().Be(1);
+            handler.PushCallCount.Should().Be(1);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [TestCase(PullResponseFailure.Zstd)]
+    [TestCase(PullResponseFailure.InvalidPage)]
+    [TestCase(PullResponseFailure.Non4KiBPage)]
+    [TestCase(PullResponseFailure.LogicalStream)]
+    public void CreateReplicaRejectsInvalidBootstrapStreamsWithoutInstallingFiles(PullResponseFailure failure)
+    {
+        var path = Path.Combine(
+            TestContext.CurrentContext.WorkDirectory,
+            $"managed-embedded-replica-invalid-bootstrap-{Guid.NewGuid():N}.db");
+        var response = failure switch
+        {
+            PullResponseFailure.Zstd => CreatePullResponse("revision-zstd", new byte[4096], zstd: true),
+            PullResponseFailure.InvalidPage => CreatePullResponse("revision-page", new byte[1]),
+            PullResponseFailure.Non4KiBPage => CreatePullResponse("revision-non-4k", new byte[4095]),
+            PullResponseFailure.LogicalStream => CreatePullResponse("revision-logical", new byte[4096], streamKind: 1),
+            _ => throw new ArgumentOutOfRangeException(nameof(failure)),
+        };
+        var handler = new PullUpdatesHandler(response);
+        var options = new AhtolaReplicaOptions(path, new Uri("https://example.test"), authToken: null)
+        {
+            HttpPolicy = new AhtolaSyncHttpPolicy(handler),
+        };
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(options);
+            Assert.Throws<InvalidDataException>(() => connection.Open());
+            handler.CallCount.Should().Be(1);
+            File.Exists(path).Should().BeFalse();
+            File.Exists(path + ".ahtola-replica-meta").Should().BeFalse();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [TestCase(UnsupportedReplicaMode.RemoteEncryption)]
+    [TestCase(UnsupportedReplicaMode.PartialPrefix)]
+    [TestCase(UnsupportedReplicaMode.PartialQuery)]
+    [TestCase(UnsupportedReplicaMode.ChunkedBootstrap)]
+    public void CreateReplicaRejectsUnsupportedModesBeforeOpeningOrMutatingLocalState(
+        UnsupportedReplicaMode mode)
+    {
+        var path = NewReplicaPath($"managed-replica-unsupported-{mode}");
+        var handler = new PullUpdatesHandler(CreatePullResponse("unused", new byte[4096]));
+        var options = CreateUnsupportedOptions(path, handler, mode);
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(options);
+            Assert.Throws<NotSupportedException>(() => connection.Open());
+
+            handler.CallCount.Should().Be(0);
+            File.Exists(path).Should().BeFalse();
+            File.Exists(path + ".ahtola-replica-meta").Should().BeFalse();
+            File.Exists(path + ManagedReplicaChangeJournal.Suffix).Should().BeFalse();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task SyncRejectsUnsafeLocalDivergenceBeforeSendingOrReplacingState()
+    {
+        var path = NewReplicaPath("managed-replica-unsafe-local-divergence");
+        var image = CreateDatabaseImage(path + ".source");
+        var handler = new PullUpdatesHandler([
+            CreatePullResponse("revision-42", image),
+            CreatePullResponse("revision-43", image),
+        ]);
+        var options = CreateOptions(path, handler);
+
+        try
+        {
+            using (var initial = AhtolaConnection.CreateReplica(options))
+                initial.Open();
+
+            using (var stream = new FileStream(path, FileMode.Open, FileAccess.Write, FileShare.None))
+            {
+                stream.Position = 60; // SQLite's user-version header field is safe to alter externally.
+                stream.WriteByte(1);
+                stream.Flush(flushToDisk: true);
+            }
+
+            var databaseBeforeSync = File.ReadAllBytes(path);
+            var metadataBeforeSync = File.ReadAllBytes(path + ".ahtola-replica-meta");
+            using (var reopened = AhtolaConnection.CreateReplica(options))
+            {
+                reopened.Open();
+                Assert.ThrowsAsync<NotSupportedException>(
+                    () => reopened.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+            }
+
+            handler.CallCount.Should().Be(1, "the divergence guard must run before issuing an incremental pull");
+            File.ReadAllBytes(path).Should().Equal(databaseBeforeSync);
+            File.ReadAllBytes(path + ".ahtola-replica-meta").Should().Equal(metadataBeforeSync);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [TestCase(PullResponseFramingFailure.TruncatedLengthPrefix)]
+    [TestCase(PullResponseFramingFailure.TruncatedPayload)]
+    [TestCase(PullResponseFramingFailure.OversizedMessage)]
+    public void CreateReplicaRejectsMalformedLengthFramingWithoutInstallingFiles(
+        PullResponseFramingFailure failure)
+    {
+        var path = NewReplicaPath($"managed-replica-malformed-framing-{failure}");
+        var response = failure switch
+        {
+            PullResponseFramingFailure.TruncatedLengthPrefix => new byte[] { 0x80 },
+            PullResponseFramingFailure.TruncatedPayload => new byte[] { 0x04, 0x01, 0x02 },
+            PullResponseFramingFailure.OversizedMessage => CreateOversizedMessagePrefix(),
+            _ => throw new ArgumentOutOfRangeException(nameof(failure)),
+        };
+        var handler = new PullUpdatesHandler(response);
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            Assert.Throws<InvalidDataException>(() => connection.Open());
+            handler.CallCount.Should().Be(1);
+            File.Exists(path).Should().BeFalse();
+            File.Exists(path + ".ahtola-replica-meta").Should().BeFalse();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [TestCase(InvalidPageSet.Duplicate)]
+    [TestCase(InvalidPageSet.OutOfRange)]
+    public void CreateReplicaRejectsDuplicateAndOutOfRangePages(InvalidPageSet invalidPageSet)
+    {
+        var path = NewReplicaPath($"managed-replica-invalid-pages-{invalidPageSet}");
+        var image = CreateDatabaseImage(path + ".source");
+        var pageCount = checked((ulong)(image.Length / 4096));
+        var response = AppendPage(
+            CreatePullResponse("revision-42", image),
+            invalidPageSet == InvalidPageSet.Duplicate ? 0UL : pageCount,
+            image.AsSpan(0, 4096));
+        var handler = new PullUpdatesHandler(response);
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            Assert.Throws<InvalidDataException>(() => connection.Open());
+            File.Exists(path).Should().BeFalse();
+            File.Exists(path + ".ahtola-replica-meta").Should().BeFalse();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task SyncAsyncRejectsAChangedRevisionWithNoPagesAndPreservesTheStoredRevision()
+    {
+        var path = NewReplicaPath("managed-replica-revision-without-pages");
+        var image = CreateDatabaseImage(path + ".source");
+        var handler = new PullUpdatesHandler([
+            CreatePullResponse("revision-42", image),
+            CreatePullResponse("revision-43", [], declaredPages: checked((ulong)(image.Length / 4096))),
+        ]);
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            connection.Open();
+            Assert.ThrowsAsync<InvalidDataException>(
+                () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.Revision.Should().Be("revision-42");
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task SyncAsyncCancelsALongPollRequest()
+    {
+        var path = NewReplicaPath("managed-replica-long-poll-cancel");
+        var image = CreateDatabaseImage(path + ".source");
+        var handler = new BlockingPullUpdatesHandler(
+            CreatePullResponse("revision-42", image),
+            CreatePullResponse("revision-42", [], declaredPages: checked((ulong)(image.Length / 4096))));
+        using var cancellation = new CancellationTokenSource();
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            connection.Open();
+            var sync = connection.SyncAsync(new AhtolaSyncOptions(), cancellation.Token);
+            await handler.SyncStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            cancellation.Cancel();
+            Assert.CatchAsync<OperationCanceledException>(() => sync);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task SyncAsyncAppliesTheConfiguredRequestTimeout()
+    {
+        var path = NewReplicaPath("managed-replica-request-timeout");
+        var image = CreateDatabaseImage(path + ".source");
+        var handler = new BlockingPullUpdatesHandler(
+            CreatePullResponse("revision-42", image),
+            CreatePullResponse("revision-42", [], declaredPages: checked((ulong)(image.Length / 4096))));
+        var options = new AhtolaReplicaOptions(path, new Uri("https://example.test/cluster"), authToken: "token-42")
+        {
+            LongPollTimeout = TimeSpan.FromSeconds(3),
+            HttpPolicy = new AhtolaSyncHttpPolicy(handler, requestTimeout: TimeSpan.FromMilliseconds(50)),
+        };
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(options);
+            connection.Open();
+            var sync = connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
+            await handler.SyncStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.CatchAsync<OperationCanceledException>(() => sync);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void ReplicaHttpHandlerOwnershipMatchesTheConfiguredPolicy(bool disposeHandler)
+    {
+        var path = NewReplicaPath($"managed-replica-handler-ownership-{disposeHandler}");
+        var image = CreateDatabaseImage(path + ".source");
+        var handler = new TrackingPullUpdatesHandler(CreatePullResponse("revision-42", image));
+        var options = new AhtolaReplicaOptions(path, new Uri("https://example.test"), authToken: null)
+        {
+            HttpPolicy = new AhtolaSyncHttpPolicy(handler, disposeMessageHandler: disposeHandler),
+        };
+
+        try
+        {
+            var connection = AhtolaConnection.CreateReplica(options);
+            connection.Open();
+            connection.Close();
+            handler.IsDisposed.Should().BeFalse();
+            connection.Open();
+            connection.Dispose();
+            handler.IsDisposed.Should().Be(disposeHandler);
+        }
+        finally
+        {
+            handler.Dispose();
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task SyncAsyncSurfacesSchemaConflictWithDurableMetadataAndRetainsJournal()
+    {
+        var path = NewReplicaPath("managed-replica-schema-conflict");
+        var image = CreateJournalDatabaseImage(path + ".source");
+        var handler = new ReplicaPushHandler(
+            [CreatePullResponse("revision-42", image)],
+            _ => ReplicaPushHandler.BatchErrorResponse(5, 2, "schema conflict detected", "SQLITE_SCHEMA"));
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            connection.Open();
+            connection.ExecuteNonQuery("CREATE TABLE local_conflict(value INTEGER NOT NULL);");
+
+            var exception = Assert.ThrowsAsync<AhtolaReplicaConflictException>(
+                () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+
+            exception!.RemoteErrorCode.Should().Be("SQLITE_SCHEMA");
+            exception.ConflictKind.Should().Be(AhtolaReplicaConflictKind.SchemaChange);
+            exception.LocalChangeSequence.Should().Be(1);
+            connection.ReadManagedReplicaLocalChanges(10).Changes.Should().ContainSingle()
+                .Which.Kind.Should().Be(ReplicaLocalChangeKind.Schema);
+            handler.PullCallCount.Should().Be(1);
+            handler.PushCallCount.Should().Be(1);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task ConflictRetryAfterReopenReusesExactPayloadAndAcknowledgesOnlyPushedEntries()
+    {
+        var path = NewReplicaPath("managed-replica-conflict-retry-after-reopen");
+        var image = CreateJournalDatabaseImage(path + ".source");
+        var payloads = new List<string>();
+        var pushAttempt = 0;
+        var handler = new ReplicaPushHandler(
+            [
+                CreatePullResponse("revision-42", image),
+                CreatePullResponse("revision-42", [], declaredPages: 1),
+                CreatePullResponse("revision-42", [], declaredPages: 1),
+            ],
+            request =>
+            {
+                payloads.Add(request.Content!.ReadAsStringAsync().GetAwaiter().GetResult());
+                pushAttempt++;
+                return pushAttempt switch
+                {
+                    1 => ReplicaPushHandler.BatchErrorResponse(
+                        stepCount: 6,
+                        errorStep: 2,
+                        message: "same row write conflict",
+                        code: "SQLITE_CONSTRAINT"),
+                    2 => ReplicaPushHandler.SuccessfulBatchResponse(stepCount: 6),
+                    3 => ReplicaPushHandler.SuccessfulBatchResponse(stepCount: 5),
+                    _ => throw new InvalidOperationException("Unexpected replica push attempt."),
+                };
+            });
+        var options = CreateOptions(path, handler, pushOperationsThreshold: 2);
+        try
+        {
+            using (var connection = AhtolaConnection.CreateReplica(options))
+            {
+                connection.Open();
+                connection.ExecuteNonQuery("INSERT INTO journal_events VALUES (10);");
+                connection.ExecuteNonQuery("INSERT INTO journal_events VALUES (20);");
+
+                Assert.ThrowsAsync<AhtolaReplicaConflictException>(
+                    () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+                connection.ReadManagedReplicaLocalChanges(10).Changes
+                    .Select(change => change.Sequence).Should().Equal(1, 2);
+            }
+
+            using (var reopened = AhtolaConnection.CreateReplica(options))
+            {
+                reopened.Open();
+                reopened.ReadManagedReplicaLocalChanges(10).Changes
+                    .Select(change => change.Sequence).Should().Equal(1, 2);
+                reopened.ExecuteNonQuery("INSERT INTO journal_events VALUES (30);");
+
+                var recovery = await reopened.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
+                recovery.Statistics.CdcOperations.Should().Be(2);
+                payloads.Should().HaveCount(2);
+                payloads[1].Should().Be(payloads[0]);
+                reopened.ReadManagedReplicaLocalChanges(10).Changes
+                    .Select(change => change.Sequence).Should().Equal(3);
+
+                var final = await reopened.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
+                final.Statistics.CdcOperations.Should().Be(1);
+                reopened.ReadManagedReplicaLocalChanges(10).Changes.Should().BeEmpty();
+            }
+
+            handler.PushCallCount.Should().Be(3);
+            handler.PullCallCount.Should().Be(3);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [TestCase(BootstrapStagedDatabaseBoundary)]
+    [TestCase(BootstrapDatabasePublishedBoundary)]
+    public async Task BootstrapCancellationAtDurableBoundaryLeavesNoUnpairedReplicaFiles(
+        int boundaryValue)
+    {
+        var boundary = (ManagedReplicaDurableBoundary)boundaryValue;
+        var path = NewReplicaPath($"managed-replica-bootstrap-cancel-{boundary}");
+        var image = CreateDatabaseImage(path + ".source");
+        var handler = new PullUpdatesHandler([
+            CreatePullResponse("revision-42", image),
+            CreatePullResponse("revision-42", image),
+        ]);
+        var options = CreateOptions(path, handler);
+        using var cancellation = new CancellationTokenSource();
+        try
+        {
+            using (ManagedReplicaFaultInjection.Push(point =>
+                   {
+                       if (point == boundary)
+                           cancellation.Cancel();
+                   }))
+            {
+                Assert.CatchAsync<OperationCanceledException>(
+                    () => ManagedReplicaBootstrapper.BootstrapAsync(options, cancellation.Token));
+            }
+
+            File.Exists(path).Should().BeFalse();
+            ManagedReplicaBootstrapper.LoadMetadata(path).Should().BeNull();
+
+            using var reopened = AhtolaConnection.CreateReplica(options);
+            reopened.Open();
+            reopened.ExecuteNonQuery("SELECT value FROM bootstrap_marker;").Should().Be(0);
+            handler.CallCount.Should().Be(2);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [TestCase(IncrementalApplyStagedDatabaseBoundary, false)]
+    [TestCase(IncrementalApplyDatabasePublishedBoundary, false)]
+    [TestCase(IncrementalApplyMetadataPublishedBoundary, true)]
+    public async Task IncrementalApplyCancellationRecoversAMatchedDatabaseAndMetadataPair(
+        int boundaryValue,
+        bool expectedRemoteImage)
+    {
+        var boundary = (ManagedReplicaDurableBoundary)boundaryValue;
+        var path = NewReplicaPath($"managed-replica-incremental-cancel-{boundary}");
+        var initialImage = CreateDatabaseImage(path + ".initial");
+        var updatedImage = CreateDatabaseImageWithMarker(path + ".updated", 84);
+        var handler = new PullUpdatesHandler([
+            CreatePullResponse("revision-42", initialImage),
+            CreatePullResponse("revision-43", updatedImage),
+        ]);
+        var options = CreateOptions(path, handler);
+        using var cancellation = new CancellationTokenSource();
+        try
+        {
+            using (var connection = AhtolaConnection.CreateReplica(options))
+            {
+                connection.Open();
+                using (ManagedReplicaFaultInjection.Push(point =>
+                       {
+                           if (point == boundary)
+                               cancellation.Cancel();
+                       }))
+                {
+                    Assert.CatchAsync<OperationCanceledException>(
+                        () => connection.SyncAsync(new AhtolaSyncOptions(), cancellation.Token));
+                }
+
+                using var verifyCommand = connection.CreateCommand();
+                verifyCommand.CommandText = "SELECT value FROM bootstrap_marker;";
+                verifyCommand.ExecuteScalar().Should().Be(expectedRemoteImage ? 84L : 42L);
+            }
+
+            File.ReadAllBytes(path).Should().Equal(expectedRemoteImage ? updatedImage : initialImage);
+            var metadata = ManagedReplicaBootstrapper.LoadMetadata(path);
+            metadata.Should().NotBeNull();
+            metadata!.Value.Revision.Should().Be(expectedRemoteImage ? "revision-43" : "revision-42");
+            ManagedReplicaBootstrapper.EnsureNoLocalDivergence(path, metadata.Value);
+
+            using var reopened = AhtolaConnection.CreateReplica(options);
+            reopened.Open();
+            reopened.ExecuteNonQuery("SELECT value FROM bootstrap_marker;").Should().Be(0);
+            using var command = reopened.CreateCommand();
+            command.CommandText = "SELECT value FROM bootstrap_marker;";
+            command.ExecuteScalar().Should().Be(expectedRemoteImage ? 84L : 42L);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public void JournalPublicationFaultsRecoverWithoutDuplicateAcknowledgedChanges()
+    {
+        var path = NewReplicaPath("managed-replica-journal-durable-boundaries");
+        try
+        {
+            var journal = ManagedReplicaChangeJournal.Open(path);
+            using (ManagedReplicaFaultInjection.Push(point =>
+                   {
+                       if (point == ManagedReplicaDurableBoundary.JournalAppendPersisted)
+                           throw new InvalidOperationException("Injected journal append interruption.");
+                   }))
+            {
+                Assert.Throws<InvalidOperationException>(
+                    () => journal.AppendCommitted([ReplicaLocalChange.Schema("CREATE TABLE journal_events(value INTEGER);")]));
+            }
+
+            var reopenedAfterAppend = ManagedReplicaChangeJournal.Open(path);
+            reopenedAfterAppend.ReadBatch(10).Changes.Select(change => change.Sequence).Should().Equal(1);
+
+            using (ManagedReplicaFaultInjection.Push(point =>
+                   {
+                       if (point == ManagedReplicaDurableBoundary.JournalAcknowledgementPersisted)
+                           throw new InvalidOperationException("Injected journal acknowledgement interruption.");
+                   }))
+            {
+                Assert.Throws<InvalidOperationException>(() => reopenedAfterAppend.Acknowledge(2));
+            }
+
+            var reopenedAfterAcknowledgement = ManagedReplicaChangeJournal.Open(path);
+            reopenedAfterAcknowledgement.ReadBatch(10).Changes.Should().BeEmpty();
+            reopenedAfterAcknowledgement.AppendCommitted(
+                [ReplicaLocalChange.Schema("CREATE TABLE journal_events_two(value INTEGER);")]);
+            reopenedAfterAcknowledgement.ReadBatch(10).Changes.Select(change => change.Sequence).Should().Equal(2);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public void CreateReplicaWithBootstrapDisabledDoesNotCreateAMissingDatabase()
+    {
+        var path = Path.Combine(
+            TestContext.CurrentContext.WorkDirectory,
+            $"managed-embedded-replica-missing-{Guid.NewGuid():N}.db");
+        var options = new AhtolaReplicaOptions(
+            path,
+            new Uri("https://example.com"),
+            authToken: null,
+            bootstrapIfEmpty: false);
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(options);
+            Assert.Throws<NotSupportedException>(() => connection.Open())!.Message.Should()
+                .Be("Managed embedded replica bootstrap is disabled and the replica path does not contain an initialized managed database.");
+            File.Exists(path).Should().BeFalse();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+        [Test]
+        public async Task SyncAsyncReportsUpToDateForTheStoredRevision()
+        {
+            var path = NewReplicaPath("managed-embedded-replica-up-to-date");
+            var image = CreateDatabaseImage(path + ".source");
+            var handler = new PullUpdatesHandler([
+                CreatePullResponse("revision-42", image),
+                CreatePullResponse("revision-42", [], declaredPages: 1),
+            ], request =>
+            {
+                if (request.Content!.Headers.ContentLength == 0)
+                    return;
+                var fields = ReadFields(request.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult());
+                if (!fields.ContainsKey(3))
+                {
+                    fields[4].Number.Should().Be(3000);
+                    return;
+                }
+                fields[3].Text.Should().Be("revision-42");
+                fields[4].Number.Should().Be(3000);
+            });
+            var progress = new ProgressRecorder();
+            try
+            {
+                using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+                connection.Open();
+                connection.Capabilities.SupportsSync.Should().BeTrue();
+                var result = await connection.SyncAsync(
+                    new AhtolaSyncOptions(progress),
+                    CancellationToken.None);
+                result.Outcome.Should().Be(AhtolaSyncOutcome.UpToDate);
+                result.Statistics.Revision.Should().Be("revision-42");
+                result.Statistics.NetworkSentBytes.Should().BeGreaterThan(0);
+                result.Statistics.NetworkReceivedBytes.Should().BeGreaterThan(0);
+                progress.Stages.Should().Contain([AhtolaSyncProgressStage.Pulling, AhtolaSyncProgressStage.Completed]);
+                handler.CallCount.Should().Be(2);
+            }
+            finally { DeleteReplicaFiles(path); }
+        }
+
+        [Test]
+        public async Task SyncAsyncWithChangedRemotePublishesTheNewRevision()
+        {
+            var path = NewReplicaPath("managed-embedded-replica-changed");
+            var image = CreateDatabaseImage(path + ".source");
+            var handler = new PullUpdatesHandler([
+                CreatePullResponse("revision-42", image),
+                CreatePullResponse("revision-43", image),
+            ]);
+            try
+            {
+                using (var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler)))
+                {
+                    connection.Open();
+                    var result = await connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
+                    result.Outcome.Should().Be(AhtolaSyncOutcome.RemoteChangesApplied);
+                    result.Statistics.Revision.Should().Be("revision-43");
+                    using var command = connection.CreateCommand();
+                    command.CommandText = "SELECT value FROM bootstrap_marker;";
+                    command.ExecuteScalar().Should().Be(42L);
+                }
+                File.ReadAllBytes(path).Should().Equal(image);
+                File.ReadAllText(path + ".ahtola-replica-meta")
+                    .Should().Contain("server_revision_base64=cmV2aXNpb24tNDM=");
+            }
+            finally { DeleteReplicaFiles(path); }
+        }
+
+    [Test]
+                public async Task QuiesceManagedReplicaReopensOnlyWhenNoReaderOrTransactionIsActive()
+                {
+                    var path = NewReplicaPath("managed-embedded-replica-quiesce");
+                    try
+                    {
+                        CreateInitializedDatabase(path);
+                        using var connection = AhtolaConnection.CreateReplica(
+                            new AhtolaReplicaOptions(path, new Uri("https://example.test"), authToken: null));
+                        connection.Open();
+                        await connection.QuiesceManagedReplicaAsync(_ => Task.CompletedTask);
+                        using (var command = connection.CreateCommand())
+                        {
+                            command.CommandText = "SELECT value FROM bootstrap_marker;";
+                            command.ExecuteScalar().Should().Be(42L);
+                        }
+
+                        using (var transaction = connection.BeginTransaction())
+                        {
+                            Assert.ThrowsAsync<InvalidOperationException>(
+                                () => connection.QuiesceManagedReplicaAsync(_ => Task.CompletedTask))!
+                                .Message.Should().Be("Managed embedded replica sync cannot run while a transaction is active.");
+                            transaction.Rollback();
+                        }
+
+                        using var readerCommand = connection.CreateCommand();
+                        readerCommand.CommandText = "SELECT value FROM bootstrap_marker;";
+                        using var reader = readerCommand.ExecuteReader();
+                        Assert.ThrowsAsync<InvalidOperationException>(
+                            () => connection.QuiesceManagedReplicaAsync(_ => Task.CompletedTask))!
+                            .Message.Should().Be("Managed embedded replica sync cannot run while a data reader is active.");
+                    }
+                    finally { DeleteReplicaFiles(path); }
+    }
+
+    [Test]
+    public async Task SyncAsyncIsSingleFlightAcrossConnectionsForTheSameReplicaPath()
+    {
+        var path = NewReplicaPath("managed-replica-single-flight");
+        var image = CreateDatabaseImage(path + ".source");
+        var handler = new BlockingPullUpdatesHandler(
+            CreatePullResponse("revision-42", image),
+            CreatePullResponse("revision-42", [], declaredPages: 1));
+        try
+        {
+            using var first = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            using var second = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            first.Open();
+            second.Open();
+
+            var firstSync = first.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
+            await handler.SyncStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            var secondSync = second.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
+            await Task.Delay(100);
+            handler.CallCount.Should().Be(2);
+
+            handler.Release();
+            var results = await Task.WhenAll(firstSync, secondSync).WaitAsync(TimeSpan.FromSeconds(5));
+            results.Should().AllSatisfy(result => result.Outcome.Should().Be(AhtolaSyncOutcome.UpToDate));
+            handler.CallCount.Should().Be(2);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task SyncAsyncWaitsForReadersAndTransactionsOnSiblingConnections()
+    {
+        var path = NewReplicaPath("managed-replica-reader-transaction-boundary");
+        var image = CreateDatabaseImage(path + ".source");
+        var handler = new PullUpdatesHandler([
+            CreatePullResponse("revision-42", image),
+            CreatePullResponse("revision-42", [], declaredPages: 1),
+            CreatePullResponse("revision-42", [], declaredPages: 1),
+            CreatePullResponse("revision-42", [], declaredPages: 1),
+        ]);
+        try
+        {
+            using var local = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            using var synchronizer = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            local.Open();
+            synchronizer.Open();
+
+            using (var transaction = local.BeginTransaction())
+            {
+                var sync = synchronizer.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
+                await Task.Delay(100);
+                sync.IsCompleted.Should().BeFalse();
+                transaction.Rollback();
+                (await sync.WaitAsync(TimeSpan.FromSeconds(5))).Outcome.Should().Be(AhtolaSyncOutcome.UpToDate);
+            }
+
+            using var prepared = local.CreateCommand();
+            prepared.CommandText = "SELECT value FROM bootstrap_marker;";
+            prepared.Prepare();
+            using var command = local.CreateCommand();
+            command.CommandText = "SELECT value FROM bootstrap_marker;";
+            using var reader = command.ExecuteReader();
+            var readerSync = synchronizer.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
+            await Task.Delay(100);
+            readerSync.IsCompleted.Should().BeFalse();
+            reader.Dispose();
+            (await readerSync.WaitAsync(TimeSpan.FromSeconds(5))).Outcome.Should().Be(AhtolaSyncOutcome.UpToDate);
+
+            prepared.ExecuteScalar().Should().Be(42L);
+
+            local.ExecuteNonQuery("BEGIN;");
+            var sqlTransactionSync = synchronizer.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
+            await Task.Delay(100);
+            sqlTransactionSync.IsCompleted.Should().BeFalse();
+            local.ExecuteNonQuery("ROLLBACK;");
+            (await sqlTransactionSync.WaitAsync(TimeSpan.FromSeconds(5))).Outcome.Should().Be(AhtolaSyncOutcome.UpToDate);
+
+            synchronizer.ExecuteNonQuery("SELECT value FROM bootstrap_marker;").Should().Be(0);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task SyncAsyncDoesNotSerializeUnrelatedReplicaPaths()
+    {
+        var firstPath = NewReplicaPath("managed-replica-path-isolation-first");
+        var secondPath = NewReplicaPath("managed-replica-path-isolation-second");
+        var firstImage = CreateDatabaseImage(firstPath + ".source");
+        var secondImage = CreateDatabaseImage(secondPath + ".source");
+        var blockedHandler = new BlockingPullUpdatesHandler(
+            CreatePullResponse("revision-42", firstImage),
+            CreatePullResponse("revision-42", [], declaredPages: 1));
+        var independentHandler = new PullUpdatesHandler([
+            CreatePullResponse("revision-42", secondImage),
+            CreatePullResponse("revision-42", [], declaredPages: 1),
+        ]);
+        try
+        {
+            using var blocked = AhtolaConnection.CreateReplica(CreateOptions(firstPath, blockedHandler));
+            using var independent = AhtolaConnection.CreateReplica(CreateOptions(secondPath, independentHandler));
+            blocked.Open();
+            independent.Open();
+
+            var blockedSync = blocked.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
+            await blockedHandler.SyncStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            (await independent.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None)
+                .WaitAsync(TimeSpan.FromSeconds(5))).Outcome.Should().Be(AhtolaSyncOutcome.UpToDate);
+            blockedSync.IsCompleted.Should().BeFalse();
+
+            blockedHandler.Release();
+            (await blockedSync.WaitAsync(TimeSpan.FromSeconds(5))).Outcome.Should().Be(AhtolaSyncOutcome.UpToDate);
+        }
+        finally
+        {
+            DeleteReplicaFiles(firstPath);
+            DeleteReplicaFiles(secondPath);
+        }
+    }
+
+    [Test]
+    public async Task ManagedReplicaSyncIntervalSchedulesSynchronizationAfterOpen()
+    {
+        var path = NewReplicaPath("managed-replica-automatic-schedule");
+        var image = CreateDatabaseImage(path + ".source");
+        var handler = new AutomaticPullUpdatesHandler(
+            CreatePullResponse("revision-42", image),
+            CreatePullResponse("revision-42", [], declaredPages: 1));
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler, syncInterval: 1));
+            connection.Open();
+
+            await handler.SyncStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            handler.SyncCallCount.Should().Be(1);
+            connection.Close();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task ManagedReplicaSyncIntervalUsesOneInFlightSyncPerPath()
+    {
+        var path = NewReplicaPath("managed-replica-automatic-single-flight");
+        var image = CreateDatabaseImage(path + ".source");
+        var handler = new AutomaticPullUpdatesHandler(
+            CreatePullResponse("revision-42", image),
+            CreatePullResponse("revision-42", [], declaredPages: 1),
+            blockSync: true);
+        try
+        {
+            using var first = AhtolaConnection.CreateReplica(CreateOptions(path, handler, syncInterval: 1));
+            using var second = AhtolaConnection.CreateReplica(CreateOptions(path, handler, syncInterval: 1));
+            first.Open();
+            second.Open();
+
+            await handler.SyncStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await Task.Delay(150);
+            handler.SyncCallCount.Should().Be(1);
+
+            handler.Release();
+            await handler.SyncCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            handler.SyncCallCount.Should().Be(1);
+            first.Close();
+            second.Close();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task ManagedReplicaSyncIntervalCancelsAndAwaitsTheBackgroundSyncOnClose()
+    {
+        var path = NewReplicaPath("managed-replica-automatic-close");
+        var image = CreateDatabaseImage(path + ".source");
+        var handler = new AutomaticPullUpdatesHandler(
+            CreatePullResponse("revision-42", image),
+            CreatePullResponse("revision-42", [], declaredPages: 1),
+            blockSync: true);
+        var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler, syncInterval: 1));
+        try
+        {
+            connection.Open();
+            await handler.SyncStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            await Task.Run(connection.Close).WaitAsync(TimeSpan.FromSeconds(5));
+            await handler.SyncCanceled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            connection.State.Should().Be(System.Data.ConnectionState.Closed);
+        }
+        finally
+        {
+            connection.Dispose();
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task ManagedReplicaSyncIntervalRetriesTransientHttpFailures()
+    {
+        var path = NewReplicaPath("managed-replica-automatic-retry");
+        var image = CreateDatabaseImage(path + ".source");
+        var handler = new AutomaticPullUpdatesHandler(
+            CreatePullResponse("revision-42", image),
+            CreatePullResponse("revision-42", [], declaredPages: 1),
+            transientFailures: 1);
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler, syncInterval: 1));
+            connection.Open();
+
+            await handler.SyncCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            handler.SyncCallCount.Should().Be(2);
+            connection.Close();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task ManagedReplicaSyncIntervalDoesNotRetryReplicaConflicts()
+    {
+        var path = NewReplicaPath("managed-replica-automatic-conflict");
+        var image = CreateJournalDatabaseImage(path + ".source");
+        var handler = new ReplicaPushHandler(
+            [CreatePullResponse("revision-42", image)],
+            _ => ReplicaPushHandler.BatchErrorResponse(5, 2, "conflicting local change", "SQLITE_CONSTRAINT"));
+        var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler, syncInterval: 1));
+        try
+        {
+            connection.Open();
+            connection.ExecuteNonQuery("INSERT INTO journal_events VALUES (10);");
+
+            await handler.PushStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await Task.Delay(150);
+            handler.PushCallCount.Should().Be(1);
+            var exception = Assert.Throws<AhtolaReplicaConflictException>(() => connection.Close());
+            exception!.ConflictKind.Should().Be(AhtolaReplicaConflictKind.RowWrite);
+            exception.LocalChangeSequence.Should().Be(1);
+            ManagedReplicaChangeJournal.Open(path).ReadBatch(10).Changes
+                .Select(change => change.Sequence).Should().Equal(1);
+        }
+        finally
+        {
+            connection.Dispose();
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public void SyncIntervalRequiresAManagedEmbeddedReplica()
+    {
+        using var local = new AhtolaConnection(
+            "Data Source=:memory:;Local Provider=Managed;Sync Interval=1");
+        Assert.Throws<NotSupportedException>(() => local.Open())!.Message.Should()
+            .Be("Sync Interval requires a managed embedded replica connection.");
+
+        using var remote = new AhtolaConnection(
+            "Data Source=https://example.test;Sync Interval=1");
+        Assert.Throws<NotSupportedException>(() => remote.Open())!.Message.Should()
+            .Be("Sync Interval requires a managed embedded replica connection.");
+    }
+
+    [Test]
+    public async Task ManagedReplicaCloudStressQualifiesConcurrentReplicationAndCoordinatorBounds()
+    {
+        var paths = Enumerable.Range(0, 3)
+            .Select(index => NewReplicaPath($"managed-replica-cloud-stress-{index}"))
+            .ToArray();
+        var sourcePath = paths[0] + ".cloud-source";
+        var initialConnections = new List<AhtolaConnection>();
+        try
+        {
+            CreateJournalDatabase(sourcePath);
+            var handler = new DeterministicCloudReplicationHandler(sourcePath, paths.Length);
+            var options = paths.Select(path => CreateOptions(path, handler)).ToArray();
+            var replicas = options.Select(option =>
+            {
+                var connection = AhtolaConnection.CreateReplica(option);
+                connection.Open();
+                initialConnections.Add(connection);
+                return connection;
+            }).ToArray();
+
+            var initialValues = new[] { 10, 20, 30 };
+            await Task.WhenAll(replicas.Select((connection, index) =>
+                    Task.Run(() => connection.ExecuteNonQuery(
+                        $"INSERT INTO journal_events VALUES ({initialValues[index]});"))))
+                .WaitAsync(TimeSpan.FromSeconds(5));
+            foreach (var replica in replicas)
+                replica.ReadManagedReplicaLocalChanges(10).Changes.Select(change => change.Sequence).Should().Equal(1);
+
+            var coordinator = AhtolaConnection.CreateReplica(options[0]);
+            var singleFlightObserver = AhtolaConnection.CreateReplica(options[0]);
+            coordinator.Open();
+            singleFlightObserver.Open();
+            initialConnections.Add(coordinator);
+            initialConnections.Add(singleFlightObserver);
+
+            using var longReaderCommand = replicas[0].CreateCommand();
+            longReaderCommand.CommandText = "SELECT value FROM journal_events;";
+            using var longReader = longReaderCommand.ExecuteReader();
+            var firstSync = coordinator.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
+            var joinedSync = singleFlightObserver.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
+            var otherSyncs = replicas.Skip(1)
+                .Select(connection => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None))
+                .ToArray();
+
+            await handler.TwoPushesArrived.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            firstSync.IsCompleted.Should().BeFalse("the long reader must hold its path's publication lease");
+            joinedSync.IsCompleted.Should().BeFalse();
+            handler.PushCallCount.Should().Be(2, "same-path sync requests must share one coordinator flight");
+
+            longReader.Dispose();
+            _ = await Task.WhenAll([firstSync, joinedSync, .. otherSyncs])
+                .WaitAsync(TimeSpan.FromSeconds(10));
+            handler.PushCallCount.Should().Be(3, "one push is expected for each distinct replica path");
+            handler.PullCallCount.Should().BeGreaterThan(paths.Length, "every synchronized path must also pull");
+            foreach (var replica in replicas)
+                replica.ReadManagedReplicaLocalChanges(10).Changes.Should().BeEmpty("a successful push acknowledges its journal");
+
+            DisposeConnections(initialConnections);
+
+            var expectedValues = initialValues.ToList();
+            for (var round = 0; round < 2; round++)
+            {
+                var reopened = new List<AhtolaConnection>();
+                try
+                {
+                    foreach (var option in options)
+                    {
+                        var connection = AhtolaConnection.CreateReplica(option);
+                        connection.Open();
+                        connection.ReadManagedReplicaLocalChanges(10).Changes.Should().BeEmpty(
+                            "acknowledged entries must remain absent after reopening");
+                        reopened.Add(connection);
+                    }
+
+                    var roundValues = Enumerable.Range(0, paths.Length)
+                        .Select(index => 100 + round * 10 + index)
+                        .ToArray();
+                    await Task.WhenAll(reopened.Select((connection, index) =>
+                            Task.Run(() => connection.ExecuteNonQuery(
+                                $"INSERT INTO journal_events VALUES ({roundValues[index]});"))))
+                        .WaitAsync(TimeSpan.FromSeconds(5));
+                    foreach (var connection in reopened)
+                    {
+                        connection.ReadManagedReplicaLocalChanges(10).Changes
+                            .Select(change => change.Sequence)
+                            .Should()
+                            .Equal(
+                                new long[] { round + 2 },
+                                "the next entry must not reuse an acknowledged sequence");
+                    }
+
+                    _ = await Task.WhenAll(reopened.Select(connection =>
+                            connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None)))
+                        .WaitAsync(TimeSpan.FromSeconds(10));
+                    foreach (var connection in reopened)
+                        connection.ReadManagedReplicaLocalChanges(10).Changes.Should().BeEmpty();
+
+                    expectedValues.AddRange(roundValues);
+                    _ = await Task.WhenAll(reopened.Select(connection =>
+                            connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None)))
+                        .WaitAsync(TimeSpan.FromSeconds(10));
+                    ReadJournalEventValues(sourcePath).Should().Equal(expectedValues.Order());
+                }
+                finally
+                {
+                    DisposeConnections(reopened);
+                }
+            }
+        }
+        finally
+        {
+            DisposeConnections(initialConnections);
+            DeleteReplicaFiles(sourcePath);
+            foreach (var path in paths)
+                DeleteReplicaFiles(path);
+        }
+    }
+
+    private static void CreateInitializedDatabase(string path, int marker = 42)
+    {
+        using var connection = new AhtolaConnection($"Data Source={path};Local Provider=Managed");
+        connection.Open();
+        connection.ExecuteNonQuery("CREATE TABLE bootstrap_marker(value INTEGER NOT NULL);");
+        connection.ExecuteNonQuery($"INSERT INTO bootstrap_marker VALUES ({marker});");
+    }
+
+    private static void CreateJournalDatabase(string path)
+    {
+        CreateInitializedDatabase(path);
+        using var connection = new AhtolaConnection($"Data Source={path};Local Provider=Managed");
+        connection.Open();
+        connection.ExecuteNonQuery("CREATE TABLE journal_events(value INTEGER NOT NULL);");
+    }
+
+    private static IReadOnlyList<int> ReadJournalEventValues(string path)
+    {
+        using var connection = new AhtolaConnection($"Data Source={path};Local Provider=Managed");
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT value FROM journal_events ORDER BY value;";
+        using var reader = command.ExecuteReader();
+        var values = new List<int>();
+        while (reader.Read())
+            values.Add(checked((int)reader.GetInt64(0)));
+        return values;
+    }
+
+    private static long ReadBootstrapMarker(AhtolaConnection connection)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT value FROM bootstrap_marker;";
+        return Convert.ToInt64(command.ExecuteScalar());
+    }
+
+    private static string NewReplicaPath(string prefix)
+        => Path.Combine(TestContext.CurrentContext.WorkDirectory, $"{prefix}-{Guid.NewGuid():N}.db");
+
+    private static byte[] CreateDatabaseImage(string path)
+    {
+        try { CreateInitializedDatabase(path); return File.ReadAllBytes(path); }
+        finally { DeleteReplicaFiles(path); }
+    }
+
+    private static byte[] CreateDatabaseImageWithMarker(string path, int marker)
+    {
+        try { CreateInitializedDatabase(path, marker); return File.ReadAllBytes(path); }
+        finally { DeleteReplicaFiles(path); }
+    }
+
+    private static byte[] CreateJournalDatabaseImage(string path)
+    {
+        try { CreateJournalDatabase(path); return File.ReadAllBytes(path); }
+        finally { DeleteReplicaFiles(path); }
+    }
+
+    private static AhtolaReplicaOptions CreateOptions(
+        string path,
+        HttpMessageHandler handler,
+        int syncInterval = 0,
+        long? pushOperationsThreshold = null)
+        => new(path, new Uri("https://example.test/cluster"), authToken: "token-42")
+        {
+            LongPollTimeout = TimeSpan.FromSeconds(3),
+            SyncInterval = syncInterval,
+            PushOperationsThreshold = pushOperationsThreshold,
+            HttpPolicy = new AhtolaSyncHttpPolicy(handler),
+        };
+
+    private static AhtolaReplicaOptions CreateUnsupportedOptions(
+        string path,
+        HttpMessageHandler handler,
+        UnsupportedReplicaMode mode)
+    {
+        var options = CreateOptions(path, handler);
+        return mode switch
+        {
+            UnsupportedReplicaMode.RemoteEncryption => new AhtolaReplicaOptions(
+                path,
+                options.RemoteUri,
+                options.AuthToken)
+            {
+                RemoteEncryption = new AhtolaRemoteEncryptionOptions(
+                    "c2VjcmV0",
+                    AhtolaRemoteEncryptionCipher.Aes256Gcm),
+                HttpPolicy = options.HttpPolicy,
+            },
+            UnsupportedReplicaMode.PartialPrefix => new AhtolaReplicaOptions(
+                path,
+                options.RemoteUri,
+                options.AuthToken)
+            {
+                PartialBootstrap = AhtolaPartialBootstrapOptions.Prefix(4096),
+                HttpPolicy = options.HttpPolicy,
+            },
+            UnsupportedReplicaMode.PartialQuery => new AhtolaReplicaOptions(
+                path,
+                options.RemoteUri,
+                options.AuthToken)
+            {
+                PartialBootstrap = AhtolaPartialBootstrapOptions.QueryPages("SELECT 1"),
+                HttpPolicy = options.HttpPolicy,
+            },
+            UnsupportedReplicaMode.ChunkedBootstrap => new AhtolaReplicaOptions(
+                path,
+                options.RemoteUri,
+                options.AuthToken)
+            {
+                PullBytesThreshold = 4096,
+                HttpPolicy = options.HttpPolicy,
+            },
+            _ => throw new ArgumentOutOfRangeException(nameof(mode)),
+        };
+    }
+
+    private static void DeleteReplicaFiles(string path)
+    {
+        foreach (var file in new[]
+                 {
+                     path,
+                     path + "-wal",
+                     path + "-shm",
+                     path + "-journal",
+                     path + ".ahtola-replica-meta",
+                     path + ManagedReplicaChangeJournal.Suffix,
+                 })
+        {
+            if (File.Exists(file))
+                File.Delete(file);
+        }
+    }
+
+    private static void DisposeConnections(List<AhtolaConnection> connections)
+    {
+        foreach (var connection in connections.AsEnumerable().Reverse().ToArray())
+            connection.Dispose();
+        connections.Clear();
+    }
+
+    private static byte[] CreatePullResponse(
+        string revision,
+        byte[] databaseImage,
+        bool zstd = false,
+        ulong streamKind = 0,
+        ulong? declaredPages = null,
+        bool omitDefaultPageId = true,
+        ulong? protocol = 1)
+    {
+        var header = new List<byte>();
+        WriteLengthDelimitedField(header, 1, Encoding.UTF8.GetBytes(revision));
+        WriteVarintField(header, 2, declaredPages ?? checked((ulong)((databaseImage.Length + 4095) / 4096)));
+        if (!zstd)
+            WriteLengthDelimitedField(header, 3, []);
+        else
+            WriteLengthDelimitedField(header, 4, []);
+        WriteVarintField(header, 5, streamKind);
+        WriteVarintField(header, 6, 1);
+        if (protocol is { } protocolValue)
+            WriteVarintField(header, 8, protocolValue);
+
+        var response = new List<byte>();
+        WriteDelimitedMessage(response, header);
+        for (var offset = 0; offset < databaseImage.Length; offset += 4096)
+        {
+            var page = new List<byte>();
+            if (!omitDefaultPageId || offset != 0)
+                WriteVarintField(page, 1, checked((ulong)(offset / 4096)));
+            var length = Math.Min(4096, databaseImage.Length - offset);
+            WriteLengthDelimitedField(page, 2, databaseImage.AsSpan(offset, length));
+            WriteDelimitedMessage(response, page);
+        }
+        return response.ToArray();
+    }
+
+    private static byte[] CreateOversizedMessagePrefix()
+    {
+        var response = new List<byte>();
+        WriteVarint(response, 64 * 1024 + 1);
+        return response.ToArray();
+    }
+
+    private static byte[] AppendPage(byte[] response, ulong pageId, ReadOnlySpan<byte> pageData)
+    {
+        var result = new List<byte>(response);
+        var page = new List<byte>();
+        WriteVarintField(page, 1, pageId);
+        WriteLengthDelimitedField(page, 2, pageData);
+        WriteDelimitedMessage(result, page);
+        return result.ToArray();
+    }
+
+    private static Dictionary<int, ulong> ReadVarintFields(byte[] payload)
+    {
+        var fields = new Dictionary<int, ulong>();
+        var offset = 0;
+        while (offset < payload.Length)
+        {
+            var key = ReadVarint(payload, ref offset);
+            (key & 7).Should().Be(0);
+            fields.Add(checked((int)(key >> 3)), ReadVarint(payload, ref offset));
+        }
+        return fields;
+    }
+
+    private static Dictionary<int, (ulong? Number, string? Text)> ReadFields(byte[] payload)
+        {
+            var fields = new Dictionary<int, (ulong?, string?)>();
+            var offset = 0;
+            while (offset < payload.Length)
+            {
+                var key = ReadVarint(payload, ref offset);
+                var field = checked((int)(key >> 3));
+                fields[field] = (key & 7) == 0
+                    ? (ReadVarint(payload, ref offset), null)
+                    : (null, Encoding.UTF8.GetString(payload, offset + 1, checked((int)payload[offset])));
+                if ((key & 7) == 2)
+                    offset += 1 + payload[offset];
+            }
+            return fields;
+        }
+    private static ulong ReadVarint(byte[] source, ref int offset)
+    {
+        ulong result = 0;
+        for (var shift = 0; shift < 64; shift += 7)
+        {
+            var next = source[offset++];
+            result |= (ulong)(next & 0x7f) << shift;
+            if ((next & 0x80) == 0)
+                return result;
+        }
+        throw new InvalidOperationException("Invalid test protobuf varint.");
+    }
+
+    private static void WriteDelimitedMessage(List<byte> destination, List<byte> message)
+    {
+        WriteVarint(destination, checked((ulong)message.Count));
+        destination.AddRange(message);
+    }
+
+    private static void WriteLengthDelimitedField(List<byte> destination, int fieldNumber, ReadOnlySpan<byte> value)
+    {
+        WriteVarint(destination, checked((ulong)fieldNumber << 3 | 2));
+        WriteVarint(destination, checked((ulong)value.Length));
+        destination.AddRange(value.ToArray());
+    }
+
+    private static void WriteVarintField(List<byte> destination, int fieldNumber, ulong value)
+    {
+        WriteVarint(destination, checked((ulong)fieldNumber << 3));
+        WriteVarint(destination, value);
+    }
+
+    private static void WriteVarint(List<byte> destination, ulong value)
+    {
+        while (value >= 0x80)
+        {
+            destination.Add((byte)((value & 0x7f) | 0x80));
+            value >>= 7;
+        }
+        destination.Add((byte)value);
+    }
+
+    public enum PullResponseFailure
+    {
+        Zstd,
+        InvalidPage,
+        Non4KiBPage,
+        LogicalStream,
+    }
+
+    public enum UnsupportedReplicaMode
+    {
+        RemoteEncryption,
+        PartialPrefix,
+        PartialQuery,
+        ChunkedBootstrap,
+    }
+
+    public enum PullResponseFramingFailure
+    {
+        TruncatedLengthPrefix,
+        TruncatedPayload,
+        OversizedMessage,
+    }
+
+    public enum InvalidPageSet
+    {
+        Duplicate,
+        OutOfRange,
+    }
+
+    private sealed class ProgressRecorder : IProgress<AhtolaSyncProgress>
+    {
+        public List<AhtolaSyncProgressStage> Stages { get; } = [];
+
+        public void Report(AhtolaSyncProgress value) => Stages.Add(value.Stage);
+    }
+
+    private sealed class PullUpdatesHandler : HttpMessageHandler
+    {
+        private readonly Queue<byte[]> _responses;
+        private readonly Action<HttpRequestMessage>? _assertRequest;
+
+        public PullUpdatesHandler(byte[] response, Action<HttpRequestMessage>? assertRequest = null)
+            : this([response], assertRequest) { }
+
+        public PullUpdatesHandler(IEnumerable<byte[]> responses, Action<HttpRequestMessage>? assertRequest = null)
+        {
+            _responses = new Queue<byte[]>(responses);
+            _assertRequest = assertRequest;
+        }
+
+        public int CallCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            _assertRequest?.Invoke(request);
+            var message = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(_responses.Dequeue()),
+            };
+            message.Content.Headers.ContentType = new MediaTypeHeaderValue("application/protobuf");
+            return Task.FromResult(message);
+        }
+    }
+
+    private sealed class TrackingPullUpdatesHandler(byte[] response) : HttpMessageHandler
+    {
+        private readonly byte[] _response = response;
+
+        public bool IsDisposed { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var message = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(_response),
+            };
+            message.Content.Headers.ContentType = new MediaTypeHeaderValue("application/protobuf");
+            return Task.FromResult(message);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                IsDisposed = true;
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class BlockingPullUpdatesHandler(byte[] bootstrapResponse, byte[] syncResponse) : HttpMessageHandler
+    {
+        private readonly TaskCompletionSource<bool> _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource<bool> SyncStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int CallCount => Volatile.Read(ref _callCount);
+
+        private int _callCount;
+
+        public void Release() => _release.TrySetResult(true);
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var call = Interlocked.Increment(ref _callCount);
+            if (call != 1)
+            {
+                SyncStarted.TrySetResult(true);
+                await _release.Task.WaitAsync(cancellationToken);
+            }
+
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(call == 1 ? bootstrapResponse : syncResponse),
+            };
+            response.Content.Headers.ContentType = new MediaTypeHeaderValue("application/protobuf");
+            return response;
+        }
+    }
+
+    private sealed class AutomaticPullUpdatesHandler(
+        byte[] bootstrapResponse,
+        byte[] syncResponse,
+        bool blockSync = false,
+        int transientFailures = 0) : HttpMessageHandler
+    {
+        private readonly TaskCompletionSource<bool> _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _requestCount;
+        private int _syncCallCount;
+
+        public TaskCompletionSource<bool> SyncStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource<bool> SyncCompleted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource<bool> SyncCanceled { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int SyncCallCount => Volatile.Read(ref _syncCallCount);
+
+        public void Release() => _release.TrySetResult(true);
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (Interlocked.Increment(ref _requestCount) == 1)
+                return CreateResponse(bootstrapResponse);
+
+            var syncCall = Interlocked.Increment(ref _syncCallCount) - 1;
+            SyncStarted.TrySetResult(true);
+            if (syncCall < transientFailures)
+                return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+
+            if (blockSync)
+            {
+                try
+                {
+                    await _release.Task.WaitAsync(cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    SyncCanceled.TrySetResult(true);
+                    throw;
+                }
+            }
+
+            SyncCompleted.TrySetResult(true);
+            return CreateResponse(syncResponse);
+        }
+
+        private static HttpResponseMessage CreateResponse(byte[] payload)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(payload),
+            };
+            response.Content.Headers.ContentType = new MediaTypeHeaderValue("application/protobuf");
+            return response;
+        }
+    }
+
+    private sealed class DeterministicCloudReplicationHandler(string sourcePath, int replicasPerWave) : HttpMessageHandler
+    {
+        private readonly object _sourceGate = new();
+        private int _bootstrapPullCount;
+        private int _pushCallCount;
+        private int _pullCallCount;
+
+        public TaskCompletionSource<bool> TwoPushesArrived { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int PushCallCount => Volatile.Read(ref _pushCallCount);
+
+        public int PullCallCount => Volatile.Read(ref _pullCallCount);
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (request.RequestUri!.AbsolutePath.EndsWith("/pull-updates", StringComparison.Ordinal))
+            {
+                Interlocked.Increment(ref _pullCallCount);
+                var bootstrap = Interlocked.Increment(ref _bootstrapPullCount) <= replicasPerWave;
+                if (!bootstrap)
+                    return CreateProtobufResponse(CreatePullResponse("revision-0", [], declaredPages: 1));
+
+                byte[] image;
+                lock (_sourceGate)
+                    image = File.ReadAllBytes(sourcePath);
+                return CreateProtobufResponse(CreatePullResponse("revision-0", image));
+            }
+
+            using var document = JsonDocument.Parse(
+                await request.Content!.ReadAsStringAsync(cancellationToken).ConfigureAwait(false));
+            var steps = document.RootElement.GetProperty("requests")[0].GetProperty("batch").GetProperty("steps");
+            lock (_sourceGate)
+            {
+                foreach (var step in steps.EnumerateArray())
+                {
+                    if (!step.TryGetProperty("stmt", out var statement)
+                        || !statement.TryGetProperty("sql", out var sqlElement))
+                    {
+                        continue;
+                    }
+
+                    var sql = sqlElement.GetString();
+                    if (sql is not null
+                        && sql.StartsWith("INSERT INTO journal_events VALUES", StringComparison.Ordinal))
+                    {
+                        using var connection = new AhtolaConnection($"Data Source={sourcePath};Local Provider=Managed");
+                        connection.Open();
+                        connection.ExecuteNonQuery(sql);
+                    }
+                }
+            }
+
+            var call = Interlocked.Increment(ref _pushCallCount);
+            if (call == replicasPerWave - 1)
+                TwoPushesArrived.TrySetResult(true);
+            return ReplicaPushHandler.SuccessfulBatchResponse(steps.GetArrayLength());
+        }
+
+        private static HttpResponseMessage CreateProtobufResponse(byte[] payload)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(payload),
+            };
+            response.Content.Headers.ContentType = new MediaTypeHeaderValue("application/protobuf");
+            return response;
+        }
+    }
+
+    private sealed class ReplicaPushHandler(
+        IEnumerable<byte[]> pullResponses,
+        Func<HttpRequestMessage, HttpResponseMessage> pushResponse) : HttpMessageHandler
+    {
+        private readonly Queue<byte[]> _pullResponses = new(pullResponses);
+
+        public int PullCallCount { get; private set; }
+
+        public int PushCallCount { get; private set; }
+
+        public TaskCompletionSource<bool> PushStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.RequestUri!.AbsolutePath.EndsWith("/pull-updates", StringComparison.Ordinal))
+            {
+                PullCallCount++;
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(_pullResponses.Dequeue()),
+                };
+                response.Content.Headers.ContentType = new MediaTypeHeaderValue("application/protobuf");
+                return Task.FromResult(response);
+            }
+
+            PushCallCount++;
+            PushStarted.TrySetResult(true);
+            return Task.FromResult(pushResponse(request));
+        }
+
+        public static HttpResponseMessage SuccessfulBatchResponse(int stepCount)
+            => BatchResponse(stepCount, errorStep: null, message: null, code: null);
+
+        public static HttpResponseMessage BatchErrorResponse(int stepCount, int errorStep, string message, string code)
+            => BatchResponse(stepCount, errorStep, message, code);
+
+        private static HttpResponseMessage BatchResponse(int stepCount, int? errorStep, string? message, string? code)
+        {
+            var results = string.Join(",", Enumerable.Range(0, stepCount)
+                .Select(index => index == errorStep ? "null" : "{}"));
+            var errors = string.Join(",", Enumerable.Range(0, stepCount)
+                .Select(index => index == errorStep
+                    ? $"{{\"message\":\"{message}\",\"code\":\"{code}\"}}"
+                    : "null"));
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    $"{{\"results\":[{{\"type\":\"ok\",\"response\":{{\"type\":\"batch\",\"result\":{{\"step_results\":[{results}],\"step_errors\":[{errors}]}}}}}}]}}",
+                    Encoding.UTF8,
+                    "application/json"),
+            };
+        }
+    }
+}

--- a/src/Ahtola.Tests/RemoteReplicationIndexTests.cs
+++ b/src/Ahtola.Tests/RemoteReplicationIndexTests.cs
@@ -41,8 +41,9 @@ public sealed class RemoteReplicationIndexTests
     }
 
     [TestCase("\"not-an-index\"")]
-    [TestCase("1")]
-    public void RemoteBatchRejectsAnInvalidOrUnencodedReplicationIndex(string encodedIndex)
+    [TestCase("1.5")]
+    [TestCase("{}")]
+    public void RemoteBatchRejectsAnInvalidReplicationIndex(string encodedIndex)
     {
         using var handler = new ReplicationIndexHandler(
             """
@@ -61,6 +62,29 @@ public sealed class RemoteReplicationIndexTests
             closeAfter: true,
             CancellationToken.None))!
             .Message.Should().Be("Remote response returned an invalid replication_index.");
+    }
+
+    [Test]
+    public async Task RemoteBatchAcceptsLegacyNumericReplicationIndex()
+    {
+        using var handler = new ReplicationIndexHandler(
+            """
+            {"results":[{"type":"ok","response":{"type":"batch","result":{"step_results":[{"cols":[],"rows":[],"affected_row_count":0}],"step_errors":[null],"replication_index":42}}}]}
+            """,
+            """
+            {"results":[{"type":"ok","response":{"type":"batch","result":{"step_results":[{"cols":[],"rows":[],"affected_row_count":0}],"step_errors":[null]}}}]}
+            """);
+        using var httpClient = new HttpClient(handler);
+        using var client = new AhtolaRemoteClient(
+            httpClient,
+            new Uri("https://example.com"),
+            authToken: null);
+        var commands = new[] { new AhtolaBatchCommand("SELECT 1") };
+
+        await client.ExecuteBatchAsync(commands, 30, wantRows: true, closeAfter: true, CancellationToken.None);
+        await client.ExecuteBatchAsync(commands, 30, wantRows: true, closeAfter: true, CancellationToken.None);
+
+        handler.RequestReplicationIndexes.Should().Equal(null, "42");
     }
 
     private sealed class ReplicationIndexHandler(params string[] responses) : HttpMessageHandler

--- a/src/Ahtola.Tests/SourceGeneratedRemoteJsonTests.cs
+++ b/src/Ahtola.Tests/SourceGeneratedRemoteJsonTests.cs
@@ -1,0 +1,68 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using AwesomeAssertions;
+
+namespace Ahtola.Tests;
+
+public sealed class SourceGeneratedRemoteJsonTests
+{
+    [Test]
+    public async Task RemotePipelineSerializesAndDeserializesUsingGeneratedMetadata()
+    {
+        using var handler = new GeneratedJsonHandler();
+        using var client = new AhtolaRemoteClient(
+            new HttpClient(handler),
+            new Uri("https://example.test"),
+            authToken: null);
+
+        var result = await client.ExecuteAsync(
+            "SELECT ?",
+            CreateParameters(),
+            wantRows: true,
+            commandTimeout: 30,
+            closeAfter: true,
+            CancellationToken.None);
+
+        handler.SerializedRequest.Should().NotBeNull();
+        handler.SerializedRequest!.RootElement
+            .GetProperty("requests")[0]
+            .GetProperty("stmt")
+            .GetProperty("args")[0]
+            .GetProperty("value")
+            .GetString()
+            .Should().Be("generated");
+        result.Rows.Should().ContainSingle().Which.Should().ContainSingle()
+            .Which.Type.Should().Be("text");
+        result.Rows[0][0].Value.GetString().Should().Be("generated");
+    }
+
+    private static AhtolaParameterCollection CreateParameters()
+    {
+        var parameters = new AhtolaParameterCollection();
+        parameters.Add(new AhtolaParameter { Value = "generated" });
+        return parameters;
+    }
+
+    private sealed class GeneratedJsonHandler : HttpMessageHandler
+    {
+        public JsonDocument? SerializedRequest { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            SerializedRequest = JsonDocument.Parse(
+                await request.Content!.ReadAsStringAsync(cancellationToken));
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """
+                    {"results":[{"type":"ok","response":{"type":"execute","result":{"cols":[{"name":"value","decltype":"TEXT"}],"rows":[[{"type":"text","value":"generated"}]],"affected_row_count":0}}}]}
+                    """,
+                    Encoding.UTF8,
+                    "application/json"),
+            };
+        }
+    }
+}

--- a/src/Devolutions.Ahtola.PowerShell/AhtolaCloudConnection.cs
+++ b/src/Devolutions.Ahtola.PowerShell/AhtolaCloudConnection.cs
@@ -1,0 +1,126 @@
+using System.Data;
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Ahtola.PSSqlite;
+
+/// <summary>
+/// A PowerShell-safe wrapper for a direct Turso Cloud or managed embedded-replica connection.
+/// The provider connection, including its bearer token, remains private.
+/// </summary>
+public sealed class AhtolaCloudConnection : DbConnection
+{
+    private readonly Ahtola.AhtolaConnection _connection;
+    private readonly string _endpoint;
+    private readonly string? _replicaPath;
+
+    internal AhtolaCloudConnection(Ahtola.AhtolaConnection connection, Uri endpoint, string? replicaPath)
+    {
+        _connection = connection;
+        _endpoint = endpoint.AbsoluteUri;
+        _replicaPath = string.IsNullOrWhiteSpace(replicaPath) ? null : Path.GetFullPath(replicaPath);
+    }
+
+    /// <summary>Gets the remote endpoint. Credentials are never included.</summary>
+    public string Endpoint => _endpoint;
+
+    /// <summary>Gets the local replica path, or null for a direct Cloud connection.</summary>
+    public string? ReplicaPath => _replicaPath;
+
+    /// <summary>Gets whether this connection uses a managed embedded replica.</summary>
+    public bool IsReplica => _replicaPath is not null;
+
+    /// <summary>
+    /// Gets a redacted connection description. The underlying connection string is never exposed.
+    /// </summary>
+    [AllowNull]
+    public override string ConnectionString
+    {
+        get => $"Data Source={_endpoint};Auth Token=***";
+        set => throw new NotSupportedException("AhtolaCloudConnection is configured when it is created.");
+    }
+
+    public override string Database => _connection.Database;
+
+    public override string DataSource => _endpoint;
+
+    public override string ServerVersion => _connection.ServerVersion;
+
+    public override ConnectionState State => _connection.State;
+
+    public override void ChangeDatabase(string databaseName) => _connection.ChangeDatabase(databaseName);
+
+    public override void Close()
+    {
+        try
+        {
+            _connection.Close();
+        }
+        catch
+        {
+            throw new InvalidOperationException("The Turso Cloud connection could not be closed.");
+        }
+    }
+
+    public override void Open()
+    {
+        try
+        {
+            _connection.Open();
+        }
+        catch
+        {
+            throw new InvalidOperationException("The Turso Cloud connection could not be opened.");
+        }
+    }
+
+    public override async Task OpenAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            throw new InvalidOperationException("The Turso Cloud connection could not be opened.");
+        }
+    }
+
+    public override string ToString() => $"{nameof(AhtolaCloudConnection)} ({_endpoint})";
+
+    internal Ahtola.AhtolaSyncResult Synchronize()
+    {
+        if (!IsReplica)
+            throw new NotSupportedException("Sync requires a managed embedded replica connection.");
+
+        try
+        {
+            return _connection.Sync(new Ahtola.AhtolaSyncOptions());
+        }
+        catch
+        {
+            throw new InvalidOperationException("The Turso Cloud replica synchronization failed.");
+        }
+    }
+
+    protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
+        => _connection.BeginTransaction(isolationLevel);
+
+    protected override DbCommand CreateDbCommand() => _connection.CreateCommand();
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            try
+            {
+                _connection.Dispose();
+            }
+            catch
+            {
+                throw new InvalidOperationException("The Turso Cloud connection could not be disposed.");
+            }
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/src/Devolutions.Ahtola.PowerShell/Module/Devolutions.Ahtola.Sqlite.psd1
+++ b/src/Devolutions.Ahtola.PowerShell/Module/Devolutions.Ahtola.Sqlite.psd1
@@ -29,6 +29,7 @@
         'Invoke-AhtolaSqliteBulkCopy'
         'Invoke-AhtolaSqliteMaintenance'
         'Invoke-AhtolaSqliteQuery'
+        'Invoke-AhtolaSqliteReplicaSync'
         'New-AhtolaSqliteConnection'
         'New-AhtolaSqliteRow'
         'Optimize-AhtolaSqliteDatabase'

--- a/src/Devolutions.Ahtola.PowerShell/Module/en-US/about_Devolutions.Ahtola.Sqlite.help.txt
+++ b/src/Devolutions.Ahtola.PowerShell/Module/en-US/about_Devolutions.Ahtola.Sqlite.help.txt
@@ -24,5 +24,17 @@ EXAMPLES
     Invoke-AhtolaSqliteQuery -Connection $connection -CommandText 'CREATE TABLE users (name TEXT)'
     Invoke-AhtolaSqliteQuery -Connection $connection -CommandText "INSERT INTO users VALUES ('Ada')"
 
+    # Direct Turso Cloud connection (token is a SecureString).
+    $token = Read-Host -AsSecureString
+    $cloud = New-AhtolaSqliteConnection -TursoUrl 'libsql://example.turso.io' -AuthToken $token
+
+    # Explicitly opt into standard Turso CLI environment variables.
+    $replica = New-AhtolaSqliteConnection -UseTursoEnvironment -ReplicaPath ./replica.db
+    Invoke-AhtolaSqliteReplicaSync -ReplicaConnection $replica
+
+    Cloud credentials are not emitted, serialized, or included in connection
+    descriptions. -UseTursoEnvironment is opt-in; it reads TURSO_REMOTE_URL
+    and TURSO_AUTH_TOKEN only when explicitly specified.
+
 KEYWORDS
     SQLite, PowerShell, CRUD, Ahtola, Devolutions

--- a/src/Devolutions.Ahtola.PowerShell/PowerShellCmdlets.cs
+++ b/src/Devolutions.Ahtola.PowerShell/PowerShellCmdlets.cs
@@ -48,18 +48,19 @@ public abstract class PSSqliteCmdlet : PSCmdlet
         return SessionState.InvokeCommand.ExpandString(value);
     }
 
-    protected static void DisposeOwnedConnection(SqliteConnection connection)
+    protected static void DisposeOwnedConnection(DbConnection connection)
     {
         if (connection.State == ConnectionState.Open)
         {
             connection.Close();
         }
 
-        SqliteConnection.ClearPool(connection);
+        if (connection is SqliteConnection sqliteConnection)
+            SqliteConnection.ClearPool(sqliteConnection);
         connection.Dispose();
     }
 
-    protected static void OpenIfNeeded(SqliteConnection connection)
+    protected static void OpenIfNeeded(DbConnection connection)
     {
         if (connection.State != ConnectionState.Open)
         {
@@ -68,8 +69,8 @@ public abstract class PSSqliteCmdlet : PSCmdlet
     }
 }
 
-[Cmdlet(VerbsCommon.New, "AhtolaSqliteConnection")]
-[OutputType(typeof(SqliteConnection))]
+[Cmdlet(VerbsCommon.New, "AhtolaSqliteConnection", DefaultParameterSetName = "byConnectionString", SupportsShouldProcess = true)]
+[OutputType(typeof(SqliteConnection), typeof(AhtolaCloudConnection))]
 public sealed class NewPSSqliteConnectionCommand : PSSqliteCmdlet
 {
     [Parameter(ParameterSetName = "byConnectionString")]
@@ -84,8 +85,43 @@ public sealed class NewPSSqliteConnectionCommand : PSSqliteCmdlet
     [Parameter]
     public SwitchParameter ReadOnly { get; set; }
 
+    [Parameter(ParameterSetName = "byTursoCloud")]
+    [Alias("RemoteUrl", "Url")]
+    public string? TursoUrl { get; set; }
+
+    [Parameter(ParameterSetName = "byTursoCloud")]
+    [Alias("Token")]
+    public SecureString? AuthToken { get; set; }
+
+    [Parameter(ParameterSetName = "byTursoCloud")]
+    public string? ReplicaPath { get; set; }
+
+    [Parameter(ParameterSetName = "byTursoCloud")]
+    public SwitchParameter UseTursoEnvironment { get; set; }
+
+    [Parameter(ParameterSetName = "byTursoCloud")]
+    [ValidateRange(0, int.MaxValue)]
+    public int SyncInterval { get; set; }
+
     protected override void ProcessRecord()
     {
+        if (ParameterSetName == "byTursoCloud")
+        {
+            var operation = string.IsNullOrWhiteSpace(ReplicaPath)
+                ? "Open Turso Cloud connection"
+                : "Open managed Turso Cloud replica";
+            if (!ShouldProcess("Turso Cloud endpoint", operation))
+                return;
+
+            WriteObject(TursoCloudConnectionFactory.Create(
+                TursoUrl,
+                AuthToken,
+                ReplicaPath,
+                UseTursoEnvironment.IsPresent,
+                SyncInterval));
+            return;
+        }
+
         var connection = ParameterSetName == "byDatabasePath"
             ? ConnectionFactory.Create(ExpandString(DatabasePath), ExpandString(DatabaseFile!))
             : ConnectionFactory.Create(ExpandString(ConnectionString));
@@ -108,7 +144,7 @@ public sealed class InvokePSSqliteQueryCommand : PSSqliteCmdlet
 {
     [Parameter(Mandatory = true, ValueFromPipeline = true)]
     [Alias("SqliteConnection")]
-    public SqliteConnection Connection { get; set; } = null!;
+    public DbConnection Connection { get; set; } = null!;
 
     [Parameter(Mandatory = true)]
     [Alias("Query")]
@@ -128,20 +164,28 @@ public sealed class InvokePSSqliteQueryCommand : PSSqliteCmdlet
     public int CommandTimeout { get; set; } = 30;
 
     [Parameter]
-    public SqliteTransaction? Transaction { get; set; }
+    public DbTransaction? Transaction { get; set; }
 
     protected override void ProcessRecord()
     {
-        var result = QueryExecutor.Execute(
-            Connection,
-            CommandText,
-            Parameters,
-            new QueryOptions
-            {
-                OutputFormat = As,
-                CommandTimeout = CommandTimeout,
-                Transaction = Transaction
-            });
+        object? result;
+        try
+        {
+            result = QueryExecutor.Execute(
+                Connection,
+                CommandText,
+                Parameters,
+                new QueryOptions
+                {
+                    OutputFormat = As,
+                    CommandTimeout = CommandTimeout,
+                    Transaction = Transaction
+                });
+        }
+        catch when (Connection is AhtolaCloudConnection)
+        {
+            throw new InvalidOperationException("The Turso Cloud query failed.");
+        }
 
         if (CastAs is not null && result is not null)
         {
@@ -386,7 +430,7 @@ public sealed class ClosePSSqliteConnectionCommand : PSSqliteCmdlet
 {
     [Parameter(ValueFromPipeline = true)]
     [Alias("SqliteConnection")]
-    public SqliteConnection? Connection { get; set; }
+    public DbConnection? Connection { get; set; }
 
     [Parameter]
     public SwitchParameter ClearPool { get; set; }
@@ -412,9 +456,9 @@ public sealed class ClosePSSqliteConnectionCommand : PSSqliteCmdlet
         }
 
         Connection.Close();
-        if (ClearPool.IsPresent)
+        if (ClearPool.IsPresent && Connection is SqliteConnection sqliteConnection)
         {
-            Ahtola.Data.Sqlite.SqliteConnection.ClearPool(Connection);
+            Ahtola.Data.Sqlite.SqliteConnection.ClearPool(sqliteConnection);
         }
 
         Connection.Dispose();

--- a/src/Devolutions.Ahtola.PowerShell/PowerShellOperationalCmdlets.cs
+++ b/src/Devolutions.Ahtola.PowerShell/PowerShellOperationalCmdlets.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using System.Management.Automation;
 using System.Net;
 using System.Security;
@@ -14,15 +15,22 @@ public sealed class TestPSSqliteConnectionCommand : PSSqliteCmdlet
 {
     [Parameter(Mandatory = true, ValueFromPipeline = true)]
     [Alias("SqliteConnection")]
-    public SqliteConnection Connection { get; set; } = null!;
+    public DbConnection Connection { get; set; } = null!;
 
     protected override void ProcessRecord()
     {
-        OpenIfNeeded(Connection);
-        using var command = Connection.CreateCommand();
-        command.CommandText = "SELECT 1;";
-        _ = command.ExecuteScalar();
-        WriteObject(true);
+        try
+        {
+            OpenIfNeeded(Connection);
+            using var command = Connection.CreateCommand();
+            command.CommandText = "SELECT 1;";
+            _ = command.ExecuteScalar();
+            WriteObject(true);
+        }
+        catch when (Connection is AhtolaCloudConnection)
+        {
+            throw new InvalidOperationException("The Turso Cloud connection test failed.");
+        }
     }
 }
 
@@ -43,12 +51,12 @@ public sealed class ClearPSSqliteConnectionPoolCommand : PSSqliteCmdlet
 }
 
 [Cmdlet(VerbsLifecycle.Start, "AhtolaSqliteTransaction")]
-[OutputType(typeof(SqliteTransaction))]
+[OutputType(typeof(DbTransaction))]
 public sealed class StartPSSqliteTransactionCommand : PSSqliteCmdlet
 {
     [Parameter(Mandatory = true, ValueFromPipeline = true)]
     [Alias("SqliteConnection")]
-    public SqliteConnection Connection { get; set; } = null!;
+    public DbConnection Connection { get; set; } = null!;
 
     [Parameter]
     public IsolationLevel IsolationLevel { get; set; } = IsolationLevel.Serializable;
@@ -59,7 +67,30 @@ public sealed class StartPSSqliteTransactionCommand : PSSqliteCmdlet
     protected override void ProcessRecord()
     {
         OpenIfNeeded(Connection);
-        WriteObject(Connection.BeginTransaction(IsolationLevel, Deferred.IsPresent));
+        if (Deferred.IsPresent && Connection is not SqliteConnection)
+            throw new NotSupportedException("Deferred transactions are supported only by local Ahtola SQLite connections.");
+
+        var transaction = Connection is SqliteConnection sqliteConnection
+            ? sqliteConnection.BeginTransaction(IsolationLevel, Deferred.IsPresent)
+            : Connection.BeginTransaction(IsolationLevel);
+        WriteObject(transaction);
+    }
+}
+
+[Cmdlet(VerbsLifecycle.Invoke, "AhtolaSqliteReplicaSync", SupportsShouldProcess = true)]
+[OutputType(typeof(Ahtola.AhtolaSyncResult))]
+public sealed class InvokePSSqliteReplicaSyncCommand : PSSqliteCmdlet
+{
+    [Parameter(Mandatory = true, ValueFromPipeline = true)]
+    [Alias("Connection")]
+    public AhtolaCloudConnection ReplicaConnection { get; set; } = null!;
+
+    protected override void ProcessRecord()
+    {
+        if (!ShouldProcess(ReplicaConnection.Endpoint, "Synchronize managed Turso Cloud replica"))
+            return;
+
+        WriteObject(ReplicaConnection.Synchronize());
     }
 }
 
@@ -67,7 +98,7 @@ public sealed class StartPSSqliteTransactionCommand : PSSqliteCmdlet
 public sealed class SavePSSqliteTransactionCommand : PSSqliteCmdlet
 {
     [Parameter(Mandatory = true, ValueFromPipeline = true)]
-    public SqliteTransaction Transaction { get; set; } = null!;
+    public DbTransaction Transaction { get; set; } = null!;
 
     [Parameter(Mandatory = true)]
     public string Name { get; set; } = string.Empty;
@@ -82,7 +113,7 @@ public sealed class SavePSSqliteTransactionCommand : PSSqliteCmdlet
 public sealed class CompletePSSqliteTransactionCommand : PSSqliteCmdlet
 {
     [Parameter(Mandatory = true, ValueFromPipeline = true)]
-    public SqliteTransaction Transaction { get; set; } = null!;
+    public DbTransaction Transaction { get; set; } = null!;
 
     [Parameter]
     public string? SavepointName { get; set; }
@@ -110,7 +141,7 @@ public sealed class CompletePSSqliteTransactionCommand : PSSqliteCmdlet
 public sealed class UndoPSSqliteTransactionCommand : PSSqliteCmdlet
 {
     [Parameter(Mandatory = true, ValueFromPipeline = true)]
-    public SqliteTransaction Transaction { get; set; } = null!;
+    public DbTransaction Transaction { get; set; } = null!;
 
     [Parameter]
     public string? SavepointName { get; set; }

--- a/src/Devolutions.Ahtola.PowerShell/README.md
+++ b/src/Devolutions.Ahtola.PowerShell/README.md
@@ -79,6 +79,13 @@ pwsh ./scripts/Invoke-PowerShellModuleTests.ps1
 - `Invoke-AhtolaSqliteQuery` emits `PSCustomObject` rows by default. Use
   `-As Scalar` or `-As NonQuery` for direct values/counts and `-As DataTable`
   or `-As DataSet` only when those ADO.NET containers are required.
+- `New-AhtolaSqliteConnection -TursoUrl <libsql-url> -AuthToken <SecureString>`
+  opens a direct Turso Cloud connection. Add `-ReplicaPath <file>` for a
+  managed embedded replica, optionally with `-SyncInterval <seconds>`, then
+  use `Invoke-AhtolaSqliteReplicaSync` for an explicit sync. `-UseTursoEnvironment`
+  opts into `TURSO_REMOTE_URL` and `TURSO_AUTH_TOKEN` defaults; explicit
+  parameters take precedence. Cloud connections expose only a redacted
+  connection string and never serialize their token.
 - `Export-AhtolaSqliteTable` and `Import-AhtolaSqliteTable` infer `Json` or
   `Csv` from the file extension when `-Format` is omitted. Export can select a
   table or a parameterized `-Query`.

--- a/src/Devolutions.Ahtola.PowerShell/SqliteServices.cs
+++ b/src/Devolutions.Ahtola.PowerShell/SqliteServices.cs
@@ -2,10 +2,14 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Data;
+using System.Data.Common;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net;
+using System.Security;
 using System.Text.RegularExpressions;
+using Ahtola;
 using Ahtola.Data.Sqlite;
 
 namespace Ahtola.PSSqlite;
@@ -23,6 +27,116 @@ internal static class StringExpansion
             expanded,
             match => Environment.GetEnvironmentVariable(match.Groups["name"].Value) ?? string.Empty);
         return expanded;
+    }
+}
+
+internal static class TursoCloudConnectionFactory
+{
+    internal const string RemoteUrlEnvironmentVariable = "TURSO_REMOTE_URL";
+    internal const string AuthTokenEnvironmentVariable = "TURSO_AUTH_TOKEN";
+
+    public static AhtolaCloudConnection Create(
+        string? remoteUrl,
+        SecureString? authToken,
+        string? replicaPath,
+        bool useTursoEnvironment,
+        int syncInterval)
+    {
+        var endpoint = ResolveEndpoint(remoteUrl, useTursoEnvironment);
+        var token = ResolveAuthToken(authToken, useTursoEnvironment);
+        string? resolvedReplicaPath = null;
+        try
+        {
+            AhtolaConnection connection;
+            if (string.IsNullOrWhiteSpace(replicaPath))
+            {
+                var builder = new AhtolaConnectionStringBuilder
+                {
+                    DataSource = endpoint.AbsoluteUri,
+                };
+                if (!string.IsNullOrWhiteSpace(token))
+                    builder.AuthToken = token;
+
+                connection = new AhtolaConnection(builder.ConnectionString);
+            }
+            else
+            {
+                resolvedReplicaPath = Path.GetFullPath(StringExpansion.Expand(replicaPath));
+                var options = new AhtolaReplicaOptions(resolvedReplicaPath, endpoint, token)
+                {
+                    SyncInterval = syncInterval,
+                };
+                connection = AhtolaConnection.CreateReplica(options);
+            }
+
+            try
+            {
+                connection.Open();
+                return new AhtolaCloudConnection(connection, endpoint, resolvedReplicaPath);
+            }
+            catch
+            {
+                try
+                {
+                    connection.Dispose();
+                }
+                catch
+                {
+                    // Keep credential-bearing provider failures out of the PowerShell error stream.
+                }
+                throw new InvalidOperationException("The Turso Cloud connection could not be opened.");
+            }
+        }
+        finally
+        {
+            token = string.Empty;
+        }
+    }
+
+    private static Uri ResolveEndpoint(string? remoteUrl, bool useTursoEnvironment)
+    {
+        var value = string.IsNullOrWhiteSpace(remoteUrl)
+            ? useTursoEnvironment
+                ? Environment.GetEnvironmentVariable(RemoteUrlEnvironmentVariable)
+                : null
+            : StringExpansion.Expand(remoteUrl);
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException(useTursoEnvironment
+                ? "TursoUrl must be supplied or TURSO_REMOTE_URL must be set when UseTursoEnvironment is specified."
+                : "TursoUrl is required unless UseTursoEnvironment is specified.");
+        }
+
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var endpoint)
+            || string.IsNullOrWhiteSpace(endpoint.Host)
+            || !string.IsNullOrEmpty(endpoint.UserInfo)
+            || !string.IsNullOrEmpty(endpoint.Query)
+            || !string.IsNullOrEmpty(endpoint.Fragment)
+            || !(endpoint.Scheme.Equals("libsql", StringComparison.OrdinalIgnoreCase)
+                 || endpoint.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+                 || endpoint.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new ArgumentException(
+                "TursoUrl must be an absolute libsql, HTTPS, or HTTP URL without user information, a query string, or a fragment.");
+        }
+
+        return endpoint;
+    }
+
+    private static string? ResolveAuthToken(SecureString? authToken, bool useTursoEnvironment)
+    {
+        if (authToken is not null)
+        {
+            var value = new NetworkCredential(string.Empty, authToken).Password;
+            if (string.IsNullOrWhiteSpace(value))
+                throw new ArgumentException("AuthToken cannot be empty.");
+            return value;
+        }
+
+        return useTursoEnvironment
+            ? Environment.GetEnvironmentVariable(AuthTokenEnvironmentVariable)
+            : null;
     }
 }
 
@@ -368,13 +482,13 @@ public sealed class QueryOptions
     public string OutputFormat { get; set; } = "PSCustomObject";
     public int CommandTimeout { get; set; } = 30;
     public string? TableName { get; set; }
-    public SqliteTransaction? Transaction { get; set; }
+    public DbTransaction? Transaction { get; set; }
 }
 
 public static class QueryExecutor
 {
     public static object? Execute(
-        SqliteConnection connection,
+        DbConnection connection,
         string commandText,
         IDictionary? parameters,
         QueryOptions? options = null)
@@ -428,10 +542,10 @@ public static class QueryExecutor
     }
 
     public static DataTable ExecuteDataTable(
-        SqliteConnection connection,
+        DbConnection connection,
         string commandText,
         IDictionary? parameters = null,
-        SqliteTransaction? transaction = null)
+        DbTransaction? transaction = null)
     {
         return (DataTable)Execute(
             connection,
@@ -444,7 +558,7 @@ public static class QueryExecutor
             })!;
     }
 
-    private static void AddParameters(SqliteCommand command, IDictionary? parameters)
+    private static void AddParameters(DbCommand command, IDictionary? parameters)
     {
         if (parameters is null)
         {

--- a/tests/PowerShell/Devolutions.Ahtola.Sqlite/Module.Tests.ps1
+++ b/tests/PowerShell/Devolutions.Ahtola.Sqlite/Module.Tests.ps1
@@ -51,6 +51,7 @@ Describe 'Devolutions.Ahtola.Sqlite module packaging' {
             'Invoke-AhtolaSqliteBulkCopy'
             'Invoke-AhtolaSqliteMaintenance'
             'Invoke-AhtolaSqliteQuery'
+            'Invoke-AhtolaSqliteReplicaSync'
             'New-AhtolaSqliteConnection'
             'New-AhtolaSqliteRow'
             'Optimize-AhtolaSqliteDatabase'
@@ -128,6 +129,47 @@ Describe 'Devolutions.Ahtola.Sqlite module packaging' {
 
         (Get-Command New-AhtolaSqliteRow).Parameters['Values'].Aliases | Should-ContainCollection 'RowData'
         (Get-Command Get-AhtolaSqliteRow).Parameters['Where'].Aliases | Should-ContainCollection 'ClauseData'
+    }
+
+    It 'offers opt-in secure Turso Cloud parameters without emitting credentials under WhatIf' {
+        $command = Get-Command New-AhtolaSqliteConnection
+        $parameters = $command.Parameters
+        $parameters['TursoUrl'] | Should-NotBeNull
+        $parameters['AuthToken'].ParameterType | Should-Be ([securestring])
+        $parameters['ReplicaPath'] | Should-NotBeNull
+        $parameters['UseTursoEnvironment'] | Should-NotBeNull
+        $parameters['SyncInterval'] | Should-NotBeNull
+        (Get-Command Invoke-AhtolaSqliteReplicaSync).Parameters['ReplicaConnection'].ParameterType |
+            Should-Be ([Ahtola.PSSqlite.AhtolaCloudConnection])
+
+        $originalUrl = $env:TURSO_REMOTE_URL
+        $originalToken = $env:TURSO_AUTH_TOKEN
+        $secret = 'module-test-secret'
+        try {
+            $env:TURSO_REMOTE_URL = 'libsql://example.turso.io'
+            $env:TURSO_AUTH_TOKEN = $secret
+            $output = @(
+                New-AhtolaSqliteConnection -UseTursoEnvironment -ReplicaPath ./replica.db -WhatIf 6>&1 |
+                    Out-String
+            ) -join [Environment]::NewLine
+
+            $output.Contains($secret) | Should-BeFalse
+            $output.Contains('TURSO_AUTH_TOKEN') | Should-BeFalse
+
+            $secureToken = ConvertTo-SecureString $secret -AsPlainText -Force
+            $errorText = try {
+                New-AhtolaSqliteConnection -TursoUrl 'http://127.0.0.1:1' -AuthToken $secureToken -ErrorAction Stop
+                throw 'Expected the unavailable local endpoint to fail.'
+            }
+            catch {
+                $_ | Out-String
+            }
+            $errorText.Contains($secret) | Should-BeFalse
+        }
+        finally {
+            $env:TURSO_REMOTE_URL = $originalUrl
+            $env:TURSO_AUTH_TOKEN = $originalToken
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Add a pure-managed embedded-replica implementation for Turso Cloud: bootstrap, raw page pull/apply, durable local change journal, guarded push, conflict retention, automatic sync, and per-path coordination.
- Add Cloud qualification coverage for recovery, conflicts, protocol/transport behavior, multi-replica stress, feature boundaries, packaged trim/AOT runtime, and PowerShell Cloud commands.
- Add environment-gated packed Cloud smoke using `TURSO_REMOTE_URL` and `TURSO_AUTH_TOKEN`; no credentials are persisted.

## Validation
- `pwsh ./build.ps1 test -Framework net10.0` (4,356 tests passed)
- Packed Cloud smoke passed on net8.0, net9.0, and net10.0 against a live Turso Cloud database.
- Live embedded replicas bootstrapped, pushed local DDL/DML, and verified remote readback; concurrent two-replica writes passed.
- Official `tursodb.exe` local file interoperability passed in both directions.
- PowerShell module Pester suite: 26 passed.

## Follow-up
Full bidirectional replication with a Cloud-capable official Turso client/SDK remains an environment-dependent qualification item; the installed official shell is local-only.