### PR TITLE
fix(mvcc): order checkpoint log and WAL retirement

### DIFF
--- a/docs/mvcc-port-contract.md
+++ b/docs/mvcc-port-contract.md
@@ -47,7 +47,7 @@ Pinned submodule: `turso-src/` @ **v0.7.2** (`046e9cbf6`).
 | **2** | Durable logical log (`*.db-log`) with Turso LML2/MVTX framing constants, CRC32C, upsert/delete ops, replay into `MvStore` on enable; checkpoint TRUNCATE clears log |
 | **3** | Header version **255** via pager `SwitchJournalMode(Mvcc)`; cold open restores `MvStore`; `MvccDualCursor` merge primitive; **shared `MvStore`/log per path** (`EmbeddedMvStoreRegistry`) so pooled multi-connection concurrent writers share one version store + rowid allocator; concurrent commit reloads durable catalog then merges store snapshots |
 | **3.5** | **SQL dual-cursor routing:** under `BEGIN CONCURRENT`, `GetNamedTableRows` merges base catalog + store via `MvccDualCursor.MergeVisibleRows`; DML records versions via `ReportRowChange` → `DeleteOrTombstoneBase` / `UpdateIncludingBase` (DELETE/UPDATE) and connection `RecordConcurrentMvccMutation` (INSERT + global rowid); peer uncommitted writes invisible; SI after peer commit; same-row WW on SQL path |
-| **3.6 (current)** | **Checkpoint SM skeleton:** `PRAGMA wal_checkpoint` in MVCC mode runs `RunMvccCheckpoint` — AcquireLock → Collect/Materialize (reuse `MergeConcurrentCatalogFromStoreLocked`) → Persist catalog → Truncate logical log (TRUNCATE/RESTART/FULL) → `GarbageCollectAfterCheckpoint` (clear store when no active txs; else prune past reader LWM). Active concurrent txs → busy=1, no truncate. Not a full Turso cooperative btree page walk. |
+| **3.6 (current)** | **Synchronous page-WAL checkpoint state machine:** `PRAGMA wal_checkpoint` in MVCC mode runs `RunMvccCheckpoint` — AcquireLock → Collect/Materialize (reuse `MergeConcurrentCatalogFromStoreLocked`) → persist pages to WAL **without automatic reset** → backfill and flush the main store → retire/upgrade the logical log → reset the WAL last for TRUNCATE/RESTART/FULL → `GarbageCollectAfterCheckpoint`. Active concurrent txs return busy before mutation. PASSIVE retains both WAL and logical-log recovery evidence. This adapts Turso's cooperative b-tree I/O state machine to managed synchronous `IFileSystem` operations. |
 | **Open** | MVCC-versioned schema rows (concurrent DDL currently fails closed); schema generation cookie polish; full per-page btree checkpoint SM / WAL TRUNCATE interleave parity with Turso if product requires it |
 
 ## Dual-cursor SQL routing notes
@@ -65,9 +65,10 @@ Pinned submodule: `turso-src/` @ **v0.7.2** (`046e9cbf6`).
 
 ## Checkpoint notes
 
-- Concurrent **commit** already merges store → catalog; checkpoint re-merges for safety then persists so TRUNCATE cannot drop the only durable copy of rows.
-- After successful truncate with no active readers, version chains are dropped (`GarbageCollectAfterCheckpoint`); dual-cursor defers to catalog.
-- PASSIVE/busy with open concurrent txs does **not** truncate the log (avoids losing unrecovered store-only frames if materialize is skipped).
+- Concurrent **commit** already merges store → catalog; checkpoint re-merges for safety, then writes a fresh page-WAL transaction without resetting it.
+- **Durable ordering:** WAL page transaction → main-store backfill/flush → logical-log retirement/flush → WAL reset. A logical-log retirement or WAL-reset failure leaves validated WAL recovery evidence; the latter may leave a header-only log with a retained WAL, which cold reopen accepts.
+- After successful restart/truncate with no active readers, version chains are dropped (`GarbageCollectAfterCheckpoint`); dual-cursor defers to catalog.
+- PASSIVE/busy with open concurrent txs does **not** mutate or truncate recovery artifacts. A successful passive checkpoint retains WAL and logical-log evidence rather than attempting a destructive reset.
 
 ## Testing
 

--- a/src/Ahtola.Core/EmbeddedDatabase.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.cs
@@ -2565,9 +2565,9 @@ public sealed partial class EmbeddedDatabase : IDisposable
     }
 
     /// <summary>
