### PR TITLE
Add MVCC typed object coverage

### DIFF
--- a/docs/wal-interoperability-contract.md
+++ b/docs/wal-interoperability-contract.md
@@ -130,7 +130,7 @@ Additional current behavior:
    readers, the single writer, and checkpoints inside the process; the shm bytes
    are a secondary boundary layered underneath it.
 
-### 1.4 MVCC mode (Phase 1)
+### 1.4 MVCC mode (Phase 2)
 
 `PRAGMA journal_mode=mvcc` enables Turso-aligned main-memory MVCC on the
 connection's main database (including in-memory databases). The engine attaches
@@ -139,18 +139,39 @@ clock and write-set conflict detection. `BEGIN CONCURRENT` is accepted only when
 MVCC is enabled; nested `BEGIN` still fails with
 `cannot start a transaction within a transaction`.
 
-Phase 1 scope and limits:
+Phase 2 scope and limits:
 
 - Concurrent transactions skip the classic single-writer reservation and use
   MVCC transaction IDs + first-committer-wins write-write conflicts.
-- Classic catalog DML still mutates `EmbeddedDatabase` table snapshots; full
-  row-version chains and dual-cursor isolation land in later phases.
+- Row identities are either integer rowids or canonical SQLite primary-key
+  records. The record form supports composite `WITHOUT ROWID` primary keys and
+  preserves built-in BINARY/NOCASE/RTRIM equality plus numeric equivalence.
+- Table scans and materialized managed-index scans merge the transaction's
+  version-store rows with its catalog snapshot. A base row shadowed by a
+  visible update/delete is never emitted; an own or committed overlay insert
+  appears once in key order.
+- `WITHOUT ROWID` INSERT/UPDATE/DELETE, trigger bodies, and foreign-key
+  cascades are routed through the typed-key overlay. They continue to expose
+  no hidden rowid and do not affect update hooks or `last_insert_rowid()`.
+- Concurrent DDL is admitted only through a fail-closed schema gate: no other
+  MVCC snapshot may be active. The catalog, `sqlite_schema` rows, and schema
+  cookie are persisted before the store publishes its next schema generation.
+  A conflicting DDL attempt reports busy rather than running against stale
+  object bindings.
 - File-backed MVCC keeps a WAL open underneath for page durability (matching
   Turso). Enabling MVCC persists SQLite header read/write version **255** and
-  opens a durable logical log (`<db>-log`, Turso LML2/MVTX framing). Cold open
-  of a version-255 database restores the in-process `MvStore` from that log.
-  Full checkpoint-into-b-tree state machine and dual-cursor SQL routing remain
-  incomplete; `MvccDualCursor` provides the merge primitive for later wiring.
+  opens a durable logical log (`<db>-log`, Turso LML2/MVTX framing). New logs
+  use V4 typed-key frames and include their logical object name so recovery
+  restores the object-id mapping. V3 rowid-only logs are upgraded only by an
+  exclusive materializing checkpoint; a cold V3 log whose table identities
+  cannot be proven fails closed instead of losing frames.
+- A logical-log write/flush failure after frame construction is an
+  indeterminate commit. The live MVCC store rejects further transactions and
+  callers must dispose and reopen; recovery then accepts a fully framed commit
+  or discards a torn tail before a later append.
+- Checkpointing folds typed table rows into the catalog and persists the
+  resulting secondary indexes through the normal pager/WAL write path before
+  truncating or upgrading the logical log.
 - `PRAGMA temp.journal_mode=mvcc` is ignored (temp stays `wal`), matching Turso.
 - MVCC is process-local and does not replace Stage 6 WAL interop. Cross-process
   MVCC is unsupported (same as Turso v0.7.2).

--- a/src/Ahtola.Core/EmbeddedDatabase.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.cs
@@ -635,6 +635,9 @@ public sealed partial class EmbeddedDatabase : IDisposable
         ReturningCteScope? ReturningCteScope = null,
         MvStore? ConcurrentMvStore = null,
         MvccTxId? ConcurrentMvccTxId = null,
+        IReadOnlyDictionary<string, EmbeddedTable>? ConcurrentBaseTables = null,
+        ConcurrentMvccIdentityTracker? ConcurrentMvccIdentityTracker = null,
+        SqliteTextEncoding MvccTextEncoding = SqliteTextEncoding.Utf8,
         IReadOnlyDictionary<string, VirtualTableDefinition>? VirtualTables = null)
     {
         /// <summary>
@@ -711,6 +714,12 @@ public sealed partial class EmbeddedDatabase : IDisposable
                         }
                 }
             }
+            else if (ConcurrentMvStore is { } typedStore
+                && ConcurrentMvccTxId is { } typedTxId
+                && !tableName.StartsWith("sqlite_", StringComparison.OrdinalIgnoreCase))
+            {
+                ReportWithoutRowidMvccChange(typedStore, typedTxId, operation, tableName, table, rowId);
+            }
 
             if (Hooks?.RowChanged is not { } rowChanged || !table.HasRowid)
                 return;
@@ -718,6 +727,127 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 return;
 
             rowChanged(operation, tableName, rowId);
+        }
+
+        private void ReportWithoutRowidMvccChange(
+            MvStore store,
+            MvccTxId txId,
+            SqliteChangeOperation operation,
+            string tableName,
+            EmbeddedTable table,
+            long rowId)
+        {
+            if (table.PrimaryKeySchema is null)
+            {
+                throw new EmbeddedSqlException(
+                    $"WITHOUT ROWID table '{tableName}' is missing primary-key metadata for concurrent MVCC.");
+            }
+
+            var tableId = store.GetOrCreateTableId(tableName);
+            var current = TryFindRow(table, rowId);
+            var baseline = ConcurrentBaseTables is not null
+                && ConcurrentBaseTables.TryGetValue(tableName, out var baseTable)
+                ? TryFindRow(baseTable, rowId)
+                : null;
+            var knownKey = ConcurrentMvccIdentityTracker?.TryGet(tableName, rowId);
+
+            switch (operation)
+            {
+                case SqliteChangeOperation.Insert when current is not null:
+                    var insertedKey = CreatePrimaryKey(current.Value.Table, current.Value.Row);
+                    store.Insert(
+                        txId,
+                        new MvccRowId(tableId, insertedKey),
+                        current.Value.Row);
+                    ConcurrentMvccIdentityTracker?.Set(tableName, rowId, insertedKey);
+                    return;
+
+                case SqliteChangeOperation.Delete:
+                    var deletedKey = knownKey
+                        ?? (baseline is not null
+                            ? CreatePrimaryKey(baseline.Value.Table, baseline.Value.Row)
+                            : (MvccKey?)null);
+                    if (deletedKey is null)
+                        break;
+                    store.DeleteOrTombstoneBase(
+                        txId,
+                        new MvccRowId(tableId, deletedKey.Value));
+                    ConcurrentMvccIdentityTracker?.Remove(tableName, rowId);
+                    return;
+
+                case SqliteChangeOperation.Update when current is not null:
+                    {
+                        var currentKey = CreatePrimaryKey(current.Value.Table, current.Value.Row);
+                        var baseKey = knownKey
+                            ?? (baseline is null
+                                ? currentKey
+                                : CreatePrimaryKey(baseline.Value.Table, baseline.Value.Row));
+                        if (baseKey == currentKey)
+                        {
+                            store.UpdateIncludingBase(
+                                txId,
+                                new MvccRowId(tableId, currentKey),
+                                current.Value.Row);
+                        }
+                        else
+                        {
+                            store.DeleteOrTombstoneBase(txId, new MvccRowId(tableId, baseKey));
+                            store.Insert(txId, new MvccRowId(tableId, currentKey), current.Value.Row);
+                        }
+
+                        ConcurrentMvccIdentityTracker?.Set(tableName, rowId, currentKey);
+                        return;
+                    }
+            }
+
+            throw new EmbeddedSqlException(
+                $"Concurrent MVCC could not resolve the primary-key identity for {operation} on WITHOUT ROWID table '{tableName}'.");
+        }
+
+        private MvccKey CreatePrimaryKey(EmbeddedTable table, SqlValue[] row)
+            => MvccKey.FromPrimaryKey(
+                table.PrimaryKeySchema
+                    ?? throw new InvalidOperationException("WITHOUT ROWID table lost its primary-key schema."),
+                row,
+                MvccTextEncoding);
+
+        private static (EmbeddedTable Table, SqlValue[] Row)? TryFindRow(EmbeddedTable table, long rowId)
+        {
+            var index = table.RowIds.IndexOf(rowId);
+            return index >= 0 && index < table.Rows.Count
+                ? (table, table.Rows[index])
+                : null;
+        }
+    }
+
+    internal sealed class ConcurrentMvccIdentityTracker
+    {
+        private readonly Dictionary<string, Dictionary<long, MvccKey>> _keys =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        internal MvccKey? TryGet(string tableName, long rowId)
+            => _keys.TryGetValue(tableName, out var rows) && rows.TryGetValue(rowId, out var key)
+                ? key
+                : null;
+
+        internal void Set(string tableName, long rowId, MvccKey key)
+        {
+            if (!_keys.TryGetValue(tableName, out var rows))
+            {
+                rows = [];
+                _keys.Add(tableName, rows);
+            }
+
+            rows[rowId] = key;
+        }
+
+        internal void Remove(string tableName, long rowId)
+        {
+            if (!_keys.TryGetValue(tableName, out var rows))
+                return;
+            rows.Remove(rowId);
+            if (rows.Count == 0)
+                _keys.Remove(tableName);
         }
     }
 
@@ -1575,7 +1705,10 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 Hooks: hooks,
                 IgnoreCheckConstraints: outer.IgnoreCheckConstraints,
                 ConcurrentMvStore: outer.ConcurrentMvStore,
-                ConcurrentMvccTxId: outer.ConcurrentMvccTxId);
+                ConcurrentMvccTxId: outer.ConcurrentMvccTxId,
+                ConcurrentBaseTables: outer.ConcurrentBaseTables,
+                ConcurrentMvccIdentityTracker: outer.ConcurrentMvccIdentityTracker,
+                MvccTextEncoding: outer.MvccTextEncoding);
             return statement switch
             {
                 InsertStatement insert => ExecuteDmlWithAutoIncrementState(
@@ -1728,11 +1861,6 @@ public sealed partial class EmbeddedDatabase : IDisposable
         if (tableName.StartsWith("sqlite_", StringComparison.OrdinalIgnoreCase))
             ThrowUnsupportedConcurrentMvccSystemTableDml();
 
-        if (!table.HasRowid)
-        {
-            throw new EmbeddedSqlException(
-                "Concurrent MVCC DML is supported only for rowid user tables; WITHOUT ROWID tables require composite-key dual-cursor routing.");
-        }
     }
 
     private static void ThrowUnsupportedConcurrentMvccSystemTableDml()
@@ -2022,7 +2150,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
         PragmaHeaderMetadata? pragmaHeader = null,
         bool forceFullRewrite = false,
         TimeSpan busyTimeout = default,
-        bool concurrent = false)
+        bool concurrent = false,
+        bool containsSchemaChanges = false)
     {
         lock (_gate)
         {
@@ -2037,7 +2166,9 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 // so concurrent writers do not clobber each other.
                 if (_fileStore is not null)
                     TryReloadFileCatalogIfChanged();
-                publishCatalog = MergeConcurrentCatalogFromStoreLocked(catalog);
+                publishCatalog = containsSchemaChanges
+                    ? catalog.Clone()
+                    : MergeConcurrentCatalogFromStoreLocked(catalog);
             }
             else if (_version != version)
             {
@@ -2085,25 +2216,29 @@ public sealed partial class EmbeddedDatabase : IDisposable
             }
 
             var liveForTable = liveRows
-                .Where(r => r.RowId.TableId == tableId)
-                .ToDictionary(r => r.RowId.RowId, r => r.Cells);
+                .Where(row => row.RowId.TableId == tableId)
+                .ToDictionary(row => row.RowId.Key, row => row.Cells);
             var deletedForTable = deleted
-                .Where(d => d.TableId == tableId)
-                .Select(d => d.RowId)
+                .Where(row => row.TableId == tableId)
+                .Select(row => row.Key)
                 .ToHashSet();
 
             var nextRows = new List<SqlValue[]>();
             var nextIds = new List<long>();
-            for (var i = 0; i < target.RowIds.Count; i++)
+            var nextSyntheticId = target.RowIds.Count == 0
+                ? 1L
+                : checked(target.RowIds.Max() + 1);
+            for (var i = 0; i < target.Rows.Count; i++)
             {
-                var rowId = target.RowIds[i];
-                if (deletedForTable.Contains(rowId))
+                var rowId = i < target.RowIds.Count ? target.RowIds[i] : nextSyntheticId++;
+                var key = GetMvccTableKey(target, target.Rows[i], rowId);
+                if (deletedForTable.Contains(key))
                     continue;
-                if (liveForTable.TryGetValue(rowId, out var cells))
+                if (liveForTable.TryGetValue(key, out var cells))
                 {
                     nextRows.Add(cells);
                     nextIds.Add(rowId);
-                    liveForTable.Remove(rowId);
+                    liveForTable.Remove(key);
                     continue;
                 }
 
@@ -2111,10 +2246,10 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 nextIds.Add(rowId);
             }
 
-            foreach (var (rowId, cells) in liveForTable.OrderBy(pair => pair.Key))
+            foreach (var (key, cells) in liveForTable)
             {
                 nextRows.Add(cells);
-                nextIds.Add(rowId);
+                nextIds.Add(target.HasRowid ? key.Integer : nextSyntheticId++);
             }
 
             target.Rows.Clear();
@@ -2124,6 +2259,9 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 target.Rows.Add(nextRows[i]);
                 target.RowIds.Add(nextIds[i]);
             }
+
+            if (!target.HasRowid)
+                SortWithoutRowid(target);
         }
 
         foreach (var (name, table) in txCatalog.Tables)
@@ -2138,6 +2276,19 @@ public sealed partial class EmbeddedDatabase : IDisposable
             merged.Triggers[name] = trigger;
 
         return merged;
+    }
+
+    private MvccKey GetMvccTableKey(EmbeddedTable table, SqlValue[] row, long rowId)
+    {
+        if (table.HasRowid)
+            return MvccKey.FromInteger(rowId);
+
+        return MvccKey.FromPrimaryKey(
+            table.PrimaryKeySchema
+                ?? throw new EmbeddedSqlException(
+                    $"WITHOUT ROWID table '{table.Name}' is missing primary-key metadata for concurrent MVCC."),
+            row,
+            GetTextEncoding());
     }
 
     internal PragmaHeaderMetadata GetPragmaHeaderMetadata()
@@ -2390,6 +2541,30 @@ public sealed partial class EmbeddedDatabase : IDisposable
     }
 
     /// <summary>
+    /// A legacy rowid-only log must be materialized before a concurrent
+    /// transaction can stage a typed primary-key operation. This runs before the
+    /// transaction enters the store, so the checkpoint can take its required
+    /// exclusive boundary without invalidating an active MVCC snapshot.
+    /// </summary>
+    internal void EnsureMvccLogVersion4()
+    {
+        lock (_gate)
+        {
+            if (_mvStore?.LogicalLog is not { RequiresVersion4Upgrade: true })
+                return;
+            if (!_mvStore.CanUpgradeLegacyLog)
+            {
+                throw new EmbeddedSqlException(
+                    "cannot safely migrate a legacy MVCC logical log with unresolved table identities; restore it with a version that can materialize its catalog first.");
+            }
+
+            var result = RunMvccCheckpoint("TRUNCATE", BusyTimeout);
+            if (result.Busy)
+                throw new EmbeddedBusyException();
+        }
+    }
+
+    /// <summary>
     /// Runs the managed MVCC checkpoint skeleton (Turso
     /// <c>CheckpointStateMachine</c> phases, synchronous):
     /// materialize store → catalog, persist, optional log truncate, GC.
