### PR TITLE
Add durable managed virtual table state

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,9 +264,12 @@ Treat Ahtola as SQLite-*compatible*, not a full SQLite replacement:
   (`PRAGMA wal_checkpoint` in MVCC mode). Not cross-process; residual schema-
   cookie polish and full per-page b-tree checkpoint SM remain open — see
   [docs/mvcc-port-contract.md](docs/mvcc-port-contract.md).
-- **Not implemented** — FTS / R-Tree modules, loadable extensions, raw
-  `sqlite3*` handles (`Handle` is null), AEGIS encryption ciphers, sync engine /
-  CDC, CREATE SEQUENCE, typed-value extensions.
+- **Managed virtual-table subset** — statically registered `fts5`, `rtree`, and
+  `rtree_i32` modules persist module-owned state in the managed catalog, but are
+  not full SQLite FTS5/R-Tree implementations and do not create interoperable
+  FTS/R-Tree shadow tables. Loadable extensions, raw `sqlite3*` handles
+  (`Handle` is null), AEGIS encryption ciphers, sync engine / CDC, CREATE
+  SEQUENCE, and typed-value extensions remain unavailable.
 - **Native / Sync companions** — not shipped. Connection-string paths that need
   them fail closed. OS P/Invoke in the pager for locks/WAL is intentional engine
   code, not a Rust SDK binding.

--- a/docs/managed-vtab-fts-rtree-integration.md
+++ b/docs/managed-vtab-fts-rtree-integration.md
@@ -39,13 +39,29 @@ N-dimensional bounds and deterministic spatial storage. The module adapters
 own virtual-table schema validation, `VUpdate` argument conversion, and
 transaction snapshots; the reusable components do not own catalog state.
 
-## Current integration scope
+## Durable managed catalog contract
 
-The initial modules are in-memory only. The current foundation intentionally
-rejects managed virtual tables on file-backed databases because it has no
-module-specific persistence/reopen contract. Consequently, managed FTS/R-Tree
-content is not durable, is not included in backup/catalog recovery, and must
-not be represented as persistent SQLite-compatible shadow tables yet.
+Each managed virtual table returns a
+`ManagedVirtualTablePersistencePayload`: a positive module-defined version and
+an opaque byte payload. The engine never reflects over modules or interprets
+their bytes. Instead, it gives the payload back to the statically registered
+module through `ManagedVirtualTableModule.Create(context, payload)` when it
+recreates a catalog snapshot, opens a file, or rolls back a
+transaction/savepoint.
+
+For file-backed databases, the catalog writes a real `sqlite_schema` row with
+`type='table'`, `rootpage=0`, and a `CREATE VIRTUAL TABLE ... USING ...`
+declaration. An Ahtola-private comment on that declaration carries the
+versioned, base64-encoded module payload. This keeps the payload in the
+SQLite-format catalog and makes full catalog rewrites, `VACUUM INTO`, reopen,
+and pager/WAL recovery restore the same registered module and state. Invalid,
+unsupported-version, truncated, or malformed payloads fail closed during
+catalog reconstruction.
+
+This is deliberately **not** an emulation of FTS5 or R-Tree shadow tables.
+Classic SQLite readers can enumerate the rootpage-zero declaration in
+`sqlite_schema`, but the private payload is meaningful only to Ahtola and
+other engines must not be expected to query or maintain these tables.
 
 `CREATE VIRTUAL TABLE`, `SELECT` scans, `DROP`, module creation, cursors, and
 SQL `INSERT`, `UPDATE`, and `DELETE` use the canonical foundation. The
@@ -56,16 +72,21 @@ equality/range plans are therefore available through ordinary SQL, while DML
 uses the VUpdate old-rowid/new-rowid/declared-column layout under
 begin/sync/commit/rollback.
 
+Every successful virtual-table DML statement publishes a new payload in the
+working catalog. Failed statements retain the prior payload; explicit
+transactions and savepoints use independent module instances recreated from
+their saved payloads, so `ROLLBACK` and `ROLLBACK TO` restore module state as
+well as schema state for `CREATE`, `DROP`, and `RENAME`.
+
 ## Remaining product limitations
 
-- The modules remain in-memory only; no file-backed catalog reopen, shadow
-  storage, backup, or recovery support exists.
 - `fts5` is a small managed query/tokenizer subset, not FTS5 compatibility:
   tokenizer options, external/contentless tables, auxiliary functions,
   ranking, snippets, and FTS5-specific command syntax are unsupported.
-- `rtree` does not yet persist shadow tables or expose SQLite's full R-Tree
-  auxiliary/geometry callback surface. `rtree_i32` accepts only signed
-  32-bit integer coordinates.
+- `rtree` does not expose SQLite's full R-Tree auxiliary/geometry callback
+  surface. `rtree_i32` accepts only signed 32-bit integer coordinates.
+- The private payload is a managed catalog extension, not a portable FTS5/R-Tree
+  file representation. Ahtola intentionally does not synthesize shadow tables.
 - The current generic DML path auto-assigns FTS rowids; explicitly naming
   `rowid` in an `INSERT` column list is not supported yet.
 - Planner extraction is deliberately limited to source-local conjunctive

--- a/docs/turso-gap-analysis.md
+++ b/docs/turso-gap-analysis.md
@@ -251,15 +251,15 @@ Four pairs of **same-name/different-meaning** opcodes are landmines:
 | 28 | `If` | consolidated | JumpIf |  |
 | 29 | `IfNot` | consolidated | JumpIf / JumpIfNotTrue |  |
 | 30 | `OpenRead` | direct | OpenReadCursor |  |
-| 31 | `VOpen` | missing | — | `vdbe-virtual-table-opcodes` |
-| 32 | `VCreate` | missing | — | `vdbe-virtual-table-opcodes` |
-| 33 | `VFilter` | missing | — | `vdbe-virtual-table-opcodes` |
-| 34 | `VColumn` | missing | — | `vdbe-virtual-table-opcodes` |
-| 35 | `VUpdate` | missing | — | `vdbe-virtual-table-opcodes` |
-| 36 | `VNext` | missing | — | `vdbe-virtual-table-opcodes` |
-| 37 | `VDestroy` | missing | — | `vdbe-virtual-table-opcodes` |
-| 38 | `VBegin` | missing | — | `vdbe-virtual-table-opcodes` |
-| 39 | `VRename` | missing | — | `vdbe-virtual-table-opcodes` |
+| 31 | `VOpen` | direct | `VOpenInstruction` | `vdbe-virtual-table-opcodes` |
+| 32 | `VCreate` | treewalker | `ExecuteCreateVirtualTable` | `vdbe-virtual-table-opcodes` |
+| 33 | `VFilter` | direct | `VFilterInstruction` | `vdbe-virtual-table-opcodes` |
+| 34 | `VColumn` | direct | `VColumnInstruction` | `vdbe-virtual-table-opcodes` |
+| 35 | `VUpdate` | direct | `VUpdateInstruction` | `vdbe-virtual-table-opcodes` |
+| 36 | `VNext` | direct | `VNextInstruction` | `vdbe-virtual-table-opcodes` |
+| 37 | `VDestroy` | treewalker | `ExecuteDropTable` | `vdbe-virtual-table-opcodes` |
+| 38 | `VBegin` | direct | `VBeginInstruction` | `vdbe-virtual-table-opcodes` |
+| 39 | `VRename` | treewalker | `ExecuteAlterTableRename` | `vdbe-virtual-table-opcodes` |
 | 40 | `OpenPseudo` | missing | — | `vdbe-open-ephemeral` |
 | 41 | `Rewind` | direct | Rewind |  |
 | 42 | `Last` | direct | Last |  |
@@ -466,7 +466,7 @@ Status totals: bydesign 24, consolidated 40, direct 26, divergent 10, missing 10
 | `vdbe-schema-cookie-opcodes` | missing | s2-capability | M | 0 | 0 | No cookie opcodes: user_version/application_id read-write and schema-cookie validation (stale-schema detection, 'database schema has changed' errors) are not modeled at t… |
 | `vdbe-sequence-opcode-family` | missing | s4-intentional | M | 0 | 0 | Turso's CREATE SEQUENCE extension (8 opcodes), not SQLite syntax. Note: distinct from AUTOINCREMENT support (sqlite_sequence), which Ahtola partially has — see vdbe-newro… |
 | `vdbe-typed-value-opcode-family` | missing | s4-intentional | L | 0 | 0 | Turso's typed-values extension (arrays/structs/unions/UDTs) — 17 opcodes, none SQLite. Ahtola has not adopted the extension; no conformance corpus coverage. Record as ups… |
-| `vdbe-virtual-table-opcodes` | missing | s2-capability | L | 0 | 0 | No virtual-table opcode family at all: modules cannot be opened, filtered with constraint push-down (xBestIndex), column-read, updated, or renamed. Blocks the entire epon… |
+| `vdbe-virtual-table-opcodes` | partial | s2-capability | L | 0 | 0 | Managed VOpen/VFilter/VColumn/VUpdate/VNext/VBegin instructions and tree-walker create/drop/rename now support statically registered modules with durable private payloads. The native extension ABI, arbitrary loadable modules, and Turso index-method parity remain out of scope. |
 
 ## 4. Compilation / translate layer
 The largest layer by entry count (38). Turso's `core/translate/` is a full
@@ -584,7 +584,7 @@ The distribution is wildly skewed by one entry:
 | `parser-bracket-quoted-identifiers` | missing | s2-capability | S | 3 | 1 | Square-bracket quoted identifiers not lexed. |
 | `parser-pragma-unrecognized-name-hard-rejection` | missing | s2-capability | M | 2 | 14 | The turso-parser grammar's `Stmt::Pragma` accepts *any* identifier as `name`, with an arbitrary optional body (`= value`, `(value)`, or none); SQLite's own behavior for a… |
 | `parser-begin-commit-transaction-name` | missing | s2-capability | S | 0 | 1 | SQLite's grammar for BEGIN/COMMIT/END admits an optional transaction name after the TRANSACTION keyword (`trans_opt ::= \| TRANSACTION \| TRANSACTION nm`), which is accep… |