-    /// Runs the managed MVCC checkpoint skeleton (Turso
-    /// <c>CheckpointStateMachine</c> phases, synchronous):
-    /// materialize store → catalog, persist, optional log truncate, GC.
+    /// Runs the managed synchronous MVCC checkpoint state machine. Page changes
+    /// first become durable in the WAL, then the main file; only then may the
+    /// logical log retire its frames and the WAL be reset.
     /// </summary>
     internal MvccCheckpointResult RunMvccCheckpoint(string? mode, TimeSpan busyTimeout = default)
     {
@@ -2596,8 +2596,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
             phase = MvccCheckpointPhase.AcquireLock;
             var wantTruncate = MvccCheckpoint.ShouldTruncateLog(mode);
 
-            // Active concurrent txs: report busy and skip materialize/truncate
-            // (Turso PASSIVE defers; FULL waits — managed skeleton does not block).
+            // An active concurrent transaction pins an MVCC reader floor. Do not
+            // materialize, retire the log, or reset the WAL beneath that snapshot.
             if (store.HasActiveTransactions())
             {
                 return new MvccCheckpointResult(
@@ -2620,10 +2620,26 @@ public sealed partial class EmbeddedDatabase : IDisposable
             }
             else
             {
-                // PersistFileCatalog takes _fileCatalogWriteLock; release _gate first?
-                // Commit path holds _gate then PersistFileCatalog which locks write lock —
-                // same order as CommitTransaction. Keep _gate held.
-                PersistFileCatalog(merged, pragmaHeader: null, forceFullRewrite: false, busyTimeout);
+                PersistFileCatalog(
+                    merged,
+                    pragmaHeader: null,
+                    forceFullRewrite: false,
+                    busyTimeout,
+                    checkpointAfterCommit: false);
+
+                phase = MvccCheckpointPhase.BackfillMainStore;
+                try
+                {
+                    _ = _fileStore.BackfillMvccCheckpoint(busyTimeout);
+                }
+                catch (SqlitePagerBusyException)
+                {
+                    return new MvccCheckpointResult(
+                        Busy: true,
+                        LogFramesBefore: logBefore,
+                        CheckpointedFrames: 0,
+                        CompletedThrough: phase);
+                }
             }
 
             var checkpointed = logBefore;
@@ -2635,6 +2651,25 @@ public sealed partial class EmbeddedDatabase : IDisposable
                     log.UpgradeToVersion4AfterCheckpoint();
                 if (wantTruncate)
                     checkpointed = logBefore;
+            }
+
+            if (wantTruncate && _fileStore is not null)
+            {
+                phase = MvccCheckpointPhase.ResetWal;
+                try
+                {
+                    _ = _fileStore.ResetMvccCheckpointWal(busyTimeout);
+                }
+                catch (SqlitePagerBusyException)
+                {
+                    // The main store and logical log are already durable. Retain the
+                    // validated WAL for a later restart rather than losing reader data.
+                    return new MvccCheckpointResult(
+                        Busy: true,
+                        LogFramesBefore: logBefore,
+                        CheckpointedFrames: checkpointed,
+                        CompletedThrough: phase);
+                }
             }
 
             phase = MvccCheckpointPhase.GarbageCollect;
@@ -2908,7 +2943,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
         SchemaCatalog catalog,
         PragmaHeaderMetadata? pragmaHeader = null,
         bool forceFullRewrite = false,
-        TimeSpan busyTimeout = default)
+        TimeSpan busyTimeout = default,
+        bool checkpointAfterCommit = true)
     {
         if (_fileStore is null || _fileSystem is null || _fileCatalogWriteLock is null)
             throw new InvalidOperationException("The managed file catalog persistence state is not initialized.");
@@ -2920,14 +2956,23 @@ public sealed partial class EmbeddedDatabase : IDisposable
             using var writeRegistration = RegisterCatalogWrite(_databasePath);
             try
             {
-                var committedVersion = _fileStore.Persist(
-                    catalog.Tables,
-                    catalog.Views,
-                    catalog.Triggers,
-                    catalog.VirtualTables,
-                    pragmaHeader,
-                    forceFullRewrite,
-                    previousTables: _tables);
+                var committedVersion = checkpointAfterCommit
+                    ? _fileStore.Persist(
+                        catalog.Tables,
+                        catalog.Views,
+                        catalog.Triggers,
+                        catalog.VirtualTables,
+                        pragmaHeader,
+                        forceFullRewrite,
+                        previousTables: _tables)
+                    : _fileStore.PersistForMvccCheckpoint(
+                        catalog.Tables,
+                        catalog.Views,
+                        catalog.Triggers,
+                        catalog.VirtualTables,
+                        pragmaHeader,
+                        forceFullRewrite,
+                        previousTables: _tables);
                 PublishCatalog(catalog, committedVersion);
             }
             catch (EmbeddedPostCommitMaintenanceException)
@@ -46792,8 +46837,8 @@ Func<string, ParsedStatement> rewrite)
         var database = ResolvePragmaDatabase(statement.Schema);
         if (database.IsMvccEnabled)
         {
-            // Turso CheckpointStateMachine skeleton: materialize → persist →
-            // truncate logical log (TRUNCATE/RESTART/FULL) → GC past reader LWM.
+            // Managed MVCC checkpoint: materialize WAL pages -> backfill/flush
+            // main storage -> retire the logical log -> reset the WAL last.
             var result = database.RunMvccCheckpoint(statement.Mode, BusyTimeout);
             return new ExecutionResult(
                 columns,

--- a/src/Ahtola.Core/EmbeddedFileStore.cs
+++ b/src/Ahtola.Core/EmbeddedFileStore.cs
@@ -1350,6 +1350,31 @@ internal sealed class EmbeddedFileStore : IDisposable
             forceFullRewrite,
             previousTables);
 
+    /// <summary>
+    /// Materializes an MVCC checkpoint into pager WAL pages without reclaiming
+    /// those frames. The checkpoint state machine must first backfill the main
+    /// store and retire the logical log before it resets the WAL.
+    /// </summary>
+    internal FileCatalogVersion PersistForMvccCheckpoint(
+        IReadOnlyDictionary<string, EmbeddedTable> tables,
+        IReadOnlyDictionary<string, ViewDefinition> views,
+        IReadOnlyDictionary<string, TriggerDefinition> triggers,
+        IReadOnlyDictionary<string, EmbeddedDatabase.VirtualTableDefinition> virtualTables,
+        PragmaHeaderMetadata? pragmaHeader = null,
+        bool forceFullRewrite = false,
+        IReadOnlyDictionary<string, EmbeddedTable>? previousTables = null)
+        => PersistCore(
+            tables,
+            views,
+            triggers,
+            virtualTables,
+            reclaimTrailingPages: false,
+            incrementSchemaCookie: false,
+            pragmaHeader,
+            forceFullRewrite,
+            previousTables,
+            checkpointAfterCommit: false);
+
     internal FileCatalogVersion CommittedCatalogVersion => FileCatalogVersion.FromHeader(_header);
 
     /// <summary>
@@ -1408,6 +1433,25 @@ internal sealed class EmbeddedFileStore : IDisposable
     }
 
     internal SqliteJournalMode JournalMode => _pager.JournalMode;