@@ -2411,6 +2586,12 @@ public sealed partial class EmbeddedDatabase : IDisposable
             var phase = MvccCheckpointPhase.Prepare;
             var log = store.LogicalLog;
             var logBefore = log?.ApproximatePayloadBytes ?? 0L;
+            var requiresLogUpgrade = log?.RequiresVersion4Upgrade == true;
+            if (requiresLogUpgrade && !store.CanUpgradeLegacyLog)
+            {
+                throw new EmbeddedSqlException(
+                    "cannot safely checkpoint a legacy MVCC logical log with unresolved table identities.");
+            }
 
             phase = MvccCheckpointPhase.AcquireLock;
             var wantTruncate = MvccCheckpoint.ShouldTruncateLog(mode);
@@ -2446,11 +2627,14 @@ public sealed partial class EmbeddedDatabase : IDisposable
             }
 
             var checkpointed = logBefore;
-            if (wantTruncate && log is not null)
+            if ((wantTruncate || requiresLogUpgrade) && log is not null)
             {
                 phase = MvccCheckpointPhase.TruncateLogicalLog;
                 log.TruncateAfterCheckpoint();
-                checkpointed = logBefore;
+                if (requiresLogUpgrade)
+                    log.UpgradeToVersion4AfterCheckpoint();
+                if (wantTruncate)
+                    checkpointed = logBefore;
             }
 
             phase = MvccCheckpointPhase.GarbageCollect;
@@ -3426,6 +3610,9 @@ public sealed partial class EmbeddedDatabase : IDisposable
             ExecuteTableList: executeTableList,
             ConcurrentMvStore: concurrentMvStore,
             ConcurrentMvccTxId: concurrentMvccTxId,
+            ConcurrentBaseTables: concurrentMvStore is null ? null : CloneTablesShallow(catalog.Tables),
+            ConcurrentMvccIdentityTracker: concurrentMvStore is null ? null : new ConcurrentMvccIdentityTracker(),
+            MvccTextEncoding: GetTextEncoding(),
             VirtualTables: catalog.VirtualTables);
         EnsureConcurrentMvccDmlTargetIsSupported(statement, tables, context);
         return statement switch
@@ -11972,6 +12159,10 @@ public sealed partial class EmbeddedDatabase : IDisposable
         var originalRowIds = table.HasRowid
             ? updatedPositions.Select(position => table.RowIds[position]).ToArray()
             : [];
+        // WITHOUT ROWID sorting moves rows after the mutation. Keep the synthetic
+        // identity selected by the update before restoring clustered key order so
+        // the MVCC mirror updates the row that was actually changed.
+        var updatedRowIds = updatedPositions.Select(position => rowIds[position]).ToArray();
         table.Rows.Clear();
         table.Rows.AddRange(rows);
         table.RowIds.Clear();
@@ -11997,8 +12188,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
 
         // SQLite reports the post-update rowid, so an UPDATE that rewrites an INTEGER PRIMARY
         // KEY notifies with the new value rather than the one the row had before.
-        foreach (var position in updatedPositions)
-            context.ReportRowChange(SqliteChangeOperation.Update, tableName, table, rowIds[position]);
+        foreach (var rowId in updatedRowIds)
+            context.ReportRowChange(SqliteChangeOperation.Update, tableName, table, rowId);
     }
 
     // Foreign-key checks run against the complete post-statement image, but only inspect
@@ -22823,15 +23014,23 @@ out bool hasReturning)
         SourceRow? outerRow)
     {
         var table = plan.Table;
-        var entries = new List<(int Position, SqlValue[] Key)>(table.Rows.Count);
-        for (var position = 0; position < table.Rows.Count; position++)
+        // The managed index executor is materialized today. Build it from the
+        // MVCC table dual cursor rather than the catalog backing list so an index
+        // scan never returns a stale base row or misses a version-store insert.
+        var visibleRows = GetNamedTableRows(
+            plan.Source,
+            context,
+            maximumRows: null,
+            outerRow).Rows;
+        var entries = new List<(SourceRow Row, SqlValue[] Key)>(visibleRows.Count);
+        foreach (var row in visibleRows)
         {
             context.CheckInterrupt();
-            var rowId = table.HasRowid ? table.RowIds[position] : (long?)null;
+            var rowId = table.HasRowid ? row.RowId : null;
             if (!IndexExpressionSemantics.Qualifies(
                     plan.Index,
                     table,
-                    table.Rows[position],
+                    row.Values,
                     rowId,
                     EvaluateIndexExpression))
             {
@@ -22839,11 +23038,11 @@ out bool hasReturning)
             }
 
             entries.Add((
-                position,
+                row,
                 IndexExpressionSemantics.ProjectKey(
                     plan.Index,
                     table,
-                    table.Rows[position],
+                    row.Values,
                     rowId,
                     EvaluateIndexExpression)));
         }
@@ -22851,23 +23050,16 @@ out bool hasReturning)
         entries.Sort((left, right) => CompareManagedIndexEntries(table, plan.Index, left, right));
         var qualifier = plan.Source.Alias ?? plan.Source.Name;
         var qualifiedColumns = BuildQualifiedColumns(qualifier, table.Columns);
-        var rows = new SourceRow[entries.Count];
-        for (var index = 0; index < entries.Count; index++)
+        var rows = entries.Select(entry => entry.Row with
         {
-            var position = entries[index].Position;
-            var rowId = table.HasRowid ? table.RowIds[position] : (long?)null;
-            rows[index] = new SourceRow(
-                table.Columns,
-                table.Rows[position],
-                qualifiedColumns,
-                outerRow,
-                RowId: rowId,
-                RowIdQualifier: qualifier,
-                ColumnDefinitions: table.ColumnDefinitions,
-                QualifiedColumnDefinitions: BuildQualifiedColumnDefinitions(
-                    qualifier,
-                    table.ColumnDefinitions));
-        }
+            QualifiedColumns = qualifiedColumns,
+            Parent = outerRow,
+            RowIdQualifier = qualifier,
+            ColumnDefinitions = table.ColumnDefinitions,
+            QualifiedColumnDefinitions = BuildQualifiedColumnDefinitions(
+                qualifier,
+                table.ColumnDefinitions),
+        }).ToArray();
 
         return new SourceData(table.Columns, rows);
     }
@@ -22997,61 +23189,57 @@ out bool hasReturning)
         SourceRow? outerRow)
     {
         var table = plan.Table;
-        var positions = new SortedSet<int>();
+        var visibleRows = GetNamedTableRows(
+            plan.Source,
+            context,
+            maximumRows: null,
+            outerRow).Rows;
+        var selected = new HashSet<MvccKey>();
+        var selectedRows = new List<SourceRow>();
         foreach (var (index, branch) in plan.Branches)
         {
-            for (var position = 0; position < table.Rows.Count; position++)
+            foreach (var row in visibleRows)
             {
                 context.CheckInterrupt();
-                var rowId = table.HasRowid ? table.RowIds[position] : (long?)null;
+                var rowId = table.HasRowid ? row.RowId : null;
                 if (!IndexExpressionSemantics.Qualifies(
                         index,
                         table,
-                        table.Rows[position],
+                        row.Values,
                         rowId,
                         EvaluateIndexExpression))
                 {
                     continue;
                 }
 
-                var probeRow = new SourceRow(
-                    table.Columns,
-                    table.Rows[position],
-                    BuildQualifiedColumns(plan.Source.Alias ?? plan.Source.Name, table.Columns),
-                    outerRow,
-                    RowId: rowId,
-                    RowIdQualifier: plan.Source.Alias ?? plan.Source.Name,
-                    ColumnDefinitions: table.ColumnDefinitions,
-                    QualifiedColumnDefinitions: BuildQualifiedColumnDefinitions(
-                        plan.Source.Alias ?? plan.Source.Name,
-                        table.ColumnDefinitions));
                 // Branch equality is re-checked so non-matching keys on this index are skipped.
-                if (!IsTrue(Evaluate(branch, parameters, probeRow, context)))
+                if (!IsTrue(Evaluate(branch, parameters, row, context)))
                     continue;
 
-                positions.Add(position);
+                var identity = table.HasRowid
+                    ? MvccKey.FromInteger(rowId!.Value)
+                    : MvccKey.FromPrimaryKey(
+                        table.PrimaryKeySchema
+                            ?? throw new InvalidOperationException("WITHOUT ROWID table has no primary-key metadata."),
+                        row.Values,
+                        context.MvccTextEncoding);
+                if (selected.Add(identity))
+                    selectedRows.Add(row);
             }
         }
 
         var qualifier = plan.Source.Alias ?? plan.Source.Name;
         var qualifiedColumns = BuildQualifiedColumns(qualifier, table.Columns);
-        var rows = new SourceRow[positions.Count];
-        var write = 0;
-        foreach (var position in positions)
+        var rows = selectedRows.Select(row => row with
         {
-            var rowId = table.HasRowid ? table.RowIds[position] : (long?)null;
-            rows[write++] = new SourceRow(
-                table.Columns,
-                table.Rows[position],
-                qualifiedColumns,
-                outerRow,
-                RowId: rowId,
-                RowIdQualifier: qualifier,
-                ColumnDefinitions: table.ColumnDefinitions,
-                QualifiedColumnDefinitions: BuildQualifiedColumnDefinitions(
-                    qualifier,
-                    table.ColumnDefinitions));
-        }
+            QualifiedColumns = qualifiedColumns,
+            Parent = outerRow,
+            RowIdQualifier = qualifier,
+            ColumnDefinitions = table.ColumnDefinitions,
+            QualifiedColumnDefinitions = BuildQualifiedColumnDefinitions(
+                qualifier,
+                table.ColumnDefinitions),
+        }).ToArray();
 
         return new SourceData(table.Columns, rows);
     }
@@ -23068,8 +23256,8 @@ out bool hasReturning)
     private int CompareManagedIndexEntries(
         EmbeddedTable table,
         EmbeddedIndex index,
-        (int Position, SqlValue[] Key) left,
-        (int Position, SqlValue[] Key) right)
+        (SourceRow Row, SqlValue[] Key) left,
+        (SourceRow Row, SqlValue[] Key) right)
     {
         for (var position = 0; position < index.Columns.Count; position++)
         {
@@ -23083,7 +23271,7 @@ out bool hasReturning)
         }
 
         if (table.HasRowid)
-            return table.RowIds[left.Position].CompareTo(table.RowIds[right.Position]);
+            return left.Row.RowId!.Value.CompareTo(right.Row.RowId!.Value);
 
         var primaryKey = table.PrimaryKeySchema
             ?? throw new InvalidOperationException("WITHOUT ROWID table has no primary-key metadata.");
@@ -23100,8 +23288,8 @@ out bool hasReturning)
                 continue;
 
             var comparison = Compare(
-                table.Rows[left.Position][suffix.ColumnIndex],
-                table.Rows[right.Position][suffix.ColumnIndex],
+                left.Row.Values[suffix.ColumnIndex],
+                right.Row.Values[suffix.ColumnIndex],
                 suffix.Collation.Name);
             if (comparison != 0)
             {
@@ -27592,38 +27780,59 @@ out bool hasReturning)
             qualifier,
             table.ColumnDefinitions);
 
-        // Concurrent MVCC: merge classic base snapshot with version-store overlays
-        // (Turso dual-cursor). Rowid tables only; WITHOUT ROWID stays catalog-only.
-        if (table.HasRowid
-            && context.ConcurrentMvStore is { } store
+        // Concurrent MVCC: merge a classic base snapshot with typed version-store
+        // overlays. WITHOUT ROWID identities are complete primary-key records.
+        if (context.ConcurrentMvStore is { } store
             && context.ConcurrentMvccTxId is { } txId)
         {
-            var baseIds = new long[table.Rows.Count];
+            SqliteIndexRecordComparer? primaryKeyComparer = null;
+            if (!table.HasRowid)
+            {
+                var primaryKey = table.PrimaryKeySchema
+                    ?? throw new EmbeddedSqlException(
+                        $"WITHOUT ROWID table '{source.Name}' is missing primary-key metadata for concurrent MVCC.");
+                primaryKeyComparer = new SqliteIndexRecordComparer(
+                    context.MvccTextEncoding,
+                    primaryKey.Terms.Select(term =>
+                        new SqliteIndexComparisonTerm(term.SortOrder, term.Collation)).ToArray());
+            }
+
+            var baseRows = new MvccDualCursor.Row[table.Rows.Count];
             for (var i = 0; i < table.Rows.Count; i++)
-                baseIds[i] = i < table.RowIds.Count ? table.RowIds[i] : i + 1;
+            {
+                var rowId = i < table.RowIds.Count ? table.RowIds[i] : i + 1;
+                var key = table.HasRowid
+                    ? MvccKey.FromInteger(rowId)
+                    : MvccKey.FromPrimaryKey(
+                        table.PrimaryKeySchema!,
+                        table.Rows[i],
+                        context.MvccTextEncoding);
+                baseRows[i] = new MvccDualCursor.Row(key, table.Rows[i]);
+            }
 
             var tableId = store.GetOrCreateTableId(source.Name);
             var merged = MvccDualCursor.MergeVisibleRows(
                 store,
                 txId,
                 tableId,
-                baseIds,
-                table.Rows);
-            var ordered = merged.OrderBy(row => row.RowId).ToList();
-            var count = ordered.Count;
+                baseRows,
+                (left, right) => table.HasRowid
+                    ? left.Integer.CompareTo(right.Integer)
+                    : primaryKeyComparer!.Compare(left.Record.Span, right.Record.Span));
+            var count = merged.Count;
             if (maximumRows is { } maximum && maximum < count)
                 count = (int)maximum;
 
             var dualSourceRows = new SourceRow[count];
             for (var outputIndex = 0; outputIndex < count; outputIndex++)
             {
-                var (rowId, cells) = ordered[outputIndex];
+                var row = merged[outputIndex];
                 dualSourceRows[outputIndex] = new SourceRow(
                     table.Columns,
-                    cells,
+                    row.Cells,
                     qualifiedColumns,
                     outerRow,
-                    RowId: rowId,
+                    RowId: table.HasRowid ? row.Key.Integer : null,
                     RowIdQualifier: qualifier,
                     ColumnDefinitions: table.ColumnDefinitions,
                     QualifiedColumnDefinitions: qualifiedColumnDefinitions);
@@ -41326,6 +41535,7 @@ public sealed class EmbeddedConnection : IDisposable
     /// <summary>When set, the open SQL transaction is a Turso <c>BEGIN CONCURRENT</c> MVCC tx.</summary>
     private bool _transactionIsConcurrent;
     private readonly Dictionary<EmbeddedDatabase, MvccTxId> _mvccTransactions = [];
+    private long _nextMvccStatementSavepoint;
     private readonly List<SavepointEntry> _savepoints = [];
     private long _lastInsertRowId;
     private bool _queryOnly;
@@ -42135,6 +42345,7 @@ public sealed class EmbeddedConnection : IDisposable
         public PragmaHeaderMetadata PragmaHeader { get; set; } = pragmaHeader;
         public bool HasChanges { get; set; }
         public bool HasSnapshotPragmaHeader { get; set; }
+        public bool HasSchemaChanges { get; set; }
         public bool ForceFullCatalogRewrite { get; set; }
         public HashSet<EmbeddedDatabase.ForeignKeyViolation> PendingDeferredViolations { get; } = [];
     }
@@ -42651,8 +42862,7 @@ public sealed class EmbeddedConnection : IDisposable
             && _transactionDatabases is not null
             && EmbeddedDatabase.MayChangeSchema(statement))
         {
-            throw new EmbeddedSqlException(
-                "Schema changes are not supported in concurrent transactions");
+            BeginConcurrentSchemaChange();
         }
 
         if (_transactionDatabases is null)
@@ -42787,6 +42997,9 @@ public sealed class EmbeddedConnection : IDisposable
                 var pendingTempTriggerRewrite = PrepareTempTriggerTableRename(routed, cancellationToken)
                     ?? PrepareTempTriggerColumnRename(routed, cancellationToken);
                 ValidateTempTriggersAfterDropColumn(routed, cancellationToken);