-| `parser-create-virtual-table-not-parsed` | missing | s2-capability | L | 0 | 0 | Turso's Stmt::CreateVirtualTable(CreateVirtualTable) is a first-class AST node capturing module name and raw argument strings. Ahtola's SqlAst.cs has no corresponding sta… |
+| `parser-create-virtual-table-not-parsed` | partial | s2-capability | L | 0 | 0 | Ahtola now parses `CREATE VIRTUAL TABLE` into `CreateVirtualTableStatement` with module name and raw argument strings. The managed contract is intentionally limited to statically registered modules; no native/loadable module ABI is exposed. |
 | `parser-trailing-named-constraint-without-body` | divergent | s3-perf | S | 0 | 3 | SQLite's own LALR grammar happens to accept a dangling `CONSTRAINT c` at the very end of a column/ADD COLUMN definition with no constraint keyword following it (an accept… |
 | `parser-turso-only-ddl-extensions-absent` | missing | s4-intentional | L | 0 | 0 | Turso's ast.rs Stmt enum includes several experimental statement kinds that are not part of SQLite's own grammar: CREATE MATERIALIZED VIEW, CREATE/DROP TYPE (custom scala… |
 | `parser-turso-only-sequence-and-optimize-statements` | missing | s4-intentional | M | 0 | 0 | CREATE/DROP SEQUENCE (standalone integer sequences, distinct from AUTOINCREMENT) and OPTIMIZE INDEX are Turso-only statement kinds with no SQLite equivalent and no hits i… |
@@ -617,7 +617,7 @@ than absent subsystems.
 | `func-array-postgres-family` | missing | s3-perf | L | 0 | 0 | Postgres-style ARRAY(...)/array_element/array_append/etc. scalar family, always compiled (not behind a cargo feature flag) but not part of stock SQLite semantics and not… |
 | `func-extension-format-btrim` | extension | s4-intentional | S | 0 | 0 | FORMAT (an alias for PRINTF, matching real SQLite's built-in but not present as a distinct entry in Turso's from_str dispatch table) and BTRIM (Postgres-style alias for T… |
 | `func-extension-uuid-family` | extension | s4-intentional | S | 0 | 0 | Ahtola registers a full UUID v4/v7 generation family (text and blob forms, plus gen_random_uuid() for Postgres compatibility) that has no counterpart anywhere in turso-sr… |
-| `func-fts-scalar-family` | missing | s3-perf | L | 0 | 0 | FTS-related scalar helpers used with Turso's fts5-style virtual tables; no equivalent in Ahtola.Core (no FTS virtual table support at all in this layer). Out of primary s… |
+| `func-fts-scalar-family` | missing | s3-perf | L | 0 | 0 | A managed `fts5` virtual-table subset now exists, but Turso/SQLite FTS scalar helpers, ranking, snippets, and auxiliary-function surfaces remain unimplemented. |
 | `func-gcd-lcm-missing` | missing | s3-perf | S | 0 | 0 | gcd()/lcm() (Turso/SQLite-3.41+-style math helpers) have no hits anywhere in src/Ahtola.Core or Ahtola.Core/EmbeddedDatabase.MathFunctions.cs. Not covered by the vendored… |
 | `func-numeric-boolean-ip-helpers-missing` | missing | s4-intentional | M | 0 | 0 | Internal-flavored helper functions supporting Turso's typed BOOLEAN/NUMERIC column extensions and validated IP address type; no SQLite equivalent and no corpus coverage.… |
 | `func-octet-length-missing` | missing | s1-correctness | S | 0 | 0 | octet_length is absent from SqliteBuiltinFunctions.Names and from EmbeddedDatabase.StringFunctions.cs / EmbeddedDatabase.cs (no case-insensitive hit for 'octet' anywhere… |

--- a/docs/turso-gap-inventory.json
+++ b/docs/turso-gap-inventory.json
@@ -29,7 +29,8 @@
       },
       "by_kind": {
         "extension": 8,
-        "missing": 79,
+        "missing": 77,
+        "partial": 2,
         "divergent": 71,
         "parity": 53
       },
@@ -90,13 +91,13 @@
     {
       "id": "vdbe-virtual-table-opcodes",
       "layer": "vdbe",
-      "kind": "missing",
+      "kind": "partial",
       "turso_ref": "turso-src/core/vdbe/insn.rs::Insn::VOpen, VFilter, VColumn, VNext, VUpdate, VDestroy, VBegin, VRename (turso-src/core/vtab.rs)",
-      "ahtola_ref": "none",
+      "ahtola_ref": "src/Ahtola.Core/Execution/VdbeProgram.cs::VOpenInstruction/VFilterInstruction/VColumnInstruction/VUpdateInstruction/VNextInstruction/VBeginInstruction; src/Ahtola.Core/EmbeddedDatabase.cs::ExecuteCreateVirtualTable/ExecuteDropTable/ExecuteAlterTableRename",
       "severity": "s4-intentional",
       "effort": "L",
       "conformance_links": [],
-      "notes": "Closed 2026-08-06 as intentional product skip with parser-create-virtual-table-not-parsed. No VOpen/VFilter/VColumn/VUpdate family; no CreateModule surface (ManagedDocumentedBoundaryTests.NoModuleSurfaceIsPublished). Classic managed SQLite path does not ship FTS/R-Tree/modules.",
+      "notes": "P1 durable managed virtual tables (2026-08-18): direct, statically registered modules now run through VOpen/VFilter/VColumn/VUpdate/VNext/VBegin and tree-walker CREATE/DROP/RENAME. File-backed catalogs persist rootpage-zero CREATE VIRTUAL TABLE declarations plus opaque module-owned payloads; reopen, VACUUM INTO, statement failure, transactions, and savepoints restore them. This remains a managed subset: no native extension ABI, arbitrary loadable modules, FTS5 shadow tables, or Turso index-method parity.",
       "status": "closed"
     },
     {
@@ -1333,13 +1334,13 @@
     {
       "id": "parser-create-virtual-table-not-parsed",
       "layer": "parser",
-      "kind": "missing",
+      "kind": "partial",
       "turso_ref": "turso-src/sqlite/parser/src/ast.rs::CreateVirtualTable { if_not_exists, tbl_name, module_name, args }",
-      "ahtola_ref": "none — src/Ahtola.Core/Parsing/SqlParser.cs line 512 detects the VIRTUAL keyword only to immediately throw",
+      "ahtola_ref": "src/Ahtola.Core/Parsing/SqlAst.cs::CreateVirtualTableStatement; src/Ahtola.Core/Parsing/SqlParser.cs::ParseCreateVirtualTable",
       "severity": "s4-intentional",
       "effort": "L",
       "conformance_links": [],
-      "notes": "Closed 2026-08-06 as intentional product skip (paired with vdbe-virtual-table-opcodes). CREATE VIRTUAL TABLE is rejected fail-closed (ManagedDocumentedBoundaryTests, README Not implemented: virtual tables/FTS/R-Tree). No module registry or AST node by design until a full module API is a product goal; do not add a parse-only stub.",
+      "notes": "P1 durable managed virtual tables (2026-08-18): CREATE VIRTUAL TABLE parses into a dedicated AST node and dispatches only to the reflection-free static module registry. The file-backed catalog stores the declaration plus an opaque versioned payload. This does not expose SQLite's native/loadable module ABI.",
       "status": "closed"
     },
     {
@@ -1730,7 +1731,7 @@
       "severity": "s3-perf",
       "effort": "L",
       "conformance_links": [],
-      "notes": "Closed 2026-08-06 as no-action until FTS virtual tables exist. The scalar helpers have no managed consumer; the actual virtual-table/parser surface remains tracked by parser-create-virtual-table-not-parsed and vdbe-virtual-table-opcodes.",
+      "notes": "A managed fts5 virtual-table subset now exists, but the Turso/SQLite FTS scalar, ranking, snippet, and auxiliary-function surfaces remain unimplemented. The managed virtual-table/parser surface is tracked separately by parser-create-virtual-table-not-parsed and vdbe-virtual-table-opcodes.",
       "status": "closed"
     },
     {

--- a/src/Ahtola.Core/EmbeddedDatabase.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.cs
@@ -332,6 +332,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
         _tables = catalog.Tables;
         _views = catalog.Views;
         _triggers = catalog.Triggers;
+        _virtualTables = catalog.VirtualTables;
         _transactionLock = EmbeddedTransactionLockRegistry.Get(fileSystem, databasePath);
     }
 
@@ -875,22 +876,39 @@ public sealed partial class EmbeddedDatabase : IDisposable
 
         public Dictionary<string, TriggerDefinition> Triggers { get; }
 
-        // Module instances are intentionally shared across transaction catalog snapshots. A virtual
-        // table owns its mutable state, so cloning it here would make rollback semantics misleading.
         public Dictionary<string, VirtualTableDefinition> VirtualTables { get; }
 
         public SchemaCatalog Clone() => new(
             CloneTables(Tables),
             new Dictionary<string, ViewDefinition>(Views, StringComparer.OrdinalIgnoreCase),
             new Dictionary<string, TriggerDefinition>(Triggers, StringComparer.OrdinalIgnoreCase),
-            new Dictionary<string, VirtualTableDefinition>(VirtualTables, StringComparer.OrdinalIgnoreCase));
+            VirtualTables.ToDictionary(
+                static entry => entry.Key,
+                static entry => entry.Value.CreateSnapshot(),
+                StringComparer.OrdinalIgnoreCase));
     }
 
     internal sealed record VirtualTableDefinition(
         string Name,
         string ModuleName,
         IReadOnlyList<string> Arguments,
-        ManagedVirtualTable Table);
+        ManagedVirtualTablePersistencePayload PersistencePayload,
+        ManagedVirtualTable Table)
+    {
+        public VirtualTableDefinition CreateSnapshot()
+        {
+            var payload = PersistencePayload.Clone();
+            var arguments = Arguments.ToArray();
+            var table = ManagedVirtualTableModuleRegistry.Resolve(ModuleName).Create(
+                new ManagedVirtualTableCreateContext(Name, arguments),
+                payload);
+            ArgumentNullException.ThrowIfNull(table);
+            return new VirtualTableDefinition(Name, ModuleName, arguments, payload, table);
+        }
+
+        public VirtualTableDefinition WithCurrentPersistencePayload()
+            => this with { PersistencePayload = Table.GetPersistencePayload() };
+    }
 
     internal sealed class AutoIncrementStatementState
     {
@@ -2557,7 +2575,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 if (pageSize == _fileCatalogVersion.PageSize)
                     _fileStore.Compact();
                 else
-                    _fileStore.MigratePageSize(pageSize, _tables, _views, _triggers);
+                    _fileStore.MigratePageSize(pageSize, _tables, _views, _triggers, _virtualTables);
                 _fileStore.AdoptCommittedTables(_tables);
                 _fileCatalogVersion = ReadFileCatalogVersion(_fileSystem, _databasePath);
                 _version++;
@@ -2628,7 +2646,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
             pageSize,
             _tables,
             _views,
-            _triggers);
+            _triggers,
+            _virtualTables);
     }
 
     internal void SetPragmaHeaderInteger(
@@ -2721,6 +2740,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
                     catalog.Tables,
                     catalog.Views,
                     catalog.Triggers,
+                    catalog.VirtualTables,
                     pragmaHeader,
                     forceFullRewrite,
                     previousTables: _tables);
@@ -2817,7 +2837,12 @@ public sealed partial class EmbeddedDatabase : IDisposable
             var previous = _fileStore!;
             _fileStore = replacement;
             replacement = null;
-            PublishCatalog(new SchemaCatalog(catalog.Tables, catalog.Views, catalog.Triggers), loadedVersion);
+            PublishCatalog(new SchemaCatalog(
+                catalog.Tables,
+                catalog.Views,
+                catalog.Triggers,
+                catalog.VirtualTables),
+                loadedVersion);
             previous.Dispose();
             return true;
         }
@@ -2901,7 +2926,11 @@ public sealed partial class EmbeddedDatabase : IDisposable
             _fileStore = replacement;
             replacement = null;
             _fileCatalogVersion = ReadFileCatalogVersion(_fileSystem, _databasePath, foreignReadOnly: true);
-            PublishCatalog(new SchemaCatalog(catalog.Tables, catalog.Views, catalog.Triggers));
+            PublishCatalog(new SchemaCatalog(
+                catalog.Tables,
+                catalog.Views,
+                catalog.Triggers,
+                catalog.VirtualTables));
             _foreignViewToken = _fileStore.CaptureCommittedViewToken();
             previous.Dispose();
         }
@@ -2975,7 +3004,11 @@ public sealed partial class EmbeddedDatabase : IDisposable
                     _fileStore = replacement;
                     replacement = null;
                     _fileCatalogVersion = ReadFileCatalogVersion(_fileSystem, _databasePath);
-                    PublishCatalog(new SchemaCatalog(catalog.Tables, catalog.Views, catalog.Triggers));
+                    PublishCatalog(new SchemaCatalog(
+                        catalog.Tables,
+                        catalog.Views,
+                        catalog.Triggers,
+                        catalog.VirtualTables));
                     previous.Dispose();
                 }
                 finally
@@ -3043,7 +3076,11 @@ public sealed partial class EmbeddedDatabase : IDisposable
                     _fileStore = replacement;
                     replacement = null;
                     PublishCatalog(
-                        new SchemaCatalog(catalog.Tables, catalog.Views, catalog.Triggers),
+                        new SchemaCatalog(
+                            catalog.Tables,
+                            catalog.Views,
+                            catalog.Triggers,
+                            catalog.VirtualTables),
                         loadedVersion);
                     previous.Dispose();
                 }
