### PR TITLE
fix(mvcc): fail closed for unsupported concurrent DML

### DIFF
--- a/docs/mvcc-port-contract.md
+++ b/docs/mvcc-port-contract.md
@@ -57,6 +57,9 @@ Pinned submodule: `turso-src/` @ **v0.7.2** (`046e9cbf6`).
 - **UPDATE of base-only row:** `UpdateIncludingBase` = tombstone prior + insert new cells.
 - **WW on concurrent base tombstones:** `ThrowIfConcurrentWriterOnRow` — pure tombstones share `End=null`, so classic chain WW alone is insufficient.
 - **SELECT:** dual-cursor path is rowid tables only; `sqlite_*` and WITHOUT ROWID stay catalog-only.
+  Concurrent DML against those catalog-only targets fails before mutation until system-table and
+  composite-key dual-cursor routing exists, preventing a transaction-local catalog change from
+  being dropped during the store-to-catalog merge.
 - **Process-local:** store is not cross-process (same as Turso process MVCC scope here).
 
 ## Checkpoint notes

--- a/docs/mvcc-port-contract.md
+++ b/docs/mvcc-port-contract.md
@@ -59,7 +59,8 @@ Pinned submodule: `turso-src/` @ **v0.7.2** (`046e9cbf6`).
 - **SELECT:** dual-cursor path is rowid tables only; `sqlite_*` and WITHOUT ROWID stay catalog-only.
   Concurrent DML against those catalog-only targets fails before mutation until system-table and
   composite-key dual-cursor routing exists, preventing a transaction-local catalog change from
-  being dropped during the store-to-catalog merge.
+  being dropped during the store-to-catalog merge. The same gate applies to row-trigger bodies
+  and foreign-key CASCADE/SET NULL/SET DEFAULT actions.
 - **Process-local:** store is not cross-process (same as Turso process MVCC scope here).
 
 ## Checkpoint notes