+                MvStore? concurrentStore = null;
+                MvccTxId? concurrentTxId = null;
+                string? mvccStatementSavepoint = null;
                 try
                 {
                     ExecutionResult result;
@@ -42800,7 +43013,15 @@ public sealed class EmbeddedConnection : IDisposable
                             includeImmediate: _deferForeignKeys);
                     }
                     var mutationReserved = ReserveTransactionMutation(routed.Database, routed.Statement);
-                    TryGetConcurrentMvccScope(routed.Database, out var concurrentStore, out var concurrentTxId);
+                    TryGetConcurrentMvccScope(routed.Database, out concurrentStore, out concurrentTxId);
+                    if (EmbeddedDatabase.MayMutate(routed.Statement)
+                        && concurrentStore is not null
+                        && concurrentTxId is not null)
+                    {
+                        mvccStatementSavepoint = BeginConcurrentStatementSavepoint(
+                            concurrentStore,
+                            concurrentTxId.Value);
+                    }
                     try
                     {
                         if (routed.ReadCatalog is not null)
@@ -42919,6 +43140,7 @@ public sealed class EmbeddedConnection : IDisposable
                                 {
                                     SchemaVersion = unchecked(transactionState.PragmaHeader.SchemaVersion + 1),
                                 };
+                                transactionState.HasSchemaChanges = true;
                             }
 
                             RecordConcurrentMvccMutation(
@@ -42940,6 +43162,10 @@ public sealed class EmbeddedConnection : IDisposable
                     if (result.Changed && pendingTempTriggerRewrite is not null)
                         PublishTempTriggerCatalogRewrite(pendingTempTriggerRewrite);
 
+                    ReleaseConcurrentStatementSavepoint(
+                        concurrentStore,
+                        concurrentTxId,
+                        mvccStatementSavepoint);
                     tempTriggerSession?.Commit();
                     return result;
                 }
@@ -42958,11 +43184,21 @@ public sealed class EmbeddedConnection : IDisposable
                 catch (EmbeddedStatementAbortException exception)
                 {
                     _lastInsertRowId = exception.LastInsertRowId;
+                    RollbackConcurrentStatementSavepoint(
+                        concurrentStore,
+                        concurrentTxId,
+                        mvccStatementSavepoint);
+                    ReleaseConcurrentSchemaGateIfUnused();
                     throw new EmbeddedSqlException(exception.Message, exception.InnerException ?? exception);
                 }
                 catch (EmbeddedStatementFailureException exception)
                 {
                     _lastInsertRowId = exception.LastInsertRowId;
+                    RollbackConcurrentStatementSavepoint(
+                        concurrentStore,
+                        concurrentTxId,
+                        mvccStatementSavepoint);
+                    ReleaseConcurrentSchemaGateIfUnused();
                     ExceptionDispatchInfo.Capture(exception.Failure).Throw();
                     throw new InvalidOperationException("ExceptionDispatchInfo.Throw unexpectedly returned.");
                 }
@@ -42988,6 +43224,11 @@ public sealed class EmbeddedConnection : IDisposable
                         _tempInitialized = true;
 
                     tempTriggerSession?.Commit();
+                    ReleaseConcurrentStatementSavepoint(
+                        concurrentStore,
+                        concurrentTxId,
+                        mvccStatementSavepoint);
+                    ReleaseConcurrentSchemaGateIfUnused();
                     throw new EmbeddedSqlException(exception.Message, exception.InnerException ?? exception);
                 }
                 catch (EmbeddedTriggerDepthException exception)
@@ -43013,15 +43254,44 @@ public sealed class EmbeddedConnection : IDisposable
                     if (ReferenceEquals(routed.Database, _tempDatabase))
                         _tempInitialized = true;
 
+                    if (!exception.PreserveChanges)
+                    {
+                        RollbackConcurrentStatementSavepoint(
+                            concurrentStore,
+                            concurrentTxId,
+                            mvccStatementSavepoint);
+                    }
+                    else
+                    {
+                        ReleaseConcurrentStatementSavepoint(
+                            concurrentStore,
+                            concurrentTxId,
+                            mvccStatementSavepoint);
+                    }
+                    ReleaseConcurrentSchemaGateIfUnused();
                     throw new EmbeddedSqlException(exception.Message, exception.InnerException ?? exception);
                 }
                 catch (OperationCanceledException)
                 {
+                    RollbackConcurrentStatementSavepoint(
+                        concurrentStore,
+                        concurrentTxId,
+                        mvccStatementSavepoint);
                     if (transactionState is not null && EmbeddedDatabase.MayMutate(routed.Statement))
                     {
                         ResetTransactionState();
                         FireRollbackHook();
                     }
+                    ReleaseConcurrentSchemaGateIfUnused();
+                    throw;
+                }
+                catch
+                {
+                    RollbackConcurrentStatementSavepoint(
+                        concurrentStore,
+                        concurrentTxId,
+                        mvccStatementSavepoint);
+                    ReleaseConcurrentSchemaGateIfUnused();
                     throw;
                 }
         }
@@ -45665,6 +45935,8 @@ Func<string, ParsedStatement> rewrite)
                 throw new EmbeddedSqlException(
                     "Concurrent transaction mode is only supported when MVCC is enabled");
             }
+
+            _database.EnsureMvccLogVersion4();
         }
 
         var databases = _attachedDatabases.Values
@@ -45955,6 +46227,44 @@ Func<string, ParsedStatement> rewrite)
         return true;
     }
 
+    private void BeginConcurrentSchemaChange()
+    {
+        if (!_transactionIsConcurrent
+            || !_mvccTransactions.TryGetValue(_database, out var txId)
+            || _database.MvStore is not { } store)
+        {
+            throw new EmbeddedSqlException(
+                "Concurrent schema changes require an active main-database MVCC transaction.");
+        }
+
+        store.BeginSchemaChange(txId);
+    }
+
+    private string BeginConcurrentStatementSavepoint(MvStore store, MvccTxId txId)
+    {
+        var name = "\u0001ahtola-mvcc-statement-" + checked(++_nextMvccStatementSavepoint);
+        store.BeginNamedSavepoint(txId, name);
+        return name;
+    }
+
+    private static void ReleaseConcurrentStatementSavepoint(
+        MvStore? store,
+        MvccTxId? txId,
+        string? name)
+    {
+        if (store is not null && txId is { } id && name is not null)
+            store.ReleaseNamedSavepoint(id, name);
+    }
+
+    private static void RollbackConcurrentStatementSavepoint(
+        MvStore? store,
+        MvccTxId? txId,
+        string? name)
+    {
+        if (store is not null && txId is { } id && name is not null)
+            store.RollbackToNamedSavepoint(id, name);
+    }
+
     private void CommitTransaction()
     {
         if (_transactionDatabases is null)
@@ -45975,11 +46285,33 @@ Func<string, ParsedStatement> rewrite)
         }
 
         // MVCC commit protocol first (clock + WW conflict), then classic catalog publish.
-        foreach (var (database, txId) in _mvccTransactions.ToArray())
+        // A schema generation stays pending across that boundary so no new BEGIN
+        // can capture old bindings while the page-one cookie is landing.
+        var pendingSchemaPublications = new List<(
+            EmbeddedDatabase Database,
+            MvccTxId TxId,
+            bool Publish)>();
+        try
         {
-            if (database.MvStore is { } store)
-                store.Commit(txId);
-            _mvccTransactions.Remove(database);
+            foreach (var (database, txId) in _mvccTransactions.ToArray())
+            {
+                if (database.MvStore is { } store)
+                {
+                    if (store.HasSchemaChange(txId))
+                    {
+                        var publish = _transactionDatabases.TryGetValue(database, out var state)
+                            && state.HasSchemaChanges;
+                        pendingSchemaPublications.Add((database, txId, publish));
+                    }
+                    store.Commit(txId);
+                }
+                _mvccTransactions.Remove(database);
+            }
+        }
+        catch (MvccLogicalLogCommitIndeterminateException)
+        {
+            ResetTransactionState();
+            throw;
         }
 
         var persistentChanges = changed
@@ -45992,27 +46324,55 @@ Func<string, ParsedStatement> rewrite)
             .Where(pair => ReferenceEquals(pair.Key, _tempDatabase))
             .Select(pair => pair.Value)
             .SingleOrDefault();
-        if (persistentChanges.Length == 1)
+        try
         {
-            var (database, state) = persistentChanges[0];
-            try
+            if (persistentChanges.Length == 1)
             {
+                var (database, state) = persistentChanges[0];
                 database.CommitTransaction(
                     state.Catalog,
                     state.Version,
-                    database.IsFileBacked && !state.HasSnapshotPragmaHeader
+                    database.IsFileBacked && !state.HasSnapshotPragmaHeader && !state.HasSchemaChanges
                         ? null
                         : state.PragmaHeader,
                     state.ForceFullCatalogRewrite,
                     busyTimeout: BusyTimeout,
-                    concurrent: _transactionIsConcurrent);
+                    concurrent: _transactionIsConcurrent,
+                    containsSchemaChanges: state.HasSchemaChanges);
             }
-            catch (EmbeddedPostCommitMaintenanceException)
+
+            foreach (var (database, txId, publish) in pendingSchemaPublications)
             {
-                CommitTemporaryTransaction(tempChange);
-                ResetTransactionState();
-                throw;
+                if (publish)
+                {
+                    database.MvStore?.CompleteSchemaCheckpoint();
+                    database.MvStore?.PublishSchemaChange(txId);
+                }
+                else
+                    database.MvStore?.CancelSchemaChange(txId);
             }
+        }
+        catch (EmbeddedPostCommitMaintenanceException)
+        {
+            foreach (var (database, txId, _) in pendingSchemaPublications)
+                database.MvStore?.CancelSchemaChange(txId);
+            CommitTemporaryTransaction(tempChange);
+            ResetTransactionState();
+            throw;
+        }
+        catch (MvccLogicalLogCommitIndeterminateException)
+        {
+            foreach (var (database, txId, _) in pendingSchemaPublications)
+                database.MvStore?.CancelSchemaChange(txId);
+            ResetTransactionState();
+            throw;
+        }
+        catch (Exception failure)
+        {
+            foreach (var (database, txId, _) in pendingSchemaPublications)
+                database.MvStore?.CancelSchemaChange(txId);
+            ResetTransactionState();
+            throw new EmbeddedPostCommitMaintenanceException(failure);
         }
 
         CommitTemporaryTransaction(tempChange);
@@ -46890,6 +47250,7 @@ Func<string, ParsedStatement> rewrite)
                     pair.Value.HasChanges,
                     pair.Value.PragmaHeader,
                     pair.Value.HasSnapshotPragmaHeader,
+                    pair.Value.HasSchemaChanges,
                     pair.Value.ForceFullCatalogRewrite,
                     new HashSet<EmbeddedDatabase.ForeignKeyViolation>(
                         pair.Value.PendingDeferredViolations))),
@@ -46931,6 +47292,7 @@ Func<string, ParsedStatement> rewrite)
             state.HasChanges = savedState.HasChanges;
             state.PragmaHeader = savedState.PragmaHeader;
             state.HasSnapshotPragmaHeader = savedState.HasSnapshotPragmaHeader;
+            state.HasSchemaChanges = savedState.HasSchemaChanges;
             state.ForceFullCatalogRewrite = savedState.ForceFullCatalogRewrite;
             state.PendingDeferredViolations.Clear();
             state.PendingDeferredViolations.UnionWith(savedState.PendingDeferredViolations);
@@ -46940,6 +47302,7 @@ Func<string, ParsedStatement> rewrite)
         // Undo concurrent version-store ops after the named mark (Turso MVCC savepoints).
         foreach (var (database, txId) in _mvccTransactions)
             database.MvStore?.RollbackToNamedSavepoint(txId, name);
+        ReleaseConcurrentSchemaGateIfUnused();
 
         // ROLLBACK TO keeps the named savepoint but cancels any created after it.
         if (index + 1 < _savepoints.Count)
@@ -46955,6 +47318,19 @@ Func<string, ParsedStatement> rewrite)
         }
 
         throw new EmbeddedSqlException($"no such savepoint: {name}");
+    }
+
+    private void ReleaseConcurrentSchemaGateIfUnused()
+    {
+        if (!_transactionIsConcurrent
+            || _transactionDatabases is null
+            || _transactionDatabases.Values.Any(state => state.HasSchemaChanges))
+        {
+            return;
+        }
+
+        foreach (var (database, txId) in _mvccTransactions)
+            database.MvStore?.CancelSchemaChange(txId);
     }
 
     private void ResetTransactionState()
@@ -46992,6 +47368,7 @@ Func<string, ParsedStatement> rewrite)
         bool HasChanges,
         PragmaHeaderMetadata PragmaHeader,
         bool HasSnapshotPragmaHeader,
+        bool HasSchemaChanges,
         bool ForceFullCatalogRewrite,
         IReadOnlySet<EmbeddedDatabase.ForeignKeyViolation> PendingDeferredViolations);
 

--- a/src/Ahtola.Core/EmbeddedDatabase.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.cs
@@ -46291,6 +46291,7 @@ Func<string, ParsedStatement> rewrite)
             EmbeddedDatabase Database,
             MvccTxId TxId,
             bool Publish)>();
+        var mvccWriteWasPublished = false;
         try
         {
             foreach (var (database, txId) in _mvccTransactions.ToArray())
@@ -46303,7 +46304,9 @@ Func<string, ParsedStatement> rewrite)
                             && state.HasSchemaChanges;
                         pendingSchemaPublications.Add((database, txId, publish));
                     }
+                    var hasPendingWrites = store.HasPendingWrites(txId);
                     store.Commit(txId);
+                    mvccWriteWasPublished |= hasPendingWrites;
                 }
                 _mvccTransactions.Remove(database);
             }
@@ -46371,6 +46374,8 @@ Func<string, ParsedStatement> rewrite)
         {
             foreach (var (database, txId, _) in pendingSchemaPublications)
                 database.MvStore?.CancelSchemaChange(txId);
+            if (!mvccWriteWasPublished)
+                throw;
             ResetTransactionState();
             throw new EmbeddedPostCommitMaintenanceException(failure);
         }

--- a/src/Ahtola.Core/Mvcc/MvStore.cs
+++ b/src/Ahtola.Core/Mvcc/MvStore.cs
@@ -7,7 +7,41 @@ internal readonly record struct MvccTxId(ulong Value)
 }
 
 /// <summary>Row identity within an MVCC table (Turso <c>RowID</c>).</summary>
-internal readonly record struct MvccRowId(long TableId, long RowId);
+internal readonly struct MvccRowId : IEquatable<MvccRowId>
+{
+    internal MvccRowId(long tableId, long rowId)
+        : this(tableId, MvccKey.FromInteger(rowId))
+    {
+    }
+
+    internal MvccRowId(long tableId, MvccKey key)
+    {
+        TableId = tableId;
+        Key = key;
+    }
+
+    internal long TableId { get; }
+
+    internal MvccKey Key { get; }
+
+    /// <summary>
+    /// Compatibility projection for the rowid-table path. Composite and typed
+    /// keys must use <see cref="Key"/> instead.
+    /// </summary>
+    internal long RowId => Key.Integer;
+
+    public bool Equals(MvccRowId other) => TableId == other.TableId && Key.Equals(other.Key);
+
+    public override bool Equals(object? obj) => obj is MvccRowId other && Equals(other);
+
+    public static bool operator ==(MvccRowId left, MvccRowId right) => left.Equals(right);
+
+    public static bool operator !=(MvccRowId left, MvccRowId right) => !left.Equals(right);
+
+    public override int GetHashCode() => HashCode.Combine(TableId, Key);
+
+    public override string ToString() => $"{TableId}:{Key}";
+}
 
 /// <summary>Lifecycle state of an MVCC transaction (Turso <c>TransactionState</c>).</summary>
 internal enum MvccTransactionState : byte