@@ -4201,13 +4238,6 @@ public sealed partial class EmbeddedDatabase : IDisposable
         SchemaCatalog catalog,
         bool inTransaction)
     {
-        ThrowIfVirtualTableSchemaChangeInTransaction(inTransaction);
-        if (_fileStore is not null)
-        {
-            throw new EmbeddedSqlException(
-                "persistent managed virtual tables require a module-specific persistence implementation");
-        }
-
         if (IsReservedObjectName(statement.Name))
             throw new EmbeddedSqlException($"object name reserved for internal use: {statement.Name}");
         if (catalog.VirtualTables.ContainsKey(statement.Name))
@@ -4232,7 +4262,12 @@ public sealed partial class EmbeddedDatabase : IDisposable
         ArgumentNullException.ThrowIfNull(table);
         catalog.VirtualTables.Add(
             statement.Name,
-            new VirtualTableDefinition(statement.Name, statement.ModuleName, statement.Arguments, table));
+            new VirtualTableDefinition(
+                statement.Name,
+                statement.ModuleName,
+                statement.Arguments.ToArray(),
+                table.GetPersistencePayload(),
+                table));
         return new ExecutionResult([], [], 0, true);
     }
 
@@ -4327,7 +4362,6 @@ public sealed partial class EmbeddedDatabase : IDisposable
 
         if (catalog.VirtualTables.Remove(statement.Name, out var virtualTable))
         {
-            ThrowIfVirtualTableSchemaChangeInTransaction(context.InTransaction);
             virtualTable.Table.Destroy();
             RemoveTriggersForTable(catalog, statement.Name);
             return new ExecutionResult([], [], 0, true);
@@ -5285,7 +5319,6 @@ public sealed partial class EmbeddedDatabase : IDisposable
         var tables = catalog.Tables;
         if (catalog.VirtualTables.TryGetValue(statement.TableName, out var virtualTable))
         {
-            ThrowIfVirtualTableSchemaChangeInTransaction(context.InTransaction);
             if (IsReservedObjectName(statement.NewName))
                 throw new EmbeddedSqlException($"object name reserved for internal use: {statement.NewName}");
             if (catalog.VirtualTables.ContainsKey(statement.NewName)
@@ -5297,11 +5330,114 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 throw new EmbeddedSqlException($"there is already an object named {statement.NewName}");
             }
 
-            virtualTable.Table.Rename(statement.NewName);
-            catalog.VirtualTables.Remove(statement.TableName);
-            catalog.VirtualTables.Add(
+            var candidatePayload = virtualTable.PersistencePayload.Clone();
+            var virtualCandidateTable = ManagedVirtualTableModuleRegistry.Resolve(virtualTable.ModuleName).Create(
+                new ManagedVirtualTableCreateContext(statement.NewName, virtualTable.Arguments),
+                candidatePayload);
+            ArgumentNullException.ThrowIfNull(virtualCandidateTable);
+            var candidateVirtualTables = new Dictionary<string, VirtualTableDefinition>(
+                catalog.VirtualTables,
+                StringComparer.OrdinalIgnoreCase);
+            candidateVirtualTables.Remove(statement.TableName);
+            candidateVirtualTables.Add(
                 statement.NewName,
-                virtualTable with { Name = statement.NewName });
+                new VirtualTableDefinition(
+                    statement.NewName,
+                    virtualTable.ModuleName,
+                    virtualTable.Arguments.ToArray(),
+                    candidatePayload,
+                    virtualCandidateTable));
+
+            try
+            {
+                Dictionary<string, ViewDefinition>? virtualCandidateViews = null;
+                Dictionary<string, TriggerDefinition>? virtualCandidateTriggers = null;
+                foreach (var view in catalog.Views.Values)
+                {
+                    context.CheckInterrupt();
+                    var rewritten = AlterTableSqlRewriter.RenameTableReferences(
+                        view.Sql, statement.TableName, statement.NewName);
+                    if (rewritten is null || string.Equals(rewritten, view.Sql, StringComparison.Ordinal))
+                        continue;
+
+                    virtualCandidateViews ??= new Dictionary<string, ViewDefinition>(
+                        catalog.Views,
+                        StringComparer.OrdinalIgnoreCase);
+                    var parsed = (CreateViewStatement)SqlParser.Parse(rewritten, SqlParameterMap.Parse(rewritten));
+                    virtualCandidateViews[view.Name] = view with { Query = parsed.Query, Sql = parsed.Sql };
+                }
+
+                foreach (var trigger in catalog.Triggers.Values)
+                {
+                    context.CheckInterrupt();
+                    var rewritten = AlterTableSqlRewriter.RenameTableReferences(
+                        trigger.Sql, statement.TableName, statement.NewName);
+                    if (rewritten is null || string.Equals(rewritten, trigger.Sql, StringComparison.Ordinal))
+                        continue;
+
+                    virtualCandidateTriggers ??= new Dictionary<string, TriggerDefinition>(
+                        catalog.Triggers,
+                        StringComparer.OrdinalIgnoreCase);
+                    var parsed = (CreateTriggerStatement)SqlParser.Parse(rewritten, SqlParameterMap.Parse(rewritten));
+                    var parsedTableName = ManagedSchemaName.TrySplit(parsed.TableName, out var parsedSchema, out var parsedLocalName)
+                        && parsedSchema.Equals("main", StringComparison.OrdinalIgnoreCase)
+                        ? parsedLocalName
+                        : parsed.TableName;
+                    virtualCandidateTriggers[trigger.Name] = trigger with
+                    {
+                        TableName = parsedTableName,
+                        UpdateOfColumns = parsed.UpdateOfColumns,
+                        When = parsed.When,
+                        Body = parsed.Body,
+                        Sql = parsed.Sql,
+                    };
+                }
+
+                var virtualCandidateCatalog = new SchemaCatalog(
+                    tables,
+                    virtualCandidateViews ?? catalog.Views,
+                    virtualCandidateTriggers ?? catalog.Triggers,
+                    candidateVirtualTables);
+                ValidateDependentSchema(
+                    virtualCandidateCatalog,
+                    context with
+                    {
+                        Tables = tables,
+                        Views = virtualCandidateCatalog.Views,
+                        Triggers = virtualCandidateCatalog.Triggers,
+                        VirtualTables = virtualCandidateCatalog.VirtualTables,
+                        SchemaValidation = true,
+                    },
+                    context.CancellationToken,
+                    "rename table",
+                    catalog,
+                    context with
+                    {
+                        Views = catalog.Views,
+                        Triggers = catalog.Triggers,
+                        SchemaValidation = true,
+                    });
+
+                virtualTable.Table.Rename(statement.NewName);
+                catalog.VirtualTables.Remove(statement.TableName);
+                catalog.VirtualTables.Add(
+                    statement.NewName,
+                    (virtualTable with { Name = statement.NewName }).WithCurrentPersistencePayload());
+                if (virtualCandidateViews is not null)
+                {
+                    foreach (var entry in virtualCandidateViews)
+                        catalog.Views[entry.Key] = entry.Value;
+                }
+                if (virtualCandidateTriggers is not null)
+                {
+                    foreach (var entry in virtualCandidateTriggers)
+                        catalog.Triggers[entry.Key] = entry.Value;
+                }
+            }
+            finally
+            {
+                virtualCandidateTable.Destroy();
+            }
             return new ExecutionResult([], [], 0, true);
         }
 
@@ -5388,7 +5524,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
             : new SchemaCatalog(
                 candidateTables,
                 candidateViews ?? catalog.Views,
-                candidateTriggers ?? catalog.Triggers);
+                candidateTriggers ?? catalog.Triggers,
+                catalog.VirtualTables);
         ValidateDependentSchema(
             candidateCatalog,
             context with
@@ -5737,7 +5874,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
             : new SchemaCatalog(
                 candidateTables,
                 candidateViews ?? catalog.Views,
-                candidateTriggers ?? catalog.Triggers);
+                candidateTriggers ?? catalog.Triggers,
+                catalog.VirtualTables);
 
         ValidateDependentSchema(
             candidateCatalog,
@@ -5901,7 +6039,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
         var candidateCatalog = new SchemaCatalog(
             candidateTables,
             candidateViews ?? catalog.Views,
-            candidateTriggers ?? catalog.Triggers);
+            candidateTriggers ?? catalog.Triggers,
+            catalog.VirtualTables);
         var candidateContext = context with
         {
             Tables = candidateTables,
@@ -7167,7 +7306,6 @@ public sealed partial class EmbeddedDatabase : IDisposable
         SqlValue[] parameters,
         QueryContext context)
     {
-        ThrowIfVirtualTableMutationInTransaction(context);
         if (statement.Source is not null
             || statement.Returning is not null
             || statement.Upsert is not null
@@ -7192,7 +7330,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
             mutations.Add(BuildVirtualTableUpdateArguments(null, null, values));
         }
 
-        return ExecuteVirtualTableMutations(definition.Table, mutations);
+        return ExecuteVirtualTableMutations(context.VirtualTables!, definition, mutations);
     }
 
     private ExecutionResult ExecuteVirtualTableUpdate(
@@ -7201,7 +7339,6 @@ public sealed partial class EmbeddedDatabase : IDisposable
         SqlValue[] parameters,
         QueryContext context)
     {
-        ThrowIfVirtualTableMutationInTransaction(context);
         if (statement.Returning is not null
             || statement.EffectiveOrderBy.Count != 0
             || statement.Limit is not null
@@ -7246,7 +7383,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
             mutations.Add(BuildVirtualTableUpdateArguments(row.RowId, row.RowId, values));
         }
 
-        return ExecuteVirtualTableMutations(definition.Table, mutations);
+        return ExecuteVirtualTableMutations(context.VirtualTables!, definition, mutations);
     }
 
     private ExecutionResult ExecuteVirtualTableDelete(
@@ -7255,7 +7392,6 @@ public sealed partial class EmbeddedDatabase : IDisposable
         SqlValue[] parameters,
         QueryContext context)
     {
-        ThrowIfVirtualTableMutationInTransaction(context);
         if (statement.Returning is not null
             || statement.EffectiveOrderBy.Count != 0
             || statement.Limit is not null
@@ -7285,7 +7421,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
                     context))
             .Select(row => BuildVirtualTableUpdateArguments(row.RowId, null, row.Values))
             .ToArray();
-        return ExecuteVirtualTableMutations(definition.Table, mutations);
+        return ExecuteVirtualTableMutations(context.VirtualTables!, definition, mutations);
     }
 
     private static int[] ResolveVirtualTableColumns(
@@ -7331,26 +7467,9 @@ public sealed partial class EmbeddedDatabase : IDisposable
         return arguments;
     }
 
-    private static void ThrowIfVirtualTableMutationInTransaction(QueryContext context)
-    {
-        if (context.InTransaction)
-        {
-            throw new EmbeddedSqlException(
-                "managed virtual-table mutations are not supported inside explicit transactions or savepoints");
-        }
-    }
-
-    private static void ThrowIfVirtualTableSchemaChangeInTransaction(bool inTransaction)
-    {
-        if (inTransaction)
-        {
-            throw new EmbeddedSqlException(
-                "managed virtual-table schema changes are not supported inside explicit transactions or savepoints");
-        }
-    }
-
     private static ExecutionResult ExecuteVirtualTableMutations(
-        ManagedVirtualTable table,
+        IReadOnlyDictionary<string, VirtualTableDefinition> virtualTables,
+        VirtualTableDefinition definition,
         IReadOnlyList<IReadOnlyList<SqlValue>> mutations)
     {
         if (mutations.Count == 0)
@@ -7383,10 +7502,13 @@ public sealed partial class EmbeddedDatabase : IDisposable
         {
             using var statement = new ResumableStatement(
                 program,
-                virtualTableBindings: [new VdbeVirtualTableBinding(table)]);
+                virtualTableBindings: [new VdbeVirtualTableBinding(definition.Table)]);
             if (statement.StepResumable() != ResumableStatementStepResult.Done)
                 throw new InvalidOperationException("A managed virtual-table mutation program yielded unexpectedly.");
 
+            var mutableVirtualTables = virtualTables as Dictionary<string, VirtualTableDefinition>
+                ?? throw new InvalidOperationException("Managed virtual-table catalog must be mutable.");
+            mutableVirtualTables[definition.Name] = definition.WithCurrentPersistencePayload();
             return new ExecutionResult([], [], statement.RowsAffected, true)
             {
                 LastInsertRowId = statement.LastInsertRowId,
@@ -7394,7 +7516,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
         }
         catch
         {
-            table.Rollback();
+            definition.Table.Rollback();
             throw;
         }
     }