--- a/src/Ahtola.Core/EmbeddedDatabase.Triggers.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.Triggers.cs
@@ -179,6 +179,8 @@ public sealed partial class EmbeddedDatabase
                 foreach (var bodyStatement in trigger.Body)
                 {
                     var localStatement = LocalizeTriggerBodyStatement(context, trigger, bodyStatement);
+                    if (localStatement is not null)
+                        EnsureConcurrentMvccDmlTargetIsSupported(localStatement, triggerContext.Tables, triggerContext);
                     var result = localStatement is null
                         ? context.TempTriggers!.ExecuteForeign(bodyStatement, triggerContext)
                         : localStatement switch

--- a/src/Ahtola.Core/EmbeddedDatabase.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.cs
@@ -1658,6 +1658,44 @@ public sealed partial class EmbeddedDatabase : IDisposable
         or AlterTableAddColumnStatement or AlterTableRenameStatement or AlterTableRenameColumnStatement
         or AlterTableAlterColumnStatement or AlterTableDropColumnStatement;
 
+    private static void EnsureConcurrentMvccDmlTargetIsSupported(
+        ParsedStatement statement,
+        IReadOnlyDictionary<string, EmbeddedTable> tables,
+        QueryContext context)
+    {
+        if (context.ConcurrentMvStore is null || context.ConcurrentMvccTxId is null)
+            return;
+
+        var tableName = GetConcurrentMvccDmlTargetName(statement);
+        if (tableName is null)
+            return;
+
+        if (ManagedSchemaName.TrySplit(tableName, out _, out var unqualifiedName))
+            tableName = unqualifiedName;
+
+        if (tableName.StartsWith("sqlite_", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new EmbeddedSqlException(
+                "Concurrent MVCC DML is supported only for rowid user tables; sqlite_* tables require system-table dual-cursor routing.");
+        }
+
+        if (tables.TryGetValue(tableName, out var table) && !table.HasRowid)
+        {
+            throw new EmbeddedSqlException(
+                "Concurrent MVCC DML is supported only for rowid user tables; WITHOUT ROWID tables require composite-key dual-cursor routing.");
+        }
+    }
+
+    private static string? GetConcurrentMvccDmlTargetName(ParsedStatement statement)
+        => statement switch
+        {
+            InsertStatement insert => insert.TableName,
+            UpdateStatement update => update.TableName,
+            DeleteStatement delete => delete.TableName,
+            WithDmlStatement with => GetConcurrentMvccDmlTargetName(with.Dml),
+            _ => null,
+        };
+
     /// <summary>
     /// A read-only view over the live schema, used to resolve column ownership while an
     /// authorizer inspects a statement. It deliberately does not clone, does not take a
@@ -3315,6 +3353,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
             ExecuteTableList: executeTableList,
             ConcurrentMvStore: concurrentMvStore,
             ConcurrentMvccTxId: concurrentMvccTxId);
+        EnsureConcurrentMvccDmlTargetIsSupported(statement, tables, context);
         return statement switch
         {
             CreateTableStatement create => ExecuteCreateTable(create, catalog, cancellationToken),
@@ -13712,6 +13751,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
 
                 foreach (var bodyStatement in trigger.Body)
                 {
+                    EnsureConcurrentMvccDmlTargetIsSupported(bodyStatement, triggerContext.Tables, triggerContext);
                     var result = bodyStatement switch
                     {
                         InsertStatement insert => ExecuteInsert(insert, EmptyParameters, triggerContext),

--- a/src/Ahtola.Core/EmbeddedDatabase.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.cs
@@ -1673,18 +1673,33 @@ public sealed partial class EmbeddedDatabase : IDisposable
         if (ManagedSchemaName.TrySplit(tableName, out _, out var unqualifiedName))
             tableName = unqualifiedName;
 
-        if (tableName.StartsWith("sqlite_", StringComparison.OrdinalIgnoreCase))
-        {
-            throw new EmbeddedSqlException(
-                "Concurrent MVCC DML is supported only for rowid user tables; sqlite_* tables require system-table dual-cursor routing.");
-        }
+        if (tables.TryGetValue(tableName, out var table))
+            EnsureConcurrentMvccTableIsSupported(tableName, table, context);
+        else if (tableName.StartsWith("sqlite_", StringComparison.OrdinalIgnoreCase))
+            ThrowUnsupportedConcurrentMvccSystemTableDml();
+    }
 
-        if (tables.TryGetValue(tableName, out var table) && !table.HasRowid)
+    private static void EnsureConcurrentMvccTableIsSupported(
+        string tableName,
+        EmbeddedTable table,
+        QueryContext context)
+    {
+        if (context.ConcurrentMvStore is null || context.ConcurrentMvccTxId is null)
+            return;
+
+        if (tableName.StartsWith("sqlite_", StringComparison.OrdinalIgnoreCase))
+            ThrowUnsupportedConcurrentMvccSystemTableDml();
+
+        if (!table.HasRowid)
         {
             throw new EmbeddedSqlException(
                 "Concurrent MVCC DML is supported only for rowid user tables; WITHOUT ROWID tables require composite-key dual-cursor routing.");
         }
     }
+
+    private static void ThrowUnsupportedConcurrentMvccSystemTableDml()
+        => throw new EmbeddedSqlException(
+            "Concurrent MVCC DML is supported only for rowid user tables; sqlite_* tables require system-table dual-cursor routing.");
 
     private static string? GetConcurrentMvccDmlTargetName(ParsedStatement statement)
         => statement switch
@@ -11718,6 +11733,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
         switch (action)
         {
             case ForeignKeyAction.Cascade when newParentValues is null:
+                EnsureConcurrentMvccTableIsSupported(childTableName, childTable, context);
                 ExecuteForeignKeyDelete(
                     context,
                     childTableName,
@@ -11727,6 +11743,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
                     oldParentValues);
                 return;
             case ForeignKeyAction.Cascade:
+                EnsureConcurrentMvccTableIsSupported(childTableName, childTable, context);
                 ExecuteForeignKeyUpdate(
                     context,
                     childTableName,
@@ -11739,6 +11756,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 return;
             case ForeignKeyAction.SetNull:
             case ForeignKeyAction.SetDefault:
+                EnsureConcurrentMvccTableIsSupported(childTableName, childTable, context);
                 ExecuteForeignKeyUpdate(
                     context,
                     childTableName,

--- a/src/Ahtola.Tests/MvccSelectDualCursorRoutingTests.cs
+++ b/src/Ahtola.Tests/MvccSelectDualCursorRoutingTests.cs
@@ -161,6 +161,29 @@ public sealed class MvccSelectDualCursorRoutingTests
         Convert.ToInt64(Scalar(connection, "SELECT COUNT(*) FROM t;")).Should().Be(1L);
     }
 
+    [TestCase("INSERT INTO t VALUES (1, 'insert');")]
+    [TestCase("UPDATE t SET value = 'update';")]
+    [TestCase("DELETE FROM t;")]
+    public void ConcurrentDmlAgainstWithoutRowidTableFailsClosed(string sql)
+    {
+        using var db = new RoutingFileDatabase(
+            "CREATE TABLE t(id INTEGER PRIMARY KEY, value TEXT) WITHOUT ROWID;");
+        using var connection = db.Connect();
+
+        connection.ExecuteNonQuery("PRAGMA journal_mode=mvcc;");
+        connection.ExecuteNonQuery("BEGIN CONCURRENT;");
+
+        var error = Capture(() => connection.ExecuteNonQuery(sql));
+        error.Should().NotBeNull();
+        error!.Message.Should().ContainEquivalentOf("rowid user tables");
+
+        Convert.ToInt64(Scalar(connection, "SELECT COUNT(*) FROM t;")).Should().Be(0L);
+        connection.ExecuteNonQuery("ROLLBACK;");
+
+        connection.ExecuteNonQuery("INSERT INTO t VALUES (1, 'outside');");
+        Convert.ToInt64(Scalar(connection, "SELECT COUNT(*) FROM t;")).Should().Be(1L);
+    }
+
     private static object? Scalar(SqliteConnection connection, string sql)
     {
         using var command = connection.CreateCommand();
@@ -188,7 +211,7 @@ public sealed class MvccSelectDualCursorRoutingTests
     {
         private readonly List<SqliteConnection> _connections = [];
 
-        public RoutingFileDatabase()
+        public RoutingFileDatabase(string schema = "CREATE TABLE t(v INTEGER);")
         {
             Path = System.IO.Path.Combine(
                 System.IO.Path.GetTempPath(),
@@ -196,7 +219,7 @@ public sealed class MvccSelectDualCursorRoutingTests
 
             using var seed = new SqliteConnection($"Data Source={Path};Local Provider=Managed");
             seed.Open();
-            seed.ExecuteNonQuery("CREATE TABLE t(v INTEGER);");
+            seed.ExecuteNonQuery(schema);
         }
 
         public string Path { get; }

--- a/src/Ahtola.Tests/MvccSelectDualCursorRoutingTests.cs
+++ b/src/Ahtola.Tests/MvccSelectDualCursorRoutingTests.cs
@@ -184,6 +184,60 @@ public sealed class MvccSelectDualCursorRoutingTests
         Convert.ToInt64(Scalar(connection, "SELECT COUNT(*) FROM t;")).Should().Be(1L);
     }
 
+    [Test]
+    public void ConcurrentRowTriggerDmlAgainstWithoutRowidTableFailsClosed()
+    {
+        using var db = new RoutingFileDatabase();
+        using var connection = db.Connect();
+        connection.ExecuteNonQuery(
+            """
+            CREATE TABLE sink(id INTEGER PRIMARY KEY, value TEXT) WITHOUT ROWID;
+            CREATE TRIGGER t_after_insert AFTER INSERT ON t BEGIN
+                INSERT INTO sink VALUES (NEW.v, 'trigger');
+            END;
+            """);
+
+        connection.ExecuteNonQuery("PRAGMA journal_mode=mvcc;");
+        connection.ExecuteNonQuery("BEGIN CONCURRENT;");
+
+        var error = Capture(() => connection.ExecuteNonQuery("INSERT INTO t VALUES (1);"));
+        error.Should().NotBeNull();
+        error!.Message.Should().ContainEquivalentOf("rowid user tables");
+
+        Convert.ToInt64(Scalar(connection, "SELECT COUNT(*) FROM t;")).Should().Be(0L);
+        Convert.ToInt64(Scalar(connection, "SELECT COUNT(*) FROM sink;")).Should().Be(0L);
+        connection.ExecuteNonQuery("ROLLBACK;");
+    }
+
+    [Test]
+    public void ConcurrentForeignKeyCascadeAgainstWithoutRowidTableFailsClosed()
+    {
+        using var db = new RoutingFileDatabase();
+        using var connection = db.Connect();
+        connection.ExecuteNonQuery(
+            """
+            PRAGMA foreign_keys=ON;
+            CREATE TABLE parent(id INTEGER PRIMARY KEY);
+            CREATE TABLE child(
+                id INTEGER PRIMARY KEY,
+                parent_id INTEGER REFERENCES parent(id) ON DELETE CASCADE
+            ) WITHOUT ROWID;
+            INSERT INTO parent VALUES (1);
+            INSERT INTO child VALUES (1, 1);
+            """);
+
+        connection.ExecuteNonQuery("PRAGMA journal_mode=mvcc;");
+        connection.ExecuteNonQuery("BEGIN CONCURRENT;");
+
+        var error = Capture(() => connection.ExecuteNonQuery("DELETE FROM parent WHERE id = 1;"));
+        error.Should().NotBeNull();
+        error!.Message.Should().ContainEquivalentOf("rowid user tables");
+
+        Convert.ToInt64(Scalar(connection, "SELECT COUNT(*) FROM parent;")).Should().Be(1L);
+        Convert.ToInt64(Scalar(connection, "SELECT COUNT(*) FROM child;")).Should().Be(1L);
+        connection.ExecuteNonQuery("ROLLBACK;");
+    }
+
     private static object? Scalar(SqliteConnection connection, string sql)
     {
         using var command = connection.CreateCommand();


### PR DESCRIPTION
## Summary
- Fail closed before `BEGIN CONCURRENT` DML can mutate catalog-only `WITHOUT ROWID` or `sqlite_*` targets that the rowid-only MVCC store cannot merge safely.
- Apply the same boundary to ordinary row-trigger bodies and FK `CASCADE`/`SET NULL`/`SET DEFAULT` actions.
- Add direct, trigger, and cascade regression coverage; document the scoped invariant.

## Validation
- `pwsh ./scripts/Invoke-ManagedTestSuite.ps1 -Framework net10.0 -Filter "FullyQualifiedName~MvccSelectDualCursorRoutingTests" -MinimumExecutedTests 10` (18 passed)

## Remaining MVCC limitations
- No composite-key dual cursor/version chains for `WITHOUT ROWID` tables.
- `sqlite_schema` is not MVCC-versioned; concurrent DDL remains rejected.
- Schema-generation invalidation and Turso-equivalent page-level cooperative checkpointing are not implemented.