@@ -29,16 +63,20 @@ internal sealed class MvccTransaction
     private readonly List<MvccSavepointMark> _savepoints = [];
     private MvccTransactionState _state = MvccTransactionState.Active;
     private ulong? _commitTimestamp;
+    private bool _schemaChange;
 
-    internal MvccTransaction(MvccTxId id, ulong beginTimestamp)
+    internal MvccTransaction(MvccTxId id, ulong beginTimestamp, ulong beginCommitGeneration)
     {
         Id = id;
         BeginTimestamp = beginTimestamp;
+        BeginCommitGeneration = beginCommitGeneration;
     }
 
     internal MvccTxId Id { get; }
 
     internal ulong BeginTimestamp { get; }
+
+    internal ulong BeginCommitGeneration { get; }
 
     internal MvccTransactionState State
     {
@@ -48,6 +86,20 @@ internal sealed class MvccTransaction
     internal ulong? CommitTimestamp
     {
         get { lock (_gate) return _commitTimestamp; }
+    }
+
+    internal bool HasSchemaChange
+    {
+        get { lock (_gate) return _schemaChange; }
+    }
+
+    internal void MarkSchemaChange()
+    {
+        lock (_gate)
+        {
+            ThrowIfNotActive();
+            _schemaChange = true;
+        }
     }
 
     internal void RecordWrite(MvccRowId rowId)
@@ -215,6 +267,11 @@ internal sealed class MvStore
     private ulong _nextTxId = 1;
     private ulong _nextVersionId = 1;
     private ulong? _exclusiveTxId;
+    private ulong _schemaGeneration;
+    private ulong _commitGeneration;
+    private ulong? _schemaChangeTransaction;
+    private bool _hasUnresolvedLegacyRows;
+    private bool _hasIndeterminateCommit;
     private MvccLogicalLog? _logicalLog;
 
     internal MvStore(ILogicalClock? clock = null, MvccLogicalLog? logicalLog = null)
@@ -226,6 +283,31 @@ internal sealed class MvStore
     internal ILogicalClock Clock => _clock;
 
     internal MvccLogicalLog? LogicalLog => _logicalLog;
+
+    /// <summary>
+    /// A V3 frame does not carry the object name needed to bind its negative table
+    /// id after a cold reopen. Such a log cannot be materialized safely, so the
+    /// V3-to-V4 checkpoint upgrade must fail rather than discard its rows.
+    /// </summary>
+    internal bool CanUpgradeLegacyLog
+    {
+        get { lock (_gate) return !_hasUnresolvedLegacyRows; }
+    }
+
+    /// <summary>
+    /// Monotonic in-process schema generation. Connections use it to fail a
+    /// concurrent DDL attempt rather than applying a catalog mutation against an
+    /// older MVCC snapshot.
+    /// </summary>
+    internal ulong SchemaGeneration
+    {
+        get { lock (_gate) return _schemaGeneration; }
+    }
+
+    internal ulong CommitGeneration
+    {
+        get { lock (_gate) return _commitGeneration; }
+    }
 
     /// <summary>Attach durable log after construction (file-backed enable path).</summary>
     internal void AttachLogicalLog(MvccLogicalLog log)
@@ -243,6 +325,14 @@ internal sealed class MvStore
         {
             foreach (var op in ops)
             {
+                if (op.ObjectName is { } objectName)
+                {
+                    RegisterRecoveredTableId(op.RowId.TableId, objectName);
+                }
+                else if (!_tableNames.ContainsKey(op.RowId.TableId))
+                {
+                    _hasUnresolvedLegacyRows = true;
+                }
                 if (!_rows.TryGetValue(op.RowId, out var chain))
                 {
                     chain = [];
@@ -251,6 +341,17 @@ internal sealed class MvStore
 
                 if (op.IsDelete)
                 {
+                    if (op.IsBaseTombstone && chain.Count == 0)
+                    {
+                        chain.Add(new MvccRowVersion(
+                            _nextVersionId++,
+                            begin: MvccStamp.FromTimestamp(commitTs),
+                            end: null,
+                            cells: [],
+                            isTombstone: true));
+                        continue;
+                    }
+
                     // End the latest live version at commitTs.
                     for (var i = chain.Count - 1; i >= 0; i--)
                     {
@@ -297,6 +398,41 @@ internal sealed class MvStore
             return _tableNames.TryGetValue(tableId, out name);
     }
 
+    private void RegisterRecoveredTableId(long tableId, string tableName)
+    {
+        if (_tableNames.TryGetValue(tableId, out var existingName)
+            && !string.Equals(existingName, tableName, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidDataException(
+                $"MVCC logical log maps table id {tableId} to both '{existingName}' and '{tableName}'.");
+        }
+        if (_tableIds.TryGetValue(tableName, out var existingId) && existingId != tableId)
+        {
+            throw new InvalidDataException(
+                $"MVCC logical log maps table '{tableName}' to both {existingId} and {tableId}.");
+        }
+
+        _tableIds[tableName] = tableId;
+        _tableNames[tableId] = tableName;
+        _nextTableId = Math.Min(_nextTableId, checked(tableId - 1));
+    }
+
+    private MvccLogOp CreateLogUpsert(MvccRowId rowId, SqlValue[] cells)
+        => MvccLogOp.Upsert(
+            rowId,
+            cells,
+            _tableNames.TryGetValue(rowId.TableId, out var objectName) ? objectName : null);
+
+    private MvccLogOp CreateLogDelete(MvccRowId rowId)
+        => MvccLogOp.Delete(
+            rowId,
+            _tableNames.TryGetValue(rowId.TableId, out var objectName) ? objectName : null);
+
+    private MvccLogOp CreateLogBaseTombstone(MvccRowId rowId)
+        => MvccLogOp.BaseTombstone(
+            rowId,
+            _tableNames.TryGetValue(rowId.TableId, out var objectName) ? objectName : null);
+
     /// <summary>
     /// Process-wide unique rowid allocator for concurrent writers that each hold
     /// a private classic catalog snapshot (pooled connections).
@@ -341,12 +477,17 @@ internal sealed class MvStore
     {
         lock (_gate)
         {
-            if (_exclusiveTxId is not null)
+            if (_hasIndeterminateCommit)
+            {
+                throw new EmbeddedSqlException(
+                    "The MVCC store has an indeterminate logical-log commit; dispose and reopen the database before starting another transaction.");
+            }
+            if (_exclusiveTxId is not null || _schemaChangeTransaction is not null)
                 throw new EmbeddedBusyException();
 
             var beginTs = NextBeginTimestamp();
             var id = new MvccTxId(_nextTxId++);
-            var tx = new MvccTransaction(id, beginTs);
+            var tx = new MvccTransaction(id, beginTs, _commitGeneration);
             _transactions.Add(id.Value, tx);
             return tx;
         }
@@ -356,6 +497,11 @@ internal sealed class MvStore
     {
         lock (_gate)
         {
+            if (_hasIndeterminateCommit)
+            {
+                throw new EmbeddedSqlException(
+                    "The MVCC store has an indeterminate logical-log commit; dispose and reopen the database before starting another transaction.");
+            }
             if (_exclusiveTxId is { } held
                 && (existing is null || held != existing.Value.Value))
             {
@@ -371,7 +517,7 @@ internal sealed class MvStore
 
             var beginTs = NextBeginTimestamp();
             var id = new MvccTxId(_nextTxId++);
-            var tx = new MvccTransaction(id, beginTs);
+            var tx = new MvccTransaction(id, beginTs, _commitGeneration);
             _transactions.Add(id.Value, tx);
             _exclusiveTxId = id.Value;
             return tx;
@@ -384,6 +530,96 @@ internal sealed class MvStore
             return _transactions.TryGetValue(id.Value, out transaction);
     }
 
+    /// <summary>
+    /// Reserves the schema publication slot for an active concurrent transaction.
+    /// DDL deliberately fails busy when another reader or writer has already
+    /// pinned an MVCC snapshot; publishing a schema against that snapshot would
+    /// otherwise leave compiled cursors with stale object bindings.
+    /// </summary>
+    internal void BeginSchemaChange(MvccTxId id)
+    {
+        lock (_gate)
+        {
+            var tx = RequireActive(id);
+            if (tx.BeginCommitGeneration != _commitGeneration)
+                throw new EmbeddedBusyException();
+            if (_schemaChangeTransaction is { } owner && owner != id.Value)
+                throw new EmbeddedBusyException();
+
+            foreach (var candidate in _transactions.Values)
+            {
+                if (candidate.Id != id
+                    && candidate.State is MvccTransactionState.Active or MvccTransactionState.Preparing)
+                {
+                    throw new EmbeddedBusyException();
+                }
+            }
+
+            tx.MarkSchemaChange();
+            _schemaChangeTransaction = id.Value;
+        }
+    }
+
+    internal bool HasSchemaChange(MvccTxId id)
+    {
+        lock (_gate)
+        {
+            return _transactions.TryGetValue(id.Value, out var tx)
+                ? tx.HasSchemaChange
+                : _schemaChangeTransaction == id.Value;
+        }
+    }
+
+    /// <summary>
+    /// Publishes a schema generation only after the catalog and page-one cookie
+    /// have committed through the normal pager/WAL path.
+    /// </summary>
+    internal void PublishSchemaChange(MvccTxId id)
+    {
+        lock (_gate)
+        {
+            if (_schemaChangeTransaction != id.Value)
+                throw new InvalidOperationException("The MVCC transaction does not own a pending schema publication.");
+            _schemaGeneration = checked(_schemaGeneration + 1);
+            _schemaChangeTransaction = null;
+        }
+    }
+
+    internal void CancelSchemaChange(MvccTxId id)
+    {
+        lock (_gate)
+        {
+            if (_schemaChangeTransaction == id.Value)
+                _schemaChangeTransaction = null;
+        }
+    }
+
+    /// <summary>
+    /// A schema catalog was durably rewritten after all concurrent snapshots were
+    /// excluded. Its catalog already contains every committed logical row, so
+    /// retire the old object identities and their log prefix before a table name
+    /// can be reused by CREATE/RENAME.
+    /// </summary>
+    internal void CompleteSchemaCheckpoint()
+    {
+        lock (_gate)
+        {
+            if (HasActiveTransactionsLocked())
+            {
+                throw new InvalidOperationException(
+                    "Cannot retire MVCC object identities while a transaction is active.");
+            }
+
+            _rows.Clear();
+            _tableIds.Clear();
+            _tableNames.Clear();
+            _nextRowIds.Clear();
+            _nextTableId = -2;
+            _logicalLog?.TruncateAfterCheckpoint();
+            if (_logicalLog is { RequiresVersion4Upgrade: true })
+                _logicalLog.UpgradeToVersion4AfterCheckpoint();
+        }
+    }
     /// <summary>Insert a new live version created by <paramref name="txId"/>.</summary>
     internal void Insert(MvccTxId txId, MvccRowId rowId, SqlValue[] cells)
     {
@@ -401,9 +637,13 @@ internal sealed class MvStore
                 chain = [];
                 _rows[rowId] = chain;
             }
+            else if (!rowId.Key.IsInteger)
+            {
+                ThrowIfTypedKeyInsertConflict(tx, chain);
+            }
 
             chain.Add(version);
-            tx.RecordLogOp(MvccLogOp.Upsert(rowId, version.Cells));
+            tx.RecordLogOp(CreateLogUpsert(rowId, version.Cells));
         }
     }
 
@@ -428,7 +668,7 @@ internal sealed class MvStore
                     throw new EmbeddedWriteWriteConflictException();
 
                 version.End = MvccStamp.FromTxId(txId);
-                tx.RecordLogOp(MvccLogOp.Delete(rowId));
+                tx.RecordLogOp(CreateLogDelete(rowId));
                 return true;
             }
 
@@ -465,7 +705,7 @@ internal sealed class MvStore
                     }
 
                     version.End = MvccStamp.FromTxId(txId);
-                    tx.RecordLogOp(MvccLogOp.Delete(rowId));
+                    tx.RecordLogOp(CreateLogDelete(rowId));
                     return;
                 }
 
@@ -483,7 +723,7 @@ internal sealed class MvStore
                 end: null,
                 cells: [],
                 isTombstone: true));
-            tx.RecordLogOp(MvccLogOp.Delete(rowId));
+            tx.RecordLogOp(CreateLogBaseTombstone(rowId));
         }
     }
 
@@ -689,6 +929,13 @@ internal sealed class MvStore
         {
             tx = RequireActive(id);
             writes = tx.SnapshotWriteSet().ToHashSet();
+            var preflightOps = tx.SnapshotLogOps();
+            if (_logicalLog is { RequiresVersion4Upgrade: true }
+                && preflightOps.Any(static op => !op.RowId.Key.IsInteger))
+            {
+                throw new MvccLogicalLogUpgradeRequiredException(
+                    "MVCC typed-key writes require a checkpoint that upgrades the logical log before commit.");
+            }
 
             foreach (var rowId in writes)
             {
@@ -699,6 +946,8 @@ internal sealed class MvStore
                     if (IsWriteWriteConflict(tx, version))
                         throw new EmbeddedWriteWriteConflictException();
                 }
+                if (!rowId.Key.IsInteger)
+                    ThrowIfTypedKeyInsertConflict(tx, chain);
             }
         }
 
@@ -723,19 +972,38 @@ internal sealed class MvStore
                 }
             }
 
-            RewriteStampsLocked(id, commitTs);
             var logOps = tx.SnapshotLogOps();
+            MvccLogicalLogCommitIndeterminateException? indeterminateCommit = null;
+            try
+            {
+                if (logOps.Count != 0)
+                    _logicalLog?.AppendCommit(commitTs, logOps);
+            }
+            catch (MvccLogicalLogCommitIndeterminateException exception)
+            {
+                indeterminateCommit = exception;
+            }
+            catch
+            {
+                AbortLocked(id, tx);
+                throw;
+            }
+
+            RewriteStampsLocked(id, commitTs);
             tx.MarkCommitted();
             _finalizedStates[id.Value] = MvccTransactionState.Committed;
             _finalizedCommitTimestamps[id.Value] = commitTs;
             ClearExclusive(id);
             _transactions.Remove(id.Value);
+            if (writes.Count != 0)
+                _commitGeneration = checked(_commitGeneration + 1);
             PruneHistoryLocked(tx.BeginTimestamp);
+            if (indeterminateCommit is not null)
+            {
+                _hasIndeterminateCommit = true;
+                throw indeterminateCommit;
+            }
 
-            // Durable log after in-memory commit is published (Turso flushes then
-            // advances visibility; we keep the store already committed and append).
-            if (logOps.Count != 0)
-                _logicalLog?.AppendCommit(commitTs, logOps);
         }
     }
 
@@ -851,6 +1119,8 @@ internal sealed class MvStore
         }
 
         tx.MarkAborted();
+        if (_schemaChangeTransaction == id.Value)
+            _schemaChangeTransaction = null;
         _finalizedStates[id.Value] = MvccTransactionState.Aborted;
         ClearExclusive(id);
         _transactions.Remove(id.Value);
@@ -996,6 +1266,30 @@ internal sealed class MvStore
             {
                 throw new EmbeddedWriteWriteConflictException();
             }
+        }
+    }
+
+    /// <summary>
+    /// A rowid allocator makes ordinary concurrent inserts distinct. A typed
+    /// primary key has no such allocator: two live versions for the same key
+    /// would violate the table's uniqueness contract even when the writers
+    /// started from independent catalog snapshots.
+    /// </summary>
+    private static void ThrowIfTypedKeyInsertConflict(
+        MvccTransaction tx,
+        IReadOnlyList<MvccRowVersion> chain)
+    {
+        foreach (var version in chain)
+        {
+            if (version.IsTombstone || version.End is not null)
+                continue;
+            if (version.Begin is { IsTimestamp: false, Value: var beginTx }
+                && beginTx == tx.Id.Value)
+            {
+                continue;
+            }
+
+            throw new EmbeddedWriteWriteConflictException();
         }
     }
 