--- a/src/Ahtola.Core/EmbeddedFileStore.cs
+++ b/src/Ahtola.Core/EmbeddedFileStore.cs
@@ -10,7 +10,76 @@ namespace Ahtola.Core;
 internal sealed record EmbeddedFileCatalog(
     Dictionary<string, EmbeddedTable> Tables,
     Dictionary<string, ViewDefinition> Views,
-    Dictionary<string, TriggerDefinition> Triggers);
+    Dictionary<string, TriggerDefinition> Triggers,
+    Dictionary<string, EmbeddedDatabase.VirtualTableDefinition> VirtualTables);
+
+internal static class ManagedVirtualTableSchemaSql
+{
+    private const string PayloadMarker = "/*ahtola-managed-vtab:";
+    private const string PayloadTerminator = "*/";
+
+    public static string Build(EmbeddedDatabase.VirtualTableDefinition definition)
+    {
+        var arguments = definition.Arguments.Count == 0
+            ? string.Empty
+            : "(" + string.Join(", ", definition.Arguments) + ")";
+        return "CREATE VIRTUAL TABLE "
+            + QuoteIdentifier(definition.Name)
+            + " USING "
+            + QuoteIdentifier(definition.ModuleName)
+            + arguments
+            + " "
+            + PayloadMarker
+            + definition.PersistencePayload.Version.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            + ":"
+            + Convert.ToBase64String(definition.PersistencePayload.Bytes.Span)
+            + PayloadTerminator;
+    }
+
+    public static (
+        CreateVirtualTableStatement Declaration,
+        ManagedVirtualTablePersistencePayload Payload) Parse(string sql)
+    {
+        var marker = sql.LastIndexOf(PayloadMarker, StringComparison.Ordinal);
+        if (marker <= 0 || !sql.EndsWith(PayloadTerminator, StringComparison.Ordinal))
+            throw new EmbeddedSqlException("managed virtual-table sqlite_schema SQL is missing its persistence payload");
+
+        var declarationSql = sql[..marker].TrimEnd();
+        var statement = SqlParser.Parse(declarationSql, SqlParameterMap.Parse(declarationSql));
+        if (statement is not CreateVirtualTableStatement declaration)
+            throw new EmbeddedSqlException("managed virtual-table sqlite_schema SQL is not a CREATE VIRTUAL TABLE statement");
+
+        var encoded = sql.AsSpan(marker + PayloadMarker.Length, sql.Length - marker - PayloadMarker.Length - PayloadTerminator.Length);
+        var separator = encoded.IndexOf(':');
+        if (separator <= 0
+            || !int.TryParse(
+                encoded[..separator],
+                System.Globalization.NumberStyles.None,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out var version)
+            || version <= 0)
+        {
+            throw new EmbeddedSqlException("managed virtual-table persistence payload version is invalid");
+        }
+
+        byte[] bytes;
+        try
+        {
+            bytes = encoded.Length == separator + 1
+                ? []
+                : Convert.FromBase64String(encoded[(separator + 1)..].ToString());
+        }
+        catch (FormatException exception)
+        {
+            throw new EmbeddedSqlException("managed virtual-table persistence payload is not valid base64", exception);
+        }
+
+        return (declaration, new ManagedVirtualTablePersistencePayload(version, bytes));
+    }
+
+    private static string QuoteIdentifier(string identifier)
+        => "\"" + identifier.Replace("\"", "\"\"", StringComparison.Ordinal) + "\"";
+}
 
 /// <summary>
 /// Bridges the managed <see cref="EmbeddedDatabase"/> catalog to durable,
@@ -183,6 +252,8 @@ internal sealed class EmbeddedFileStore : IDisposable
         var tables = new Dictionary<string, EmbeddedTable>(StringComparer.OrdinalIgnoreCase);
         var views = new Dictionary<string, ViewDefinition>(StringComparer.OrdinalIgnoreCase);
         var triggers = new Dictionary<string, TriggerDefinition>(StringComparer.OrdinalIgnoreCase);
+        var virtualTables = new Dictionary<string, EmbeddedDatabase.VirtualTableDefinition>(
+            StringComparer.OrdinalIgnoreCase);
         var rootPages = new Dictionary<string, uint>(StringComparer.OrdinalIgnoreCase);
         var indexRootPages = new Dictionary<string, uint>(StringComparer.OrdinalIgnoreCase);
         var loadedIndexes = new Dictionary<string, EmbeddedIndex>(StringComparer.OrdinalIgnoreCase);
@@ -193,7 +264,7 @@ internal sealed class EmbeddedFileStore : IDisposable
 
         var occupiedBtreePages = new HashSet<uint>(
             schemaEntries
-                .Where(entry => entry.Type is "table" or "index")
+                .Where(entry => entry.Type is "table" or "index" && entry.RootPage != 0)
                 .Select(entry => entry.RootPage));
 
         // Materialize tables first so views and triggers can be parsed afterwards.
@@ -201,6 +272,31 @@ internal sealed class EmbeddedFileStore : IDisposable
         {
             if (!string.Equals(entry.Type, "table", StringComparison.Ordinal))
                 continue;
+
+            if (entry.RootPage == 0)
+            {
+                var (declaration, payload) = ManagedVirtualTableSchemaSql.Parse(entry.Sql!);
+                if (!string.Equals(declaration.Name, entry.Name, StringComparison.OrdinalIgnoreCase)
+                    || !string.Equals(entry.Name, entry.TableName, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new EmbeddedSqlException(
+                        $"Stored virtual table '{entry.Name}' does not match its sqlite_schema metadata.");
+                }
+
+                var virtualTable = ManagedVirtualTableModuleRegistry.Resolve(declaration.ModuleName).Create(
+                    new ManagedVirtualTableCreateContext(declaration.Name, declaration.Arguments),
+                    payload);
+                ArgumentNullException.ThrowIfNull(virtualTable);
+                virtualTables.Add(
+                    entry.Name,
+                    new EmbeddedDatabase.VirtualTableDefinition(
+                        declaration.Name,
+                        declaration.ModuleName,
+                        declaration.Arguments.ToArray(),
+                        payload,
+                        virtualTable));
+                continue;
+            }
 
             var statement = SqlParser.Parse(entry.Sql!, SqlParameterMap.Parse(entry.Sql!));
             if (statement is not CreateTableStatement create)
@@ -306,7 +402,7 @@ internal sealed class EmbeddedFileStore : IDisposable
         }
 
         EmbeddedDatabase.ValidateSqliteSequenceCatalog(tables);
-        ValidateAllocationMap(schemaEntries, tables, loadedIndexes);
+        ValidateAllocationMap(schemaEntries, tables, loadedIndexes, virtualTables);
 
         foreach (var entry in schemaEntries)
         {
@@ -344,13 +440,14 @@ internal sealed class EmbeddedFileStore : IDisposable
         _indexRootPages = indexRootPages;
         _lastSchemaSignature = ComputeSchemaSignature(schemaEntries);
         _committedTables = tables;
-        return new EmbeddedFileCatalog(tables, views, triggers);
+        return new EmbeddedFileCatalog(tables, views, triggers, virtualTables);
     }
 
     private void ValidateAllocationMap(
         IReadOnlyList<SchemaEntry> schemaEntries,
         IReadOnlyDictionary<string, EmbeddedTable> tables,
-        IReadOnlyDictionary<string, EmbeddedIndex> loadedIndexes)
+        IReadOnlyDictionary<string, EmbeddedIndex> loadedIndexes,
+        IReadOnlyDictionary<string, EmbeddedDatabase.VirtualTableDefinition> virtualTables)
     {
         try
         {
@@ -378,6 +475,15 @@ internal sealed class EmbeddedFileStore : IDisposable
                 switch (entry.Type)
                 {
                     case "table":
+                        if (entry.RootPage == 0)
+                        {
+                            if (!virtualTables.ContainsKey(entry.Name))
+                            {
+                                throw new InvalidDataException(
+                                    $"Managed file database is missing virtual table '{entry.Name}'.");
+                            }
+                            break;
+                        }
                         if (!tables.TryGetValue(entry.Name, out var table))
                         {
                             throw new InvalidDataException(
@@ -1229,6 +1335,7 @@ internal sealed class EmbeddedFileStore : IDisposable
         IReadOnlyDictionary<string, EmbeddedTable> tables,
         IReadOnlyDictionary<string, ViewDefinition> views,
         IReadOnlyDictionary<string, TriggerDefinition> triggers,
+        IReadOnlyDictionary<string, EmbeddedDatabase.VirtualTableDefinition> virtualTables,
         PragmaHeaderMetadata? pragmaHeader = null,
         bool forceFullRewrite = false,
         IReadOnlyDictionary<string, EmbeddedTable>? previousTables = null)
@@ -1236,6 +1343,7 @@ internal sealed class EmbeddedFileStore : IDisposable
             tables,
             views,
             triggers,
+            virtualTables,
             reclaimTrailingPages: false,
             incrementSchemaCookie: false,
             pragmaHeader,
@@ -1257,6 +1365,7 @@ internal sealed class EmbeddedFileStore : IDisposable
             catalog.Tables,
             catalog.Views,
             catalog.Triggers,
+            catalog.VirtualTables,
             reclaimTrailingPages: true,
             incrementSchemaCookie: true,
             pragmaHeader: null,
@@ -1313,7 +1422,8 @@ internal sealed class EmbeddedFileStore : IDisposable
         int pageSize,
         IReadOnlyDictionary<string, EmbeddedTable> tables,
         IReadOnlyDictionary<string, ViewDefinition> views,
-        IReadOnlyDictionary<string, TriggerDefinition> triggers)
+        IReadOnlyDictionary<string, TriggerDefinition> triggers,
+        IReadOnlyDictionary<string, EmbeddedDatabase.VirtualTableDefinition> virtualTables)
     {
         ThrowIfDisposed();
         ThrowIfPostCommitMaintenanceFaulted();
@@ -1338,7 +1448,7 @@ internal sealed class EmbeddedFileStore : IDisposable
                        initialPageSize: pageSize,
                        initialTextEncoding: _textEncoding))
             {
-                replacement.Persist(tables, views, triggers);
+                replacement.Persist(tables, views, triggers, virtualTables);
                 replacement.SwitchJournalMode(SqliteJournalMode.Delete);
                 replacement.RewriteVacuumHeader(_header);
             }
@@ -1367,7 +1477,8 @@ internal sealed class EmbeddedFileStore : IDisposable
         int pageSize,
         IReadOnlyDictionary<string, EmbeddedTable> tables,
         IReadOnlyDictionary<string, ViewDefinition> views,
-        IReadOnlyDictionary<string, TriggerDefinition> triggers)
+        IReadOnlyDictionary<string, TriggerDefinition> triggers,
+        IReadOnlyDictionary<string, EmbeddedDatabase.VirtualTableDefinition> virtualTables)
     {
         ThrowIfDisposed();
         ThrowIfPostCommitMaintenanceFaulted();
@@ -1417,7 +1528,7 @@ internal sealed class EmbeddedFileStore : IDisposable
                        initialPageSize: pageSize,
                        initialTextEncoding: _textEncoding))
             {
-                replacement.Persist(tables, views, triggers);
+                replacement.Persist(tables, views, triggers, virtualTables);
                 replacement.SwitchJournalMode(SqliteJournalMode.Delete);
                 replacement.RewriteVacuumHeader(_header);
             }
@@ -1491,6 +1602,7 @@ internal sealed class EmbeddedFileStore : IDisposable
         IReadOnlyDictionary<string, EmbeddedTable> tables,
         IReadOnlyDictionary<string, ViewDefinition> views,
         IReadOnlyDictionary<string, TriggerDefinition> triggers,
+        IReadOnlyDictionary<string, EmbeddedDatabase.VirtualTableDefinition> virtualTables,
         bool reclaimTrailingPages,
         bool incrementSchemaCookie,
         PragmaHeaderMetadata? pragmaHeader,
@@ -1504,7 +1616,7 @@ internal sealed class EmbeddedFileStore : IDisposable
         foreach (var (name, table) in tables)
             EmbeddedFileStore.ValidateTableRepresentable(name, table);
         EmbeddedDatabase.ValidateSqliteSequenceCatalog(tables);
