### PR TITLE
feat: improve PowerShell module usability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ permissions:
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
+  PLATYPS_VERSION: 1.0.3
   # Keep this in sync with the managed test count. The wrapper fails closed if
   # the runner discovers or executes fewer tests than this threshold.
   MINIMUM_EXECUTED_TESTS: "2500"
@@ -77,6 +78,13 @@ jobs:
         shell: pwsh
         run: ./build.ps1 restore
 
+      - name: Install PlatyPS
+        shell: pwsh
+        run: |
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+          Install-Module -Name Microsoft.PowerShell.PlatyPS -RequiredVersion $env:PLATYPS_VERSION `
+            -Force -Scope CurrentUser -SkipPublisherCheck -AllowClobber
+
       - name: Build
         shell: pwsh
         run: ./build.ps1 build -Framework net10.0
@@ -137,12 +145,20 @@ jobs:
         shell: pwsh
         run: ./build.ps1 restore
 
-      - name: Install Pester 6
+      - name: Install PowerShell test tools
         shell: pwsh
         run: |
           Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+          Install-Module -Name Microsoft.PowerShell.PlatyPS -RequiredVersion $env:PLATYPS_VERSION `
+            -Force -Scope CurrentUser -SkipPublisherCheck -AllowClobber
           Install-Module -Name Pester -MinimumVersion 6.0.0 -MaximumVersion 6.99.99 `
             -Force -Scope CurrentUser -SkipPublisherCheck -AllowClobber
+          $platyPS = Get-Module -ListAvailable -Name Microsoft.PowerShell.PlatyPS |
+            Where-Object { $_.Version.ToString() -eq $env:PLATYPS_VERSION } |
+            Select-Object -First 1
+          if (-not $platyPS) {
+            throw "Microsoft.PowerShell.PlatyPS $env:PLATYPS_VERSION was not installed."
+          }
           $pester = Get-Module -ListAvailable -Name Pester |
             Where-Object { $_.Version -ge [version]'6.0.0' } |
             Sort-Object Version -Descending |
@@ -229,6 +245,13 @@ jobs:
             8.0.x
             9.0.x
             10.0.x
+
+      - name: Install PlatyPS
+        shell: pwsh
+        run: |
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+          Install-Module -Name Microsoft.PowerShell.PlatyPS -RequiredVersion $env:PLATYPS_VERSION `
+            -Force -Scope CurrentUser -SkipPublisherCheck -AllowClobber
 
       - name: Pack Release nupkgs
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   NUGET_SOURCE: https://api.nuget.org/v3/index.json
+  PLATYPS_VERSION: 1.0.3
   PSIGN_MODULE_VERSION: 0.6.2
   PSIGN_MODULE_SHA256: ec833a64291d3a3b0b95403d9b2235ef156c124899bb0031f0278ff01e32bc81
 
@@ -90,6 +91,13 @@ jobs:
       - name: Restore
         shell: pwsh
         run: ./build.ps1 restore