+
+    /// <summary>Backfills the WAL pages materialized by an MVCC checkpoint.</summary>
+    internal SqliteCheckpointResult BackfillMvccCheckpoint(TimeSpan busyTimeout)
+    {
+        ThrowIfDisposed();
+        ThrowIfPostCommitMaintenanceFaulted();
+        return _pager.CheckpointToMainStore(busyTimeout);
+    }
+
+    /// <summary>
+    /// Reclaims a previously backfilled MVCC checkpoint WAL only after the
+    /// logical log has been durably retired.
+    /// </summary>
+    internal SqliteCheckpointResult ResetMvccCheckpointWal(TimeSpan busyTimeout)
+    {
+        ThrowIfDisposed();
+        ThrowIfPostCommitMaintenanceFaulted();
+        return _pager.CheckpointToMainStoreAndResetWal(busyTimeout);
+    }
 
     internal SqliteJournalMode SwitchJournalMode(SqliteJournalMode journalMode)
     {
@@ -1607,7 +1651,8 @@ internal sealed class EmbeddedFileStore : IDisposable
         bool incrementSchemaCookie,
         PragmaHeaderMetadata? pragmaHeader,
         bool forceFullRewrite,
-        IReadOnlyDictionary<string, EmbeddedTable>? previousTables = null)
+        IReadOnlyDictionary<string, EmbeddedTable>? previousTables = null,
+        bool checkpointAfterCommit = true)
     {
         ThrowIfDisposed();
         ThrowIfPostCommitMaintenanceFaulted();
@@ -1624,13 +1669,25 @@ internal sealed class EmbeddedFileStore : IDisposable
         {
             if (previousTables is not null
                 && ReferenceEquals(previousTables, _committedTables)
-                && TryPersistIncrementalRowMutation(tables, views, triggers, virtualTables, previousTables))
+                && TryPersistIncrementalRowMutation(
+                    tables,
+                    views,
+                    triggers,
+                    virtualTables,
+                    previousTables,
+                    checkpointAfterCommit))
             {
                 _committedTables = tables;
                 return CommittedCatalogVersion;
             }
 
-            if (TryPersistBoundedTableLeafMutation(tables, views, triggers, virtualTables))
+            if (checkpointAfterCommit
+                && TryPersistBoundedTableLeafMutation(
+                    tables,
+                    views,
+                    triggers,
+                    virtualTables,
+                    checkpointAfterCommit))
             {
                 _committedTables = tables;
                 return CommittedCatalogVersion;
@@ -1778,7 +1835,8 @@ internal sealed class EmbeddedFileStore : IDisposable
         // checkpoint has durably installed that view, retain neither its WAL frames
         // nor overlay so later rewrites do not rescan an unbounded history.
         _header = newHeader;
-        CheckpointCommittedMutation(reclaimTrailingPages);
+        if (checkpointAfterCommit)
+            CheckpointCommittedMutation(reclaimTrailingPages);
         _tableRootPages = rootPages;
         _indexRootPages = indexRootPages;
         _lastSchemaSignature = signature;
@@ -1854,7 +1912,8 @@ internal sealed class EmbeddedFileStore : IDisposable
         IReadOnlyDictionary<string, ViewDefinition> views,
         IReadOnlyDictionary<string, TriggerDefinition> triggers,
         IReadOnlyDictionary<string, EmbeddedDatabase.VirtualTableDefinition> virtualTables,
-        IReadOnlyDictionary<string, EmbeddedTable> previousTables)
+        IReadOnlyDictionary<string, EmbeddedTable> previousTables,
+        bool checkpointAfterCommit)
     {
         if (!HasCurrentSchemaShape(tables, views, triggers, virtualTables))
             return false;
@@ -1945,7 +2004,8 @@ internal sealed class EmbeddedFileStore : IDisposable
         }
 
         _header = newHeader;