-        ValidateSchemaDefinitions(tables, views, triggers);
+        ValidateSchemaDefinitions(tables, views, triggers, virtualTables);
 
         if (!forceFullRewrite
             && !reclaimTrailingPages
@@ -1512,13 +1624,13 @@ internal sealed class EmbeddedFileStore : IDisposable
         {
             if (previousTables is not null
                 && ReferenceEquals(previousTables, _committedTables)
-                && TryPersistIncrementalRowMutation(tables, views, triggers, previousTables))
+                && TryPersistIncrementalRowMutation(tables, views, triggers, virtualTables, previousTables))
             {
                 _committedTables = tables;
                 return CommittedCatalogVersion;
             }
 
-            if (TryPersistBoundedTableLeafMutation(tables, views, triggers))
+            if (TryPersistBoundedTableLeafMutation(tables, views, triggers, virtualTables))
             {
                 _committedTables = tables;
                 return CommittedCatalogVersion;
@@ -1537,7 +1649,7 @@ internal sealed class EmbeddedFileStore : IDisposable
             currentFreelist.LeafPageNumbers,
             reclaimTrailingPages);
         var tableNames = tables.Keys.OrderBy(name => name, StringComparer.OrdinalIgnoreCase).ToArray();
-        var indexes = GetIndexDefinitions(tableNames, tables, views, triggers);
+        var indexes = GetIndexDefinitions(tableNames, tables, views, triggers, virtualTables);
         var rootPages = new Dictionary<string, uint>(StringComparer.OrdinalIgnoreCase);
         var indexRootPages = new Dictionary<string, uint>(StringComparer.OrdinalIgnoreCase);
         foreach (var name in tableNames)
@@ -1564,7 +1676,13 @@ internal sealed class EmbeddedFileStore : IDisposable
                 allocator);
         }
 
-        var schemaEntries = BuildSchemaEntries(tables, views, triggers, rootPages, indexRootPages);
+        var schemaEntries = BuildSchemaEntries(
+            tables,
+            views,
+            triggers,
+            virtualTables,
+            rootPages,
+            indexRootPages);
         var schemaTree = BuildSchemaTree(schemaEntries, allocator);
         var activePages = CollectRewriteActivePages(
             schemaTree,
@@ -1735,9 +1853,10 @@ internal sealed class EmbeddedFileStore : IDisposable
         IReadOnlyDictionary<string, EmbeddedTable> tables,
         IReadOnlyDictionary<string, ViewDefinition> views,
         IReadOnlyDictionary<string, TriggerDefinition> triggers,
+        IReadOnlyDictionary<string, EmbeddedDatabase.VirtualTableDefinition> virtualTables,
         IReadOnlyDictionary<string, EmbeddedTable> previousTables)
     {
-        if (!HasCurrentSchemaShape(tables, views, triggers))
+        if (!HasCurrentSchemaShape(tables, views, triggers, virtualTables))
             return false;
 
         var currentHeader = SqliteDatabaseHeader.Parse(_pager.ReadCommittedPage(SchemaRootPage));
@@ -1758,7 +1877,7 @@ internal sealed class EmbeddedFileStore : IDisposable
             return false;
 
         var tableNames = tables.Keys.OrderBy(name => name, StringComparer.OrdinalIgnoreCase).ToArray();
-        var indexesByTable = GetIndexDefinitions(tableNames, tables, views, triggers)
+        var indexesByTable = GetIndexDefinitions(tableNames, tables, views, triggers, virtualTables)
             .GroupBy(definition => definition.TableName, StringComparer.OrdinalIgnoreCase)
             .ToDictionary(
                 group => group.Key,
@@ -2086,16 +2205,17 @@ internal sealed class EmbeddedFileStore : IDisposable
     private bool TryPersistBoundedTableLeafMutation(
         IReadOnlyDictionary<string, EmbeddedTable> tables,
         IReadOnlyDictionary<string, ViewDefinition> views,
-        IReadOnlyDictionary<string, TriggerDefinition> triggers)
+        IReadOnlyDictionary<string, TriggerDefinition> triggers,
+        IReadOnlyDictionary<string, EmbeddedDatabase.VirtualTableDefinition> virtualTables)
     {
         var schemaPage = _pager.ReadCommittedPage(SchemaRootPage);
         var currentHeader = SqliteDatabaseHeader.Parse(schemaPage);
 
-        if (!HasCurrentSchemaShape(tables, views, triggers))
+        if (!HasCurrentSchemaShape(tables, views, triggers, virtualTables))
             return false;
 
         var persisted = Load();
-        if (!HasCurrentSchemaShape(tables, views, triggers)
+        if (!HasCurrentSchemaShape(tables, views, triggers, virtualTables)
             || !TryGetSingleChangedTable(tables, persisted.Tables, out var tableName, out var table))
         {
             return false;
@@ -2111,7 +2231,7 @@ internal sealed class EmbeddedFileStore : IDisposable
         }
 
         var tableNames = tables.Keys.OrderBy(name => name, StringComparer.OrdinalIgnoreCase).ToArray();
-        var indexes = GetIndexDefinitions(tableNames, tables, views, triggers)
+        var indexes = GetIndexDefinitions(tableNames, tables, views, triggers, virtualTables)
             .Where(index => string.Equals(index.TableName, tableName, StringComparison.OrdinalIgnoreCase))
             .ToArray();
         if (indexes.Length != table.Indexes.Count
@@ -7155,7 +7275,8 @@ internal sealed class EmbeddedFileStore : IDisposable
     private bool HasCurrentSchemaShape(
         IReadOnlyDictionary<string, EmbeddedTable> tables,
         IReadOnlyDictionary<string, ViewDefinition> views,
-        IReadOnlyDictionary<string, TriggerDefinition> triggers)
+        IReadOnlyDictionary<string, TriggerDefinition> triggers,
+        IReadOnlyDictionary<string, EmbeddedDatabase.VirtualTableDefinition> virtualTables)
     {
         if (tables.Count != _tableRootPages.Count
             || tables.Keys.Any(name => !_tableRootPages.ContainsKey(name)))
@@ -7164,14 +7285,20 @@ internal sealed class EmbeddedFileStore : IDisposable
         }
 
         var tableNames = tables.Keys.OrderBy(name => name, StringComparer.OrdinalIgnoreCase).ToArray();
-        var indexes = GetIndexDefinitions(tableNames, tables, views, triggers);
+        var indexes = GetIndexDefinitions(tableNames, tables, views, triggers, virtualTables);
         if (indexes.Count != _indexRootPages.Count
             || indexes.Any(index => !_indexRootPages.ContainsKey(index.Index.Name)))
         {
             return false;
         }
 
-        var entries = BuildSchemaEntries(tables, views, triggers, _tableRootPages, _indexRootPages);
+        var entries = BuildSchemaEntries(
+            tables,
+            views,
+            triggers,
+            virtualTables,
+            _tableRootPages,
+            _indexRootPages);
         return string.Equals(
             ComputeSchemaSignature(entries),
             _lastSchemaSignature,
@@ -7905,8 +8032,20 @@ internal sealed class EmbeddedFileStore : IDisposable
     private static void ValidateSchemaDefinitions(
         IReadOnlyDictionary<string, EmbeddedTable> tables,
         IReadOnlyDictionary<string, ViewDefinition> views,
-        IReadOnlyDictionary<string, TriggerDefinition> triggers)
+        IReadOnlyDictionary<string, TriggerDefinition> triggers,
+        IReadOnlyDictionary<string, EmbeddedDatabase.VirtualTableDefinition> virtualTables)
     {
+        foreach (var (catalogName, definition) in virtualTables)
+        {
+            if (!string.Equals(catalogName, definition.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new EmbeddedSqlException(
+                    $"The managed file engine cannot persist virtual table '{catalogName}' because its catalog key and definition name differ.");
+            }
+
+            _ = ManagedVirtualTableSchemaSql.Parse(ManagedVirtualTableSchemaSql.Build(definition));
+        }
+
         foreach (var (catalogName, view) in views)
             ValidateViewDefinition(catalogName, view);
 
@@ -10115,6 +10254,7 @@ internal sealed class EmbeddedFileStore : IDisposable
         IReadOnlyDictionary<string, EmbeddedTable> tables,
         IReadOnlyDictionary<string, ViewDefinition> views,
         IReadOnlyDictionary<string, TriggerDefinition> triggers,
+        IReadOnlyDictionary<string, EmbeddedDatabase.VirtualTableDefinition> virtualTables,
         IReadOnlyDictionary<string, uint> rootPages,
         IReadOnlyDictionary<string, uint> indexRootPages)
     {
@@ -10127,6 +10267,18 @@ internal sealed class EmbeddedFileStore : IDisposable
                 name,
                 rootPages[name],
                 tables[name].Sql ?? EmbeddedDatabase.BuildCreateTableSql(name, tables[name])));
+        }
+
+        foreach (var definition in virtualTables.Values.OrderBy(
+                     static value => value.Name,
+                     StringComparer.OrdinalIgnoreCase))
+        {
+            entries.Add(new SchemaEntry(
+                "table",
+                definition.Name,
+                definition.Name,
+                0,
+                ManagedVirtualTableSchemaSql.Build(definition)));
         }
 
         foreach (var tableName in tables.Keys.OrderBy(value => value, StringComparer.OrdinalIgnoreCase))
@@ -10170,7 +10322,8 @@ internal sealed class EmbeddedFileStore : IDisposable
         IReadOnlyList<string> tableNames,
         IReadOnlyDictionary<string, EmbeddedTable> tables,
         IReadOnlyDictionary<string, ViewDefinition> views,
-        IReadOnlyDictionary<string, TriggerDefinition> triggers)
+        IReadOnlyDictionary<string, TriggerDefinition> triggers,
+        IReadOnlyDictionary<string, EmbeddedDatabase.VirtualTableDefinition> virtualTables)
     {
         var names = new HashSet<string>(tables.Keys, StringComparer.OrdinalIgnoreCase);
         foreach (var name in views.Keys)
@@ -10179,6 +10332,11 @@ internal sealed class EmbeddedFileStore : IDisposable
                 throw new EmbeddedSqlException($"The managed file engine cannot persist duplicate schema name '{name}'.");
         }
         foreach (var name in triggers.Keys)