+
+      - name: Install PlatyPS
+        shell: pwsh
+        run: |
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+          Install-Module -Name Microsoft.PowerShell.PlatyPS -RequiredVersion $env:PLATYPS_VERSION `
+            -Force -Scope CurrentUser -SkipPublisherCheck -AllowClobber
 
       - name: Pack Release nupkgs
         shell: pwsh

--- a/build.ps1
+++ b/build.ps1
@@ -48,7 +48,7 @@ param(
 
         # Floor for Pester module tests (test-powershell). Keep in sync with
         # tests/PowerShell/Devolutions.Ahtola.Sqlite/Module.Tests.ps1.
-        [int]$PowerShellMinimumExecutedTests = 25
+        [int]$PowerShellMinimumExecutedTests = 34
     )
 
 Set-StrictMode -Version Latest
@@ -67,6 +67,8 @@ $Solution = './Ahtola.slnx'
 $PowerShellModuleName = 'Devolutions.Ahtola.Sqlite'
 $PowerShellModuleOutput = "./artifacts/powershell-modules/$PowerShellModuleName"
 $PowerShellAssemblyName = 'Devolutions.Ahtola.PowerShell'
+$PowerShellHelpMarkdown = Join-Path $RepoRoot "docs/powershell-help/$PowerShellModuleName"
+$PowerShellHelpBuilder = Join-Path $RepoRoot 'scripts/Build-PowerShellHelp.ps1'
 $PowerShellTestRunner = Join-Path $RepoRoot 'scripts/Invoke-PowerShellModuleTests.ps1'
 $ConsumerProject = './samples/ManagedPackageConsumer/ManagedPackageConsumer.csproj'
 $ConsumerNugetConfig = './samples/ManagedPackageConsumer/obj/managed-package-consumer.nuget.config'
@@ -187,6 +189,14 @@ function Invoke-Build {
         if (-not (Test-Path -LiteralPath $assemblyPath)) {
             throw "Expected staged module assembly at $assemblyPath"
         }
+        if (-not (Test-Path -LiteralPath $PowerShellHelpBuilder -PathType Leaf)) {
+            throw "PowerShell help builder not found: $PowerShellHelpBuilder"
+        }
+
+        Invoke-PwshScript -Path $PowerShellHelpBuilder -Arguments @(
+            '-ModulePath', $moduleAbsolute,
+            '-MarkdownPath', $PowerShellHelpMarkdown
+        )
 
         if (-not [string]::IsNullOrWhiteSpace($Version)) {
             if ($Version -notmatch '^\d+\.\d+\.\d+(?:\.\d+)?$') {

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Backup-AhtolaSqliteDatabase.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Backup-AhtolaSqliteDatabase.md
@@ -1,0 +1,157 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Backup-AhtolaSqliteDatabase
+---
+
+# Backup-AhtolaSqliteDatabase
+
+## SYNOPSIS
+
+Copies a local Ahtola SQLite database to another connection.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Backup-AhtolaSqliteDatabase -SourceConnection <SqliteConnection>
+ -DestinationConnection <SqliteConnection> [-WhatIf] [-Confirm]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Performs a page-level backup from a local source connection to a distinct local destination connection. Both connections remain caller-owned.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$source = New-AhtolaSqliteConnection
+$destination = New-AhtolaSqliteConnection
+try { Backup-AhtolaSqliteDatabase -SourceConnection $source -DestinationConnection $destination -Confirm:$false }
+finally { $source | Close-AhtolaSqliteConnection -Confirm:$false; $destination | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -DestinationConnection
+
+Local connection receiving the backup. It must differ from `SourceConnection`.
+
+```yaml
+Type: Ahtola.Data.Sqlite.SqliteConnection
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -SourceConnection
+
+Local connection to back up. It must differ from `DestinationConnection`.
+
+```yaml
+Type: Ahtola.Data.Sqlite.SqliteConnection
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+None. This cmdlet does not accept pipeline input.
+
+## OUTPUTS
+
+No pipeline output.
+
+## NOTES
+
+Supports `-WhatIf` and `-Confirm`. Source and destination must be different connection instances.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Checkpoint-AhtolaSqliteDatabase.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Checkpoint-AhtolaSqliteDatabase.md
@@ -1,0 +1,183 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Checkpoint-AhtolaSqliteDatabase
+---
+
+# Checkpoint-AhtolaSqliteDatabase
+
+## SYNOPSIS
+
+Runs a WAL checkpoint on a local Ahtola database.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Checkpoint-AhtolaSqliteDatabase -Connection <SqliteConnection> [-Mode <string>]
+ [-CommandTimeout <int>] [-WhatIf] [-Confirm]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Runs `PRAGMA wal_checkpoint` with the selected mode and writes the checkpoint result.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$connection = New-AhtolaSqliteConnection
+try {
+    Checkpoint-AhtolaSqliteDatabase -Connection $connection -Mode Truncate -Confirm:$false
+} finally { $connection | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -CommandTimeout
+
+Command timeout in seconds. Zero is allowed; the default is 30 seconds.
+
+```yaml
+Type: System.Int32
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Connection
+
+Caller-owned Ahtola connection. It can be opened if needed but is never closed or disposed by this cmdlet.
+
+```yaml
+Type: Ahtola.Data.Sqlite.SqliteConnection
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SqliteConnection
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Mode
+
+WAL checkpoint mode: `Passive`, `Full`, `Restart`, or `Truncate`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### Ahtola.Data.Sqlite.SqliteConnection
+
+A value can be piped to the pipeline-enabled parameter.
+
+## OUTPUTS
+
+### System.Object
+
+Checkpoint status objects returned by SQLite.
+
+## NOTES
+
+Supports `-WhatIf` and `-Confirm`. A checkpoint can report busy when other connections prevent completion.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Clear-AhtolaSqliteConnectionPool.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Clear-AhtolaSqliteConnectionPool.md
@@ -1,0 +1,138 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Clear-AhtolaSqliteConnectionPool
+---
+
+# Clear-AhtolaSqliteConnectionPool
+
+## SYNOPSIS
+
+Clears the pool for a local Ahtola connection.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Clear-AhtolaSqliteConnectionPool -Connection <SqliteConnection> [-WhatIf] [-Confirm]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Clears the local Ahtola SQLite connection pool without closing or disposing the supplied connection.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$connection = New-AhtolaSqliteConnection
+try {
+    Clear-AhtolaSqliteConnectionPool -Connection $connection -Confirm:$false
+} finally { $connection | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Connection
+
+Caller-owned Ahtola connection. It can be opened if needed but is never closed or disposed by this cmdlet.
+
+```yaml
+Type: Ahtola.Data.Sqlite.SqliteConnection
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SqliteConnection
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### Ahtola.Data.Sqlite.SqliteConnection
+
+A value can be piped to the pipeline-enabled parameter.
+
+## OUTPUTS
+
+No pipeline output.
+
+## NOTES
+
+Supports `-WhatIf` and `-Confirm`. The supplied connection remains caller-owned and open.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Clear-AhtolaSqlitePassword.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Clear-AhtolaSqlitePassword.md
@@ -1,0 +1,138 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Clear-AhtolaSqlitePassword
+---
+
+# Clear-AhtolaSqlitePassword
+
+## SYNOPSIS
+
+Clears the Ahtola-managed password from a local database.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Clear-AhtolaSqlitePassword -Connection <SqliteConnection> [-WhatIf] [-Confirm]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Opens the local connection if needed and removes its Ahtola-managed database password. It does not support SQLCipher or third-party encryption formats.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$connection = New-AhtolaSqliteConnection
+try {
+    Clear-AhtolaSqlitePassword -Connection $connection -Confirm:$false
+} finally { $connection | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Connection
+
+Caller-owned Ahtola connection. It can be opened if needed but is never closed or disposed by this cmdlet.
+
+```yaml
+Type: Ahtola.Data.Sqlite.SqliteConnection
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SqliteConnection
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### Ahtola.Data.Sqlite.SqliteConnection
+
+A value can be piped to the pipeline-enabled parameter.
+
+## OUTPUTS
+
+No pipeline output.
+
+## NOTES
+
+Supports `-WhatIf` and `-Confirm`. The connection remains caller-owned.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Close-AhtolaSqliteConnection.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Close-AhtolaSqliteConnection.md
@@ -1,0 +1,179 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Close-AhtolaSqliteConnection
+---
+
+# Close-AhtolaSqliteConnection
+
+## SYNOPSIS
+
+Closes and disposes an Ahtola connection, or clears all local pools.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Close-AhtolaSqliteConnection [-Connection <DbConnection>] [-ClearPool] [-AllPools] [-WhatIf]
+ [-Confirm]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Closes and disposes a supplied connection. `ClearPool` clears its pool after closing and `AllPools` clears all Ahtola SQLite pools. Without a connection, it only clears all pools.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$connection = New-AhtolaSqliteConnection
+$connection | Close-AhtolaSqliteConnection -ClearPool -Confirm:$false
+```
+
+## PARAMETERS
+
+### -AllPools
+
+Clears every Ahtola SQLite connection pool. With no connection, this is the only operation performed.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ClearPool
+
+After closing the supplied local connection, clears its Ahtola connection-pool entry.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Connection
+
+Caller-owned Ahtola connection. It can be opened if needed but is never closed or disposed by this cmdlet.
+
+```yaml
+Type: System.Data.Common.DbConnection
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SqliteConnection
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Data.Common.DbConnection
+
+A value can be piped to the pipeline-enabled parameter.
+
+## OUTPUTS
+
+No pipeline output.
+
+## NOTES
+
+Use only for connections the caller is finished using. `-WhatIf` leaves the connection open and does not clear pools.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Compare-AhtolaSqliteDatabaseVersion.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Compare-AhtolaSqliteDatabaseVersion.md
@@ -1,0 +1,114 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Compare-AhtolaSqliteDatabaseVersion
+---
+
+# Compare-AhtolaSqliteDatabaseVersion
+
+## SYNOPSIS
+
+Compares a configured database metadata version with an expected version.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Compare-AhtolaSqliteDatabaseVersion [-Configuration] <SQLiteDBConfig> [-ExpectedVersion <string>]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Reports deployed and expected versions, comparison direction, deployment state, and reasons. The expected version defaults to `Configuration.Version`.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$config = [Devolutions.Ahtola.Sqlite.SQLiteDBConfig]::new('Data Source=app.db')
+Compare-AhtolaSqliteDatabaseVersion -Configuration $config -ExpectedVersion '1'
+```
+
+## PARAMETERS
+
+### -Configuration
+
+A `SQLiteDBConfig` that supplies the connection string and settings for this operation.
+
+```yaml
+Type: Ahtola.PSSqlite.SQLiteDBConfig
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- DatabaseConfig
+- SqliteDBConfig
+ParameterSets:
+- Name: (All)
+  Position: 0
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ExpectedVersion
+
+Version to compare with stored metadata. If omitted, `Configuration.Version` is used.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+None. This cmdlet does not accept pipeline input.
+
+## OUTPUTS
+
+### Ahtola.PSSqlite.DBVersionComparisonResult
+
+A `DBVersionComparisonResult` with the comparison outcome.
+
+## NOTES
+
+This command does not change the database. Missing databases or metadata are reported in the result.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Complete-AhtolaSqliteTransaction.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Complete-AhtolaSqliteTransaction.md
@@ -1,0 +1,160 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Complete-AhtolaSqliteTransaction
+---
+
+# Complete-AhtolaSqliteTransaction
+
+## SYNOPSIS
+
+Commits a transaction or releases a savepoint.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Complete-AhtolaSqliteTransaction -Transaction <DbTransaction> [-SavepointName <string>] [-WhatIf]
+ [-Confirm]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Commits the transaction when `SavepointName` is omitted. With a savepoint name, releases only that savepoint and leaves the outer transaction active.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$connection = New-AhtolaSqliteConnection
+try {
+    $tx = Start-AhtolaSqliteTransaction -Connection $connection
+    Complete-AhtolaSqliteTransaction -Transaction $tx -Confirm:$false
+} finally { $connection | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -SavepointName
+
+Existing savepoint name to release or roll back to instead of completing the whole transaction.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Transaction
+
+Caller-owned active transaction. It must belong to the supplied connection when both are present.
+
+```yaml
+Type: System.Data.Common.DbTransaction
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Data.Common.DbTransaction
+
+A value can be piped to the pipeline-enabled parameter.
+
+## OUTPUTS
+
+No pipeline output.
+
+## NOTES
+
+Supports `-WhatIf` and `-Confirm`. This cmdlet does not dispose the transaction or its connection.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Devolutions.Ahtola.Sqlite.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Devolutions.Ahtola.Sqlite.md
@@ -1,0 +1,142 @@
+---
+document type: module
+Help Version: 1.0.0.0
+HelpInfoUri: 
+Locale: en-US
+Module Guid: b7c2f0d1-8a4e-4f6b-9c3d-2e1a0b9f8d7c
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Devolutions.Ahtola.Sqlite Module
+---
+
+# Devolutions.Ahtola.Sqlite Module
+
+## Description
+
+`Devolutions.Ahtola.Sqlite` exposes the pure-managed Ahtola SQLite engine to PowerShell 7.4 or later. It provides local connections, parameterized queries, configuration-driven row operations, transactions, schema and maintenance commands, table import/export, managed passwords, and optional Turso Cloud or replica connections.
+
+Import it with `Import-Module Devolutions.Ahtola.Sqlite`. It requires PowerShell 7.4+ on .NET 8+; Windows PowerShell 5.1 is unsupported. Local operations do not require a native SQLite library. Connections returned by `New-AhtolaSqliteConnection` are caller-owned and should be closed with `Close-AhtolaSqliteConnection`. Commands that change data, files, pools, passwords, or replicas support `-WhatIf` and `-Confirm`.
+
+## Devolutions.Ahtola.Sqlite
+
+### [Backup-AhtolaSqliteDatabase](Backup-AhtolaSqliteDatabase.md)
+
+Copies a local Ahtola SQLite database to another connection.
+
+### [Checkpoint-AhtolaSqliteDatabase](Checkpoint-AhtolaSqliteDatabase.md)
+
+Runs a WAL checkpoint on a local Ahtola database.
+
+### [Clear-AhtolaSqliteConnectionPool](Clear-AhtolaSqliteConnectionPool.md)
+
+Clears the pool for a local Ahtola connection.
+
+### [Clear-AhtolaSqlitePassword](Clear-AhtolaSqlitePassword.md)
+
+Clears the Ahtola-managed password from a local database.
+
+### [Close-AhtolaSqliteConnection](Close-AhtolaSqliteConnection.md)
+
+Closes and disposes an Ahtola connection, or clears all local pools.
+
+### [Compare-AhtolaSqliteDatabaseVersion](Compare-AhtolaSqliteDatabaseVersion.md)
+
+Compares a configured database metadata version with an expected version.
+
+### [Complete-AhtolaSqliteTransaction](Complete-AhtolaSqliteTransaction.md)
+
+Commits a transaction or releases a savepoint.
+
+### [Export-AhtolaSqliteTable](Export-AhtolaSqliteTable.md)
+
+Exports a table or query result to JSON or CSV.
+
+### [Get-AhtolaSqliteDatabaseInfo](Get-AhtolaSqliteDatabaseInfo.md)
+
+Retrieves basic page, journal, and connection state information.
+
+### [Get-AhtolaSqliteDatabaseMetadata](Get-AhtolaSqliteDatabaseMetadata.md)
+
+Retrieves stored Ahtola SQLite metadata values.
+
+### [Get-AhtolaSqliteIndex](Get-AhtolaSqliteIndex.md)
+
+Lists indexes and their definitions.
+
+### [Get-AhtolaSqliteRow](Get-AhtolaSqliteRow.md)
+
+Retrieves rows from a configured table or view.
+
+### [Get-AhtolaSqliteSchema](Get-AhtolaSqliteSchema.md)
+
+Retrieves an ADO.NET schema collection from a local Ahtola connection.
+
+### [Get-AhtolaSqliteTable](Get-AhtolaSqliteTable.md)
+
+Lists user tables and their CREATE statements.
+
+### [Import-AhtolaSqliteTable](Import-AhtolaSqliteTable.md)
+
+Imports JSON or CSV rows into a local SQLite table.
+
+### [Invoke-AhtolaSqliteBulkCopy](Invoke-AhtolaSqliteBulkCopy.md)
+
+Bulk inserts piped objects into a local SQLite table.
+
+### [Invoke-AhtolaSqliteMaintenance](Invoke-AhtolaSqliteMaintenance.md)
+
+Runs an explicit SQLite maintenance operation.
+
+### [Invoke-AhtolaSqliteQuery](Invoke-AhtolaSqliteQuery.md)
+
+Executes parameterized SQL against an Ahtola local or Turso Cloud connection.
+
+### [Invoke-AhtolaSqliteReplicaSync](Invoke-AhtolaSqliteReplicaSync.md)
+
+Synchronizes a managed Turso Cloud replica with its remote endpoint.
+
+### [New-AhtolaSqliteConnection](New-AhtolaSqliteConnection.md)
+
+Creates and opens a local Ahtola SQLite, Turso Cloud, or managed replica connection.
+
+### [New-AhtolaSqliteRow](New-AhtolaSqliteRow.md)
+
+Inserts a row into a configured SQLite table.
+
+### [Optimize-AhtolaSqliteDatabase](Optimize-AhtolaSqliteDatabase.md)
+
+Runs VACUUM, optionally followed by ANALYZE, on a local database.
+
+### [Remove-AhtolaSqliteRow](Remove-AhtolaSqliteRow.md)
+
+Deletes rows from a configured SQLite table.
+
+### [Save-AhtolaSqliteTransaction](Save-AhtolaSqliteTransaction.md)
+
+Creates a named savepoint in an active transaction.
+
+### [Set-AhtolaSqlitePassword](Set-AhtolaSqlitePassword.md)
+
+Sets or rotates the Ahtola-managed password for a local database.
+
+### [Set-AhtolaSqliteRow](Set-AhtolaSqliteRow.md)
+
+Updates or upserts rows in a configured SQLite table.
+
+### [Start-AhtolaSqliteTransaction](Start-AhtolaSqliteTransaction.md)
+
+Starts an ADO.NET transaction on an Ahtola connection.
+
+### [Test-AhtolaSqliteConnection](Test-AhtolaSqliteConnection.md)
+
+Tests an Ahtola local or Turso Cloud connection with `SELECT 1`.
+
+### [Test-AhtolaSqliteIntegrity](Test-AhtolaSqliteIntegrity.md)
+
+Runs SQLite `PRAGMA integrity_check`.
+
+### [Undo-AhtolaSqliteTransaction](Undo-AhtolaSqliteTransaction.md)
+
+Rolls back a transaction or rolls back to a savepoint.
+

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Export-AhtolaSqliteTable.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Export-AhtolaSqliteTable.md
@@ -1,0 +1,255 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Export-AhtolaSqliteTable
+---
+
+# Export-AhtolaSqliteTable
+
+## SYNOPSIS
+
+Exports a table or query result to JSON or CSV.
+
+## SYNTAX
+
+### Table
+
+```
+Export-AhtolaSqliteTable -Connection <SqliteConnection> -Table <string> -Path <string>
+ [-Format <string>] [-WhatIf] [-Confirm]
+```
+
+### Query
+
+```
+Export-AhtolaSqliteTable -Connection <SqliteConnection> -Query <string> -Path <string>
+ [-Parameters <IDictionary>] [-Format <string>] [-WhatIf] [-Confirm]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Exports every row from a table, or from a query, to JSON or CSV. Format is inferred from the extension or selected explicitly.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$connection = New-AhtolaSqliteConnection
+try {
+    Invoke-AhtolaSqliteQuery -Connection $connection -CommandText 'CREATE TABLE Items(Id INTEGER); INSERT INTO Items VALUES (1);' -As NonQuery
+    Export-AhtolaSqliteTable -Connection $connection -Table Items -Path ./items.json -Confirm:$false
+} finally { $connection | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Connection
+
+Caller-owned Ahtola connection. It can be opened if needed but is never closed or disposed by this cmdlet.
+
+```yaml
+Type: Ahtola.Data.Sqlite.SqliteConnection
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SqliteConnection
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Format
+
+Interchange format: `Json` or `Csv`. If omitted, it is inferred from the file extension.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Parameters
+
+Dictionary of SQL parameter names and values; keys match placeholders such as `$name`.
+
+```yaml
+Type: System.Collections.IDictionary
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: Query
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Path
+
+Import or export path. Relative and expandable paths resolve from the current filesystem location.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Query
+
+SQL query to export. Use this parameter set instead of `Table` for filtering or projection.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: Query
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Table
+
+SQLite table name. The cmdlet quotes the identifier; this is not a SQL fragment.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- TableName
+ParameterSets:
+- Name: Table
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### Ahtola.Data.Sqlite.SqliteConnection
+
+A value can be piped to the pipeline-enabled parameter.
+
+## OUTPUTS
+
+### System.String
+
+The resolved path of the file written.
+
+## NOTES
+
+Supports `-WhatIf` and `-Confirm`. JSON writes binary values as a `$binary` base64 object.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Get-AhtolaSqliteDatabaseInfo.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Get-AhtolaSqliteDatabaseInfo.md
@@ -1,0 +1,96 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Get-AhtolaSqliteDatabaseInfo
+---
+
+# Get-AhtolaSqliteDatabaseInfo
+
+## SYNOPSIS
+
+Retrieves basic page, journal, and connection state information.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Get-AhtolaSqliteDatabaseInfo -Connection <SqliteConnection>
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Reads `page_count`, `page_size`, and `journal_mode` and returns them with the local connection data source and state.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$connection = New-AhtolaSqliteConnection
+try {
+    Get-AhtolaSqliteDatabaseInfo -Connection $connection
+} finally { $connection | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -Connection
+
+Caller-owned Ahtola connection. It can be opened if needed but is never closed or disposed by this cmdlet.
+
+```yaml
+Type: Ahtola.Data.Sqlite.SqliteConnection
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SqliteConnection
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### Ahtola.Data.Sqlite.SqliteConnection
+
+A value can be piped to the pipeline-enabled parameter.
+
+## OUTPUTS
+
+### Ahtola.PSSqlite.AhtolaSqliteDatabaseInfo
+
+An `AhtolaSqliteDatabaseInfo` object.
+
+## NOTES
+
+The connection is caller-owned and is not closed.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Get-AhtolaSqliteDatabaseMetadata.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Get-AhtolaSqliteDatabaseMetadata.md
@@ -1,0 +1,117 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Get-AhtolaSqliteDatabaseMetadata
+---
+
+# Get-AhtolaSqliteDatabaseMetadata
+
+## SYNOPSIS
+
+Retrieves stored Ahtola SQLite metadata values.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Get-AhtolaSqliteDatabaseMetadata -Connection <SqliteConnection> [-MetadataKey <string[]>]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Reads metadata from the supplied local connection. Specify keys, or omit `MetadataKey` to request all values using the default `*`.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$connection = New-AhtolaSqliteConnection
+try {
+    Get-AhtolaSqliteDatabaseMetadata -Connection $connection
+} finally { $connection | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -Connection
+
+Caller-owned Ahtola connection. It can be opened if needed but is never closed or disposed by this cmdlet.
+
+```yaml
+Type: Ahtola.Data.Sqlite.SqliteConnection
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SqliteConnection
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -MetadataKey
+
+One or more metadata keys. The default `*` requests all stored metadata.
+
+```yaml
+Type: System.String[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### Ahtola.Data.Sqlite.SqliteConnection
+
+A value can be piped to the pipeline-enabled parameter.
+
+## OUTPUTS
+
+### System.Collections.IDictionary
+
+A dictionary of metadata keys and values when metadata is present.
+
+## NOTES
+
+The supplied connection is caller-owned and is not closed.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Get-AhtolaSqliteIndex.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Get-AhtolaSqliteIndex.md
@@ -1,0 +1,118 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Get-AhtolaSqliteIndex
+---
+
+# Get-AhtolaSqliteIndex
+
+## SYNOPSIS
+
+Lists indexes and their definitions.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Get-AhtolaSqliteIndex -Connection <SqliteConnection> [-Table <string>]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Queries `sqlite_schema` for indexes. `Table` restricts results to one table; omit it to list all indexes.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$connection = New-AhtolaSqliteConnection
+try {
+    Get-AhtolaSqliteIndex -Connection $connection
+} finally { $connection | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -Connection
+
+Caller-owned Ahtola connection. It can be opened if needed but is never closed or disposed by this cmdlet.
+
+```yaml
+Type: Ahtola.Data.Sqlite.SqliteConnection
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SqliteConnection
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Table
+
+SQLite table name. The cmdlet quotes the identifier; this is not a SQL fragment.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- TableName
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### Ahtola.Data.Sqlite.SqliteConnection
+
+A value can be piped to the pipeline-enabled parameter.
+
+## OUTPUTS
+
+### System.Management.Automation.PSCustomObject
+
+PowerShell objects with `name`, `table_name`, and `sql` properties.
+
+## NOTES
+
+The connection is caller-owned and is not closed.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Get-AhtolaSqliteRow.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Get-AhtolaSqliteRow.md
@@ -1,0 +1,228 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Get-AhtolaSqliteRow
+---
+
+# Get-AhtolaSqliteRow
+
+## SYNOPSIS
+
+Retrieves rows from a configured table or view.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Get-AhtolaSqliteRow -Configuration <SQLiteDBConfig> -Table <string> [-Where <IDictionary>]
+ [-Connection <SqliteConnection>] [-CaseSensitive] [-Transaction <SqliteTransaction>] [-As <string>]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Builds a SELECT from a `SQLiteDBConfig`, table name, and optional equality filter. Without `Connection`, it creates and disposes a temporary connection from `Configuration.ConnectionString`.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$config = [Devolutions.Ahtola.Sqlite.SQLiteDBConfig]::new('Data Source=:memory:')
+$connection = New-AhtolaSqliteConnection
+try {
+    Invoke-AhtolaSqliteQuery -Connection $connection -CommandText "CREATE TABLE Items(Id INTEGER, Name TEXT); INSERT INTO Items VALUES (1, 'One');" -As NonQuery
+    Get-AhtolaSqliteRow -Configuration $config -Connection $connection -Table Items -Where @{ Id = 1}
+} finally { $connection | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -As
+
+Selects an output representation allowed by this cmdlet. `PSCustomObject` is the pipeline-friendly choice.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -CaseSensitive
+
+Makes `Values` and `Where` column-name matching case-sensitive. The default is case-insensitive.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Configuration
+
+A `SQLiteDBConfig` that supplies the connection string and settings for this operation.
+
+```yaml
+Type: Ahtola.PSSqlite.SQLiteDBConfig
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SqliteDBConfig
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Connection
+
+Caller-owned Ahtola connection. It can be opened if needed but is never closed or disposed by this cmdlet.
+
+```yaml
+Type: Ahtola.Data.Sqlite.SqliteConnection
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SqliteConnection
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Table
+
+SQLite table name. The cmdlet quotes the identifier; this is not a SQL fragment.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- TableName
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Transaction
+
+Caller-owned active transaction. It must belong to the supplied connection when both are present.
+
+```yaml
+Type: Ahtola.Data.Sqlite.SqliteTransaction
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Where
+
+Dictionary of column names and values used to select rows. Omit only to intentionally operate on all rows.
+
+```yaml
+Type: System.Collections.IDictionary
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- ClauseData
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### Ahtola.Data.Sqlite.SqliteConnection
+
+A value can be piped to the pipeline-enabled parameter.
+
+## OUTPUTS
+
+### System.Object
+
+Rows in the selected output format; the default is `PSCustomObject`.
+
+## NOTES
+
+Omitting `Where` reads all rows. Supplied connections and transactions remain caller-owned.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Get-AhtolaSqliteSchema.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Get-AhtolaSqliteSchema.md
@@ -1,0 +1,160 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Get-AhtolaSqliteSchema
+---
+
+# Get-AhtolaSqliteSchema
+
+## SYNOPSIS
+
+Retrieves an ADO.NET schema collection from a local Ahtola connection.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Get-AhtolaSqliteSchema -Connection <SqliteConnection> [-Collection <string>]
+ [-RestrictionValues <string[]>] [-As <string>]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Calls `DbConnection.GetSchema` for the selected collection and converts the result to the requested output format. Restrictions pass through in collection-specific order.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$connection = New-AhtolaSqliteConnection
+try {
+    Get-AhtolaSqliteSchema -Connection $connection -Collection Tables
+} finally { $connection | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -As
+
+Selects an output representation allowed by this cmdlet. `PSCustomObject` is the pipeline-friendly choice.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Collection
+
+Schema collection: `MetaDataCollections`, `ReservedWords`, `Tables`, `Columns`, `Indexes`, or `IndexColumns`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Connection
+
+Caller-owned Ahtola connection. It can be opened if needed but is never closed or disposed by this cmdlet.
+
+```yaml
+Type: Ahtola.Data.Sqlite.SqliteConnection
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SqliteConnection
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -RestrictionValues
+
+Values passed to `DbConnection.GetSchema` in collection-specific order.
+
+```yaml
+Type: System.String[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### Ahtola.Data.Sqlite.SqliteConnection
+
+A value can be piped to the pipeline-enabled parameter.
+
+## OUTPUTS
+
+### System.Object
+
+Schema data in the selected output representation.
+
+## NOTES
+
+The connection is caller-owned and opened if needed. Collection names follow ADO.NET conventions.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Get-AhtolaSqliteTable.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Get-AhtolaSqliteTable.md
@@ -1,0 +1,118 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Get-AhtolaSqliteTable
+---
+
+# Get-AhtolaSqliteTable
+
+## SYNOPSIS
+
+Lists user tables and their CREATE statements.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Get-AhtolaSqliteTable -Connection <SqliteConnection> [-Table <string>]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Queries `sqlite_schema` for non-system tables. `Table` restricts results to one table; omit it to list all user tables.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$connection = New-AhtolaSqliteConnection
+try {
+    Get-AhtolaSqliteTable -Connection $connection
+} finally { $connection | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -Connection
+
+Caller-owned Ahtola connection. It can be opened if needed but is never closed or disposed by this cmdlet.
+
+```yaml
+Type: Ahtola.Data.Sqlite.SqliteConnection
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SqliteConnection
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Table
+
+SQLite table name. The cmdlet quotes the identifier; this is not a SQL fragment.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- TableName
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### Ahtola.Data.Sqlite.SqliteConnection
+
+A value can be piped to the pipeline-enabled parameter.
+
+## OUTPUTS
+
+### System.Management.Automation.PSCustomObject
+
+PowerShell objects with `name` and `sql` properties.
+
+## NOTES
+
+The connection is caller-owned and is not closed.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Import-AhtolaSqliteTable.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Import-AhtolaSqliteTable.md
@@ -1,0 +1,249 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Import-AhtolaSqliteTable
+---
+
+# Import-AhtolaSqliteTable
+
+## SYNOPSIS
+
+Imports JSON or CSV rows into a local SQLite table.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Import-AhtolaSqliteTable -Connection <SqliteConnection> -Table <string> -Path <string>
+ [-Format <string>] [-BatchSize <int>] [-Transaction <SqliteTransaction>] [-WhatIf] [-Confirm]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Reads a JSON array of objects or header-based CSV and bulk inserts rows into the named table. Format is inferred from the extension or selected explicitly.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+Set-Content -LiteralPath ./items.csv -Value "Id`n1"
+$connection = New-AhtolaSqliteConnection
+try {
+    Invoke-AhtolaSqliteQuery -Connection $connection -CommandText 'CREATE TABLE Items(Id INTEGER);' -As NonQuery
+    Import-AhtolaSqliteTable -Connection $connection -Table Items -Path ./items.csv -Confirm:$false
+} finally { $connection | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -BatchSize
+
+Maximum rows processed between bulk-copy batch boundaries. Valid values are from 1 through 100000.
+
+```yaml
+Type: System.Int32
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Connection
+
+Caller-owned Ahtola connection. It can be opened if needed but is never closed or disposed by this cmdlet.
+
+```yaml
+Type: Ahtola.Data.Sqlite.SqliteConnection
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SqliteConnection
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Format
+
+Interchange format: `Json` or `Csv`. If omitted, it is inferred from the file extension.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Path
+
+Import or export path. Relative and expandable paths resolve from the current filesystem location.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Table
+
+SQLite table name. The cmdlet quotes the identifier; this is not a SQL fragment.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- TableName
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Transaction
+
+Caller-owned active transaction. It must belong to the supplied connection when both are present.
+
+```yaml
+Type: Ahtola.Data.Sqlite.SqliteTransaction
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### Ahtola.Data.Sqlite.SqliteConnection
+
+A value can be piped to the pipeline-enabled parameter.
+
+## OUTPUTS
+
+### System.Int32
+
+The number of rows imported.
+
+## NOTES
+
+Supports `-WhatIf` and `-Confirm`. Invalid input and insert failures throw; supplied connections remain caller-owned.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Invoke-AhtolaSqliteBulkCopy.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Invoke-AhtolaSqliteBulkCopy.md
@@ -1,0 +1,227 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Invoke-AhtolaSqliteBulkCopy
+---
+
+# Invoke-AhtolaSqliteBulkCopy
+
+## SYNOPSIS
+
+Bulk inserts piped objects into a local SQLite table.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Invoke-AhtolaSqliteBulkCopy -InputObject <Object> -Connection <SqliteConnection> -Table <string>
+ [-BatchSize <int>] [-Transaction <SqliteTransaction>] [-WhatIf] [-Confirm]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Buffers at most `BatchSize` pipeline rows, converts them to rows, and inserts them as the pipeline is consumed. Without `Transaction`, it owns one transaction for the complete pipeline and rolls it back on failure; with a caller transaction, it uses one savepoint and rolls all bulk-copy rows back on failure.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$connection = New-AhtolaSqliteConnection
+try {
+    Invoke-AhtolaSqliteQuery -Connection $connection -CommandText 'CREATE TABLE Items(Id INTEGER, Name TEXT);' -As NonQuery
+    [pscustomobject]@{ Id = 1; Name = 'One' } | Invoke-AhtolaSqliteBulkCopy -Connection $connection -Table Items -Confirm:$false
+} finally { $connection | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -BatchSize
+
+Maximum number of pipeline rows retained before they are executed and discarded. Valid values are from 1 through 100000. The batch size bounds cmdlet memory use; it does not split the operation into separate commits.
+
+```yaml
+Type: System.Int32
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Connection
+
+Caller-owned Ahtola connection. It can be opened if needed but is never closed or disposed by this cmdlet.
+
+```yaml
+Type: Ahtola.Data.Sqlite.SqliteConnection
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SqliteConnection
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -InputObject
+
+A `DataRow`, dictionary, or object with readable properties to insert. All batch rows need the same columns.
+
+```yaml
+Type: System.Object
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Table
+
+SQLite table name. The cmdlet quotes the identifier; this is not a SQL fragment.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- TableName
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Transaction
+
+Caller-owned active transaction. It must belong to the supplied connection when both are present.
+
+```yaml
+Type: Ahtola.Data.Sqlite.SqliteTransaction
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Object
+
+A value can be piped to the pipeline-enabled parameter.
+
+## OUTPUTS
+
+### System.Int32
+
+The number of rows inserted.
+
+## NOTES
+
+Supports `-WhatIf` and `-Confirm`. All rows must expose the same column names. A later failed row rolls back rows that were already flushed from earlier batches.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Invoke-AhtolaSqliteMaintenance.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Invoke-AhtolaSqliteMaintenance.md
@@ -1,0 +1,225 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Invoke-AhtolaSqliteMaintenance
+---
+
+# Invoke-AhtolaSqliteMaintenance
+
+## SYNOPSIS
+
+Runs an explicit SQLite maintenance operation.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Invoke-AhtolaSqliteMaintenance -Connection <SqliteConnection> -Operation <string>
+ [-CheckpointMode <string>] [-CommandTimeout <int>] [-As <string>] [-WhatIf] [-Confirm]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Runs `VACUUM`, `ANALYZE`, `PRAGMA integrity_check`, or `PRAGMA wal_checkpoint` on a local connection. Integrity checks and checkpoints write results.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$connection = New-AhtolaSqliteConnection
+try {
+    Invoke-AhtolaSqliteMaintenance -Connection $connection -Operation IntegrityCheck -Confirm:$false
+} finally { $connection | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -As
+
+Selects an output representation allowed by this cmdlet. `PSCustomObject` is the pipeline-friendly choice.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -CheckpointMode
+
+Checkpoint mode: `Passive`, `Full`, `Restart`, or `Truncate`. The default is `Truncate`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -CommandTimeout
+
+Command timeout in seconds. Zero is allowed; the default is 30 seconds.
+
+```yaml
+Type: System.Int32
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Connection
+
+Caller-owned Ahtola connection. It can be opened if needed but is never closed or disposed by this cmdlet.
+
+```yaml
+Type: Ahtola.Data.Sqlite.SqliteConnection
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SqliteConnection
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Operation
+
+Maintenance action: `Vacuum`, `Analyze`, `IntegrityCheck`, or `Checkpoint`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### Ahtola.Data.Sqlite.SqliteConnection
+
+A value can be piped to the pipeline-enabled parameter.
+
+## OUTPUTS
+
+### System.Object
+
+Integrity-check or checkpoint results when applicable.
+
+## NOTES
+
+Supports `-WhatIf` and `-Confirm`. Vacuum and analyze can change storage or statistics.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Invoke-AhtolaSqliteQuery.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Invoke-AhtolaSqliteQuery.md
@@ -1,0 +1,224 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Invoke-AhtolaSqliteQuery
+---
+
+# Invoke-AhtolaSqliteQuery
+
+## SYNOPSIS
+
+Executes parameterized SQL against an Ahtola local or Turso Cloud connection.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Invoke-AhtolaSqliteQuery -Connection <DbConnection> -CommandText <string> [-As <string>]
+ [-CastAs <type>] [-Parameters <IDictionary>] [-CommandTimeout <int>] [-Transaction <DbTransaction>]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Executes SQL and writes the selected result format. `PSCustomObject` is the default. Bind values through `Parameters`; do not concatenate values into SQL. Connections and transactions remain caller-owned.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$connection = New-AhtolaSqliteConnection
+try {
+    Invoke-AhtolaSqliteQuery -Connection $connection -CommandText 'SELECT $value AS Value;' -Parameters @{ '$value' = 42 }
+} finally { $connection | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -As
+
+Selects an output representation allowed by this cmdlet. `PSCustomObject` is the pipeline-friendly choice.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -CastAs
+
+Converts the result to this .NET type by using PowerShell conversion rules.
+
+```yaml
+Type: System.Type
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -CommandText
+
+SQL statement or statements to execute. Use `Parameters` rather than interpolating values.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- Query
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -CommandTimeout
+
+Command timeout in seconds. Zero is allowed; the default is 30 seconds.
+
+```yaml
+Type: System.Int32
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Connection
+
+Caller-owned Ahtola connection. It can be opened if needed but is never closed or disposed by this cmdlet.
+
+```yaml
+Type: System.Data.Common.DbConnection
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SqliteConnection
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Parameters
+
+Dictionary of SQL parameter names and values; keys match placeholders such as `$name`.
+
+```yaml
+Type: System.Collections.IDictionary
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Transaction
+
+Caller-owned active transaction. It must belong to the supplied connection when both are present.
+
+```yaml
+Type: System.Data.Common.DbTransaction
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Data.Common.DbConnection
+
+A value can be piped to the pipeline-enabled parameter.
+
+## OUTPUTS
+
+### System.Object
+
+The selected result format, such as PowerShell objects, a table, scalar, or affected-row count.
+
+## NOTES
+
+A closed caller-owned connection is opened if needed and left open. Cloud failures are reported generically to avoid exposing credentials.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Invoke-AhtolaSqliteReplicaSync.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Invoke-AhtolaSqliteReplicaSync.md
@@ -1,0 +1,140 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Invoke-AhtolaSqliteReplicaSync
+---
+
+# Invoke-AhtolaSqliteReplicaSync
+
+## SYNOPSIS
+
+Synchronizes a managed Turso Cloud replica with its remote endpoint.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Invoke-AhtolaSqliteReplicaSync -ReplicaConnection <AhtolaCloudConnection> [-WhatIf] [-Confirm]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Pushes local replica changes and pulls remote changes for a connection created with `-ReplicaPath`. It does not apply to a direct cloud connection.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$token = Read-Host -AsSecureString -Prompt 'Turso auth token'
+$replica = New-AhtolaSqliteConnection -TursoUrl 'libsql://example.turso.io' -AuthToken $token -ReplicaPath ./replica.db
+try { Invoke-AhtolaSqliteReplicaSync -ReplicaConnection $replica -Confirm:$false }
+finally { $replica | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ReplicaConnection
+
+Caller-owned managed Turso replica created with `New-AhtolaSqliteConnection -ReplicaPath`.
+
+```yaml
+Type: Ahtola.PSSqlite.AhtolaCloudConnection
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- Connection
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### Ahtola.PSSqlite.AhtolaCloudConnection
+
+A value can be piped to the pipeline-enabled parameter.
+
+## OUTPUTS
+
+### Ahtola.AhtolaSyncResult
+
+An `AhtolaSyncResult` with outcome and statistics.
+
+## NOTES
+
+Supports `-WhatIf` and `-Confirm`. Sync failures, including conflicts, are surfaced to the caller.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/New-AhtolaSqliteConnection.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/New-AhtolaSqliteConnection.md
@@ -1,0 +1,332 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: New-AhtolaSqliteConnection
+---
+
+# New-AhtolaSqliteConnection
+
+## SYNOPSIS
+
+Creates and opens a local Ahtola SQLite, Turso Cloud, or managed replica connection.
+
+## SYNTAX
+
+### byConnectionString (Default)
+
+```
+New-AhtolaSqliteConnection [-ConnectionString <string>] [-ReadOnly] [-WhatIf] [-Confirm]
+```
+
+### byDatabasePath
+
+```
+New-AhtolaSqliteConnection -DatabaseFile <string> [-DatabasePath <string>] [-ReadOnly] [-WhatIf]
+ [-Confirm]
+```
+
+### byTursoCloud
+
+```
+New-AhtolaSqliteConnection [-TursoUrl <string>] [-AuthToken <securestring>] [-ReplicaPath <string>]
+ [-UseTursoEnvironment] [-SyncInterval <int>] [-WhatIf] [-Confirm]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Creates a connection from a connection string, database path and file, or Turso endpoint. The returned connection is open and caller-owned. Local relative paths resolve from the current filesystem location.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$connection = New-AhtolaSqliteConnection
+try {
+    Invoke-AhtolaSqliteQuery -Connection $connection -CommandText 'SELECT 1 AS Value;'
+} finally { $connection | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -AuthToken
+
+Secure Turso authentication token used only while opening the cloud connection.
+
+```yaml
+Type: System.Security.SecureString
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- Token
+ParameterSets:
+- Name: byTursoCloud
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ConnectionString
+
+Ahtola SQLite connection string; relative `Data Source` values resolve from the current filesystem location.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: byConnectionString
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -DatabaseFile
+
+File name to combine with `DatabasePath` for a local connection.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: byDatabasePath
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -DatabasePath
+
+Directory containing `DatabaseFile`; relative paths resolve from the current filesystem location.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: byDatabasePath
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ReadOnly
+
+Opens a local database with `Mode=ReadOnly`. It is unavailable for Turso Cloud connections.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: byConnectionString
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: byDatabasePath
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ReplicaPath
+
+Local database file for a managed Turso replica.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: byTursoCloud
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -SyncInterval
+
+Replica synchronization interval in seconds. Zero disables interval-based sync.
+
+```yaml
+Type: System.Int32
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: byTursoCloud
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -TursoUrl
+
+Absolute `libsql`, `https`, or `http` Turso endpoint without user information, query, or fragment.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- RemoteUrl
+- Url
+ParameterSets:
+- Name: byTursoCloud
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -UseTursoEnvironment
+
+Uses `TURSO_REMOTE_URL` and `TURSO_AUTH_TOKEN` as defaults if explicit parameters are absent.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: byTursoCloud
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+None. This cmdlet does not accept pipeline input.
+
+## OUTPUTS
+
+### Ahtola.Data.Sqlite.SqliteConnection
+
+An open local Ahtola SQLite connection.
+
+### Ahtola.PSSqlite.AhtolaCloudConnection
+
+An open direct Turso Cloud connection or managed replica connection.
+
+## NOTES
+
+`-WhatIf` reports the request without opening a connection or creating a local database file. Close the returned connection explicitly.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/New-AhtolaSqliteRow.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/New-AhtolaSqliteRow.md
@@ -1,0 +1,230 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: New-AhtolaSqliteRow
+---
+
+# New-AhtolaSqliteRow
+
+## SYNOPSIS
+
+Inserts a row into a configured SQLite table.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+New-AhtolaSqliteRow -Configuration <SQLiteDBConfig> -Table <string> -Values <IDictionary>
+ [-Connection <SqliteConnection>] [-Transaction <SqliteTransaction>] [-WhatIf] [-Confirm]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Builds an INSERT from `Values` and writes its result. Without a connection, it uses and disposes a temporary connection from the configuration.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$config = [Devolutions.Ahtola.Sqlite.SQLiteDBConfig]::new('Data Source=:memory:')
+$connection = New-AhtolaSqliteConnection
+try {
+    Invoke-AhtolaSqliteQuery -Connection $connection -CommandText "CREATE TABLE Items(Id INTEGER, Name TEXT); INSERT INTO Items VALUES (1, 'One');" -As NonQuery
+    New-AhtolaSqliteRow -Configuration $config -Connection $connection -Table Items -Values @{ Id = 2; Name = 'Two' }
+} finally { $connection | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -Configuration
+
+A `SQLiteDBConfig` that supplies the connection string and settings for this operation.
+
+```yaml
+Type: Ahtola.PSSqlite.SQLiteDBConfig
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SqliteDBConfig
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Connection
+
+Caller-owned Ahtola connection. It can be opened if needed but is never closed or disposed by this cmdlet.
+
+```yaml
+Type: Ahtola.Data.Sqlite.SqliteConnection
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SqliteConnection
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Table
+
+SQLite table name. The cmdlet quotes the identifier; this is not a SQL fragment.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- TableName
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Transaction
+
+Caller-owned active transaction. It must belong to the supplied connection when both are present.
+
+```yaml
+Type: Ahtola.Data.Sqlite.SqliteTransaction
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Values
+
+Dictionary of column names and values to insert or update.
+
+```yaml
+Type: System.Collections.IDictionary
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- RowData
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### Ahtola.Data.Sqlite.SqliteConnection
+
+A value can be piped to the pipeline-enabled parameter.
+
+## OUTPUTS
+
+### System.Object
+
+The result returned by the INSERT operation.
+
+## NOTES
+
+Supports `-WhatIf` and `-Confirm`. Explicit connections and transactions remain caller-owned.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Optimize-AhtolaSqliteDatabase.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Optimize-AhtolaSqliteDatabase.md
@@ -1,0 +1,181 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Optimize-AhtolaSqliteDatabase
+---
+
+# Optimize-AhtolaSqliteDatabase
+
+## SYNOPSIS
+
+Runs VACUUM, optionally followed by ANALYZE, on a local database.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Optimize-AhtolaSqliteDatabase -Connection <SqliteConnection> [-Analyze] [-CommandTimeout <int>]
+ [-WhatIf] [-Confirm]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Runs `VACUUM` on a local Ahtola connection. With `Analyze`, it then runs `ANALYZE`.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$connection = New-AhtolaSqliteConnection
+try {
+    Optimize-AhtolaSqliteDatabase -Connection $connection -Analyze -Confirm:$false
+} finally { $connection | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -Analyze
+
+Also runs `ANALYZE` after `VACUUM`.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -CommandTimeout
+
+Command timeout in seconds. Zero is allowed; the default is 30 seconds.
+
+```yaml
+Type: System.Int32
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Connection
+
+Caller-owned Ahtola connection. It can be opened if needed but is never closed or disposed by this cmdlet.
+
+```yaml
+Type: Ahtola.Data.Sqlite.SqliteConnection
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SqliteConnection
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### Ahtola.Data.Sqlite.SqliteConnection
+
+A value can be piped to the pipeline-enabled parameter.
+
+## OUTPUTS
+
+No pipeline output.
+
+## NOTES
+
+Supports `-WhatIf` and `-Confirm`. VACUUM can require temporary disk space and cannot run in an incompatible active transaction.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Remove-AhtolaSqliteRow.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Remove-AhtolaSqliteRow.md
@@ -1,0 +1,252 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Remove-AhtolaSqliteRow
+---
+
+# Remove-AhtolaSqliteRow
+
+## SYNOPSIS
+
+Deletes rows from a configured SQLite table.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Remove-AhtolaSqliteRow -Configuration <SQLiteDBConfig> -Table <string> [-Where <IDictionary>]
+ [-CaseSensitive] [-Connection <SqliteConnection>] [-Transaction <SqliteTransaction>] [-WhatIf]
+ [-Confirm]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Builds a DELETE from a `SQLiteDBConfig`, table name, and optional equality filter. Without a connection, it uses and disposes a temporary connection from the configuration.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$config = [Devolutions.Ahtola.Sqlite.SQLiteDBConfig]::new('Data Source=:memory:')
+$connection = New-AhtolaSqliteConnection
+try {
+    Invoke-AhtolaSqliteQuery -Connection $connection -CommandText "CREATE TABLE Items(Id INTEGER, Name TEXT); INSERT INTO Items VALUES (1, 'One');" -As NonQuery
+    Remove-AhtolaSqliteRow -Configuration $config -Connection $connection -Table Items -Where @{ Id = 1}
+} finally { $connection | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -CaseSensitive
+
+Makes `Values` and `Where` column-name matching case-sensitive. The default is case-insensitive.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Configuration
+
+A `SQLiteDBConfig` that supplies the connection string and settings for this operation.
+
+```yaml
+Type: Ahtola.PSSqlite.SQLiteDBConfig
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SqliteDBConfig
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Connection
+
+Caller-owned Ahtola connection. It can be opened if needed but is never closed or disposed by this cmdlet.
+
+```yaml
+Type: Ahtola.Data.Sqlite.SqliteConnection
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SqliteConnection
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Table
+
+SQLite table name. The cmdlet quotes the identifier; this is not a SQL fragment.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- TableName
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Transaction
+
+Caller-owned active transaction. It must belong to the supplied connection when both are present.
+
+```yaml
+Type: Ahtola.Data.Sqlite.SqliteTransaction
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Where
+
+Dictionary of column names and values used to select rows. Omit only to intentionally operate on all rows.
+
+```yaml
+Type: System.Collections.IDictionary
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- ClauseData
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### Ahtola.Data.Sqlite.SqliteConnection
+
+A value can be piped to the pipeline-enabled parameter.
+
+## OUTPUTS
+
+### System.Int32
+
+The number of rows deleted.
+
+## NOTES
+
+Supports `-WhatIf` and `-Confirm`. Omitting `Where` deletes every row in the table.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Save-AhtolaSqliteTransaction.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Save-AhtolaSqliteTransaction.md
@@ -1,0 +1,160 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Save-AhtolaSqliteTransaction
+---
+
+# Save-AhtolaSqliteTransaction
+
+## SYNOPSIS
+
+Creates a named savepoint in an active transaction.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Save-AhtolaSqliteTransaction -Transaction <DbTransaction> -Name <string> [-WhatIf] [-Confirm]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Creates a savepoint in the caller-owned transaction. Use the complete or undo transaction cmdlet with the savepoint name to release it or roll back to it.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$connection = New-AhtolaSqliteConnection
+try {
+    $tx = Start-AhtolaSqliteTransaction -Connection $connection
+    Save-AhtolaSqliteTransaction -Transaction $tx -Name sample -Confirm:$false
+    Undo-AhtolaSqliteTransaction -Transaction $tx -Confirm:$false
+} finally { $connection | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Name
+
+Savepoint name to create.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Transaction
+
+Caller-owned active transaction. It must belong to the supplied connection when both are present.
+
+```yaml
+Type: System.Data.Common.DbTransaction
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Data.Common.DbTransaction
+
+A value can be piped to the pipeline-enabled parameter.
+
+## OUTPUTS
+
+No pipeline output.
+
+## NOTES
+
+Supports `-WhatIf` and `-Confirm`. Savepoint names must be valid for the underlying provider.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Set-AhtolaSqlitePassword.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Set-AhtolaSqlitePassword.md
@@ -1,0 +1,159 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Set-AhtolaSqlitePassword
+---
+
+# Set-AhtolaSqlitePassword
+
+## SYNOPSIS
+
+Sets or rotates the Ahtola-managed password for a local database.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Set-AhtolaSqlitePassword -Connection <SqliteConnection> -Password <securestring> [-WhatIf]
+ [-Confirm]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Opens the local connection if needed and sets or rotates its managed database password. The password is a `SecureString`; this is not a SQLCipher facility.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$connection = New-AhtolaSqliteConnection -ConnectionString 'Data Source=protected.db'
+try { Set-AhtolaSqlitePassword -Connection $connection -Password (Read-Host -AsSecureString -Prompt 'Database password') -Confirm:$false }
+finally { $connection | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Connection
+
+Caller-owned Ahtola connection. It can be opened if needed but is never closed or disposed by this cmdlet.
+
+```yaml
+Type: Ahtola.Data.Sqlite.SqliteConnection
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SqliteConnection
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Password
+
+Secure password used to set or rotate the Ahtola-managed database password.
+
+```yaml
+Type: System.Security.SecureString
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### Ahtola.Data.Sqlite.SqliteConnection
+
+A value can be piped to the pipeline-enabled parameter.
+
+## OUTPUTS
+
+No pipeline output.
+
+## NOTES
+
+Supports `-WhatIf` and `-Confirm`. Use only with Ahtola-managed file encryption.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Set-AhtolaSqliteRow.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Set-AhtolaSqliteRow.md
@@ -1,0 +1,295 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Set-AhtolaSqliteRow
+---
+
+# Set-AhtolaSqliteRow
+
+## SYNOPSIS
+
+Updates or upserts rows in a configured SQLite table.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Set-AhtolaSqliteRow -Configuration <SQLiteDBConfig> -Table <string> -Values <IDictionary>
+ [-Where <IDictionary>] [-CaseSensitive] [-Connection <SqliteConnection>] [-OnConflict <string>]
+ [-Transaction <SqliteTransaction>] [-WhatIf] [-Confirm]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Builds an UPDATE or UPSERT from `Values`, an optional equality filter, and the selected conflict mode. Without a connection, it uses and disposes a temporary connection from the configuration.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$config = [Devolutions.Ahtola.Sqlite.SQLiteDBConfig]::new('Data Source=:memory:')
+$connection = New-AhtolaSqliteConnection
+try {
+    Invoke-AhtolaSqliteQuery -Connection $connection -CommandText "CREATE TABLE Items(Id INTEGER, Name TEXT); INSERT INTO Items VALUES (1, 'One');" -As NonQuery
+    Set-AhtolaSqliteRow -Configuration $config -Connection $connection -Table Items -Values @{ Name = 'New' } -Where @{ Id = 1 }
+} finally { $connection | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -CaseSensitive
+
+Makes `Values` and `Where` column-name matching case-sensitive. The default is case-insensitive.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Configuration
+
+A `SQLiteDBConfig` that supplies the connection string and settings for this operation.
+
+```yaml
+Type: Ahtola.PSSqlite.SQLiteDBConfig
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SqliteDBConfig
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Connection
+
+Caller-owned Ahtola connection. It can be opened if needed but is never closed or disposed by this cmdlet.
+
+```yaml
+Type: Ahtola.Data.Sqlite.SqliteConnection
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SqliteConnection
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -OnConflict
+
+Write mode: `UPDATE` or `UPSERT`. The default is `UPDATE`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Table
+
+SQLite table name. The cmdlet quotes the identifier; this is not a SQL fragment.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- TableName
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Transaction
+
+Caller-owned active transaction. It must belong to the supplied connection when both are present.
+
+```yaml
+Type: Ahtola.Data.Sqlite.SqliteTransaction
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Values
+
+Dictionary of column names and values to insert or update.
+
+```yaml
+Type: System.Collections.IDictionary
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- RowData
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Where
+
+Dictionary of column names and values used to select rows. Omit only to intentionally operate on all rows.
+
+```yaml
+Type: System.Collections.IDictionary
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- ClauseData
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### Ahtola.Data.Sqlite.SqliteConnection
+
+A value can be piped to the pipeline-enabled parameter.
+
+## OUTPUTS
+
+### System.Int32
+
+The number of rows affected.
+
+## NOTES
+
+Supports `-WhatIf` and `-Confirm`. Omitting `Where` intentionally targets all rows.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Start-AhtolaSqliteTransaction.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Start-AhtolaSqliteTransaction.md
@@ -1,0 +1,139 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Start-AhtolaSqliteTransaction
+---
+
+# Start-AhtolaSqliteTransaction
+
+## SYNOPSIS
+
+Starts an ADO.NET transaction on an Ahtola connection.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Start-AhtolaSqliteTransaction -Connection <DbConnection> [-IsolationLevel <IsolationLevel>]
+ [-Deferred]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Opens the caller-owned connection if needed and begins a transaction with the selected isolation level. `Deferred` works only with local Ahtola SQLite connections.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$connection = New-AhtolaSqliteConnection
+try {
+    Start-AhtolaSqliteTransaction -Connection $connection
+} finally { $connection | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -Connection
+
+Caller-owned Ahtola connection. It can be opened if needed but is never closed or disposed by this cmdlet.
+
+```yaml
+Type: System.Data.Common.DbConnection
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SqliteConnection
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Deferred
+
+Starts a local transaction with `BEGIN DEFERRED`; unsupported by Turso Cloud connections.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -IsolationLevel
+
+ADO.NET isolation level for the transaction. The default is `Serializable`.
+
+```yaml
+Type: System.Data.IsolationLevel
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Data.Common.DbConnection
+
+A value can be piped to the pipeline-enabled parameter.
+
+## OUTPUTS
+
+### System.Data.Common.DbTransaction
+
+An active caller-owned `DbTransaction`.
+
+## NOTES
+
+Complete or undo the returned transaction before disposing its connection.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Test-AhtolaSqliteConnection.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Test-AhtolaSqliteConnection.md
@@ -1,0 +1,96 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Test-AhtolaSqliteConnection
+---
+
+# Test-AhtolaSqliteConnection
+
+## SYNOPSIS
+
+Tests an Ahtola local or Turso Cloud connection with `SELECT 1`.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Test-AhtolaSqliteConnection -Connection <DbConnection>
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Opens the supplied connection if needed, executes `SELECT 1`, and writes `$true` on success. The connection remains caller-owned and open.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$connection = New-AhtolaSqliteConnection
+try {
+    Test-AhtolaSqliteConnection -Connection $connection
+} finally { $connection | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -Connection
+
+Caller-owned Ahtola connection. It can be opened if needed but is never closed or disposed by this cmdlet.
+
+```yaml
+Type: System.Data.Common.DbConnection
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SqliteConnection
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Data.Common.DbConnection
+
+A value can be piped to the pipeline-enabled parameter.
+
+## OUTPUTS
+
+### System.Boolean
+
+`$true` when the test query succeeds.
+
+## NOTES
+
+The cmdlet throws on failure; it does not return `$false`.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Test-AhtolaSqliteIntegrity.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Test-AhtolaSqliteIntegrity.md
@@ -1,0 +1,138 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Test-AhtolaSqliteIntegrity
+---
+
+# Test-AhtolaSqliteIntegrity
+
+## SYNOPSIS
+
+Runs SQLite `PRAGMA integrity_check`.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Test-AhtolaSqliteIntegrity -Connection <SqliteConnection> [-CommandTimeout <int>] [-As <string>]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Executes `PRAGMA integrity_check` against a local connection and writes the result in the selected format. A normal result contains `ok`.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$connection = New-AhtolaSqliteConnection
+try {
+    Test-AhtolaSqliteIntegrity -Connection $connection
+} finally { $connection | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -As
+
+Selects an output representation supported by this cmdlet. `PSCustomObject` is the pipeline-friendly choice.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -CommandTimeout
+
+Command timeout in seconds. Zero is allowed; the default is 30 seconds.
+
+```yaml
+Type: System.Int32
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Connection
+
+Caller-owned Ahtola connection. It can be opened if needed but is never closed or disposed by this cmdlet.
+
+```yaml
+Type: Ahtola.Data.Sqlite.SqliteConnection
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SqliteConnection
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### Ahtola.Data.Sqlite.SqliteConnection
+
+A value can be piped to the pipeline-enabled parameter.
+
+## OUTPUTS
+
+### System.Object
+
+Integrity-check results in the selected output format.
+
+## NOTES
+
+The supplied connection is caller-owned and is not closed.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-help/Devolutions.Ahtola.Sqlite/Undo-AhtolaSqliteTransaction.md
+++ b/docs/powershell-help/Devolutions.Ahtola.Sqlite/Undo-AhtolaSqliteTransaction.md
@@ -1,0 +1,160 @@
+---
+document type: cmdlet
+external help file: Devolutions.Ahtola.PowerShell.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Devolutions.Ahtola.Sqlite
+ms.date: 08/14/2026
+PlatyPS schema version: 2024-05-01
+title: Undo-AhtolaSqliteTransaction
+---
+
+# Undo-AhtolaSqliteTransaction
+
+## SYNOPSIS
+
+Rolls back a transaction or rolls back to a savepoint.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Undo-AhtolaSqliteTransaction -Transaction <DbTransaction> [-SavepointName <string>] [-WhatIf]
+ [-Confirm]
+```
+
+## ALIASES
+
+This cmdlet has no aliases.
+
+## DESCRIPTION
+
+Rolls back the transaction when `SavepointName` is omitted. With a savepoint name, it rolls back only work after that savepoint.
+
+## EXAMPLES
+
+### Example 1
+
+This example uses a caller-owned connection and closes it when complete.
+
+```powershell
+$connection = New-AhtolaSqliteConnection
+try {
+    $tx = Start-AhtolaSqliteTransaction -Connection $connection
+    Undo-AhtolaSqliteTransaction -Transaction $tx -Confirm:$false
+} finally { $connection | Close-AhtolaSqliteConnection -Confirm:$false }
+```
+
+## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -SavepointName
+
+Existing savepoint name to roll back to instead of completing the whole transaction.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Transaction
+
+Caller-owned active transaction. It must belong to the supplied connection when both are present.
+
+```yaml
+Type: System.Data.Common.DbTransaction
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Data.Common.DbTransaction
+
+A value can be piped to the pipeline-enabled parameter.
+
+## OUTPUTS
+
+No pipeline output.
+
+## NOTES
+
+Supports `-WhatIf` and `-Confirm`. This cmdlet does not dispose the transaction or its connection.
+
+## RELATED LINKS
+
+[PowerShell module guide](https://github.com/Devolutions/ahtola/blob/master/docs/powershell-module.md)

--- a/docs/powershell-module.md
+++ b/docs/powershell-module.md
@@ -49,6 +49,13 @@ source. To update later:
 Update-Module -Name Devolutions.Ahtola.Sqlite
 ```
 
+The module bundles offline command help:
+
+```powershell
+Get-Help New-AhtolaSqliteConnection -Full
+Get-Help Invoke-AhtolaSqliteQuery -Examples
+```
+
 Model types are available as module-qualified type accelerators once the
 module is imported, e.g. `[Devolutions.Ahtola.Sqlite.SqliteDBConfig]` for the
 CRUD-row cmdlets below.
@@ -73,10 +80,12 @@ may open it if it's closed, but never closes or disposes it for you.
 | `byTursoCloud` | `-TursoUrl`/`-RemoteUrl`/`-Url`, `-AuthToken`/`-Token`, `-ReplicaPath`, `-UseTursoEnvironment`, `-SyncInterval` | `AhtolaCloudConnection` |
 
 `-ReadOnly` applies to the first two sets and sets `Mode=ReadOnly` on the
-connection string before opening. `-DatabasePath`/`-DatabaseFile` and
-`-ConnectionString` support PowerShell string expansion (`$env:...`,
-`$variable`) via `ExpandString`, so you can pass `'$env:USERPROFILE\data.db'`
-directly.
+connection string before opening. Relative `Data Source`, `-DatabasePath`, and
+`-ReplicaPath` values resolve from the active PowerShell filesystem location.
+`-DatabasePath`/`-DatabaseFile` and `-ConnectionString` support PowerShell
+string expansion (`$env:...`, `$variable`) via `ExpandString`, so you can pass
+`'$env:USERPROFILE\data.db'` directly. `-WhatIf` previews local and Cloud
+connection creation without opening a connection or creating a database file.
 
 ```powershell
 # In-memory, shared cache (default)
@@ -250,9 +259,12 @@ Export-AhtolaSqliteTable -Connection $file -Query 'SELECT * FROM Items WHERE Qty
 Import-AhtolaSqliteTable -Connection $file -Table Items -Path ./items.csv -BatchSize 500
 ```
 
-`Invoke-AhtolaSqliteBulkCopy` inserts all pipelined rows in one
+Relative import and export `-Path` values resolve from the active PowerShell
+filesystem location. `Invoke-AhtolaSqliteBulkCopy` inserts all pipelined rows in one
 all-or-nothing transaction (or savepoint, with a caller-owned `-Transaction`)
-and fails/rolls back on the first conflicting row. `Export-AhtolaSqliteTable`
+takes at most `-BatchSize` rows from the pipeline at a time, so large pipeline
+inputs do not accumulate in memory. A failed later batch still rolls back every
+row inserted by the bulk copy. `Export-AhtolaSqliteTable`
 takes either `-Table` or `-Query`+`-Parameters` (mutually exclusive parameter
 sets) and writes `Json` or `Csv` (`-Format` overrides extension inference).
 `Import-AhtolaSqliteTable` reads the same two formats back in with the same
@@ -279,8 +291,9 @@ Get-AhtolaSqliteDatabaseMetadata -Connection $file -MetadataKey SchemaVersion, A
 Compare-AhtolaSqliteDatabaseVersion -Configuration $config -ExpectedVersion '2'
 ```
 
-`Get-AhtolaSqliteDatabaseMetadata` reads stored key/value metadata for a
-connection string (`-MetadataKey` defaults to `*`, i.e. everything).
+`Get-AhtolaSqliteDatabaseMetadata` reads stored key/value metadata from the
+supplied connection (`-MetadataKey` defaults to `*`, i.e. everything), so it
+also sees in-memory databases and uncommitted metadata changes.
 `Compare-AhtolaSqliteDatabaseVersion` compares a `SQLiteDBConfig`'s deployed
 version against an expected one (defaulting to `$Configuration.Version`) —
 useful as a gate before running schema-migration scripts.

--- a/scripts/Build-PowerShellHelp.ps1
+++ b/scripts/Build-PowerShellHelp.ps1
@@ -1,0 +1,157 @@
+#Requires -Version 7.4
+<#
+.SYNOPSIS
+    Validates PlatyPS Markdown and generates MAML help for a staged module.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$ModulePath,
+
+    [Parameter(Mandatory)]
+    [string]$MarkdownPath,
+
+    [version]$MinimumPlatyPSVersion = '1.0.3'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$ModulePath = [System.IO.Path]::GetFullPath($ModulePath)
+$MarkdownPath = [System.IO.Path]::GetFullPath($MarkdownPath)
+
+if (-not (Test-Path -LiteralPath $ModulePath -PathType Container)) {
+    throw "Staged PowerShell module path not found: $ModulePath"
+}
+
+if (-not (Test-Path -LiteralPath $MarkdownPath -PathType Container)) {
+    throw "PlatyPS Markdown help path not found: $MarkdownPath"
+}
+
+$platyPS = Get-Module -ListAvailable -Name Microsoft.PowerShell.PlatyPS |
+    Where-Object { $_.Version -ge $MinimumPlatyPSVersion -and $_.Version.Major -eq $MinimumPlatyPSVersion.Major } |
+    Sort-Object Version -Descending |
+    Select-Object -First 1
+if (-not $platyPS) {
+    throw "Microsoft.PowerShell.PlatyPS $MinimumPlatyPSVersion or newer is required. Install with: Install-Module Microsoft.PowerShell.PlatyPS -MinimumVersion $MinimumPlatyPSVersion -MaximumVersion $($MinimumPlatyPSVersion.Major).99.99 -Scope CurrentUser"
+}
+
+Import-Module $platyPS.Path -Force -ErrorAction Stop
+
+$manifest = Get-ChildItem -LiteralPath $ModulePath -Filter '*.psd1' -File | Select-Object -First 1
+if (-not $manifest) {
+    throw "No module manifest was found in $ModulePath"
+}
+
+$moduleName = [System.IO.Path]::GetFileNameWithoutExtension($manifest.Name)
+$importedModules = @(Import-Module $manifest.FullName -Force -PassThru -ErrorAction Stop)
+$module = $importedModules |
+    Where-Object { $_.Name -eq $moduleName } |
+    Select-Object -First 1
+if (-not $module) {
+    throw "Could not import module '$moduleName' from $($manifest.FullName)"
+}
+try {
+    $modulePage = Join-Path $MarkdownPath "$($module.Name).md"
+    if (-not (Test-Path -LiteralPath $modulePage -PathType Leaf)) {
+        throw "Module Markdown help file not found: $modulePage"
+    }
+
+    $commandFiles = @(
+        Get-ChildItem -LiteralPath $MarkdownPath -Filter '*.md' -File |
+            Where-Object { $_.FullName -ne $modulePage } |
+            Sort-Object Name
+    )
+    if ($commandFiles.Count -eq 0) {
+        throw "No command Markdown help files were found in $MarkdownPath"
+    }
+
+    $placeholderFiles = @(
+        Get-ChildItem -LiteralPath $MarkdownPath -Filter '*.md' -File |
+            Where-Object {
+                (Get-Content -LiteralPath $_.FullName -Raw) -match '\{\{|\bFill (in|[A-Za-z]+ Description)\b|\bInsert list of aliases\b|\bAdd example description\b'
+            }
+    )
+    if ($placeholderFiles.Count -gt 0) {
+        throw "PlatyPS Markdown still contains placeholders: $($placeholderFiles.Name -join ', ')"
+    }
+
+    $moduleHelp = Import-MarkdownModuleFile -Path $modulePage
+    $commandHelp = @($commandFiles.FullName | ForEach-Object { Import-MarkdownCommandHelp -Path $_ })
+
+    $diagnostics = @(
+        $moduleHelp.Diagnostics.Messages
+        $commandHelp | ForEach-Object { $_.Diagnostics.Messages }
+    )
+    $errors = @($diagnostics | Where-Object { $_.Severity.ToString() -eq 'Error' })
+    if ($errors.Count -gt 0) {
+        $messages = $errors | ForEach-Object { "$($_.Source): $($_.Message)" }
+        throw "PlatyPS Markdown validation failed:`n$($messages -join [Environment]::NewLine)"
+    }
+
+    $expectedCommands = @(
+        Get-Command -Module $module.Name |
+            Where-Object { $_.CommandType -eq 'Cmdlet' } |
+            Select-Object -ExpandProperty Name |
+            Sort-Object -Unique
+    )
+    $documentedCommands = @($commandHelp | Select-Object -ExpandProperty Title | Sort-Object -Unique)
+    $missingCommands = @($expectedCommands | Where-Object { $_ -notin $documentedCommands })
+    $orphanedCommands = @($documentedCommands | Where-Object { $_ -notin $expectedCommands })
+    if ($missingCommands.Count -gt 0 -or $orphanedCommands.Count -gt 0) {
+        $details = @()
+        if ($missingCommands.Count -gt 0) {
+            $details += "Missing command help: $($missingCommands -join ', ')"
+        }
+        if ($orphanedCommands.Count -gt 0) {
+            $details += "Orphaned command help: $($orphanedCommands -join ', ')"
+        }
+        throw ($details -join [Environment]::NewLine)
+    }
+
+    $incompleteCommands = @(
+        $commandHelp | Where-Object {
+            [string]::IsNullOrWhiteSpace($_.Synopsis) -or
+            [string]::IsNullOrWhiteSpace($_.Description) -or
+            $_.Examples.Count -eq 0 -or
+            @($_.Parameters | Where-Object { [string]::IsNullOrWhiteSpace($_.Description) }).Count -gt 0
+        }
+    )
+    if ($incompleteCommands.Count -gt 0) {
+        throw "PlatyPS Markdown is incomplete for: $($incompleteCommands.Title -join ', ')"
+    }
+
+    $externalHelpFiles = @($commandHelp | Select-Object -ExpandProperty ExternalHelpFile -Unique)
+    if ($externalHelpFiles.Count -ne 1 -or [string]::IsNullOrWhiteSpace($externalHelpFiles[0])) {
+        throw "Command help must define exactly one external help file. Found: $($externalHelpFiles -join ', ')"
+    }
+
+    $outputFolder = Join-Path $ModulePath 'en-US'
+    New-Item -ItemType Directory -Path $outputFolder -Force | Out-Null
+    $outputFile = Join-Path $outputFolder $externalHelpFiles[0]
+    Remove-Item -LiteralPath $outputFile -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath (Join-Path $outputFolder $module.Name) -Recurse -Force -ErrorAction SilentlyContinue
+    $temporaryOutput = Join-Path ([System.IO.Path]::GetTempPath()) ("ahtola-platyps-maml-" + [guid]::NewGuid().ToString('N'))
+    try {
+        $commandHelp | Export-MamlCommandHelp -OutputFolder $temporaryOutput -Force | Out-Null
+        $generatedMaml = Get-ChildItem -LiteralPath $temporaryOutput -Recurse -Filter $externalHelpFiles[0] -File |
+            Select-Object -First 1
+        if (-not $generatedMaml) {
+            throw "PlatyPS did not generate expected MAML help file: $($externalHelpFiles[0])"
+        }
+
+        Copy-Item -LiteralPath $generatedMaml.FullName -Destination $outputFile -Force
+    }
+    finally {
+        Remove-Item -LiteralPath $temporaryOutput -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    if (-not (Test-Path -LiteralPath $outputFile -PathType Leaf)) {
+        throw "Could not stage generated MAML help file: $outputFile"
+    }
+
+    Write-Host "Generated MAML help: $outputFile" -ForegroundColor Green
+}
+finally {
+    Remove-Module $module.Name -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/New-PowerShellHelpMarkdown.ps1
+++ b/scripts/New-PowerShellHelpMarkdown.ps1
@@ -1,0 +1,67 @@
+#Requires -Version 7.4
+<#
+.SYNOPSIS
+    Scaffolds missing PlatyPS Markdown help files for the staged module.
+#>
+[CmdletBinding()]
+param(
+    [string]$ModulePath = (Join-Path $PSScriptRoot '..\artifacts\powershell-modules\Devolutions.Ahtola.Sqlite'),
+
+    [string]$OutputRoot = (Join-Path $PSScriptRoot '..\docs\powershell-help')
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$ModulePath = [System.IO.Path]::GetFullPath($ModulePath)
+$OutputRoot = [System.IO.Path]::GetFullPath($OutputRoot)
+$platyPS = Get-Module -ListAvailable -Name Microsoft.PowerShell.PlatyPS |
+    Where-Object { $_.Version -ge [version]'1.0.3' -and $_.Version.Major -eq 1 } |
+    Sort-Object Version -Descending |
+    Select-Object -First 1
+if (-not $platyPS) {
+    throw 'Microsoft.PowerShell.PlatyPS 1.0.3 or newer is required. Install it before scaffolding help.'
+}
+
+$manifest = Get-ChildItem -LiteralPath $ModulePath -Filter '*.psd1' -File | Select-Object -First 1
+if (-not $manifest) {
+    throw "No staged module manifest was found in $ModulePath. Run './build.ps1 pack-powershell' first."
+}
+
+Import-Module $platyPS.Path -Force -ErrorAction Stop
+$moduleName = [System.IO.Path]::GetFileNameWithoutExtension($manifest.Name)
+$importedModules = @(Import-Module $manifest.FullName -Force -PassThru -ErrorAction Stop)
+$module = $importedModules |
+    Where-Object { $_.Name -eq $moduleName } |
+    Select-Object -First 1
+if (-not $module) {
+    throw "Could not import module '$moduleName' from $($manifest.FullName)"
+}
+try {
+    $temporaryRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("ahtola-platyps-" + [guid]::NewGuid().ToString('N'))
+    try {
+        New-MarkdownCommandHelp -ModuleInfo $module -OutputFolder $temporaryRoot -WithModulePage -Force | Out-Null
+        $generatedPath = Join-Path $temporaryRoot $module.Name
+        $destinationPath = Join-Path $OutputRoot $module.Name
+        New-Item -ItemType Directory -Path $destinationPath -Force | Out-Null
+
+        $copied = 0
+        foreach ($file in Get-ChildItem -LiteralPath $generatedPath -Filter '*.md' -File) {
+            $destination = Join-Path $destinationPath $file.Name
+            if (Test-Path -LiteralPath $destination) {
+                continue
+            }
+
+            Copy-Item -LiteralPath $file.FullName -Destination $destination
+            $copied++
+        }
+
+        Write-Host "Created $copied missing PlatyPS Markdown help file(s) in $destinationPath" -ForegroundColor Green
+    }
+    finally {
+        Remove-Item -LiteralPath $temporaryRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+finally {
+    Remove-Module $module.Name -Force -ErrorAction SilentlyContinue
+}

--- a/src/Devolutions.Ahtola.PowerShell/Module/en-US/about_Devolutions.Ahtola.Sqlite.help.txt
+++ b/src/Devolutions.Ahtola.PowerShell/Module/en-US/about_Devolutions.Ahtola.Sqlite.help.txt
@@ -24,6 +24,10 @@ EXAMPLES
     Invoke-AhtolaSqliteQuery -Connection $connection -CommandText 'CREATE TABLE users (name TEXT)'
     Invoke-AhtolaSqliteQuery -Connection $connection -CommandText "INSERT INTO users VALUES ('Ada')"
 
+    Relative database, replica, import, and export paths resolve from the active
+    PowerShell filesystem location. Use -WhatIf to preview connection creation
+    without opening a connection or creating a local database file.
+
     # Direct Turso Cloud connection (token is a SecureString).
     $token = Read-Host -AsSecureString
     $cloud = New-AhtolaSqliteConnection -TursoUrl 'libsql://example.turso.io' -AuthToken $token

--- a/src/Devolutions.Ahtola.PowerShell/PowerShellCmdlets.cs
+++ b/src/Devolutions.Ahtola.PowerShell/PowerShellCmdlets.cs
@@ -48,6 +48,31 @@ public abstract class PSSqliteCmdlet : PSCmdlet
         return SessionState.InvokeCommand.ExpandString(value);
     }
 
+    protected string ResolveFileSystemPath(string value)
+    {
+        var expanded = ExpandString(value);
+        return string.IsNullOrWhiteSpace(expanded)
+            ? SessionState.Path.CurrentFileSystemLocation.Path
+            : SessionState.Path.GetUnresolvedProviderPathFromPSPath(expanded);
+    }
+
+    protected string ResolveConnectionString(string connectionString)
+    {
+        var builder = new SqliteConnectionStringBuilder(connectionString);
+        var dataSource = builder.DataSource;
+        if (string.IsNullOrWhiteSpace(dataSource)
+            || Path.IsPathRooted(dataSource)
+            || dataSource.Equals(":memory:", StringComparison.OrdinalIgnoreCase)
+            || dataSource.StartsWith("file:", StringComparison.OrdinalIgnoreCase)
+            || dataSource.StartsWith("|DataDirectory|", StringComparison.OrdinalIgnoreCase))
+        {
+            return connectionString;
+        }
+
+        builder.DataSource = ResolveFileSystemPath(dataSource);
+        return builder.ToString();
+    }
+
     protected static void DisposeOwnedConnection(DbConnection connection)
     {
         if (connection.State == ConnectionState.Open)
@@ -67,6 +92,42 @@ public abstract class PSSqliteCmdlet : PSCmdlet
             connection.Open();
         }
     }
+
+    protected static SqliteConnection ResolveCrudConnection(
+        SqliteConnection? connection,
+        SqliteTransaction? transaction,
+        string connectionString,
+        out bool ownsConnection)
+    {
+        if (transaction is not null)
+        {
+            if (transaction.Connection is not SqliteConnection transactionConnection)
+            {
+                throw new ArgumentException(
+                    "Transaction must be active and belong to an Ahtola SQLite connection.",
+                    nameof(transaction));
+            }
+
+            if (connection is not null && !ReferenceEquals(connection, transactionConnection))
+            {
+                throw new ArgumentException(
+                    "Connection must match the connection that owns Transaction.",
+                    nameof(connection));
+            }
+
+            ownsConnection = false;
+            return transactionConnection;
+        }
+
+        if (connection is not null)
+        {
+            ownsConnection = false;
+            return connection;
+        }
+
+        ownsConnection = true;
+        return ConnectionFactory.Create(connectionString);
+    }
 }
 
 [Cmdlet(VerbsCommon.New, "AhtolaSqliteConnection", DefaultParameterSetName = "byConnectionString", SupportsShouldProcess = true)]
@@ -77,12 +138,13 @@ public sealed class NewPSSqliteConnectionCommand : PSSqliteCmdlet
     public string ConnectionString { get; set; } = "Data Source=:memory:;Cache=Shared;";
 
     [Parameter(ParameterSetName = "byDatabasePath")]
-    public string DatabasePath { get; set; } = Directory.GetCurrentDirectory();
+    public string DatabasePath { get; set; } = string.Empty;
 
     [Parameter(Mandatory = true, ParameterSetName = "byDatabasePath")]
     public string? DatabaseFile { get; set; }
 
-    [Parameter]
+    [Parameter(ParameterSetName = "byConnectionString")]
+    [Parameter(ParameterSetName = "byDatabasePath")]
     public SwitchParameter ReadOnly { get; set; }
 
     [Parameter(ParameterSetName = "byTursoCloud")]
@@ -107,6 +169,9 @@ public sealed class NewPSSqliteConnectionCommand : PSSqliteCmdlet
     {
         if (ParameterSetName == "byTursoCloud")
         {
+            var replicaPath = string.IsNullOrWhiteSpace(ReplicaPath)
+                ? null
+                : ResolveFileSystemPath(ReplicaPath);
             var operation = string.IsNullOrWhiteSpace(ReplicaPath)
                 ? "Open Turso Cloud connection"
                 : "Open managed Turso Cloud replica";
@@ -116,15 +181,34 @@ public sealed class NewPSSqliteConnectionCommand : PSSqliteCmdlet
             WriteObject(TursoCloudConnectionFactory.Create(
                 TursoUrl,
                 AuthToken,
-                ReplicaPath,
+                replicaPath,
                 UseTursoEnvironment.IsPresent,
                 SyncInterval));
             return;
         }
 
-        var connection = ParameterSetName == "byDatabasePath"
-            ? ConnectionFactory.Create(ExpandString(DatabasePath), ExpandString(DatabaseFile!))
-            : ConnectionFactory.Create(ExpandString(ConnectionString));
+        string connectionString;
+        if (ParameterSetName == "byDatabasePath")
+        {
+            var databasePath = ResolveFileSystemPath(DatabasePath);
+            var databaseFile = ExpandString(DatabaseFile!);
+            connectionString = new SqliteConnectionStringBuilder
+            {
+                DataSource = Path.Combine(databasePath, databaseFile)
+            }.ToString();
+        }
+        else
+        {
+            connectionString = ResolveConnectionString(ExpandString(ConnectionString));
+        }
+
+        var target = new SqliteConnectionStringBuilder(connectionString).DataSource;
+        if (!ShouldProcess(target, "Open Ahtola SQLite connection"))
+        {
+            return;
+        }
+
+        var connection = ConnectionFactory.Create(connectionString);
         if (ReadOnly.IsPresent)
         {
             var builder = new SqliteConnectionStringBuilder(connection.ConnectionString)
@@ -134,8 +218,16 @@ public sealed class NewPSSqliteConnectionCommand : PSSqliteCmdlet
             connection.ConnectionString = builder.ToString();
         }
 
-        connection.Open();
-        WriteObject(connection);
+        try
+        {
+            connection.Open();
+            WriteObject(connection);
+        }
+        catch
+        {
+            connection.Dispose();
+            throw;
+        }
     }
 }
 
@@ -161,6 +253,7 @@ public sealed class InvokePSSqliteQueryCommand : PSSqliteCmdlet
     public IDictionary? Parameters { get; set; }
 
     [Parameter]
+    [ValidateRange(0, int.MaxValue)]
     public int CommandTimeout { get; set; } = 30;
 
     [Parameter]
@@ -228,8 +321,11 @@ public sealed class GetPSSqliteRowCommand : PSSqliteCmdlet
 
     protected override void ProcessRecord()
     {
-        var ownsConnection = Connection is null;
-        var connection = Connection ?? ConnectionFactory.Create(Configuration.ConnectionString!);
+        var connection = ResolveCrudConnection(
+            Connection,
+            Transaction,
+            Configuration.ConnectionString!,
+            out var ownsConnection);
         try
         {
             var result = CrudSqlBuilder.ExecuteSelect(
@@ -282,8 +378,11 @@ public sealed class NewPSSqliteRowCommand : PSSqliteCmdlet
             return;
         }
 
-        var ownsConnection = Connection is null;
-        var connection = Connection ?? ConnectionFactory.Create(Configuration.ConnectionString!);
+        var connection = ResolveCrudConnection(
+            Connection,
+            Transaction,
+            Configuration.ConnectionString!,
+            out var ownsConnection);
         try
         {
             var result = CrudSqlBuilder.ExecuteInsert(
@@ -345,8 +444,11 @@ public sealed class SetPSSqliteRowCommand : PSSqliteCmdlet
             return;
         }
 
-        var ownsConnection = Connection is null;
-        var connection = Connection ?? ConnectionFactory.Create(Configuration.ConnectionString!);
+        var connection = ResolveCrudConnection(
+            Connection,
+            Transaction,
+            Configuration.ConnectionString!,
+            out var ownsConnection);
         try
         {
             WriteObject(CrudSqlBuilder.ExecuteUpdate(
@@ -402,8 +504,11 @@ public sealed class RemovePSSqliteRowCommand : PSSqliteCmdlet
             return;
         }
 
-        var ownsConnection = Connection is null;
-        var connection = Connection ?? ConnectionFactory.Create(Configuration.ConnectionString!);
+        var connection = ResolveCrudConnection(
+            Connection,
+            Transaction,
+            Configuration.ConnectionString!,
+            out var ownsConnection);
         try
         {
             WriteObject(CrudSqlBuilder.ExecuteDelete(
@@ -481,8 +586,7 @@ public sealed class GetPSSqliteDBMetadataCommand : PSSqliteCmdlet
 
     protected override void ProcessRecord()
     {
-        var connectionString = Connection.ConnectionString;
-        var metadata = MetadataStore.Get(connectionString, MetadataKey);
+        var metadata = MetadataStore.Get(Connection, MetadataKey);
         if (metadata is not null)
         {
             WriteObject(metadata);

--- a/src/Devolutions.Ahtola.PowerShell/PowerShellOperationalCmdlets.cs
+++ b/src/Devolutions.Ahtola.PowerShell/PowerShellOperationalCmdlets.cs
@@ -94,7 +94,7 @@ public sealed class InvokePSSqliteReplicaSyncCommand : PSSqliteCmdlet
     }
 }
 
-[Cmdlet(VerbsData.Save, "AhtolaSqliteTransaction")]
+[Cmdlet(VerbsData.Save, "AhtolaSqliteTransaction", SupportsShouldProcess = true)]
 public sealed class SavePSSqliteTransactionCommand : PSSqliteCmdlet
 {
     [Parameter(Mandatory = true, ValueFromPipeline = true)]
@@ -105,7 +105,12 @@ public sealed class SavePSSqliteTransactionCommand : PSSqliteCmdlet
 
     protected override void ProcessRecord()
     {
-        Transaction.Save(Name);
+        if (ShouldProcess(
+                Transaction.Connection?.DataSource ?? "SQLite transaction",
+                $"Create savepoint '{Name}'"))
+        {
+            Transaction.Save(Name);
+        }
     }
 }
 
@@ -235,6 +240,7 @@ public sealed class InvokePSSqliteMaintenanceCommand : PSSqliteCmdlet
     public string CheckpointMode { get; set; } = "Truncate";
 
     [Parameter]
+    [ValidateRange(0, int.MaxValue)]
     public int CommandTimeout { get; set; } = 30;
 
     [Parameter]
@@ -277,6 +283,7 @@ public sealed class TestAhtolaSqliteIntegrityCommand : PSSqliteCmdlet
     public SqliteConnection Connection { get; set; } = null!;
 
     [Parameter]
+    [ValidateRange(0, int.MaxValue)]
     public int CommandTimeout { get; set; } = 30;
 
     [Parameter]
@@ -308,6 +315,7 @@ public sealed class OptimizeAhtolaSqliteDatabaseCommand : PSSqliteCmdlet
     public SwitchParameter Analyze { get; set; }
 
     [Parameter]
+    [ValidateRange(0, int.MaxValue)]
     public int CommandTimeout { get; set; } = 30;
 
     protected override void ProcessRecord()
@@ -345,6 +353,7 @@ public sealed class CheckpointAhtolaSqliteDatabaseCommand : PSSqliteCmdlet
     public string Mode { get; set; } = "Truncate";
 
     [Parameter]
+    [ValidateRange(0, int.MaxValue)]
     public int CommandTimeout { get; set; } = 30;
 
     protected override void ProcessRecord()

--- a/src/Devolutions.Ahtola.PowerShell/PowerShellTransferCmdlets.cs
+++ b/src/Devolutions.Ahtola.PowerShell/PowerShellTransferCmdlets.cs
@@ -13,7 +13,9 @@ namespace Ahtola.PSSqlite;
 [OutputType(typeof(int))]
 public sealed class InvokePSSqliteBulkCopyCommand : PSSqliteCmdlet
 {
-    private readonly List<OrderedDictionary> _rows = new();
+    private readonly List<OrderedDictionary> _batch = new();
+    private BulkCopySession? _session;
+    private bool? _shouldProcess;
 
     [Parameter(Mandatory = true, ValueFromPipeline = true)]
     public object InputObject { get; set; } = null!;
@@ -35,22 +37,80 @@ public sealed class InvokePSSqliteBulkCopyCommand : PSSqliteCmdlet
 
     protected override void ProcessRecord()
     {
-        _rows.Add(PowerShellRow.ToDictionary(InputObject));
-    }
+        if (_shouldProcess is null)
+        {
+            _shouldProcess = ShouldProcess(Table, "Bulk copy piped rows");
+        }
 
-    protected override void EndProcessing()
-    {
-        if (_rows.Count == 0 || !ShouldProcess(Table, $"Bulk copy {_rows.Count} row(s)"))
+        if (!_shouldProcess.Value)
         {
             return;
         }
 
-        WriteObject(BulkCopyExecutor.Execute(
-            Connection,
-            Table,
-            _rows,
-            BatchSize,
-            Transaction));
+        try
+        {
+            _batch.Add(PowerShellRow.ToDictionary(InputObject));
+            if (_batch.Count >= BatchSize)
+            {
+                FlushBatch();
+            }
+        }
+        catch
+        {
+            Abort();
+            throw;
+        }
+    }
+
+    protected override void EndProcessing()
+    {
+        try
+        {
+            if (_shouldProcess is not true)
+            {
+                return;
+            }
+
+            FlushBatch();
+            if (_session is null)
+            {
+                return;
+            }
+
+            _session.Complete();
+            WriteObject(_session.RowsWritten);
+        }
+        catch
+        {
+            Abort();
+            throw;
+        }
+        finally
+        {
+            _session?.Dispose();
+            _session = null;
+            _batch.Clear();
+        }
+    }
+
+    private void FlushBatch()
+    {
+        if (_batch.Count == 0)
+        {
+            return;
+        }
+
+        _session ??= new BulkCopySession(Connection, Table, Transaction);
+        _session.WriteBatch(_batch);
+        _batch.Clear();
+    }
+
+    private void Abort()
+    {
+        _session?.Abort();
+        _session?.Dispose();
+        _session = null;
+        _batch.Clear();
     }
 }
 
@@ -80,7 +140,7 @@ public sealed class ExportPSSqliteTableCommand : PSSqliteCmdlet
 
     protected override void ProcessRecord()
     {
-        var outputPath = System.IO.Path.GetFullPath(ExpandString(Path));
+        var outputPath = ResolveFileSystemPath(Path);
         var format = TableInterchange.ResolveFormat(outputPath, Format);
         var commandText = ParameterSetName == "Query"
             ? Query!
@@ -129,7 +189,7 @@ public sealed class ImportPSSqliteTableCommand : PSSqliteCmdlet
 
     protected override void ProcessRecord()
     {
-        var inputPath = System.IO.Path.GetFullPath(ExpandString(Path));
+        var inputPath = ResolveFileSystemPath(Path);
         if (!File.Exists(inputPath))
         {
             throw new FileNotFoundException($"Import file not found: {inputPath}", inputPath);
@@ -230,83 +290,171 @@ internal static class BulkCopyExecutor
             return 0;
         }
 
-        var columns = rows[0].Keys.Cast<string>().ToArray();
-        if (columns.Length == 0)
+        using var session = new BulkCopySession(connection, tableName, transaction);
+        try
         {
-            throw new ArgumentException("Bulk-copy rows must have at least one column.", nameof(rows));
+            for (var offset = 0; offset < rows.Count; offset += batchSize)
+            {
+                var count = Math.Min(batchSize, rows.Count - offset);
+                session.WriteBatch(rows.Skip(offset).Take(count).ToArray());
+            }
+
+            session.Complete();
+            return session.RowsWritten;
+        }
+        catch
+        {
+            session.Abort();
+            throw;
+        }
+    }
+}
+
+internal sealed class BulkCopySession : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly string _tableName;
+    private readonly SqliteTransaction? _providedTransaction;
+    private SqliteTransaction? _transaction;
+    private SqliteCommand? _command;
+    private string[]? _columns;
+    private string? _savepointName;
+    private bool _ownsTransaction;
+    private bool _completed;
+    private bool _aborted;
+
+    public BulkCopySession(
+        SqliteConnection connection,
+        string tableName,
+        SqliteTransaction? transaction)
+    {
+        _connection = connection ?? throw new ArgumentNullException(nameof(connection));
+        _tableName = string.IsNullOrWhiteSpace(tableName)
+            ? throw new ArgumentException("Table name is required.", nameof(tableName))
+            : tableName;
+        _providedTransaction = transaction;
+    }
+
+    public int RowsWritten { get; private set; }
+
+    public void WriteBatch(IReadOnlyList<OrderedDictionary> rows)
+    {
+        ObjectDisposedException.ThrowIf(_completed || _aborted, this);
+        if (rows.Count == 0)
+        {
+            return;
+        }
+
+        EnsureInitialized(rows[0]);
+        foreach (var row in rows)
+        {
+            ValidateRowColumns(row, _columns!);
         }
 
         foreach (var row in rows)
         {
-            ValidateRowColumns(row, columns);
-        }
+            _command!.Parameters.Clear();
+            foreach (var column in _columns!.Select((name, index) => (name, index)))
+            {
+                _command.Parameters.AddWithValue("$value" + column.index, row[column.name] ?? DBNull.Value);
+            }
 
-        if (connection.State != ConnectionState.Open)
+            _ = _command.ExecuteNonQuery();
+            RowsWritten++;
+        }
+    }
+
+    public void Complete()
+    {
+        ObjectDisposedException.ThrowIf(_completed || _aborted, this);
+        if (_transaction is null)
         {
-            connection.Open();
+            _completed = true;
+            return;
         }
 
-        var ownsTransaction = transaction is null;
-        var activeTransaction = transaction ?? connection.BeginTransaction();
-        if (transaction is not null && !ReferenceEquals(transaction.Connection, connection))
+        if (_ownsTransaction)
         {
-            throw new ArgumentException("Transaction must belong to SqliteConnection.", nameof(transaction));
+            _transaction.Commit();
         }
-
-        var savepointName = ownsTransaction ? null : $"ps_bulk_{Guid.NewGuid():N}";
-        try
+        else
         {
-            if (savepointName is not null)
-            {
-                activeTransaction.Save(savepointName);
-            }
-
-            using var command = connection.CreateCommand();
-            command.Transaction = activeTransaction;
-            command.CommandText =
-                $"INSERT INTO {SqlIdentifier.QuoteQualified(tableName)} ({string.Join(", ", columns.Select(SqlIdentifier.Quote))}) " +
-                $"VALUES ({string.Join(", ", columns.Select((_, index) => "$value" + index))});";
-            for (var index = 0; index < rows.Count; index++)
-            {
-                command.Parameters.Clear();
-                foreach (var column in columns.Select((name, columnIndex) => (name, columnIndex)))
-                {
-                    command.Parameters.AddWithValue("$value" + column.columnIndex, rows[index][column.name] ?? DBNull.Value);
-                }
-
-                _ = command.ExecuteNonQuery();
-                if ((index + 1) % batchSize == 0 && savepointName is not null)
-                {
-                    activeTransaction.Release(savepointName);
-                    activeTransaction.Save(savepointName);
-                }
-            }
-
-            if (ownsTransaction)
-            {
-                activeTransaction.Commit();
-            }
-            else if (savepointName is not null)
-            {
-                activeTransaction.Release(savepointName);
-            }
-
-            return rows.Count;
+            _transaction.Release(_savepointName!);
         }
-        catch
+
+        _completed = true;
+    }
+
+    public void Abort()
+    {
+        if (_completed || _aborted || _transaction is null)
         {
-            if (ownsTransaction)
-            {
-                activeTransaction.Rollback();
-            }
-            else if (savepointName is not null)
-            {
-                activeTransaction.Rollback(savepointName);
-                activeTransaction.Release(savepointName);
-            }
-
-            throw;
+            return;
         }
+
+        if (_ownsTransaction)
+        {
+            _transaction.Rollback();
+        }
+        else
+        {
+            _transaction.Rollback(_savepointName!);
+            _transaction.Release(_savepointName!);
+        }
+
+        _aborted = true;
+    }
+
+    public void Dispose()
+    {
+        if (!_completed && !_aborted)
+        {
+            Abort();
+        }
+
+        _command?.Dispose();
+        if (_ownsTransaction)
+        {
+            _transaction?.Dispose();
+        }
+    }
+
+    private void EnsureInitialized(OrderedDictionary firstRow)
+    {
+        if (_command is not null)
+        {
+            return;
+        }
+
+        if (_providedTransaction is not null && !ReferenceEquals(_providedTransaction.Connection, _connection))
+        {
+            throw new ArgumentException("Transaction must belong to SqliteConnection.", nameof(_providedTransaction));
+        }
+
+        _columns = firstRow.Keys.Cast<string>().ToArray();
+        if (_columns.Length == 0)
+        {
+            throw new ArgumentException("Bulk-copy rows must have at least one column.", nameof(firstRow));
+        }
+
+        if (_connection.State != ConnectionState.Open)
+        {
+            _connection.Open();
+        }
+
+        _ownsTransaction = _providedTransaction is null;
+        _transaction = _providedTransaction ?? _connection.BeginTransaction();
+        _savepointName = _ownsTransaction ? null : $"ps_bulk_{Guid.NewGuid():N}";
+        if (_savepointName is not null)
+        {
+            _transaction.Save(_savepointName);
+        }
+
+        _command = _connection.CreateCommand();
+        _command.Transaction = _transaction;
+        _command.CommandText =
+            $"INSERT INTO {SqlIdentifier.QuoteQualified(_tableName)} ({string.Join(", ", _columns.Select(SqlIdentifier.Quote))}) " +
+            $"VALUES ({string.Join(", ", _columns.Select((_, index) => "$value" + index))});";
     }
 
     private static void ValidateRowColumns(OrderedDictionary row, IReadOnlyCollection<string> columns)

--- a/src/Devolutions.Ahtola.PowerShell/README.md
+++ b/src/Devolutions.Ahtola.PowerShell/README.md
@@ -45,6 +45,8 @@ Get-Command -Module Devolutions.Ahtola.Sqlite
 ```
 
 No native SQLite assets are required; PreLoadTypes loads the managed Ahtola assemblies from `bin/`.
+The staged module includes offline MAML command help; use `Get-Help <cmdlet> -Full`
+or `Get-Help <cmdlet> -Examples` after import.
 
 ## Tests
 
@@ -76,6 +78,9 @@ pwsh ./scripts/Invoke-PowerShellModuleTests.ps1
   never closes or disposes it. `New-AhtolaSqliteConnection` returns an open
   connection, and `Close-AhtolaSqliteConnection` is the explicit disposal
   command.
+- Relative database, replica, import, and export paths resolve from the active
+  PowerShell filesystem location. `-WhatIf` previews connection creation
+  without opening a connection or creating a local database file.
 - `Invoke-AhtolaSqliteQuery` emits `PSCustomObject` rows by default. Use
   `-As Scalar` or `-As NonQuery` for direct values/counts and `-As DataTable`
   or `-As DataSet` only when those ADO.NET containers are required.

--- a/src/Devolutions.Ahtola.PowerShell/SqliteServices.cs
+++ b/src/Devolutions.Ahtola.PowerShell/SqliteServices.cs
@@ -689,7 +689,19 @@ public static class MetadataStore
     public static OrderedDictionary? Get(string connectionString, IReadOnlyCollection<string> keys)
     {
         using var connection = ConnectionFactory.Create(connectionString);
-        connection.Open();
+        return Get(connection, keys);
+    }
+
+    public static OrderedDictionary? Get(SqliteConnection connection, IReadOnlyCollection<string> keys)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        ArgumentNullException.ThrowIfNull(keys);
+
+        if (connection.State != ConnectionState.Open)
+        {
+            connection.Open();
+        }
+
         using var tableCheck = connection.CreateCommand();
         tableCheck.CommandText = "SELECT name FROM sqlite_schema WHERE name = $name COLLATE NOCASE";
         tableCheck.Parameters.AddWithValue("$name", "_metadata");

--- a/tests/PowerShell/Devolutions.Ahtola.Sqlite/Module.Tests.ps1
+++ b/tests/PowerShell/Devolutions.Ahtola.Sqlite/Module.Tests.ps1
@@ -30,6 +30,23 @@ Describe 'Devolutions.Ahtola.Sqlite module packaging' {
         Test-Path -LiteralPath $script:ManifestPath | Should-BeTrue
     }
 
+    It 'ships complete MAML help for every exported cmdlet' {
+        $mamlPath = Join-Path $script:ModulePath 'en-US\Devolutions.Ahtola.PowerShell.dll-Help.xml'
+        Test-Path -LiteralPath $mamlPath -PathType Leaf | Should-BeTrue
+
+        foreach ($command in Get-Command -Module $script:ModuleName | Sort-Object Name) {
+            $help = Get-Help -Name $command.Name -Full
+            $rendered = $help | Out-String -Width 200
+
+            [string]::IsNullOrWhiteSpace([string]$help.Synopsis) | Should-BeFalse
+            @($help.Description).Count | Should-BeGreaterThan 0
+            @($help.Examples.Example).Count | Should-BeGreaterThan 0
+            @($help.Parameters.Parameter).Count | Should-BeGreaterThan 0
+            $rendered.Contains('{{') | Should-BeFalse
+            $rendered.Contains('Fill in the') | Should-BeFalse
+        }
+    }
+
     It 'exports the expected AhtolaSqlite cmdlets' {
         $commands = @(Get-Command -Module $script:ModuleName | Select-Object -ExpandProperty Name)
         $expected = @(
@@ -139,6 +156,13 @@ Describe 'Devolutions.Ahtola.Sqlite module packaging' {
         $parameters['ReplicaPath'] | Should-NotBeNull
         $parameters['UseTursoEnvironment'] | Should-NotBeNull
         $parameters['SyncInterval'] | Should-NotBeNull
+        $readOnlySets = @(
+            $command.ParameterSets |
+                Where-Object { $_.Parameters.Name -contains 'ReadOnly' } |
+                Select-Object -ExpandProperty Name
+        )
+        $readOnlySets | Should-ContainCollection 'byConnectionString', 'byDatabasePath'
+        ($readOnlySets -contains 'byTursoCloud') | Should-BeFalse
         (Get-Command Invoke-AhtolaSqliteReplicaSync).Parameters['ReplicaConnection'].ParameterType |
             Should-Be ([Ahtola.PSSqlite.AhtolaCloudConnection])
 
@@ -206,6 +230,106 @@ Describe 'Devolutions.Ahtola.Sqlite connections and queries' {
         $table | Should-NotBeNull
         $table.Rows.Count | Should-Be 1
         [int]$table.Rows[0]['value'] | Should-Be 1
+    }
+
+    It 'reads metadata from the supplied in-memory connection' {
+        $null = Invoke-AhtolaSqliteQuery `
+            -Connection $script:Connection `
+            -CommandText "CREATE TABLE _metadata(key TEXT PRIMARY KEY, value TEXT); INSERT INTO _metadata VALUES ('version', '1');" `
+            -As NonQuery
+
+        $metadata = Get-AhtolaSqliteDatabaseMetadata -Connection $script:Connection
+
+        $metadata | Should-NotBeNull
+        [string]$metadata['version'] | Should-BeString '1'
+    }
+
+    It 'resolves a relative data source from the current PowerShell location' {
+        $directory = Join-Path ([System.IO.Path]::GetTempPath()) ("ahtola-relative-" + [guid]::NewGuid().ToString('N'))
+        $database = Join-Path $directory 'items.sqlite'
+        $connection = $null
+        New-Item -ItemType Directory -Path $directory -Force | Out-Null
+
+        try {
+            Push-Location -LiteralPath $directory
+            $connection = New-AhtolaSqliteConnection -ConnectionString 'Data Source=items.sqlite;Pooling=False'
+
+            $connection.DataSource | Should-Be $database
+            Invoke-AhtolaSqliteQuery -Connection $connection -CommandText 'CREATE TABLE Items(Id INTEGER PRIMARY KEY, Name TEXT);' -As NonQuery | Should-Be 0
+            Invoke-AhtolaSqliteQuery -Connection $connection -CommandText "INSERT INTO Items(Name) VALUES ('Widget');" -As NonQuery | Should-Be 1
+            [int](Invoke-AhtolaSqliteQuery -Connection $connection -CommandText 'SELECT COUNT(*) FROM Items;' -As Scalar) | Should-Be 1
+        }
+        finally {
+            if ($null -ne $connection) {
+                $connection | Close-AhtolaSqliteConnection -Confirm:$false
+            }
+
+            Pop-Location
+            Remove-Item -LiteralPath $directory -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'resolves DatabasePath from the current PowerShell location' {
+        $directory = Join-Path ([System.IO.Path]::GetTempPath()) ("ahtola-database-path-" + [guid]::NewGuid().ToString('N'))
+        $database = Join-Path $directory 'items.sqlite'
+        $connection = $null
+        New-Item -ItemType Directory -Path $directory -Force | Out-Null
+
+        try {
+            Push-Location -LiteralPath $directory
+            $connection = New-AhtolaSqliteConnection -DatabasePath . -DatabaseFile 'items.sqlite'
+
+            $connection.DataSource | Should-Be $database
+            Test-Path -LiteralPath $database | Should-BeTrue
+        }
+        finally {
+            if ($null -ne $connection) {
+                $connection | Close-AhtolaSqliteConnection -Confirm:$false
+            }
+
+            Pop-Location
+            Remove-Item -LiteralPath $directory -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'does not create a local database under WhatIf' {
+        $directory = Join-Path ([System.IO.Path]::GetTempPath()) ("ahtola-what-if-" + [guid]::NewGuid().ToString('N'))
+        $database = Join-Path $directory 'items.sqlite'
+        New-Item -ItemType Directory -Path $directory -Force | Out-Null
+
+        try {
+            Push-Location -LiteralPath $directory
+            @(New-AhtolaSqliteConnection -ConnectionString 'Data Source=items.sqlite;Pooling=False' -WhatIf).Count | Should-Be 0
+            Test-Path -LiteralPath $database | Should-BeFalse
+        }
+        finally {
+            Pop-Location
+            Remove-Item -LiteralPath $directory -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'validates non-negative command timeouts' {
+        $timeoutCommands = @(
+            'Invoke-AhtolaSqliteQuery'
+            'Invoke-AhtolaSqliteMaintenance'
+            'Test-AhtolaSqliteIntegrity'
+            'Optimize-AhtolaSqliteDatabase'
+            'Checkpoint-AhtolaSqliteDatabase'
+        )
+
+        foreach ($name in $timeoutCommands) {
+            $validation = @(
+                (Get-Command $name).Parameters['CommandTimeout'].Attributes |
+                    Where-Object { $_ -is [System.Management.Automation.ValidateRangeAttribute] }
+            )
+
+            $validation.Count | Should-Be 1
+            [int]$validation[0].MinRange | Should-Be 0
+        }
+
+        {
+            Invoke-AhtolaSqliteQuery -Connection $script:Connection -CommandText 'SELECT 1;' -CommandTimeout -1
+        } | Should-Throw
     }
 
     It 'opens a caller-owned closed pipeline connection and returns PowerShell objects by default' {
@@ -349,6 +473,7 @@ Describe 'Devolutions.Ahtola.Sqlite connections and queries' {
             -As NonQuery
 
         $transaction = $script:Connection | Start-AhtolaSqliteTransaction
+        @(Save-AhtolaSqliteTransaction -Transaction $transaction -Name previewed -WhatIf).Count | Should-Be 0
         $transaction | Save-AhtolaSqliteTransaction -Name discarded
         $null = Invoke-AhtolaSqliteQuery -Connection $script:Connection `
             -Transaction $transaction `
@@ -396,7 +521,7 @@ Describe 'Devolutions.Ahtola.Sqlite connections and queries' {
             @(
                 [pscustomobject]@{ id = 3; name = 'three' }
                 [pscustomobject]@{ id = 1; name = 'duplicate' }
-            ) | Invoke-AhtolaSqliteBulkCopy -Connection $script:Connection -Table bulk
+            ) | Invoke-AhtolaSqliteBulkCopy -Connection $script:Connection -Table bulk -BatchSize 1
         } | Should-Throw
         [int](Invoke-AhtolaSqliteQuery -SqliteConnection $script:Connection -CommandText 'SELECT COUNT(*) FROM bulk;' -As Scalar) | Should-Be 2
 
@@ -460,6 +585,36 @@ Describe 'Devolutions.Ahtola.Sqlite backup and table interchange' {
         finally {
             $source | Close-AhtolaSqliteConnection -Confirm:$false
             $destination | Close-AhtolaSqliteConnection -Confirm:$false
+        }
+    }
+
+    It 'resolves import and export paths from the current PowerShell location' {
+        $directory = Join-Path ([System.IO.Path]::GetTempPath()) ("ahtola-transfer-path-" + [guid]::NewGuid().ToString('N'))
+        $path = Join-Path $directory 'items.json'
+        $source = New-AhtolaSqliteConnection -ConnectionString 'Data Source=:memory:'
+        $destination = New-AhtolaSqliteConnection -ConnectionString 'Data Source=:memory:'
+        New-Item -ItemType Directory -Path $directory -Force | Out-Null
+
+        try {
+            $null = Invoke-AhtolaSqliteQuery -Connection $source `
+                -CommandText "CREATE TABLE items(id INTEGER PRIMARY KEY, name TEXT); INSERT INTO items VALUES (1, 'Widget');" `
+                -As NonQuery
+            $null = Invoke-AhtolaSqliteQuery -Connection $destination `
+                -CommandText 'CREATE TABLE items(id INTEGER PRIMARY KEY, name TEXT);' `
+                -As NonQuery
+
+            Push-Location -LiteralPath $directory
+            Export-AhtolaSqliteTable -Connection $source -Table items -Path 'items.json' -Confirm:$false | Should-Be $path
+            Import-AhtolaSqliteTable -Connection $destination -Table items -Path 'items.json' -Confirm:$false | Should-Be 1
+
+            Test-Path -LiteralPath $path | Should-BeTrue
+            [int](Invoke-AhtolaSqliteQuery -Connection $destination -CommandText 'SELECT COUNT(*) FROM items;' -As Scalar) | Should-Be 1
+        }
+        finally {
+            Pop-Location
+            $source | Close-AhtolaSqliteConnection -Confirm:$false
+            $destination | Close-AhtolaSqliteConnection -Confirm:$false
+            Remove-Item -LiteralPath $directory -Recurse -Force -ErrorAction SilentlyContinue
         }
     }
 
@@ -704,6 +859,64 @@ Describe 'Devolutions.Ahtola.Sqlite programmatic configuration and CRUD' {
             }
 
             Close-AhtolaSqliteConnection
+        }
+    }
+
+    It 'uses the transaction connection for CRUD when Connection is omitted' {
+        $config = $script:Config
+        $connection = New-AhtolaSqliteConnection -DatabasePath $config.DatabasePath -DatabaseFile $config.DatabaseFile
+        $otherConnection = New-AhtolaSqliteConnection -ConnectionString 'Data Source=:memory:'
+        $transaction = $null
+        try {
+            $transaction = Start-AhtolaSqliteTransaction -Connection $connection
+
+            {
+                Get-AhtolaSqliteRow `
+                    -Configuration $config `
+                    -Table Items `
+                    -Connection $otherConnection `
+                    -Transaction $transaction
+            } | Should-Throw
+
+            New-AhtolaSqliteRow `
+                -Configuration $config `
+                -Table Items `
+                -Values @{ Id = 100; Name = 'transactional'; Qty = 1 } `
+                -Transaction $transaction | Should-NotBeNull
+
+            Set-AhtolaSqliteRow `
+                -Configuration $config `
+                -Table Items `
+                -Values @{ Qty = 2 } `
+                -Where @{ Id = 100 } `
+                -Transaction $transaction | Should-Be 1
+
+            $rows = @(Get-AhtolaSqliteRow `
+                    -Configuration $config `
+                    -Table Items `
+                    -Where @{ Id = 100 } `
+                    -Transaction $transaction `
+                    -As OrderedDictionary)
+            $rows.Count | Should-Be 1
+            [int]$rows[0]['Qty'] | Should-Be 2
+
+            Remove-AhtolaSqliteRow `
+                -Configuration $config `
+                -Table Items `
+                -Where @{ Id = 100 } `
+                -Transaction $transaction | Should-Be 1
+
+            Complete-AhtolaSqliteTransaction -Transaction $transaction -Confirm:$false
+            $transaction = $null
+            [int](Invoke-AhtolaSqliteQuery -Connection $connection -CommandText 'SELECT COUNT(*) FROM Items WHERE Id = 100;' -As Scalar) | Should-Be 0
+        }
+        finally {
+            if ($null -ne $transaction) {
+                Undo-AhtolaSqliteTransaction -Transaction $transaction -Confirm:$false
+            }
+
+            $otherConnection | Close-AhtolaSqliteConnection -Confirm:$false
+            $connection | Close-AhtolaSqliteConnection -Confirm:$false
         }
     }
 


### PR DESCRIPTION
## Summary
- Resolve PowerShell-relative database, replica, import, and export paths from the active location; honor local connection `-WhatIf` and validate command timeouts.
- Fix cmdlet contracts for Cloud `-ReadOnly`, caller-connection metadata, CRUD transaction ownership, and savepoint `-WhatIf`.
- Add complete offline per-cmdlet MAML help authored in PlatyPS Markdown, with CI/release generation and coverage gates.
- Stream `Invoke-AhtolaSqliteBulkCopy` in `-BatchSize`-bounded buffers while preserving full transaction/savepoint rollback behavior.

## Validation
- `pwsh ./build.ps1 test-powershell`