-        CheckpointCommittedMutation(reclaimTrailingPages: false);
+        if (checkpointAfterCommit)
+            CheckpointCommittedMutation(reclaimTrailingPages: false);
         return true;
     }
 
@@ -2206,7 +2266,8 @@ internal sealed class EmbeddedFileStore : IDisposable
         IReadOnlyDictionary<string, EmbeddedTable> tables,
         IReadOnlyDictionary<string, ViewDefinition> views,
         IReadOnlyDictionary<string, TriggerDefinition> triggers,
-        IReadOnlyDictionary<string, EmbeddedDatabase.VirtualTableDefinition> virtualTables)
+        IReadOnlyDictionary<string, EmbeddedDatabase.VirtualTableDefinition> virtualTables,
+        bool checkpointAfterCommit)
     {
         var schemaPage = _pager.ReadCommittedPage(SchemaRootPage);
         var currentHeader = SqliteDatabaseHeader.Parse(schemaPage);

--- a/src/Ahtola.Core/Mvcc/MvccCheckpoint.cs
+++ b/src/Ahtola.Core/Mvcc/MvccCheckpoint.cs
@@ -12,9 +12,11 @@ internal enum MvccCheckpointPhase : byte
     CollectRows = 2,
     MaterializeCatalog = 3,
     PersistCatalog = 4,
-    TruncateLogicalLog = 5,
-    GarbageCollect = 6,
-    Finalize = 7,
+    BackfillMainStore = 5,
+    TruncateLogicalLog = 6,
+    ResetWal = 7,
+    GarbageCollect = 8,
+    Finalize = 9,
 }
 
 /// <summary>Outcome of a managed MVCC checkpoint attempt.</summary>
@@ -25,11 +27,9 @@ internal readonly record struct MvccCheckpointResult(
     MvccCheckpointPhase CompletedThrough);
 
 /// <summary>