+        {
+            if (!names.Add(name))
+                throw new EmbeddedSqlException($"The managed file engine cannot persist duplicate schema name '{name}'.");
+        }
+        foreach (var name in virtualTables.Keys)
         {
             if (!names.Add(name))
                 throw new EmbeddedSqlException($"The managed file engine cannot persist duplicate schema name '{name}'.");
@@ -10577,6 +10735,16 @@ internal sealed class EmbeddedFileStore : IDisposable
                     {
                         throw new EmbeddedSqlException(
                             $"Managed file database table '{entry.Name}' has a mismatched sqlite_schema table name.");
+                    }
+                    if (entry.RootPage == 0)
+                    {
+                        var (declaration, _) = ManagedVirtualTableSchemaSql.Parse(entry.Sql);
+                        if (!string.Equals(declaration.Name, entry.Name, StringComparison.OrdinalIgnoreCase))
+                        {
+                            throw new EmbeddedSqlException(
+                                $"Managed file database virtual table '{entry.Name}' has mismatched CREATE VIRTUAL TABLE SQL.");
+                        }
+                        break;
                     }
                     goto case "index";
                 case "index":

--- a/src/Ahtola.Core/ManagedSearchVirtualTables.cs
+++ b/src/Ahtola.Core/ManagedSearchVirtualTables.cs
@@ -13,6 +13,15 @@ internal sealed class ManagedFts5Module : ManagedVirtualTableModule
     public override ManagedVirtualTable Create(ManagedVirtualTableCreateContext context)
         => new ManagedFts5Table(context.TableName, ParseColumnNames(context));
 
+    public override ManagedVirtualTable Create(
+        ManagedVirtualTableCreateContext context,
+        ManagedVirtualTablePersistencePayload payload)
+    {
+        var table = new ManagedFts5Table(context.TableName, ParseColumnNames(context));
+        table.RestorePersistencePayload(payload);
+        return table;
+    }
+
     private static IReadOnlyList<string> ParseColumnNames(ManagedVirtualTableCreateContext context)
     {
         if (context.Arguments.Count == 0)
@@ -75,6 +84,15 @@ internal abstract class ManagedRTreeModuleBase(string name, bool requireIntegerC
         return new ManagedRTreeTable(columns, _requireIntegerCoordinates);
     }
 
+    public override ManagedVirtualTable Create(
+        ManagedVirtualTableCreateContext context,
+        ManagedVirtualTablePersistencePayload payload)
+    {
+        var table = Create(context);
+        ((ManagedRTreeTable)table).RestorePersistencePayload(payload);
+        return table;
+    }
+
     private static bool IsIdentifier(string value)
         => value.All(static character => char.IsLetterOrDigit(character) || character == '_')
             && !char.IsDigit(value[0]);
@@ -83,9 +101,11 @@ internal abstract class ManagedRTreeModuleBase(string name, bool requireIntegerC
 internal sealed class ManagedFts5Table : ManagedVirtualTable
 {
     private const int MatchPlan = 1;
+    private const int PersistenceVersion = 1;
 
     private readonly string[] _columnNames;
-    private readonly ManagedVirtualTableSchema _schema;
+    private string _tableName;
+    private ManagedVirtualTableSchema _schema;
     private readonly Dictionary<long, SqlValue[]> _rows = [];
     private readonly ManagedFtsIndex _index = new();
     private Dictionary<long, SqlValue[]>? _transactionSnapshot;
@@ -98,11 +118,15 @@ internal sealed class ManagedFts5Table : ManagedVirtualTable
         if (_columnNames.Contains(tableName, StringComparer.OrdinalIgnoreCase))
             throw new EmbeddedSqlException("an fts5 column cannot have the same name as its table");
 
-        _schema = new ManagedVirtualTableSchema(
+        _tableName = tableName;
+        _schema = CreateSchema(tableName);
+    }
+
+    private ManagedVirtualTableSchema CreateSchema(string tableName)
+        => new(
             _columnNames
                 .Select(static name => new ManagedVirtualTableColumn(name, ManagedVirtualTableAffinity.Text))
                 .Append(new ManagedVirtualTableColumn(tableName, ManagedVirtualTableAffinity.Text, IsHidden: true)));
-    }
 
     public override ManagedVirtualTableSchema Schema => _schema;
 
@@ -182,6 +206,68 @@ internal sealed class ManagedFts5Table : ManagedVirtualTable
         _transactionSnapshot = null;
         _nextRowId = _transactionNextRowId!.Value;
         _transactionNextRowId = null;
+    }
+
+    public override ManagedVirtualTablePersistencePayload GetPersistencePayload()
+    {
+        var writer = new ManagedVirtualTablePayloadWriter();
+        writer.WriteInt32(_columnNames.Length);
+        writer.WriteInt64(_nextRowId);
+        writer.WriteInt32(_rows.Count);
+        foreach (var (rowId, values) in _rows.OrderBy(static entry => entry.Key))
+        {
+            writer.WriteInt64(rowId);
+            foreach (var value in values)
+                ManagedVirtualTablePayloadValues.Write(writer, value);
+        }
+
+        return new ManagedVirtualTablePersistencePayload(PersistenceVersion, writer.ToArray());
+    }
+
+    public override void Rename(string newName)
+    {
+        if (string.IsNullOrWhiteSpace(newName))
+            throw new EmbeddedSqlException("virtual table name cannot be empty");
+
+        _tableName = newName;
+        _schema = CreateSchema(_tableName);
+    }
+
+    internal void RestorePersistencePayload(ManagedVirtualTablePersistencePayload payload)
+    {
+        if (payload.Version != PersistenceVersion)
+        {
+            throw new EmbeddedSqlException(
+                $"unsupported fts5 managed virtual-table persistence payload version {payload.Version}");
+        }
+
+        var reader = new ManagedVirtualTablePayloadReader(payload.Bytes.Span);
+        if (reader.ReadCount() != _columnNames.Length)
+            throw new EmbeddedSqlException("fts5 persistence payload column count does not match the declaration");
+        var nextRowId = reader.ReadInt64();
+        if (nextRowId < 1)
+            throw new EmbeddedSqlException("fts5 persistence payload has an invalid next rowid");
+
+        var rows = new Dictionary<long, SqlValue[]>();
+        var count = reader.ReadCount();
+        for (var index = 0; index < count; index++)
+        {
+            var rowId = reader.ReadInt64();
+            var values = new SqlValue[_columnNames.Length];
+            for (var column = 0; column < values.Length; column++)
+                values[column] = ManagedVirtualTablePayloadValues.Read(ref reader);
+            if (!rows.TryAdd(rowId, values))
+                throw new EmbeddedSqlException("fts5 persistence payload contains duplicate rowids");
+            if (rowId >= nextRowId)
+                throw new EmbeddedSqlException("fts5 persistence payload has an invalid next rowid");
+        }
+        reader.RequireEnd();
+
+        _rows.Clear();
+        foreach (var (rowId, values) in rows)
+            _rows.Add(rowId, values);
+        _nextRowId = nextRowId;
+        RebuildIndex();
     }
 
     private void Remove(long rowId)
@@ -267,6 +353,7 @@ internal sealed class ManagedFts5Table : ManagedVirtualTable
 internal sealed class ManagedRTreeTable : ManagedVirtualTable
 {
     private const int ConstraintPlan = 1;
+    private const int PersistenceVersion = 1;
 
     private readonly bool _requireIntegerCoordinates;
     private readonly ManagedVirtualTableSchema _schema;
@@ -380,6 +467,83 @@ internal sealed class ManagedRTreeTable : ManagedVirtualTable
         _transactionSnapshot = null;
         _nextRowId = _transactionNextRowId!.Value;
         _transactionNextRowId = null;
+    }
+
+    public override ManagedVirtualTablePersistencePayload GetPersistencePayload()
+    {
+        var writer = new ManagedVirtualTablePayloadWriter();
+        writer.WriteInt32(_schema.Columns.Count);
+        writer.WriteInt64(_nextRowId);
+        writer.WriteInt32(_rows.Count);
+        foreach (var (rowId, bounds) in _rows.OrderBy(static entry => entry.Key))
+        {
+            writer.WriteInt64(rowId);
+            for (var coordinate = 0; coordinate < _schema.Columns.Count - 1; coordinate++)
+            {
+                var value = coordinate % 2 == 0
+                    ? bounds.Minimum(coordinate / 2)
+                    : bounds.Maximum(coordinate / 2);
+                if (_requireIntegerCoordinates)
+                    writer.WriteInt32(checked((int)value));
+                else
+                    writer.WriteDouble(value);
+            }
+        }
+
+        return new ManagedVirtualTablePersistencePayload(PersistenceVersion, writer.ToArray());
+    }
+
+    internal void RestorePersistencePayload(ManagedVirtualTablePersistencePayload payload)
+    {
+        if (payload.Version != PersistenceVersion)
+        {
+            throw new EmbeddedSqlException(
+                $"unsupported {(_requireIntegerCoordinates ? "rtree_i32" : "rtree")} managed virtual-table persistence payload version {payload.Version}");
+        }
+
+        var reader = new ManagedVirtualTablePayloadReader(payload.Bytes.Span);
+        if (reader.ReadCount() != _schema.Columns.Count)
+            throw new EmbeddedSqlException("rtree persistence payload column count does not match the declaration");
+        var nextRowId = reader.ReadInt64();
+        if (nextRowId < 1)
+            throw new EmbeddedSqlException("rtree persistence payload has an invalid next rowid");
+
+        var rows = new Dictionary<long, ManagedRTreeBounds>();
+        var count = reader.ReadCount();
+        for (var index = 0; index < count; index++)
+        {
+            var rowId = reader.ReadInt64();
+            var coordinates = new double[_schema.Columns.Count - 1];
+            for (var coordinate = 0; coordinate < coordinates.Length; coordinate++)
+            {
+                coordinates[coordinate] = _requireIntegerCoordinates
+                    ? reader.ReadInt32()
+                    : reader.ReadDouble();
+                if (!double.IsFinite(coordinates[coordinate]))
+                    throw new EmbeddedSqlException("rtree persistence payload contains a non-finite coordinate");
+            }
+
+            ManagedRTreeBounds bounds;
+            try
+            {
+                bounds = new ManagedRTreeBounds(coordinates);
+            }
+            catch (ArgumentOutOfRangeException exception)
+            {
+                throw new EmbeddedSqlException("rtree persistence payload contains invalid bounds", exception);
+            }
+            if (!rows.TryAdd(rowId, bounds))
+                throw new EmbeddedSqlException("rtree persistence payload contains duplicate rowids");
+            if (rowId >= nextRowId)
+                throw new EmbeddedSqlException("rtree persistence payload has an invalid next rowid");
+        }
+        reader.RequireEnd();
+
+        _rows.Clear();
+        foreach (var (rowId, bounds) in rows)
+            _rows.Add(rowId, bounds);
+        _nextRowId = nextRowId;
+        RebuildIndex();
     }
 
     private static bool IsRangeOperator(ManagedVirtualTableConstraintOperator value)

--- a/src/Ahtola.Core/ManagedVirtualTables.cs
+++ b/src/Ahtola.Core/ManagedVirtualTables.cs
@@ -1,4 +1,6 @@
+using System.Buffers.Binary;
 using System.Collections.ObjectModel;
+using System.Text;
 using Ahtola.Core.Search;
 using Ahtola.Core.Spatial;
 
@@ -146,6 +148,35 @@ public sealed class ManagedVirtualTablePlan
 public sealed record ManagedVirtualTableCreateContext(string TableName, IReadOnlyList<string> Arguments);
 
 /// <summary>
+/// Opaque, module-owned state that the managed catalog persists for a virtual table. The engine
+/// transports this value unchanged; a module owns both the version number and binary layout.
+/// </summary>
+public sealed class ManagedVirtualTablePersistencePayload
+{
+    internal const int MaximumLength = 64 * 1024 * 1024;
+    private readonly byte[] _bytes;
+
+    public ManagedVirtualTablePersistencePayload(int version, ReadOnlySpan<byte> bytes)
+    {
+        if (version <= 0)
+            throw new ArgumentOutOfRangeException(nameof(version));
+        if (bytes.Length > MaximumLength)
+            throw new ArgumentOutOfRangeException(nameof(bytes));
+
+        Version = version;
+        _bytes = bytes.ToArray();
+    }
+
+    /// <summary>The module-defined, positive serialization version.</summary>
+    public int Version { get; }
+
+    /// <summary>A read-only view of the opaque module-owned state.</summary>
+    public ReadOnlyMemory<byte> Bytes => _bytes;
+
+    internal ManagedVirtualTablePersistencePayload Clone() => new(Version, _bytes);
+}
+
+/// <summary>
 /// Explicit module registration contract. Implementations are instantiated directly and registered through
 /// <see cref="ManagedVirtualTableModuleRegistry.Register"/>; the engine never discovers modules by reflection.
 /// This keeps the mechanism NativeAOT and trimming safe.
@@ -155,6 +186,16 @@ public abstract class ManagedVirtualTableModule
     public abstract string Name { get; }
 
     public abstract ManagedVirtualTable Create(ManagedVirtualTableCreateContext context);
+
+    /// <summary>
+    /// Recreates a table from the payload that this module previously produced. Modules that support
+    /// durable or transactional virtual tables must override this method without reflection.
+    /// </summary>
+    public virtual ManagedVirtualTable Create(
+        ManagedVirtualTableCreateContext context,
+        ManagedVirtualTablePersistencePayload payload)
+        => throw new EmbeddedSqlException(
+            $"managed virtual table module '{Name}' does not support persistence payload version {payload.Version}");
 }
 
 /// <summary>
@@ -170,6 +211,14 @@ public abstract class ManagedVirtualTable
         IReadOnlyList<ManagedVirtualTableOrderBy> orderBy);
 
     public abstract ManagedVirtualTableCursor Open();