--- a/src/Ahtola.Core/Mvcc/MvStore.cs
+++ b/src/Ahtola.Core/Mvcc/MvStore.cs
@@ -530,6 +530,12 @@ internal sealed class MvStore
             return _transactions.TryGetValue(id.Value, out transaction);
     }
 
+    internal bool HasPendingWrites(MvccTxId id)
+    {
+        lock (_gate)
+            return RequireActive(id).SnapshotWriteSet().Count != 0;
+    }
+
     /// <summary>
     /// Reserves the schema publication slot for an active concurrent transaction.
     /// DDL deliberately fails busy when another reader or writer has already

--- a/src/Ahtola.Core/Mvcc/MvccDualCursor.cs
+++ b/src/Ahtola.Core/Mvcc/MvccDualCursor.cs
@@ -8,6 +8,58 @@ namespace Ahtola.Core.Mvcc;
 /// </summary>
 internal static class MvccDualCursor
 {
+    internal readonly record struct Row(MvccKey Key, SqlValue[] Cells);
+
+    /// <summary>
+    /// Merges an ordered base image with typed MVCC overlays. The supplied
+    /// comparison must be the owning table's SQLite key comparison, including
+    /// collations and directions for a WITHOUT ROWID primary key.
+    /// </summary>
+    internal static IReadOnlyList<Row> MergeVisibleRows(
+        MvStore store,
+        MvccTxId txId,
+        long tableId,
+        IReadOnlyList<Row> baseRows,
+        Comparison<MvccKey> compare)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(baseRows);
+        ArgumentNullException.ThrowIfNull(compare);
+
+        var results = new List<Row>(baseRows.Count);
+        var covered = new HashSet<MvccKey>();
+
+        foreach (var baseRow in baseRows)
+        {
+            var identity = new MvccRowId(tableId, baseRow.Key);
+            if (store.TryRead(txId, identity, out var overlay) && overlay is not null)
+            {
+                results.Add(new Row(baseRow.Key, overlay));
+                covered.Add(baseRow.Key);
+                continue;
+            }
+
+            if (store.IsBaseRowInvalidated(txId, identity))
+            {
+                covered.Add(baseRow.Key);
+                continue;
+            }
+
+            results.Add(new Row(baseRow.Key, (SqlValue[])baseRow.Cells.Clone()));
+            covered.Add(baseRow.Key);
+        }
+
+        foreach (var (identity, cells) in store.ScanVisible(txId))
+        {
+            if (identity.TableId != tableId || covered.Contains(identity.Key))
+                continue;
+            results.Add(new Row(identity.Key, cells));
+        }
+
+        results.Sort((left, right) => compare(left.Key, right.Key));
+        return results;
+    }
+
     /// <summary>
     /// Returns the row set visible to <paramref name="txId"/>: base rows not
     /// invalidated by the store, plus live store versions for this table id.
@@ -25,39 +77,19 @@ internal static class MvccDualCursor
         if (baseRowIds.Count != baseRows.Count)
             throw new ArgumentException("Base row id and cell lists must have equal length.");
 
-        var results = new List<(long, SqlValue[])>(baseRowIds.Count);
-        var covered = new HashSet<long>();
-
+        var typedBaseRows = new Row[baseRowIds.Count];
         for (var i = 0; i < baseRowIds.Count; i++)
         {
-            var rowId = baseRowIds[i];
-            var key = new MvccRowId(tableId, rowId);
-            if (store.TryRead(txId, key, out var overlay) && overlay is not null)
-            {
-                // Live store version (insert or update) overrides the base image.
-                results.Add((rowId, overlay));
-                covered.Add(rowId);
-                continue;
-            }
-
-            if (store.IsBaseRowInvalidated(txId, key))
-            {
-                // Deleted or otherwise invalidated for this snapshot.
-                covered.Add(rowId);
-                continue;
-            }
-
-            results.Add((rowId, (SqlValue[])baseRows[i].Clone()));
-            covered.Add(rowId);
+            typedBaseRows[i] = new Row(MvccKey.FromInteger(baseRowIds[i]), baseRows[i]);
         }
 
-        foreach (var (key, cells) in store.ScanVisible(txId))
-        {
-            if (key.TableId != tableId || covered.Contains(key.RowId))
-                continue;
-            results.Add((key.RowId, cells));
-        }
-
-        return results;
+        return MergeVisibleRows(
+                store,
+                txId,
+                tableId,
+                typedBaseRows,
+                static (left, right) => left.Integer.CompareTo(right.Integer))
+            .Select(static row => (row.Key.Integer, row.Cells))
+            .ToArray();
     }
 }

--- a/src/Ahtola.Core/Mvcc/MvccKey.cs
+++ b/src/Ahtola.Core/Mvcc/MvccKey.cs
@@ -1,0 +1,132 @@
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Core.Mvcc;
+
+/// <summary>
+/// The identity portion of an MVCC row key. A rowid table uses
+/// <see cref="Integer"/>; WITHOUT ROWID tables and indexes use a complete SQLite
+/// record encoded with the owning object's key descriptor.
+/// </summary>
+internal readonly struct MvccKey : IEquatable<MvccKey>
+{
+    private readonly long _integer;
+    private readonly byte[]? _record;
+
+    private MvccKey(long integer)
+    {
+        _integer = integer;
+        _record = null;
+        Kind = MvccKeyKind.Integer;
+    }
+
+    private MvccKey(byte[] record)
+    {
+        _integer = default;
+        _record = record;
+        Kind = MvccKeyKind.Record;
+    }
+
+    internal MvccKeyKind Kind { get; }
+
+    internal bool IsInteger => Kind == MvccKeyKind.Integer;
+
+    internal long Integer
+        => IsInteger
+            ? _integer
+            : throw new InvalidOperationException("The MVCC key is a SQLite record, not an integer rowid.");
+
+    internal ReadOnlyMemory<byte> Record
+        => !IsInteger
+            ? _record!
+            : throw new InvalidOperationException("The MVCC key is an integer rowid, not a SQLite record.");
+
+    internal static MvccKey FromInteger(long value) => new(value);
+
+    internal static MvccKey FromRecord(ReadOnlySpan<byte> value)
+        => new(value.ToArray());
+
+    internal static MvccKey FromPrimaryKey(
+        SqlitePrimaryKeySchema schema,
+        IReadOnlyList<SqlValue> row,
+        SqliteTextEncoding textEncoding)
+    {
+        ArgumentNullException.ThrowIfNull(schema);
+        ArgumentNullException.ThrowIfNull(row);
+        var values = schema.ProjectKey(row);
+        for (var index = 0; index < values.Length; index++)
+            values[index] = Canonicalize(values[index], schema.Terms[index].Collation);
+        return FromRecord(SqliteRecordCodec.Encode(values, textEncoding));
+    }
+
+    public bool Equals(MvccKey other)
+    {
+        if (Kind != other.Kind)
+            return false;
+        return IsInteger || Record.Span.SequenceEqual(other.Record.Span);
+    }
+
+    public override bool Equals(object? obj) => obj is MvccKey other && Equals(other);
+
+    public static bool operator ==(MvccKey left, MvccKey right) => left.Equals(right);
+
+    public static bool operator !=(MvccKey left, MvccKey right) => !left.Equals(right);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add((byte)Kind);
+        if (IsInteger)
+        {
+            hash.Add(_integer);
+        }
+        else
+        {
+            foreach (var value in _record!)
+                hash.Add(value);
+        }
+
+        return hash.ToHashCode();
+    }
+
+    public override string ToString()
+        => IsInteger ? _integer.ToString() : Convert.ToHexString(_record!);
+
+    private static SqlValue Canonicalize(SqlValue value, SqliteKeyCollation collation)
+    {
+        if (value.Kind == SqlValueKind.Real)
+        {
+            var real = value.AsReal();
+            if (real >= long.MinValue && real < -(double)long.MinValue)
+            {
+                var integer = (long)real;
+                if (real == integer)
+                    return SqlValue.Integer(integer);
+            }
+        }
+
+        if (value.Kind != SqlValueKind.Text)
+            return value;
+
+        var text = value.AsText();
+        if (collation.IsNoCase)
+        {
+            var chars = text.ToCharArray();
+            for (var index = 0; index < chars.Length; index++)
+            {
+                if (chars[index] is >= 'A' and <= 'Z')
+                    chars[index] = (char)(chars[index] + ('a' - 'A'));
+            }
+            return SqlValue.Text(new string(chars));
+        }
+
+        return collation.IsRTrim
+            ? SqlValue.Text(text.TrimEnd(' '))
+            : value;
+    }
+}
+
+internal enum MvccKeyKind : byte
+{
+    Integer = 0,
+    Record = 1,
+}

--- a/src/Ahtola.Core/Mvcc/MvccLogicalLog.cs
+++ b/src/Ahtola.Core/Mvcc/MvccLogicalLog.cs
@@ -12,7 +12,8 @@ internal sealed class MvccLogicalLog : IDisposable
 {
     // Turso logical_log.rs constants.
     private const uint LogMagic = 0x4C4D4C32; // "LML2"
-    private const byte LogVersion = 3;
+    private const byte LegacyLogVersion = 3;
+    private const byte CurrentLogVersion = 4;
     private const int LogHeaderSize = 56;
     private const int LogHeaderSaltStart = 8;
     private const int LogHeaderCrcStart = 52;
@@ -22,6 +23,7 @@ internal sealed class MvccLogicalLog : IDisposable
     private const int TxTrailerSize = 8; // crc(4)+end_magic(4)
     private const byte OpUpsertTable = 0;
     private const byte OpDeleteTable = 1;
+    private const byte OpBaseTombstone = 0x80;
 
     private readonly IFileSystem _fileSystem;
     private readonly string _path;
@@ -29,15 +31,23 @@ internal sealed class MvccLogicalLog : IDisposable
     private IFile? _file;
     private long _offset;
     private ulong _salt;
+    private byte _version;
     private bool _disposed;
 
-    private MvccLogicalLog(IFileSystem fileSystem, string path, IFile file, long offset, ulong salt)
+    private MvccLogicalLog(
+        IFileSystem fileSystem,
+        string path,
+        IFile file,
+        long offset,
+        ulong salt,
+        byte version)
     {
         _fileSystem = fileSystem;
         _path = path;
         _file = file;
         _offset = offset;
         _salt = salt;
+        _version = version;
     }
 
     internal string Path => _path;
@@ -45,6 +55,15 @@ internal sealed class MvccLogicalLog : IDisposable
     internal long Offset
     {
         get { lock (_gate) return _offset; }
+    }
+
+    /// <summary>
+    /// Whether this log needs the exclusive materializing checkpoint that upgrades
+    /// legacy rowid-only frames before typed keys can be appended.
+    /// </summary>
+    internal bool RequiresVersion4Upgrade
+    {
+        get { lock (_gate) return _version < CurrentLogVersion; }
     }
 
     /// <summary>Bytes past the log header (approximate "frames" size for checkpoint stats).</summary>
@@ -81,8 +100,21 @@ internal sealed class MvccLogicalLog : IDisposable
 
                 Span<byte> header = stackalloc byte[LogHeaderSize];
                 ReadExact(existing, 0, header);
-                var salt = ValidateHeader(header);
-                return new MvccLogicalLog(fileSystem, path, existing, existing.Length, salt);
+                try
+                {
+                    var (salt, version) = ValidateHeader(header);
+                    return new MvccLogicalLog(fileSystem, path, existing, existing.Length, salt, version);
+                }
+                catch (InvalidDataException) when (existing.Length == LogHeaderSize)
+                {
+                    // A header-only log has no committed frame to lose. This is
+                    // the recoverable interruption point of a non-atomic V3→V4
+                    // header rewrite, so recreate it instead of making a valid
+                    // catalog permanently unopenable.
+                    existing.Dispose();
+                    fileSystem.DeleteFile(path);
+                    return CreateNew(fileSystem, path);
+                }
             }
             catch
             {
@@ -101,10 +133,16 @@ internal sealed class MvccLogicalLog : IDisposable
         {
             var salt = unchecked((ulong)Random.Shared.NextInt64());
             Span<byte> header = stackalloc byte[LogHeaderSize];
-            WriteHeader(header, salt);
+            WriteHeader(header, salt, CurrentLogVersion);
             file.Write(0, header);
             file.FlushToDisk();
-            return new MvccLogicalLog(fileSystem, path, file, LogHeaderSize, salt);
+            return new MvccLogicalLog(
+                fileSystem,
+                path,
+                file,
+                LogHeaderSize,
+                salt,
+                CurrentLogVersion);
         }
         catch
         {
@@ -122,7 +160,13 @@ internal sealed class MvccLogicalLog : IDisposable
             ThrowIfDisposed();
             var file = _file ?? throw new ObjectDisposedException(nameof(MvccLogicalLog));
 
-            var payload = EncodeOps(ops);
+            if (RequiresVersion4(ops) && _version < CurrentLogVersion)
+            {
+                throw new MvccLogicalLogUpgradeRequiredException(
+                    "MVCC typed keys require an exclusive checkpoint before upgrading the logical log to version 4.");
+            }
+
+            var payload = EncodeOps(ops, _version);
             var frameSize = TxHeaderSize + payload.Length + TxTrailerSize;
             var frame = new byte[frameSize];
             BinaryPrimitives.WriteUInt32LittleEndian(frame.AsSpan(0, 4), FrameMagic);
@@ -138,8 +182,18 @@ internal sealed class MvccLogicalLog : IDisposable
                 frame.AsSpan(TxHeaderSize + payload.Length + 4, 4),
                 EndMagic);
 
-            file.Write(_offset, frame);
-            file.FlushToDisk();
+            try
+            {
+                file.Write(_offset, frame);
+                file.FlushToDisk();
+            }
+            catch (Exception exception)
+            {
+                // The frame may have reached durable storage even when the
+                // caller receives an I/O failure. The commit path must not
+                // silently abort it in memory and disagree with recovery.
+                throw new MvccLogicalLogCommitIndeterminateException(exception);
+            }
             _offset += frame.Length;
         }
     }
@@ -186,12 +240,25 @@ internal sealed class MvccLogicalLog : IDisposable
                 if (actualCrc != expectedCrc)
                     throw new InvalidDataException("MVCC log frame CRC mismatch.");
 
-                var ops = DecodeOps(frame.AsSpan(TxHeaderSize, (int)payloadSize), (int)opCount);
+                var ops = DecodeOps(
+                    frame.AsSpan(TxHeaderSize, (int)payloadSize),
+                    (int)opCount,
+                    _version);
                 store.ApplyRecoveredCommit(commitTs, ops);
                 position += frameLen;
             }
 
-            _offset = Math.Max(_offset, position);
+            // A short final frame is a torn append, not a valid durability
+            // boundary. Retain the validated prefix and physically remove the
+            // tail before accepting another commit; otherwise every later reopen
+            // would stop at the same bytes and lose valid frames appended after it.
+            if (position != file.Length)
+            {
+                file.SetLength(position);
+                file.FlushToDisk();
+            }
+
+            _offset = position;
         }
     }
 
@@ -203,11 +270,85 @@ internal sealed class MvccLogicalLog : IDisposable
             ThrowIfDisposed();
             var file = _file ?? throw new ObjectDisposedException(nameof(MvccLogicalLog));
             Span<byte> header = stackalloc byte[LogHeaderSize];
-            WriteHeader(header, _salt);
+            WriteHeader(header, _salt, _version);
             file.SetLength(0);
             file.Write(0, header);
             file.FlushToDisk();
             _offset = LogHeaderSize;