-/// Skeleton port of Turso <c>CheckpointStateMachine</c>:
-/// materialize committed version-store rows into the classic catalog, durably
-/// persist, truncate the logical log (TRUNCATE/RESTART), then GC history past
-/// the reader low-water mark. PASSIVE skips truncate when concurrent txs are
-/// still open.
+/// Synchronous managed port of Turso's checkpoint durability sequence:
+/// materialize into WAL pages, backfill and flush the main file, retire the
+/// logical log, then reset the WAL last.
 /// </summary>
 internal static class MvccCheckpoint
 {

--- a/src/Ahtola.Tests/MvccCheckpointStateMachineTests.cs
+++ b/src/Ahtola.Tests/MvccCheckpointStateMachineTests.cs
@@ -116,6 +116,126 @@ public sealed class MvccCheckpointStateMachineTests
     }
 
     [Test]
+    public void TruncateRetainsWalWhenLogicalLogRetirementFails()
+    {
+        var faults = new DeterministicFaultInjector();
+        var fileSystem = new InMemoryFileSystem(faults);
+        const string path = "mvcc-log-retirement-failure.db";
+        long logLength;
+
+        using (var database = EmbeddedDatabase.OpenFile(path, fileSystem))
+        using (var connection = database.Connect())
+        {
+            Execute(connection, "CREATE TABLE t(v INTEGER);");
+            Execute(connection, "PRAGMA journal_mode=mvcc;");
+            Execute(connection, "BEGIN CONCURRENT;");
+            Execute(connection, "INSERT INTO t VALUES (41);");
+            Execute(connection, "COMMIT;");
+
+            logLength = ReadFileLength(fileSystem, path + "-log");
+            logLength.Should().BeGreaterThan(56);
+            faults.FailNext(FileSystemOperation.SetLength);
+
+            Assert.Throws<IOException>(() => database.RunMvccCheckpoint("TRUNCATE"));
+
+            ReadFileLength(fileSystem, path + "-log").Should().Be(logLength);
+            AssertCommittedWal(fileSystem, path + "-wal");
+        }
+
+        using var reopened = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        ReadScalar(reopenedConnection, "SELECT v FROM t;").Should().Be(41L);
+    }
+
+    [Test]
+    public void TruncateRetiresLogicalLogBeforeWalResetAndRecoversAfterResetFault()
+    {
+        var faults = new DeterministicFaultInjector();
+        var fileSystem = new InMemoryFileSystem(faults);
+        const string path = "mvcc-wal-reset-failure.db";
+
+        using (var database = EmbeddedDatabase.OpenFile(path, fileSystem))
+        using (var connection = database.Connect())
+        {
+            Execute(connection, "CREATE TABLE t(v INTEGER);");
+            Execute(connection, "PRAGMA journal_mode=mvcc;");
+            Execute(connection, "BEGIN CONCURRENT;");
+            Execute(connection, "INSERT INTO t VALUES (73);");
+            Execute(connection, "COMMIT;");
+
+            // The first SetLength retires the logical log; the next one is the
+            // WAL reset. A failure there must leave the durable WAL recoverable.
+            faults.FailNextAfter(FileSystemOperation.SetLength, FileSystemOperation.SetLength);
+
+            Assert.Throws<IOException>(() => database.RunMvccCheckpoint("TRUNCATE"));
+
+            ReadFileLength(fileSystem, path + "-log").Should().Be(56);
+            AssertCommittedWal(fileSystem, path + "-wal");
+        }
+
+        using (var reopened = EmbeddedDatabase.OpenFile(path, fileSystem))
+        using (var connection = reopened.Connect())
+        {
+            ReadScalar(connection, "SELECT v FROM t;").Should().Be(73L);
+            reopened.RunMvccCheckpoint("TRUNCATE").Busy.Should().BeFalse();
+        }
+
+        using var finalWal = SqliteWalFile.Open(fileSystem, path + "-wal", readOnly: true);
+        finalWal.ScanRecovery().LastCommittedFrameNumber.Should().Be(0);
+    }
+
+    [Test]
+    public void ActiveConcurrentReaderPreventsLogicalLogRetirement()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        const string path = "mvcc-reader-floor.db";
+
+        using var database = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var writer = database.Connect();
+        using var reader = database.Connect();
+        Execute(writer, "CREATE TABLE t(v INTEGER);");
+        Execute(writer, "PRAGMA journal_mode=mvcc;");
+        Execute(writer, "BEGIN CONCURRENT;");
+        Execute(writer, "INSERT INTO t VALUES (91);");
+        Execute(writer, "COMMIT;");
+
+        var logLength = ReadFileLength(fileSystem, path + "-log");
+        Execute(reader, "BEGIN CONCURRENT;");
+
+        var blocked = database.RunMvccCheckpoint("TRUNCATE");
+        blocked.Busy.Should().BeTrue();
+        blocked.CompletedThrough.Should().Be(MvccCheckpointPhase.AcquireLock);
+        ReadFileLength(fileSystem, path + "-log").Should().Be(logLength);
+
+        Execute(reader, "ROLLBACK;");
+        database.RunMvccCheckpoint("TRUNCATE").Busy.Should().BeFalse();
+        ReadFileLength(fileSystem, path + "-log").Should().Be(56);
+    }
+
+    [Test]
+    public void TruncatePreservesTypedObjectRowsAcrossColdReopen()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        const string path = "mvcc-typed-checkpoint.db";
+
+        using (var database = EmbeddedDatabase.OpenFile(path, fileSystem))
+        using (var connection = database.Connect())
+        {
+            Execute(connection, "CREATE TABLE t(k TEXT PRIMARY KEY, v TEXT) WITHOUT ROWID;");
+            Execute(connection, "PRAGMA journal_mode=mvcc;");
+            Execute(connection, "BEGIN CONCURRENT;");
+            Execute(connection, "INSERT INTO t VALUES ('tenant', 'value');");
+            Execute(connection, "COMMIT;");
+
+            database.RunMvccCheckpoint("TRUNCATE").Busy.Should().BeFalse();
+        }
+
+        using var reopened = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        ReadText(reopenedConnection, "SELECT v FROM t WHERE k = 'tenant';").Should().Be("value");
+    }
+
+    [Test]
     public void CheckpointUpgradesAHeaderOnlyLegacyLogicalLogBeforeTypedWrites()
     {
         const string path = "mvcc-v3-checkpoint-upgrade.db";
@@ -162,6 +282,35 @@ public sealed class MvccCheckpointStateMachineTests
 
     private static string ReadValue(SqliteConnection connection, string sql)
         => Convert.ToString(Scalar(connection, sql)) ?? string.Empty;
+
+    private static long ReadScalar(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        statement.Step().Should().Be(StatementStepResult.Row);
+        return statement.GetValue(0).AsInteger();
+    }
+
+    private static string ReadText(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        statement.Step().Should().Be(StatementStepResult.Row);
+        return statement.GetValue(0).AsText();
+    }
+
+    private static long ReadFileLength(IFileSystem fileSystem, string path)
+    {
+        using var file = fileSystem.OpenFile(path, FileOpenMode.OpenExisting, readOnly: true);
+        return file.Length;
+    }
+
+    private static void AssertCommittedWal(IFileSystem fileSystem, string path)
+    {
+        using var wal = SqliteWalFile.Open(fileSystem, path, readOnly: true);
+        var recovery = wal.ScanRecovery();
+        recovery.StopReason.Should().Be(SqliteWalRecoveryStopReason.EndOfFile);
+        recovery.LastCommittedFrameNumber.Should().BeGreaterThan(0);
+        recovery.LastCommittedFrameNumber.Should().Be(recovery.LastValidFrameNumber);
+    }
 
     private sealed class CheckpointFileDatabase : IDisposable
     {


### PR DESCRIPTION
## Summary
- retain MVCC checkpoint WAL frames while materializing the catalog, backfill the main store, retire the logical log, then reset the WAL last
- preserve typed-object/schema catalog materialization and surface reader-lock contention as a non-destructive busy result
- add recovery fault coverage for logical-log retirement, WAL reset, active reader floors, typed keys, and WAL validation

## Validation
- `pwsh ./build.ps1 test -Configuration Debug`
- `pwsh ./scripts/Invoke-ManagedTestSuite.ps1 -Framework net10.0 -Filter "FullyQualifiedName~MvccCheckpointStateMachineTests|FullyQualifiedName~MvccLogicalLogTests|FullyQualifiedName~MvccSelectDualCursorRoutingTests|FullyQualifiedName~MvccStoreUnitTests|FullyQualifiedName~ManagedJournalPageMigrationTests|FullyQualifiedName~SqlitePagerCheckpointRecoveryVisibilityTests|FullyQualifiedName~ManagedWalCheckpointResetLifecycleTests" -MinimumExecutedTests 1`