+
+    /// <summary>
+    /// Captures all module-owned mutable state in a deterministic, versioned payload. The catalog
+    /// uses this snapshot for file persistence, transaction rollback, and savepoints.
+    /// </summary>
+    public virtual ManagedVirtualTablePersistencePayload GetPersistencePayload()
+        => throw new EmbeddedSqlException(
+            "managed virtual table does not support persistence; override GetPersistencePayload and Create(context, payload)");
 
     /// <summary>
     /// Receives SQLite's VUpdate argv layout: old rowid, new rowid, then declared column values.
@@ -189,6 +238,183 @@ public abstract class ManagedVirtualTable
     public virtual void Rollback() { }
     public virtual void Rename(string newName) { }
     public virtual void Destroy() { }
+}
+
+/// <summary>Small deterministic binary writer shared by the built-in module payloads.</summary>
+internal sealed class ManagedVirtualTablePayloadWriter
+{
+    private readonly MemoryStream _stream = new();
+
+    public void WriteByte(byte value) => _stream.WriteByte(value);
+
+    public void WriteInt32(int value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(int)];
+        BinaryPrimitives.WriteInt32LittleEndian(bytes, value);
+        _stream.Write(bytes);
+    }
+
+    public void WriteInt64(long value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(long)];
+        BinaryPrimitives.WriteInt64LittleEndian(bytes, value);
+        _stream.Write(bytes);
+    }
+
+    public void WriteDouble(double value) => WriteInt64(BitConverter.DoubleToInt64Bits(value));
+
+    public void WriteBytes(ReadOnlySpan<byte> bytes)
+    {
+        WriteInt32(bytes.Length);
+        _stream.Write(bytes);
+    }
+
+    public void WriteText(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        WriteBytes(Encoding.UTF8.GetBytes(value));
+    }
+
+    public byte[] ToArray() => _stream.ToArray();
+}
+
+/// <summary>Strict bounds-checked reader shared by the built-in module payloads.</summary>
+internal ref struct ManagedVirtualTablePayloadReader
+{
+    private static readonly Encoding StrictUtf8 = new UTF8Encoding(
+        encoderShouldEmitUTF8Identifier: false,
+        throwOnInvalidBytes: true);
+
+    private readonly ReadOnlySpan<byte> _bytes;
+    private int _position;
+
+    public ManagedVirtualTablePayloadReader(ReadOnlySpan<byte> bytes)
+    {
+        _bytes = bytes;
+        _position = 0;
+    }
+
+    public byte ReadByte()
+    {
+        Require(sizeof(byte));
+        return _bytes[_position++];
+    }
+
+    public int ReadInt32()
+    {
+        Require(sizeof(int));
+        var value = BinaryPrimitives.ReadInt32LittleEndian(_bytes.Slice(_position, sizeof(int)));
+        _position += sizeof(int);
+        return value;
+    }
+
+    public long ReadInt64()
+    {
+        Require(sizeof(long));
+        var value = BinaryPrimitives.ReadInt64LittleEndian(_bytes.Slice(_position, sizeof(long)));
+        _position += sizeof(long);
+        return value;
+    }
+
+    public double ReadDouble() => BitConverter.Int64BitsToDouble(ReadInt64());
+
+    public byte[] ReadBytes()
+    {
+        var length = ReadLength();
+        Require(length);
+        var value = _bytes.Slice(_position, length).ToArray();
+        _position += length;
+        return value;
+    }
+
+    public string ReadText()
+    {
+        try
+        {
+            return StrictUtf8.GetString(ReadBytes());
+        }
+        catch (DecoderFallbackException exception)
+        {
+            throw new EmbeddedSqlException("invalid managed virtual-table persistence payload text", exception);
+        }
+    }
+
+    public void RequireEnd()
+    {
+        if (_position != _bytes.Length)
+            throw new EmbeddedSqlException("invalid managed virtual-table persistence payload trailing bytes");
+    }
+
+    public int ReadCount()
+    {
+        var value = ReadInt32();
+        if (value < 0 || value > ManagedVirtualTablePersistencePayload.MaximumLength)
+            throw new EmbeddedSqlException("invalid managed virtual-table persistence payload count");
+        return value;
+    }
+
+    private int ReadLength()
+    {
+        var length = ReadInt32();
+        if (length < 0 || length > ManagedVirtualTablePersistencePayload.MaximumLength)
+            throw new EmbeddedSqlException("invalid managed virtual-table persistence payload length");
+        return length;
+    }
+
+    private void Require(int length)
+    {
+        if (length < 0 || _position > _bytes.Length - length)
+            throw new EmbeddedSqlException("truncated managed virtual-table persistence payload");
+    }
+}
+
+/// <summary>Canonical value encoding used only inside module-private virtual-table payloads.</summary>
+internal static class ManagedVirtualTablePayloadValues
+{
+    private const byte Null = 0;
+    private const byte Integer = 1;
+    private const byte Real = 2;
+    private const byte Text = 3;
+    private const byte Blob = 4;
+
+    public static void Write(ManagedVirtualTablePayloadWriter writer, SqlValue value)
+    {
+        switch (value.Kind)
+        {
+            case SqlValueKind.Null:
+                writer.WriteByte(Null);
+                return;
+            case SqlValueKind.Integer:
+                writer.WriteByte(Integer);
+                writer.WriteInt64(value.AsInteger());
+                return;
+            case SqlValueKind.Real:
+                writer.WriteByte(Real);
+                writer.WriteDouble(value.AsReal());
+                return;
+            case SqlValueKind.Text:
+                writer.WriteByte(Text);
+                writer.WriteText(value.AsText());
+                return;
+            case SqlValueKind.Blob:
+                writer.WriteByte(Blob);
+                writer.WriteBytes(value.AsBlob().Span);
+                return;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(value));
+        }
+    }
+
+    public static SqlValue Read(ref ManagedVirtualTablePayloadReader reader)
+        => reader.ReadByte() switch
+        {
+            Null => SqlValue.Null,
+            Integer => SqlValue.Integer(reader.ReadInt64()),
+            Real => SqlValue.Real(reader.ReadDouble()),
+            Text => SqlValue.Text(reader.ReadText()),
+            Blob => SqlValue.Blob(reader.ReadBytes()),
+            _ => throw new EmbeddedSqlException("invalid managed virtual-table persistence payload value type"),
+        };
 }
 
 /// <summary>One open virtual-table scan. Filter positions on the first row, if any.</summary>

--- a/src/Ahtola.Tests/ManagedSearchVirtualTableTests.cs
+++ b/src/Ahtola.Tests/ManagedSearchVirtualTableTests.cs
@@ -1,5 +1,6 @@
 using AwesomeAssertions;
 using Ahtola.Core;
+using MsData = Microsoft.Data.Sqlite;
 
 namespace Ahtola.Tests;
 
@@ -217,6 +218,223 @@ public sealed class ManagedSearchVirtualTableTests
             .WithMessage("*signed 32-bit integer*");
     }
 
+    [Test]
+    public void ManagedFtsAndRTreePersistAcrossFileReopenAndVacuumInto()
+    {
+        var sourcePath = CreateDatabasePath("managed-vtab-source");
+        var backupPath = CreateDatabasePath("managed-vtab-backup");
+        try
+        {
+            using (var database = EmbeddedDatabase.OpenFile(sourcePath))
+            using (var connection = database.Connect())
+            {
+                Execute(connection, "CREATE VIRTUAL TABLE documents USING fts5(title, body);");
+                Execute(connection, "CREATE VIRTUAL TABLE bounds USING rtree(id, min_x, max_x, min_y, max_y);");
+                Execute(connection, "CREATE TABLE metadata(value INTEGER);");
+                Execute(connection, "ALTER TABLE metadata RENAME TO renamed_metadata;");
+                Execute(connection, "INSERT INTO documents(title, body) VALUES ('Orchid', 'Purple flower');");
+                Execute(connection, "INSERT INTO bounds VALUES (7, 0, 10, 0, 10);");
+                Execute(connection, $"VACUUM INTO '{EscapeSqlLiteral(backupPath)}';");
+            }
+
+            AssertPersistedSearchState(sourcePath);
+            AssertPersistedSearchState(backupPath);
+        }
+        finally
+        {
+            DeleteDatabase(sourcePath);
+            DeleteDatabase(backupPath);
+        }
+    }
+
+    [Test]
+    public void ManagedVirtualTableDmlAndSchemaChangesRollBackAtTransactionAndSavepointBoundaries()
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, "CREATE VIRTUAL TABLE documents USING fts5(title, body);");
+        Execute(connection, "CREATE VIRTUAL TABLE bounds USING rtree(id, min_x, max_x);");
+
+        Execute(connection, "BEGIN;");
+        Execute(connection, "INSERT INTO documents(title, body) VALUES ('Orchid', 'Purple flower');");
+        Execute(connection, "INSERT INTO bounds VALUES (1, 0, 10);");
+        ReadRows(connection, "SELECT title FROM documents WHERE documents MATCH 'orchid';").Should().ContainSingle();
+        Execute(connection, "ROLLBACK;");
+        ReadRows(connection, "SELECT title FROM documents WHERE documents MATCH 'orchid';").Should().BeEmpty();
+        ReadRows(connection, "SELECT id FROM bounds;").Should().BeEmpty();
+
+        Execute(connection, "SAVEPOINT vtab_state;");
+        Execute(connection, "INSERT INTO documents(title, body) VALUES ('Rose', 'Red flower');");
+        Execute(connection, "CREATE VIRTUAL TABLE transient_bounds USING rtree(id, min_x, max_x);");
+        Execute(connection, "ALTER TABLE bounds RENAME TO renamed_bounds;");
+        Execute(connection, "ROLLBACK TO vtab_state;");
+        Execute(connection, "RELEASE vtab_state;");
+
+        ReadRows(connection, "SELECT title FROM documents WHERE documents MATCH 'rose';").Should().BeEmpty();
+        ReadRows(connection, "SELECT id FROM bounds;").Should().BeEmpty();
+        Action readRenamed = () => ReadRows(connection, "SELECT id FROM renamed_bounds;");
+        readRenamed.Should().Throw<EmbeddedSqlException>().WithMessage("*no such table*");
+        Action readCreated = () => ReadRows(connection, "SELECT id FROM transient_bounds;");
+        readCreated.Should().Throw<EmbeddedSqlException>().WithMessage("*no such table*");
+    }
+
+    [Test]
+    public void RenamingManagedVirtualTableRewritesDependentViews()
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, "CREATE VIRTUAL TABLE documents USING fts5(title);");
+        Execute(connection, "INSERT INTO documents(title) VALUES ('Orchid');");
+        Execute(connection, "CREATE VIEW document_titles AS SELECT title FROM documents;");
+
+        Execute(connection, "ALTER TABLE documents RENAME TO renamed_documents;");
+
+        ReadRows(connection, "SELECT title FROM document_titles;")
+            .Should().ContainSingle()
+            .Which.Should().Equal(SqlValue.Text("Orchid"));
+    }
+
+    [Test]
+    public void ManagedVirtualTableStatementFailureRestoresThePriorModulePayload()
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, "CREATE VIRTUAL TABLE bounds USING rtree(id, min_x, max_x);");
+
+        Action insert = () => Execute(
+            connection,
+            "INSERT INTO bounds VALUES (1, 0, 10), (2, 'not-a-coordinate', 20);");
+
+        insert.Should().Throw<EmbeddedSqlException>().WithMessage("*rtree coordinates must be numeric*");
+        ReadRows(connection, "SELECT id FROM bounds;").Should().BeEmpty();
+    }
+
+    [Test]
+    public void ManagedFtsAndRTreeRejectUnsupportedAndMalformedPersistencePayloads()
+    {
+        var fts5 = ManagedVirtualTableModuleRegistry.Resolve("fts5");
+        var rtree = ManagedVirtualTableModuleRegistry.Resolve("rtree");
+
+        Action unsupportedFtsVersion = () => fts5.Create(
+            new ManagedVirtualTableCreateContext("documents", ["title"]),
+            new ManagedVirtualTablePersistencePayload(2, []));
+        unsupportedFtsVersion.Should().Throw<EmbeddedSqlException>()
+            .WithMessage("*unsupported fts5*version 2");
+
+        Action truncatedFts = () => fts5.Create(
+            new ManagedVirtualTableCreateContext("documents", ["title"]),
+            new ManagedVirtualTablePersistencePayload(1, []));
+        truncatedFts.Should().Throw<EmbeddedSqlException>()
+            .WithMessage("*truncated managed virtual-table persistence payload*");
+
+        Action unsupportedRtreeVersion = () => rtree.Create(
+            new ManagedVirtualTableCreateContext("bounds", ["id", "min_x", "max_x"]),
+            new ManagedVirtualTablePersistencePayload(2, []));
+        unsupportedRtreeVersion.Should().Throw<EmbeddedSqlException>()
+            .WithMessage("*unsupported rtree*version 2");
+
+        Action truncatedRtree = () => rtree.Create(
+            new ManagedVirtualTableCreateContext("bounds", ["id", "min_x", "max_x"]),
+            new ManagedVirtualTablePersistencePayload(1, []));
+        truncatedRtree.Should().Throw<EmbeddedSqlException>()
+            .WithMessage("*truncated managed virtual-table persistence payload*");
+
+        var table = fts5.Create(new ManagedVirtualTableCreateContext("documents", ["title"]));
+        try
+        {
+            var declaration = new EmbeddedDatabase.VirtualTableDefinition(
+                "documents",
+                "fts5",
+                ["title"],
+                new ManagedVirtualTablePersistencePayload(1, []),
+                table);
+            var (_, emptyPayload) = ManagedVirtualTableSchemaSql.Parse(
+                ManagedVirtualTableSchemaSql.Build(declaration));
+            emptyPayload.Version.Should().Be(1);
+            emptyPayload.Bytes.Length.Should().Be(0);
+        }
+        finally
+        {
+            table.Destroy();
+        }
+    }
+
+    [Test]
+    public void ManagedVirtualTableCatalogRejectsMalformedOpaquePayloadOnReopen()
+    {
+        var path = CreateDatabasePath("managed-vtab-malformed");
+        try
+        {
+            using (var database = EmbeddedDatabase.OpenFile(path))
+            using (var connection = database.Connect())
+            {
+                Execute(connection, "CREATE VIRTUAL TABLE documents USING fts5(title);");
+                Execute(connection, "INSERT INTO documents(title) VALUES ('Orchid');");
+            }
+
+            using (var sqlite = new MsData.SqliteConnection($"Data Source={path}"))
+            {
+                sqlite.Open();
+                using var command = sqlite.CreateCommand();
+                command.CommandText = """
+                    PRAGMA writable_schema=ON;
+                    UPDATE sqlite_schema
+                    SET sql = 'CREATE VIRTUAL TABLE "documents" USING "fts5"(title) /*ahtola-managed-vtab:1:not-base64*/'
+                    WHERE type = 'table' AND name = 'documents';
+                    PRAGMA writable_schema=OFF;
+                    """;
+                command.ExecuteNonQuery();
+            }
+
+            Action reopen = () =>
+            {
+                using var database = EmbeddedDatabase.OpenFile(path);
+            };
+            reopen.Should().Throw<EmbeddedSqlException>()
+                .WithMessage("*persistence payload is not valid base64*");
+        }
+        finally
+        {
+            MsData.SqliteConnection.ClearAllPools();
+            DeleteDatabase(path);
+        }
+    }
+
+    [Test]
+    public void ClassicSqliteCanEnumerateTheRootpageZeroVirtualTableDeclaration()
+    {
+        var path = CreateDatabasePath("managed-vtab-schema");
+        try
+        {
+            using (var database = EmbeddedDatabase.OpenFile(path))
+            using (var connection = database.Connect())
+                Execute(connection, "CREATE VIRTUAL TABLE documents USING fts5(title);");
+
+            using var sqlite = new MsData.SqliteConnection($"Data Source={path};Mode=ReadOnly");
+            sqlite.Open();
+            using var command = sqlite.CreateCommand();
+            command.CommandText = """
+                SELECT type, name, tbl_name, rootpage, sql
+                FROM sqlite_schema
+                WHERE name = 'documents';
+                """;
+            using var reader = command.ExecuteReader();
+            reader.Read().Should().BeTrue();
+            reader.GetString(0).Should().Be("table");
+            reader.GetString(1).Should().Be("documents");
+            reader.GetString(2).Should().Be("documents");
+            reader.GetInt64(3).Should().Be(0);
+            reader.GetString(4).Should().Contain("CREATE VIRTUAL TABLE");
+            reader.GetString(4).Should().Contain("ahtola-managed-vtab:1:");
+            reader.Read().Should().BeFalse();
+        }
+        finally
+        {
+            MsData.SqliteConnection.ClearAllPools();
+            DeleteDatabase(path);
+        }
+    }
+
     private static IReadOnlyList<SqlValue[]> ReadRows(
         ManagedVirtualTable table,
         ManagedVirtualTablePlan plan,
@@ -259,5 +477,31 @@ public sealed class ManagedSearchVirtualTableTests
         }
 
         return rows;