+        }
+    }
+
+    /// <summary>
+    /// Rewrites a legacy header only after its frames were materialized into the
+    /// SQLite catalog. This is intentionally forbidden while a frame remains,
+    /// avoiding a mixed V3/V4 log after interruption.
+    /// </summary>
+    internal void UpgradeToVersion4AfterCheckpoint()
+    {
+        lock (_gate)
+        {
+            ThrowIfDisposed();
+            if (_version >= CurrentLogVersion)
+                return;
+            if (_offset != LogHeaderSize)
+            {
+                throw new InvalidOperationException(
+                    "The MVCC logical log must be checkpointed to a header-only state before its version is upgraded.");
+            }
+
+            Span<byte> header = stackalloc byte[LogHeaderSize];
+            WriteHeader(header, _salt, CurrentLogVersion);
+            if (_fileSystem is IAtomicFileSystem atomicFileSystem)
+            {
+                var temporaryPath = _path + ".v4-upgrade";
+                if (_fileSystem.FileExists(temporaryPath))
+                    _fileSystem.DeleteFile(temporaryPath);
+                using (var replacement = _fileSystem.OpenFile(
+                           temporaryPath,
+                           FileOpenMode.CreateNew,
+                           readOnly: false))
+                {
+                    replacement.Write(0, header);
+                    replacement.FlushToDisk();
+                }
+
+                var current = _file ?? throw new ObjectDisposedException(nameof(MvccLogicalLog));
+                // The catalog checkpoint already made every V3 frame durable in
+                // SQLite pages. Clearing the destination first gives every
+                // IAtomicFileSystem the same safe replacement contract: if the
+                // process stops here, reopen recreates a harmless empty V4 log.
+                current.SetLength(0);
+                current.FlushToDisk();
+                current.Dispose();
+                _file = null;
+                try
+                {
+                    atomicFileSystem.ReplaceFileAtomically(
+                        temporaryPath,
+                        _path,
+                        replaceEmptyDestination: true);
+                    _file = _fileSystem.OpenFile(_path, FileOpenMode.OpenExisting, readOnly: false);
+                }
+                catch
+                {
+                    if (_fileSystem.FileExists(_path))
+                        _file = _fileSystem.OpenFile(_path, FileOpenMode.OpenExisting, readOnly: false);
+                    throw;
+                }
+            }
+            else
+            {
+                // The fallback first makes the old header disappear durably.
+                // CreateOrOpen treats a short or invalid header-only file as an
+                // empty log, so an interruption here cannot strand catalog data.
+                var file = _file ?? throw new ObjectDisposedException(nameof(MvccLogicalLog));
+                file.SetLength(0);
+                file.FlushToDisk();
+                file.Write(0, header);
+                file.FlushToDisk();
+            }
+
+            _version = CurrentLogVersion;
         }
     }
 
@@ -228,11 +369,11 @@ internal sealed class MvccLogicalLog : IDisposable
         ObjectDisposedException.ThrowIf(_disposed, this);
     }
 
-    private static void WriteHeader(Span<byte> header, ulong salt)
+    private static void WriteHeader(Span<byte> header, ulong salt, byte version)
     {
         header.Clear();
         BinaryPrimitives.WriteUInt32LittleEndian(header, LogMagic);
-        header[4] = LogVersion;
+        header[4] = version;
         header[5] = 0;
         BinaryPrimitives.WriteUInt16LittleEndian(header[6..], (ushort)LogHeaderSize);
         BinaryPrimitives.WriteUInt64LittleEndian(header[LogHeaderSaltStart..], salt);
@@ -240,13 +381,13 @@ internal sealed class MvccLogicalLog : IDisposable
         BinaryPrimitives.WriteUInt32LittleEndian(header[LogHeaderCrcStart..], crc);
     }
 
-    private static ulong ValidateHeader(ReadOnlySpan<byte> header)
+    private static (ulong Salt, byte Version) ValidateHeader(ReadOnlySpan<byte> header)
     {
         var magic = BinaryPrimitives.ReadUInt32LittleEndian(header);
         if (magic != LogMagic)
             throw new InvalidDataException("Invalid MVCC logical log magic.");
         var version = header[4];
-        if (version is not (2 or 3))
+        if (version is not (2 or LegacyLogVersion or CurrentLogVersion))
             throw new InvalidDataException($"Unsupported MVCC logical log version {version}.");
         var hdrLen = BinaryPrimitives.ReadUInt16LittleEndian(header[6..]);
         if (hdrLen != LogHeaderSize)
@@ -260,18 +401,41 @@ internal sealed class MvccLogicalLog : IDisposable
         if (expected != actual)
             throw new InvalidDataException("MVCC logical log header CRC mismatch.");
 
-        return BinaryPrimitives.ReadUInt64LittleEndian(header[LogHeaderSaltStart..]);
+        return (BinaryPrimitives.ReadUInt64LittleEndian(header[LogHeaderSaltStart..]), version);
     }
 
-    private static byte[] EncodeOps(IReadOnlyList<MvccLogOp> ops)
+    private static bool RequiresVersion4(IReadOnlyList<MvccLogOp> ops)
+        => ops.Any(static op => !op.RowId.Key.IsInteger);
+
+    private static byte[] EncodeOps(IReadOnlyList<MvccLogOp> ops, byte version)
     {
         using var buffer = new MemoryStream();
         using var writer = new BinaryWriter(buffer);
         foreach (var op in ops)
         {
-            writer.Write(op.IsDelete ? OpDeleteTable : OpUpsertTable);
+            writer.Write((byte)(
+                (op.IsDelete ? OpDeleteTable : OpUpsertTable)
+                | (op.IsBaseTombstone ? OpBaseTombstone : 0)));
             writer.Write(op.RowId.TableId);
-            writer.Write(op.RowId.RowId);
+            if (version >= CurrentLogVersion)
+            {
+                WriteObjectName(writer, op.ObjectName);
+                writer.Write((byte)op.RowId.Key.Kind);
+                if (op.RowId.Key.IsInteger)
+                {
+                    writer.Write(op.RowId.Key.Integer);
+                }
+                else
+                {
+                    var key = op.RowId.Key.Record;
+                    writer.Write(key.Length);
+                    writer.Write(key.Span);
+                }
+            }
+            else
+            {
+                writer.Write(op.RowId.RowId);
+            }
             if (op.IsDelete)
             {
                 writer.Write(0);
@@ -287,7 +451,7 @@ internal sealed class MvccLogicalLog : IDisposable
         return buffer.ToArray();
     }
 
-    private static List<MvccLogOp> DecodeOps(ReadOnlySpan<byte> payload, int opCount)
+    private static List<MvccLogOp> DecodeOps(ReadOnlySpan<byte> payload, int opCount, byte version)
     {
         var ops = new List<MvccLogOp>(opCount);
         var offset = 0;
@@ -295,30 +459,110 @@ internal sealed class MvccLogicalLog : IDisposable
         {
             if (offset >= payload.Length)
                 throw new InvalidDataException("MVCC log op truncated.");
-            var kind = payload[offset++];
-            if (offset + 16 > payload.Length)
+            var encodedKind = payload[offset++];
+            var isBaseTombstone = version >= CurrentLogVersion
+                && (encodedKind & OpBaseTombstone) != 0;
+            var kind = (byte)(encodedKind & ~OpBaseTombstone);
+            if (isBaseTombstone && kind != OpDeleteTable)
+                throw new InvalidDataException("MVCC log base-tombstone flag requires a delete operation.");
+            if (offset + sizeof(long) > payload.Length)
                 throw new InvalidDataException("MVCC log op row id truncated.");
             var tableId = BinaryPrimitives.ReadInt64LittleEndian(payload[offset..]);
             offset += 8;
-            var rowId = BinaryPrimitives.ReadInt64LittleEndian(payload[offset..]);
-            offset += 8;
+            string? objectName = null;
+            if (version >= CurrentLogVersion)
+                objectName = ReadObjectName(payload, ref offset);
+            MvccKey key;
+            if (version >= CurrentLogVersion)
+            {
+                if (offset >= payload.Length)
+                    throw new InvalidDataException("MVCC log key kind truncated.");
+                var keyKind = (MvccKeyKind)payload[offset++];
+                key = keyKind switch
+                {
+                    MvccKeyKind.Integer => ReadIntegerKey(payload, ref offset),
+                    MvccKeyKind.Record => ReadRecordKey(payload, ref offset),
+                    _ => throw new InvalidDataException($"Unknown MVCC log key kind {(byte)keyKind}."),
+                };
+            }
+            else
+            {
+                if (offset + sizeof(long) > payload.Length)
+                    throw new InvalidDataException("MVCC log integer row id truncated.");
+                key = MvccKey.FromInteger(BinaryPrimitives.ReadInt64LittleEndian(payload[offset..]));
+                offset += sizeof(long);
+            }
             if (offset + 4 > payload.Length)
                 throw new InvalidDataException("MVCC log op cell count truncated.");
             var cellCount = BinaryPrimitives.ReadInt32LittleEndian(payload[offset..]);
             offset += 4;
             if (kind == OpDeleteTable)
             {
-                ops.Add(MvccLogOp.Delete(new MvccRowId(tableId, rowId)));
+                ops.Add(isBaseTombstone
+                    ? MvccLogOp.BaseTombstone(new MvccRowId(tableId, key), objectName)
+                    : MvccLogOp.Delete(new MvccRowId(tableId, key), objectName));
                 continue;
             }
 
             var cells = new SqlValue[cellCount];
             for (var c = 0; c < cellCount; c++)
                 cells[c] = ReadCell(payload, ref offset);
-            ops.Add(MvccLogOp.Upsert(new MvccRowId(tableId, rowId), cells));
+            ops.Add(MvccLogOp.Upsert(new MvccRowId(tableId, key), cells, objectName));
         }
 
         return ops;
+    }
+
+    private static MvccKey ReadIntegerKey(ReadOnlySpan<byte> payload, ref int offset)
+    {
+        if (offset + sizeof(long) > payload.Length)
+            throw new InvalidDataException("MVCC log integer key truncated.");
+        var value = BinaryPrimitives.ReadInt64LittleEndian(payload[offset..]);
+        offset += sizeof(long);
+        return MvccKey.FromInteger(value);
+    }
+
+    private static MvccKey ReadRecordKey(ReadOnlySpan<byte> payload, ref int offset)
+    {
+        if (offset + sizeof(int) > payload.Length)
+            throw new InvalidDataException("MVCC log record-key length truncated.");
+        var length = BinaryPrimitives.ReadInt32LittleEndian(payload[offset..]);
+        offset += sizeof(int);
+        if (length < 0 || offset + length > payload.Length)
+            throw new InvalidDataException("MVCC log record key truncated.");
+        var key = MvccKey.FromRecord(payload.Slice(offset, length));
+        offset += length;
+        return key;
+    }
+
+    private static void WriteObjectName(BinaryWriter writer, string? objectName)
+    {
+        if (objectName is null)
+        {
+            writer.Write(-1);
+            return;
+        }
+
+        var bytes = System.Text.Encoding.UTF8.GetBytes(objectName);
+        writer.Write(bytes.Length);
+        writer.Write(bytes);
+    }
+
+    private static string? ReadObjectName(ReadOnlySpan<byte> payload, ref int offset)
+    {
+        if (offset + sizeof(int) > payload.Length)
+            throw new InvalidDataException("MVCC log object-name length truncated.");
+        var length = BinaryPrimitives.ReadInt32LittleEndian(payload[offset..]);
+        offset += sizeof(int);
+        if (length == -1)
+            return null;
+        if (length < 0 || offset + length > payload.Length)
+            throw new InvalidDataException("MVCC log object name truncated.");
+        var name = System.Text.Encoding.UTF8.GetString(payload.Slice(offset, length));
+        offset += length;
+        if (string.IsNullOrWhiteSpace(name))
+            throw new InvalidDataException("MVCC log object name is empty.");
+        return name;
     }
 
     private static void WriteCell(BinaryWriter writer, SqlValue value)
@@ -352,6 +596,7 @@ internal sealed class MvccLogicalLog : IDisposable
                 writer.Write((byte)0);
                 break;
         }
+
     }
 
     private static SqlValue ReadCell(ReadOnlySpan<byte> payload, ref int offset)
@@ -427,25 +672,55 @@ internal sealed class MvccLogicalLog : IDisposable
     }
 }
 
+internal sealed class MvccLogicalLogUpgradeRequiredException : EmbeddedSqlException
+{
+    internal MvccLogicalLogUpgradeRequiredException(string message)
+        : base(message)
+    {
+    }
+}
+
+internal sealed class MvccLogicalLogCommitIndeterminateException : EmbeddedSqlException
+{
+    internal MvccLogicalLogCommitIndeterminateException(Exception innerException)
+        : base(
+            "The MVCC logical-log commit may have reached durable storage. Dispose and reopen the database before retrying.",
+            innerException)
+    {
+    }
+}
+
 /// <summary>One recovered or to-be-logged MVCC operation.</summary>
 internal readonly struct MvccLogOp
 {
-    private MvccLogOp(MvccRowId rowId, SqlValue[]? cells, bool isDelete)
+    private MvccLogOp(
+        MvccRowId rowId,
+        SqlValue[]? cells,
+        bool isDelete,
+        bool isBaseTombstone,
+        string? objectName)
     {
         RowId = rowId;
         Cells = cells;
         IsDelete = isDelete;
+        IsBaseTombstone = isBaseTombstone;
+        ObjectName = objectName;
     }
 
     internal MvccRowId RowId { get; }
     internal SqlValue[]? Cells { get; }
     internal bool IsDelete { get; }
+    internal bool IsBaseTombstone { get; }
+    internal string? ObjectName { get; }
 
-    internal static MvccLogOp Upsert(MvccRowId rowId, SqlValue[] cells)
-        => new(rowId, cells, isDelete: false);
+    internal static MvccLogOp Upsert(MvccRowId rowId, SqlValue[] cells, string? objectName = null)
+        => new(rowId, cells, isDelete: false, isBaseTombstone: false, objectName);
 
-    internal static MvccLogOp Delete(MvccRowId rowId)
-        => new(rowId, cells: null, isDelete: true);
+    internal static MvccLogOp Delete(MvccRowId rowId, string? objectName = null)
+        => new(rowId, cells: null, isDelete: true, isBaseTombstone: false, objectName);
+
+    internal static MvccLogOp BaseTombstone(MvccRowId rowId, string? objectName = null)
+        => new(rowId, cells: null, isDelete: true, isBaseTombstone: true, objectName);
 }
 
 /// <summary>CRC-32C (Castagnoli) used by Turso logical log framing.</summary>

--- a/src/Ahtola.Tests/MvccCheckpointStateMachineTests.cs
+++ b/src/Ahtola.Tests/MvccCheckpointStateMachineTests.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using Ahtola.Core;
 using Ahtola.Core.Mvcc;
+using Ahtola.Core.Storage;
 using Ahtola.Data.Sqlite;
 
 namespace Ahtola.Tests;
@@ -114,11 +115,49 @@ public sealed class MvccCheckpointStateMachineTests
         store.VersionChainCount.Should().Be(0);
     }
 
+    [Test]
+    public void CheckpointUpgradesAHeaderOnlyLegacyLogicalLogBeforeTypedWrites()
+    {
+        const string path = "mvcc-v3-checkpoint-upgrade.db";
+        var fileSystem = new InMemoryFileSystem();
+
+        using (var database = EmbeddedDatabase.OpenFile(path, fileSystem))
+        using (var connection = database.Connect())
+        {
+            Execute(connection, "PRAGMA journal_mode=mvcc;");
+        }
+
+        var logPath = MvccLogicalLog.LogPathForDatabase(path);
+        using (var file = fileSystem.OpenFile(logPath, FileOpenMode.OpenExisting))
+        {
+            var header = new byte[56];
+            file.Read(0, header).Should().Be(header.Length);
+            header[4] = 3;
+            header.AsSpan(52).Clear();
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(
+                header.AsSpan(52),
+                Crc32C.Compute(header));
+            file.Write(0, header);
+            file.FlushToDisk();
+        }
+
+        using var reopened = EmbeddedDatabase.OpenFile(path, fileSystem);
+        reopened.MvStore!.LogicalLog!.RequiresVersion4Upgrade.Should().BeTrue();
+        reopened.RunMvccCheckpoint("PASSIVE").Busy.Should().BeFalse();
+        reopened.MvStore!.LogicalLog!.RequiresVersion4Upgrade.Should().BeFalse();
+    }
+
     private static object? Scalar(SqliteConnection connection, string sql)
     {
         using var command = connection.CreateCommand();
         command.CommandText = sql;
         return command.ExecuteScalar();
+    }
+
+    private static void Execute(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        _ = statement.Step();
     }
 
     private static string ReadValue(SqliteConnection connection, string sql)