+    }
+
+    private static void AssertPersistedSearchState(string path)
+    {
+        using var database = EmbeddedDatabase.OpenFile(path);
+        using var connection = database.Connect();
+        ReadRows(connection, "SELECT title FROM documents WHERE documents MATCH 'orchid';")
+            .Should().ContainSingle()
+            .Which.Should().Equal(SqlValue.Text("Orchid"));
+        ReadRows(connection, "SELECT id FROM bounds WHERE max_x >= 5 AND min_x <= 5;")
+            .Should().ContainSingle()
+            .Which.Should().Equal(SqlValue.Integer(7));
+    }
+
+    private static string CreateDatabasePath(string name)
+        => Path.Combine(Path.GetTempPath(), $"{name}-{Guid.NewGuid():N}.db");
+
+    private static string EscapeSqlLiteral(string value) => value.Replace("'", "''", StringComparison.Ordinal);
+
+    private static void DeleteDatabase(string path)
+    {
+        foreach (var candidate in new[] { path, path + "-wal", path + "-shm", path + "-journal" })
+        {
+            if (File.Exists(candidate))
+                File.Delete(candidate);
+        }
     }
 }

--- a/src/Ahtola.Tests/ManagedVirtualTableTests.cs
+++ b/src/Ahtola.Tests/ManagedVirtualTableTests.cs
@@ -162,53 +162,50 @@ public sealed class ManagedVirtualTableTests
     }
 
     [Test]
-    public void VirtualTableDmlRejectsExplicitTransactionsBeforeMutatingTheModule()
+    public void VirtualTableDmlParticipatesInExplicitTransactionsAndSavepoints()
     {
         _ = Module;
         using var database = new EmbeddedDatabase();
         using var connection = database.Connect();
         Execute(connection, $"CREATE VIRTUAL TABLE entries USING {ModuleName};");
-        var table = Module.LastCreated!;
 
         Execute(connection, "BEGIN;");
-        Action insert = () => Execute(connection, "INSERT INTO entries(value) VALUES (7);");
-        insert.Should().Throw<EmbeddedSqlException>()
-            .WithMessage("*not supported inside explicit transactions or savepoints");
+        Execute(connection, "INSERT INTO entries(value) VALUES (7);");
+        var transactionTable = Module.LastCreated!;
+        transactionTable.Updates.Should().ContainSingle();
         Execute(connection, "ROLLBACK;");
 
         Execute(connection, "SAVEPOINT virtual_table_write;");
-        insert.Should().Throw<EmbeddedSqlException>()
-            .WithMessage("*not supported inside explicit transactions or savepoints");
+        Execute(connection, "INSERT INTO entries(value) VALUES (8);");
+        Module.LastCreated!.Updates.Should().ContainSingle();
         Execute(connection, "ROLLBACK TO virtual_table_write;");
         Execute(connection, "RELEASE virtual_table_write;");
 
-        table.BeginCalls.Should().Be(0);
-        table.Updates.Should().BeEmpty();
-        table.RollbackCalls.Should().Be(0);
+        ReadRows(connection, "SELECT value FROM entries;").Should().HaveCount(2);
     }
 
     [Test]
-    public void VirtualTableSchemaChangesRejectExplicitTransactionsBeforeLifecycleCallbacks()
+    public void VirtualTableSchemaChangesRollBackWithTheirTransaction()
     {
         _ = Module;
         using var database = new EmbeddedDatabase();
         using var connection = database.Connect();
         Execute(connection, $"CREATE VIRTUAL TABLE entries USING {ModuleName};");
-        var table = Module.LastCreated!;
 
         Execute(connection, "BEGIN;");
-        Action create = () => Execute(connection, $"CREATE VIRTUAL TABLE other_entries USING {ModuleName};");
-        create.Should().Throw<EmbeddedSqlException>()
-            .WithMessage("*not supported inside explicit transactions or savepoints");
-        Action drop = () => Execute(connection, "DROP TABLE entries;");
-        drop.Should().Throw<EmbeddedSqlException>()
-            .WithMessage("*not supported inside explicit transactions or savepoints");
-        Action rename = () => Execute(connection, "ALTER TABLE entries RENAME TO renamed_entries;");
-        rename.Should().Throw<EmbeddedSqlException>()
-            .WithMessage("*not supported inside explicit transactions or savepoints");
+        Execute(connection, $"CREATE VIRTUAL TABLE other_entries USING {ModuleName};");
         Execute(connection, "ROLLBACK;");
+        Action selectCreated = () => ReadRows(connection, "SELECT * FROM other_entries;");
+        selectCreated.Should().Throw<EmbeddedSqlException>().WithMessage("*no such table*");
 
-        table.Destroyed.Should().BeFalse();
+        Execute(connection, "BEGIN;");
+        Execute(connection, "ALTER TABLE entries RENAME TO renamed_entries;");
+        Execute(connection, "ROLLBACK;");
+        ReadRows(connection, "SELECT value FROM entries;").Should().HaveCount(2);
+
+        Execute(connection, "BEGIN;");
+        Execute(connection, "DROP TABLE entries;");
+        Execute(connection, "ROLLBACK;");
         ReadRows(connection, "SELECT value FROM entries;").Should().HaveCount(2);
     }
 
@@ -294,6 +291,15 @@ public sealed class ManagedVirtualTableTests
 
         public override ManagedVirtualTable Create(ManagedVirtualTableCreateContext context)
             => LastCreated = new TestTable();
+
+        public override ManagedVirtualTable Create(
+            ManagedVirtualTableCreateContext context,
+            ManagedVirtualTablePersistencePayload payload)
+        {
+            if (payload.Version != 1 || !payload.Bytes.Span.SequenceEqual(new byte[] { 1 }))
+                throw new EmbeddedSqlException("invalid test virtual-table persistence payload");
+            return LastCreated = new TestTable();
+        }
     }
 
     private sealed class TestTable : ManagedVirtualTable
@@ -322,6 +328,8 @@ public sealed class ManagedVirtualTableTests
         public long? InsertedRowId { get; set; }
 
         public override ManagedVirtualTableSchema Schema => TestSchema;
+
+        public override ManagedVirtualTablePersistencePayload GetPersistencePayload() => new(1, new byte[] { 1 });
 
         public override ManagedVirtualTablePlan BestIndex(
             IReadOnlyList<ManagedVirtualTableConstraint> constraints,


### PR DESCRIPTION
## Summary
- Add versioned, reflection-free managed virtual-table persistence payloads and deterministic FTS/R-Tree state restoration.
- Persist rootpage-zero virtual declarations plus opaque payloads in the file-backed SQLite catalog, including reopen and VACUUM INTO.
- Make virtual DML and CREATE/DROP/RENAME reversible through statement, transaction, and savepoint catalog snapshots.
- Add durability, recovery-safety, classic-reader, rollback, and malformed-payload coverage across supported frameworks.

## Validation
- Focused ManagedSearchVirtualTableTests and ManagedVirtualTableTests: 23 passing on net8.0, net9.0, and net10.0.
- pwsh ./build.ps1 build
- pwsh ./build.ps1 validate-package