--- a/src/Ahtola.Tests/MvccLogicalLogTests.cs
+++ b/src/Ahtola.Tests/MvccLogicalLogTests.cs
@@ -12,11 +12,12 @@ public sealed class MvccLogicalLogTests
     {
         var fs = new InMemoryFileSystem();
         const string dbPath = "mvcc-log.db";
+        long table;
 
         using (var log = MvccLogicalLog.CreateOrOpen(fs, dbPath))
         {
             var store = new MvStore(logicalLog: log);
-            var table = store.GetOrCreateTableId("t");
+            table = store.GetOrCreateTableId("t");
             var tx = store.BeginTransaction();
             store.Insert(tx.Id, new MvccRowId(table, 1), [SqlValue.Text("hello")]);
             store.Insert(tx.Id, new MvccRowId(table, 2), [SqlValue.Integer(7)]);
@@ -26,6 +27,7 @@ public sealed class MvccLogicalLogTests
         using var reopened = MvccLogicalLog.CreateOrOpen(fs, dbPath);
         var recovered = new MvStore();
         reopened.ReplayInto(recovered);
+        recovered.GetOrCreateTableId("t").Should().Be(table);
 
         var reader = recovered.BeginTransaction();
         // Table name→id map is not durable yet; scan by row id from recovered chains.
@@ -86,5 +88,154 @@ public sealed class MvccLogicalLogTests
         reopened.ReplayInto(recovered);
         var reader = recovered.BeginTransaction();
         recovered.ScanVisible(reader.Id).Should().BeEmpty();
+    }
+
+    [Test]
+    public void TypedPrimaryKeyFramesSurviveReopenAndReplay()
+    {
+        var fs = new InMemoryFileSystem();
+        const string dbPath = "mvcc-typed-log.db";
+        var key = MvccKey.FromRecord(SqliteRecordCodec.Encode(
+            [SqlValue.Text("tenant"), SqlValue.Integer(7)]));
+
+        using (var log = MvccLogicalLog.CreateOrOpen(fs, dbPath))
+        {
+            var store = new MvStore(logicalLog: log);
+            var table = store.GetOrCreateTableId("items");
+            var tx = store.BeginTransaction();
+            store.Insert(tx.Id, new MvccRowId(table, key), [SqlValue.Text("value")]);
+            store.Commit(tx.Id);
+        }
+
+        using var reopened = MvccLogicalLog.CreateOrOpen(fs, dbPath);
+        var recovered = new MvStore();
+        reopened.ReplayInto(recovered);
+
+        var reader = recovered.BeginTransaction();
+        recovered.TryRead(reader.Id, new MvccRowId(-2, key), out var cells).Should().BeTrue();
+        cells!.Should().Equal(SqlValue.Text("value"));
+    }
+
+    [Test]
+    public void LegacyHeaderUpgradesOnlyAfterTheLogIsHeaderOnly()
+    {
+        var fs = new InMemoryFileSystem();
+        const string dbPath = "mvcc-v3-upgrade.db";
+        var logPath = MvccLogicalLog.LogPathForDatabase(dbPath);
+        var header = new byte[56];
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(header, 0x4C4D4C32);
+        header[4] = 3;
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(header.AsSpan(6), (ushort)header.Length);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(header.AsSpan(8), 123UL);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(52), Crc32C.Compute(header));
+        using (var file = fs.OpenFile(logPath, FileOpenMode.CreateNew))
+        {
+            file.Write(0, header);
+            file.FlushToDisk();
+        }
+
+        using var log = MvccLogicalLog.CreateOrOpen(fs, dbPath);
+        log.RequiresVersion4Upgrade.Should().BeTrue();
+        log.TruncateAfterCheckpoint();
+        log.UpgradeToVersion4AfterCheckpoint();
+        log.RequiresVersion4Upgrade.Should().BeFalse();
+    }
+
+    [Test]
+    public void RecoveryTruncatesATornTailBeforeAcceptingAnotherCommit()
+    {
+        var fs = new InMemoryFileSystem();
+        const string dbPath = "mvcc-torn-tail.db";
+        long table;
+
+        using (var log = MvccLogicalLog.CreateOrOpen(fs, dbPath))
+        {
+            var store = new MvStore(logicalLog: log);
+            table = store.GetOrCreateTableId("items");
+            var tx = store.BeginTransaction();
+            store.Insert(tx.Id, new MvccRowId(table, 1), [SqlValue.Text("first")]);
+            store.Commit(tx.Id);
+        }
+
+        var logPath = MvccLogicalLog.LogPathForDatabase(dbPath);
+        using (var file = fs.OpenFile(logPath, FileOpenMode.OpenExisting))
+        {
+            file.Write(file.Length, [0x4D, 0x56, 0x54]);
+            file.FlushToDisk();
+        }
+
+        using (var recoveredLog = MvccLogicalLog.CreateOrOpen(fs, dbPath))
+        {
+            var recovered = new MvStore(logicalLog: recoveredLog);
+            recoveredLog.ReplayInto(recovered);
+            recovered.GetOrCreateTableId("items").Should().Be(table);
+            var tx = recovered.BeginTransaction();
+            recovered.Insert(tx.Id, new MvccRowId(table, 2), [SqlValue.Text("second")]);
+            recovered.Commit(tx.Id);
+        }
+
+        using var reopenedLog = MvccLogicalLog.CreateOrOpen(fs, dbPath);
+        var reopened = new MvStore();
+        reopenedLog.ReplayInto(reopened);
+        var reader = reopened.BeginTransaction();
+        reopened.ScanVisible(reader.Id)
+            .Select(row => row.Cells[0].AsText())
+            .Should()
+            .BeEquivalentTo(["first", "second"]);
+    }
+
+    [Test]
+    public void FlushFailurePoisonsTheLiveStoreButRecoveryHonorsTheWrittenFrame()
+    {
+        var faults = new DeterministicFaultInjector();
+        var fs = new InMemoryFileSystem(faults);
+        const string dbPath = "mvcc-indeterminate-commit.db";
+        long table;
+
+        using (var log = MvccLogicalLog.CreateOrOpen(fs, dbPath))
+        {
+            var store = new MvStore(logicalLog: log);
+            table = store.GetOrCreateTableId("items");
+            var tx = store.BeginTransaction();
+            store.Insert(tx.Id, new MvccRowId(table, 1), [SqlValue.Text("durable")]);
+            faults.FailNext(FileSystemOperation.FlushToDisk);
+
+            var commit = () => store.Commit(tx.Id);
+            commit.Should().Throw<MvccLogicalLogCommitIndeterminateException>();
+            var begin = () => store.BeginTransaction();
+            begin.Should().Throw<EmbeddedSqlException>()
+                .WithMessage("*indeterminate logical-log commit*");
+            faults.ClearScheduled();
+        }
+
+        using var reopenedLog = MvccLogicalLog.CreateOrOpen(fs, dbPath);
+        var reopened = new MvStore();
+        reopenedLog.ReplayInto(reopened);
+        var reader = reopened.BeginTransaction();
+        reopened.TryRead(reader.Id, new MvccRowId(table, 1), out var cells).Should().BeTrue();
+        cells!.Should().Equal(SqlValue.Text("durable"));
+    }
+
+    [Test]
+    public void ReplayPreservesABaseOnlyDeleteAsATombstone()
+    {
+        var fs = new InMemoryFileSystem();
+        const string dbPath = "mvcc-base-tombstone.db";
+        long table;
+
+        using (var log = MvccLogicalLog.CreateOrOpen(fs, dbPath))
+        {
+            var store = new MvStore(logicalLog: log);
+            table = store.GetOrCreateTableId("items");
+            var tx = store.BeginTransaction();
+            store.DeleteOrTombstoneBase(tx.Id, new MvccRowId(table, 1));
+            store.Commit(tx.Id);
+        }
+
+        using var reopenedLog = MvccLogicalLog.CreateOrOpen(fs, dbPath);
+        var reopened = new MvStore();
+        reopenedLog.ReplayInto(reopened);
+        var reader = reopened.BeginTransaction();
+        reopened.IsBaseRowInvalidated(reader.Id, new MvccRowId(table, 1)).Should().BeTrue();
     }
 }

--- a/src/Ahtola.Tests/MvccSelectDualCursorRoutingTests.cs
+++ b/src/Ahtola.Tests/MvccSelectDualCursorRoutingTests.cs
@@ -137,34 +137,195 @@ public sealed class MvccSelectDualCursorRoutingTests
         Convert.ToInt64(Scalar(a, "SELECT v FROM t;")).Should().Be(200L);
     }
 
-    [TestCase("CREATE TABLE other(value INTEGER);")]
-    [TestCase("CREATE TABLE other AS SELECT v FROM t;")]
-    [TestCase("DROP TABLE t;")]
-    [TestCase("ALTER TABLE t ADD COLUMN other INTEGER;")]
-    [TestCase("CREATE INDEX ix_t_v ON t(v);")]
-    [TestCase("CREATE VIEW t_view AS SELECT v FROM t;")]
-    [TestCase("CREATE TRIGGER t_insert AFTER INSERT ON t BEGIN SELECT new.v; END;")]
-    public void ConcurrentSchemaChangesFailClosed(string sql)
+    [Test]
+    public void ConcurrentIndexScanMergesVersionStoreRowsAtThePinnedSnapshot()
+    {
+        using var db = new RoutingFileDatabase(
+            """
+            CREATE TABLE t(id INTEGER PRIMARY KEY, value TEXT);
+            CREATE INDEX ix_t_value ON t(value);
+            """);
+        using var seeder = db.Connect();
+        using var writer = db.Connect();
+        using var reader = db.Connect();
+
+        seeder.ExecuteNonQuery("PRAGMA journal_mode=mvcc;");
+        seeder.ExecuteNonQuery("INSERT INTO t VALUES (1, 'base');");
+
+        writer.ExecuteNonQuery("BEGIN CONCURRENT;");
+        reader.ExecuteNonQuery("BEGIN CONCURRENT;");
+        writer.ExecuteNonQuery("INSERT INTO t VALUES (2, 'overlay');");
+
+        Convert.ToInt64(Scalar(
+            writer,
+            "SELECT id FROM t INDEXED BY ix_t_value WHERE value = 'overlay';")).Should().Be(2L);
+        Convert.ToInt64(Scalar(
+            reader,
+            "SELECT COUNT(*) FROM t INDEXED BY ix_t_value WHERE value = 'overlay';")).Should().Be(0L);
+
+        writer.ExecuteNonQuery("COMMIT;");
+        Convert.ToInt64(Scalar(
+            reader,
+            "SELECT COUNT(*) FROM t INDEXED BY ix_t_value WHERE value = 'overlay';")).Should().Be(0L);
+        reader.ExecuteNonQuery("COMMIT;");
+
+        Convert.ToInt64(Scalar(
+            reader,
+            "SELECT id FROM t INDEXED BY ix_t_value WHERE value = 'overlay';")).Should().Be(2L);
+    }
+
+    [Test]
+    public void ConcurrentIndexScanSuppressesTheOldKeyAfterAnUpdate()
+    {
+        using var db = new RoutingFileDatabase(
+            """
+            CREATE TABLE t(id INTEGER PRIMARY KEY, value TEXT);
+            CREATE INDEX ix_t_value ON t(value);
+            """);
+        using var connection = db.Connect();
+
+        connection.ExecuteNonQuery("PRAGMA journal_mode=mvcc;");
+        connection.ExecuteNonQuery("INSERT INTO t VALUES (1, 'before');");
+        connection.ExecuteNonQuery("BEGIN CONCURRENT;");
+        connection.ExecuteNonQuery("UPDATE t SET value = 'after' WHERE id = 1;");
+
+        Convert.ToInt64(Scalar(
+            connection,
+            "SELECT COUNT(*) FROM t INDEXED BY ix_t_value WHERE value = 'before';")).Should().Be(0L);
+        Convert.ToInt64(Scalar(
+            connection,
+            "SELECT id FROM t INDEXED BY ix_t_value WHERE value = 'after';")).Should().Be(1L);
+        connection.ExecuteNonQuery("COMMIT;");
+    }
+
+    [Test]
+    public void ConcurrentSchemaChangePublishesItsCookieAfterTheCatalogCommit()
+    {
+        using var db = new RoutingFileDatabase();
+        using var connection = db.Connect();
+
+        connection.ExecuteNonQuery("PRAGMA journal_mode=mvcc;");
+        var before = Convert.ToInt64(Scalar(connection, "PRAGMA schema_version;"));
+        connection.ExecuteNonQuery("BEGIN CONCURRENT;");
+        connection.ExecuteNonQuery("CREATE INDEX ix_t_v ON t(v);");
+        connection.ExecuteNonQuery("COMMIT;");
+
+        Convert.ToInt64(Scalar(connection, "PRAGMA schema_version;")).Should().Be(before + 1);
+        connection.ExecuteNonQuery("INSERT INTO t VALUES (1);");
+        Convert.ToInt64(Scalar(
+            connection,
+            "SELECT v FROM t INDEXED BY ix_t_v WHERE v = 1;")).Should().Be(1L);
+    }
+
+    [Test]
+    public void ConcurrentSchemaChangeFailsBusyWhileAPeerSnapshotIsOpen()
+    {
+        using var db = new RoutingFileDatabase();
+        using var writer = db.Connect();
+        using var schemaWriter = db.Connect();
+
+        writer.ExecuteNonQuery("PRAGMA journal_mode=mvcc;");
+        writer.ExecuteNonQuery("BEGIN CONCURRENT;");
+        schemaWriter.ExecuteNonQuery("BEGIN CONCURRENT;");
+
+        var error = Capture(() => schemaWriter.ExecuteNonQuery("CREATE INDEX ix_t_v ON t(v);"));
+        error.Should().NotBeNull();
+        error!.Message.Should().ContainEquivalentOf("locked");
+
+        schemaWriter.ExecuteNonQuery("ROLLBACK;");
+        writer.ExecuteNonQuery("ROLLBACK;");
+    }
+
+    [Test]
+    public void FailedOrSavepointRolledBackConcurrentDdlReleasesTheSchemaGate()
+    {
+        using var db = new RoutingFileDatabase();
+        using var writer = db.Connect();
+        using var peer = db.Connect();
+
+        writer.ExecuteNonQuery("PRAGMA journal_mode=mvcc;");
+        writer.ExecuteNonQuery("BEGIN CONCURRENT;");
+        var failure = Capture(() => writer.ExecuteNonQuery("CREATE INDEX ix_bad ON t(no_such_column);"));
+        failure.Should().NotBeNull();
+
+        peer.ExecuteNonQuery("BEGIN CONCURRENT;");
+        peer.ExecuteNonQuery("ROLLBACK;");
+
+        writer.ExecuteNonQuery("SAVEPOINT ddl;");
+        writer.ExecuteNonQuery("CREATE INDEX ix_t_v ON t(v);");
+        writer.ExecuteNonQuery("ROLLBACK TO ddl;");
+
+        peer.ExecuteNonQuery("BEGIN CONCURRENT;");
+        peer.ExecuteNonQuery("ROLLBACK;");
+        writer.ExecuteNonQuery("ROLLBACK;");
+    }
+
+    [Test]
+    public void ConcurrentDdlRejectsATransactionWhoseDataSnapshotIsStale()
+    {
+        using var db = new RoutingFileDatabase();
+        using var stale = db.Connect();
+        using var writer = db.Connect();
+
+        stale.ExecuteNonQuery("PRAGMA journal_mode=mvcc;");
+        stale.ExecuteNonQuery("BEGIN CONCURRENT;");
+        writer.ExecuteNonQuery("BEGIN CONCURRENT;");
+        writer.ExecuteNonQuery("INSERT INTO t VALUES (1);");
+        writer.ExecuteNonQuery("COMMIT;");
+
+        var error = Capture(() => stale.ExecuteNonQuery("CREATE INDEX ix_t_v ON t(v);"));
+        error.Should().NotBeNull();
+        error!.Message.Should().ContainEquivalentOf("locked");
+        stale.ExecuteNonQuery("ROLLBACK;");
+    }
+
+    [Test]
+    public void ConcurrentDropAndRecreateRetiresThePriorTableIdentity()
     {
         using var db = new RoutingFileDatabase();
         using var connection = db.Connect();
 
         connection.ExecuteNonQuery("PRAGMA journal_mode=mvcc;");
         connection.ExecuteNonQuery("BEGIN CONCURRENT;");
-
-        var error = Capture(() => connection.ExecuteNonQuery(sql));
-        error.Should().NotBeNull();
-        error!.Message.Should().ContainEquivalentOf("schema changes");
-
         connection.ExecuteNonQuery("INSERT INTO t VALUES (1);");
         connection.ExecuteNonQuery("COMMIT;");
-        Convert.ToInt64(Scalar(connection, "SELECT COUNT(*) FROM t;")).Should().Be(1L);
+
+        connection.ExecuteNonQuery("BEGIN CONCURRENT;");
+        connection.ExecuteNonQuery("DROP TABLE t;");
+        connection.ExecuteNonQuery("CREATE TABLE t(v INTEGER);");
+        connection.ExecuteNonQuery("COMMIT;");
+
+        Convert.ToInt64(Scalar(connection, "SELECT COUNT(*) FROM t;")).Should().Be(0L);
+        connection.ExecuteNonQuery("INSERT INTO t VALUES (2);");
+        Convert.ToInt64(Scalar(connection, "SELECT v FROM t;")).Should().Be(2L);
     }
 
-    [TestCase("INSERT INTO t VALUES (1, 'insert');")]
-    [TestCase("UPDATE t SET value = 'update';")]
-    [TestCase("DELETE FROM t;")]
-    public void ConcurrentDmlAgainstWithoutRowidTableFailsClosed(string sql)
+    [Test]
+    public void AbortedConcurrentTriggerStatementRollsBackItsMvccOverlay()
+    {
+        using var db = new RoutingFileDatabase(
+            """
+            CREATE TABLE t(id INTEGER PRIMARY KEY, value INTEGER);
+            CREATE TRIGGER abort_insert AFTER INSERT ON t WHEN NEW.id = 1 BEGIN
+                SELECT RAISE(ABORT, 'abort-trigger');
+            END;
+            """);
+        using var connection = db.Connect();
+
+        connection.ExecuteNonQuery("PRAGMA journal_mode=mvcc;");
+        connection.ExecuteNonQuery("BEGIN CONCURRENT;");
+        var error = Capture(() => connection.ExecuteNonQuery("INSERT INTO t VALUES (1, 1);"));
+        error.Should().NotBeNull();
+
+        connection.ExecuteNonQuery("INSERT INTO t VALUES (2, 2);");
+        connection.ExecuteNonQuery("COMMIT;");
+
+        Convert.ToInt64(Scalar(connection, "SELECT COUNT(*) FROM t;")).Should().Be(1L);
+        Convert.ToInt64(Scalar(connection, "SELECT id FROM t;")).Should().Be(2L);
+    }
+
+    [Test]
+    public void ConcurrentInsertAgainstWithoutRowidTableIsVisibleToWriterAndSurvivesCommit()
     {
         using var db = new RoutingFileDatabase(
             "CREATE TABLE t(id INTEGER PRIMARY KEY, value TEXT) WITHOUT ROWID;");
@@ -172,20 +333,62 @@ public sealed class MvccSelectDualCursorRoutingTests
 
         connection.ExecuteNonQuery("PRAGMA journal_mode=mvcc;");
         connection.ExecuteNonQuery("BEGIN CONCURRENT;");
+        connection.ExecuteNonQuery("INSERT INTO t VALUES (1, 'insert');");
+        Convert.ToInt64(Scalar(connection, "SELECT COUNT(*) FROM t;")).Should().Be(1L);
+        Convert.ToString(Scalar(connection, "SELECT value FROM t WHERE id = 1;")).Should().Be("insert");
+        connection.ExecuteNonQuery("COMMIT;");
 
-        var error = Capture(() => connection.ExecuteNonQuery(sql));
-        error.Should().NotBeNull();
-        error!.Message.Should().ContainEquivalentOf("rowid user tables");
+        Convert.ToString(Scalar(connection, "SELECT value FROM t WHERE id = 1;")).Should().Be("insert");
+    }
 
-        Convert.ToInt64(Scalar(connection, "SELECT COUNT(*) FROM t;")).Should().Be(0L);
-        connection.ExecuteNonQuery("ROLLBACK;");
+    [Test]
+    public void ConcurrentUpdateAndDeleteAgainstWithoutRowidTableUseThePrimaryKeyIdentity()
+    {
+        using var db = new RoutingFileDatabase(
+            "CREATE TABLE t(id INTEGER PRIMARY KEY, value TEXT) WITHOUT ROWID;");
+        using var connection = db.Connect();
 
-        connection.ExecuteNonQuery("INSERT INTO t VALUES (1, 'outside');");
+        connection.ExecuteNonQuery("PRAGMA journal_mode=mvcc;");
+        connection.ExecuteNonQuery("INSERT INTO t VALUES (1, 'before');");
+        connection.ExecuteNonQuery("INSERT INTO t VALUES (2, 'stable');");
+        connection.ExecuteNonQuery("BEGIN CONCURRENT;");
+        // Move the first key after an untouched key so clustered primary-key
+        // sorting cannot change the row identity reported to MVCC.
+        connection.ExecuteNonQuery("UPDATE t SET id = 3, value = 'after' WHERE id = 1;");
+        Convert.ToString(Scalar(connection, "SELECT value FROM t WHERE id = 3;")).Should().Be("after");
+        connection.ExecuteNonQuery("COMMIT;");
+
+        connection.ExecuteNonQuery("BEGIN CONCURRENT;");
+        connection.ExecuteNonQuery("DELETE FROM t WHERE id = 3;");
+        Convert.ToInt64(Scalar(connection, "SELECT COUNT(*) FROM t;")).Should().Be(1L);
+        connection.ExecuteNonQuery("COMMIT;");
         Convert.ToInt64(Scalar(connection, "SELECT COUNT(*) FROM t;")).Should().Be(1L);
     }
 
     [Test]
-    public void ConcurrentRowTriggerDmlAgainstWithoutRowidTableFailsClosed()
+    public void ConcurrentDuplicateWithoutRowidInsertRaisesAWriteConflict()
+    {
+        using var db = new RoutingFileDatabase(
+            "CREATE TABLE t(id INTEGER PRIMARY KEY, value TEXT) WITHOUT ROWID;");
+        using var first = db.Connect();
+        using var second = db.Connect();
+
+        first.ExecuteNonQuery("PRAGMA journal_mode=mvcc;");
+        first.ExecuteNonQuery("BEGIN CONCURRENT;");
+        second.ExecuteNonQuery("BEGIN CONCURRENT;");
+        first.ExecuteNonQuery("INSERT INTO t VALUES (1, 'first');");
+
+        var error = Capture(() => second.ExecuteNonQuery("INSERT INTO t VALUES (1, 'second');"));
+        error.Should().NotBeNull();
+        error!.Message.Should().ContainEquivalentOf("write-write conflict");
+        second.ExecuteNonQuery("ROLLBACK;");
+        first.ExecuteNonQuery("COMMIT;");
+
+        Convert.ToString(Scalar(first, "SELECT value FROM t WHERE id = 1;")).Should().Be("first");
+    }
+
+    [Test]
+    public void ConcurrentRowTriggerDmlAgainstWithoutRowidTableIsVersioned()
     {
         using var db = new RoutingFileDatabase();
         using var connection = db.Connect();
@@ -194,23 +397,25 @@ public sealed class MvccSelectDualCursorRoutingTests
             CREATE TABLE sink(id INTEGER PRIMARY KEY, value TEXT) WITHOUT ROWID;
             CREATE TRIGGER t_after_insert AFTER INSERT ON t BEGIN
                 INSERT INTO sink VALUES (NEW.v, 'trigger');
+                UPDATE sink SET id = id + 10 WHERE id = NEW.v;
             END;
             """);
 
         connection.ExecuteNonQuery("PRAGMA journal_mode=mvcc;");
         connection.ExecuteNonQuery("BEGIN CONCURRENT;");
 
-        var error = Capture(() => connection.ExecuteNonQuery("INSERT INTO t VALUES (1);"));
-        error.Should().NotBeNull();
-        error!.Message.Should().ContainEquivalentOf("rowid user tables");
+        connection.ExecuteNonQuery("INSERT INTO t VALUES (1);");
+        Convert.ToInt64(Scalar(connection, "SELECT COUNT(*) FROM t;")).Should().Be(1L);
+        Convert.ToInt64(Scalar(connection, "SELECT COUNT(*) FROM sink;")).Should().Be(1L);
+        Convert.ToInt64(Scalar(connection, "SELECT id FROM sink;")).Should().Be(11L);
+        connection.ExecuteNonQuery("COMMIT;");
 
-        Convert.ToInt64(Scalar(connection, "SELECT COUNT(*) FROM t;")).Should().Be(0L);
-        Convert.ToInt64(Scalar(connection, "SELECT COUNT(*) FROM sink;")).Should().Be(0L);
-        connection.ExecuteNonQuery("ROLLBACK;");
+        Convert.ToInt64(Scalar(connection, "SELECT COUNT(*) FROM sink;")).Should().Be(1L);
+        Convert.ToInt64(Scalar(connection, "SELECT id FROM sink;")).Should().Be(11L);
     }
 
     [Test]
-    public void ConcurrentForeignKeyCascadeAgainstWithoutRowidTableFailsClosed()
+    public void ConcurrentForeignKeyCascadeAgainstWithoutRowidTableUsesPrimaryKeyIdentity()
     {
         using var db = new RoutingFileDatabase();
         using var connection = db.Connect();
@@ -229,13 +434,13 @@ public sealed class MvccSelectDualCursorRoutingTests
         connection.ExecuteNonQuery("PRAGMA journal_mode=mvcc;");
         connection.ExecuteNonQuery("BEGIN CONCURRENT;");
 
-        var error = Capture(() => connection.ExecuteNonQuery("DELETE FROM parent WHERE id = 1;"));
-        error.Should().NotBeNull();
-        error!.Message.Should().ContainEquivalentOf("rowid user tables");
+        connection.ExecuteNonQuery("DELETE FROM parent WHERE id = 1;");
+        Convert.ToInt64(Scalar(connection, "SELECT COUNT(*) FROM parent;")).Should().Be(0L);
+        Convert.ToInt64(Scalar(connection, "SELECT COUNT(*) FROM child;")).Should().Be(0L);
+        connection.ExecuteNonQuery("COMMIT;");
 
-        Convert.ToInt64(Scalar(connection, "SELECT COUNT(*) FROM parent;")).Should().Be(1L);
-        Convert.ToInt64(Scalar(connection, "SELECT COUNT(*) FROM child;")).Should().Be(1L);
-        connection.ExecuteNonQuery("ROLLBACK;");
+        Convert.ToInt64(Scalar(connection, "SELECT COUNT(*) FROM parent;")).Should().Be(0L);
+        Convert.ToInt64(Scalar(connection, "SELECT COUNT(*) FROM child;")).Should().Be(0L);
     }
 
     private static object? Scalar(SqliteConnection connection, string sql)

--- a/src/Ahtola.Tests/MvccStoreUnitTests.cs
+++ b/src/Ahtola.Tests/MvccStoreUnitTests.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using Ahtola.Core;
 using Ahtola.Core.Mvcc;
+using Ahtola.Core.Storage;
 
 namespace Ahtola.Tests;
 
@@ -187,5 +188,45 @@ public sealed class MvccStoreUnitTests
 
         store.SnapshotLiveCommittedRows().Should().ContainSingle(row =>
             row.RowId == key && row.Cells[0].Equals(SqlValue.Text("new")));
+    }
+
+    [Test]
+    public void TypedPrimaryKeyCanonicalizationMatchesBuiltInSqliteCollations()
+    {
+        var noCase = new SqlitePrimaryKeySchema(
+        [
+            new SqlitePrimaryKeyTerm(
+                0,
+                "key",
+                SqliteKeySortOrder.Ascending,
+                SqliteKeyCollation.FromName("NOCASE")),
+        ]);
+        var rtrim = new SqlitePrimaryKeySchema(
+        [
+            new SqlitePrimaryKeyTerm(
+                0,
+                "key",
+                SqliteKeySortOrder.Ascending,
+                SqliteKeyCollation.FromName("RTRIM")),
+        ]);
+
+        MvccKey.FromPrimaryKey(noCase, [SqlValue.Text("Alpha")], SqliteTextEncoding.Utf8)
+            .Should()
+            .Be(MvccKey.FromPrimaryKey(noCase, [SqlValue.Text("alpha")], SqliteTextEncoding.Utf8));
+        MvccKey.FromPrimaryKey(rtrim, [SqlValue.Text("key")], SqliteTextEncoding.Utf8)
+            .Should()
+            .Be(MvccKey.FromPrimaryKey(rtrim, [SqlValue.Text("key   ")], SqliteTextEncoding.Utf8));
+    }
+
+    [Test]
+    public void LegacyRecoveryWithoutAnObjectNameFailsClosedForTheV4Upgrade()
+    {
+        var store = new MvStore();
+
+        store.ApplyRecoveredCommit(
+            1,
+            [MvccLogOp.Upsert(new MvccRowId(-2, 1), [SqlValue.Text("legacy")])]);
+
+        store.CanUpgradeLegacyLog.Should().BeFalse();
     }
 }


### PR DESCRIPTION
## Summary
- Generalize MVCC identities from integer rowids to integer or canonical SQLite-record keys, including composite `WITHOUT ROWID` primary keys and built-in NOCASE/RTRIM/numeric-equivalence handling.
- Route `WITHOUT ROWID` DML, trigger/cascade mutations, base-overlay scans, and materialized managed-index scans through the typed MVCC merge path.
- Add V4 logical-log frames with typed keys, durable object names, base-tombstone replay, torn-tail repair, indeterminate-flush handling, and a fail-closed V3 migration checkpoint.
- Add concurrent schema gating with schema-cookie publication after catalog persistence, stale-snapshot rejection, savepoint/error gate release, and object-identity retirement after DROP/CREATE-style schema publication.
- Document MVCC Phase 2 behavior and recovery limits.

## V3 to V4 migration
Legacy V3 logs upgrade only through a header-only, exclusive materializing checkpoint. A cold V3 log with frames whose table identities cannot be proven fails closed rather than risking data loss. Header upgrades use atomic replacement when available; an interrupted header-only rewrite is safely recreated.

## Intentional limits
- MVCC remains process-local and does not alter the SQLite WAL interoperability protocol.
- Managed index plans currently materialize rows from the MVCC table merge before applying index ordering/seek logic; they do not yet use Turso's lazy skiplist index cursor/finger implementation.
- Concurrent DDL is intentionally exclusive with respect to all active MVCC snapshots; conflicting/stale schema work reports busy instead of attempting a live rebase.

## Validation
- `pwsh ./scripts/Invoke-ManagedTestSuite.ps1 -Framework net8.0 -Filter "FullyQualifiedName~Mvcc" -MinimumExecutedTests 1` (59 passed)
- `pwsh ./scripts/Invoke-ManagedTestSuite.ps1 -Framework net9.0 -Filter "FullyQualifiedName~Mvcc" -MinimumExecutedTests 1` (59 passed)
- `pwsh ./scripts/Invoke-ManagedTestSuite.ps1 -Framework net10.0 -Filter "FullyQualifiedName~Mvcc" -MinimumExecutedTests 1` (59 passed)
- Changed-project `dotnet format --verify-no-changes --no-restore` checks
- `pwsh ./build.ps1 validate-project-closure`