### PR TITLE
Add public SQL CDC

### DIFF
--- a/docs/turso-gap-analysis.md
+++ b/docs/turso-gap-analysis.md
@@ -424,9 +424,9 @@ Four pairs of **same-name/different-meaning** opcodes are landmines:
 | 201 | `HashGraceAdvancePartition` | missing | — | `vdbe-hash-join-opcodes` |
 | 202 | `VacuumInto` | bydesign | — (tree-walked; file-backed source only) | `vdbe-ddl-executed-by-treewalker` |
 | 203 | `Vacuum` | bydesign | — (tree-walked) | `vdbe-ddl-executed-by-treewalker` |
-| 204 | `InitCdcVersion` | missing | — | `vdbe-cdc-opcode` |
+| 204 | `InitCdcVersion` | bydesign | — (tree-walked connection CDC) | `vdbe-cdc-opcode` |
 
-Status totals: bydesign 24, consolidated 40, direct 26, divergent 10, missing 104 (of 204).
+Status totals: bydesign 25, consolidated 40, direct 26, divergent 10, missing 103 (of 204).
 
 ### 3.7 VDBE gap inventory
 
@@ -448,7 +448,7 @@ Status totals: bydesign 24, consolidated 40, direct 26, divergent 10, missing 10
 | `vdbe-autoindex-for-joins` | missing | s3-perf | M | 3 | 3 | Turso can build a transient auto-index when no usable index exists for a join. Combined with the missing cost-based join order (compilation entry), Ahtola's joins are O(N… |
 | `vdbe-checkpoint-opcode` | missing | s2-capability | S | 3 | 1 | Checkpoint coordination exists internally (storage layer) but there is no Checkpoint opcode, so `PRAGMA wal_checkpoint(...)` has no execution path — directly causes the t… |
 | `vdbe-comparison-opcode-consolidation` | divergent | s4-intentional | S | 2 | 0 | Verified near-parity consolidation: Ahtola evaluates the comparison to a tri-state value (IS/IS NOT handled null-safely; NULL -> NULL; affinities applied per side; collat… |
-| `vdbe-cdc-opcode` | missing | s2-capability | M | 1 | 0 | CDC bootstrap opcode; feeds Turso's CDC capture consumed by sync. No Ahtola counterpart (sync layer lacks CDC too — see sync entries). |
+| `vdbe-cdc-opcode` | bydesign | s4-intentional | M | 0 | 0 | Public SQL CDC is implemented by the managed tree-walking connection: `capture_data_changes_conn` provisions pinned Turso V1/V2 tables, captures transactional rows/schema changes, and writes V2 COMMIT records. It deliberately has no VDBE `InitCdcVersion` opcode because Ahtola's DDL/connection-state execution is tree-walked. The managed replica journal remains separate. |
 | `vdbe-explain-output-parity` | partial | s3-perf | M | 1 | 0 | Ahtola has a real EXPLAIN implementation over its own opcode set, so output necessarily diverges from SQLite/Turso text (different opcode names, no p1-p5 operand columns)… |
 | `vdbe-open-ephemeral` | missing | s2-capability | M | 1 | 0 | No general-purpose ephemeral btree opcode: Turso materializes IN (...) sets, DISTINCT intermediates, subquery results, and auto-indexes into ephemeral tables with full cu… |
 | `vdbe-bloom-filter-opcodes` | missing | s3-perf | M | 0 | 0 | Turso builds a bloom filter over a join/IN side and probes it to skip btree seeks. Ahtola has no bloom machinery. NAME COLLISION: Ahtola's VdbeOpcode.Filter (12) is a row… |
@@ -705,14 +705,14 @@ The earlier behavioral gaps below are closed or reduced:
 ## 9. Sync / replication & provider surface
 18 entries, 1 mapped failure line — expected: the conformance suite exercises
 the local engine, not replication. Turso's `sync/engine/` (logical
-replication, CDC capture, bootstrap/apply, conflict policy) has **no managed
+replication, CDC replay, bootstrap/apply, conflict policy) has **no managed
 counterpart**; Ahtola.Data instead provides the Hrana remote client and
 optional-companion dispatch (`AhtolaNativeProvider`/`AhtolaReplicaProvider`/
 `SqliteNativeProvider` load `Turso.Data.Native`/`Turso.Data.Sync` by name and
 fail closed when absent — an intentional product decision, not a gap to
 "fix" by renaming).
 The 11 `missing` entries (sync engine core, bootstrap protocol, conflict
-resolution, CDC capture — including `vdbe-cdc-opcode`'s `InitCdcVersion`) are
+resolution, CDC replay) are
 **upstream-ahead features**; adopting them is a roadmap decision (s4-adjacent
 but filed as `missing`/s2 since they are unshipped rather than rejected).
 2 `extension` entries cover Ahtola-only provider conveniences.
@@ -748,7 +748,7 @@ claimed by the managed replica.
 
 | ID | Kind | Severity | Effort | Mapped fails | Cited | Summary |
 | --- | --- | --- | --- | ---: | ---: | --- |
-| `sync-no-cdc-capture-pragma` | missing | s2-capability | L | 1 | 0 | Turso captures local writes into a `turso_cdc` change-data-capture table (via a CDC pragma) so they can be diffed and pushed to the remote and replayed against a revert/s… |
+| `sync-no-cdc-capture-pragma` | divergent | s2-capability | L | 0 | 0 | Ahtola implements the public pinned-Turso `capture_data_changes_conn` V1/V2 table surface, but its managed replica intentionally continues to capture committed local changes in the private `<db>.ahtola-replica-journal`. Public CDC is not yet consumed by replica push/pull or logical replay. |
 | `sync-checkpoint-mode-mismatch-vs-managed-storage` | divergent | s2-capability | M | 0 | 0 | Turso's sync checkpoint explicitly composes Passive (checkpoint only the already-synced WAL prefix, tracked by a watermark) followed by Truncate (once fully synced) to ke… |
 | `sync-conflict-error-surfaced-not-handled` | missing | s2-capability | M | 0 | 0 | Turso's push path distinguishes a specific 'conflict' HTTP status from the remote wal_push endpoint and surfaces a typed DatabaseSyncEngineConflict error that callers can… |
 | `sync-connection-pooling-no-replica-awareness` | partial | s3-perf | M | 0 | 0 | Turso's engine has a wait_changes_from_remote long-poll loop that lets a replica connection block until the server reports new changes, enabling push-driven refresh inste… |

--- a/src/Ahtola.Core/ChangeDataCapture.cs
+++ b/src/Ahtola.Core/ChangeDataCapture.cs
@@ -1,0 +1,703 @@
+using Ahtola.Core.Mvcc;
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Core;
+
+internal enum ChangeDataCaptureMode
+{
+    Id,
+    Before,
+    After,
+    Full,
+}
+
+internal enum ChangeDataCaptureVersion
+{
+    V1 = 1,
+    V2 = 2,
+}
+
+internal sealed record ChangeDataCaptureConfiguration(
+    ChangeDataCaptureMode Mode,
+    string Table,
+    ChangeDataCaptureVersion Version)
+{
+    internal const string DefaultTableName = "turso_cdc";
+    internal const string VersionTableName = "turso_cdc_version";
+
+    internal bool HasBefore => Mode is ChangeDataCaptureMode.Before or ChangeDataCaptureMode.Full;
+
+    internal bool HasAfter => Mode is ChangeDataCaptureMode.After or ChangeDataCaptureMode.Full;
+
+    internal bool HasUpdates => Mode == ChangeDataCaptureMode.Full;
+
+    internal string ModeName => Mode switch
+    {
+        ChangeDataCaptureMode.Id => "id",
+        ChangeDataCaptureMode.Before => "before",
+        ChangeDataCaptureMode.After => "after",
+        ChangeDataCaptureMode.Full => "full",
+        _ => throw new InvalidOperationException($"Unknown CDC mode {Mode}."),
+    };
+
+    internal string VersionName => Version switch
+    {
+        ChangeDataCaptureVersion.V1 => "v1",
+        ChangeDataCaptureVersion.V2 => "v2",
+        _ => throw new InvalidOperationException($"Unknown CDC version {Version}."),
+    };
+
+    internal static ChangeDataCaptureConfiguration? Parse(
+        string value,
+        ChangeDataCaptureVersion version)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        var separator = value.IndexOf(',');
+        var modeText = separator < 0 ? value : value[..separator];
+        var table = separator < 0 ? DefaultTableName : value[(separator + 1)..];
+        if (modeText.Equals("off", StringComparison.OrdinalIgnoreCase))
+            return null;
+        if (string.IsNullOrWhiteSpace(table)
+            || ManagedSchemaName.TrySplit(table, out _, out _))
+        {
+            throw InvalidValue();
+        }
+
+        var mode = modeText.ToLowerInvariant() switch
+        {
+            "id" => ChangeDataCaptureMode.Id,
+            "before" => ChangeDataCaptureMode.Before,
+            "after" => ChangeDataCaptureMode.After,
+            "full" => ChangeDataCaptureMode.Full,
+            _ => throw InvalidValue(),
+        };
+
+        return new ChangeDataCaptureConfiguration(mode, table, version);
+    }
+
+    private static EmbeddedSqlException InvalidValue()
+        => new(
+            "unexpected pragma value: expected '<mode>' or '<mode>,<cdc-table-name>' parameter where mode is one of off|id|before|after|full");
+}
+
+internal readonly record struct ChangeDataCaptureTransactionSnapshot(
+    long TransactionId,
+    bool HasCapturedRows);
+
+/// <summary>
+/// Connection-owned Turso CDC state. Captured records are appended directly to
+/// the current catalog's ordinary table, so existing statement/savepoint/WAL
+/// rollback and concurrent-MVCC commit paths remain the source of atomicity.
+/// </summary>
+internal sealed class ChangeDataCaptureSession(ChangeDataCaptureConfiguration configuration)
+{
+    private readonly ChangeDataCaptureConfiguration _configuration = configuration;
+    private long _transactionId = -1;
+    private bool _hasCapturedRows;
+    private bool _statementEligible;
+
+    internal ChangeDataCaptureConfiguration Configuration => _configuration;
+
+    internal void BeginStatement(ParsedStatement statement)
+        => _statementEligible = IsCaptureableStatement(statement);
+
+    internal void StartTransaction()
+    {
+        _transactionId = -1;
+        _hasCapturedRows = false;
+        _statementEligible = false;
+    }
+
+    internal void ResetTransaction()
+    {
+        _transactionId = -1;
+        _hasCapturedRows = false;
+        _statementEligible = false;
+    }
+
+    internal ChangeDataCaptureTransactionSnapshot Snapshot()
+        => new(_transactionId, _hasCapturedRows);
+
+    internal ChangeDataCaptureSession Reconfigure(ChangeDataCaptureConfiguration configuration)
+        => new ChangeDataCaptureSession(configuration)
+        {
+            _transactionId = _transactionId,
+            _hasCapturedRows = _hasCapturedRows,
+            _statementEligible = _statementEligible,
+        };
+
+    internal void Restore(ChangeDataCaptureTransactionSnapshot snapshot)
+    {
+        _transactionId = snapshot.TransactionId;
+        _hasCapturedRows = snapshot.HasCapturedRows;
+    }
+
+    internal void RecordRow(
+        EmbeddedDatabase.QueryContext context,
+        SqliteChangeOperation operation,
+        string tableName,
+        EmbeddedTable table,
+        long rowId,
+        SqlValue[]? before,
+        SqlValue[]? after)
+    {
+        if (IsExcludedTable(tableName))
+            return;
+        if (!table.HasRowid)
+            throw new EmbeddedSqlException("CDC does not support WITHOUT ROWID tables");
+
+        after ??= TryFindRow(table, rowId);
+        var beforeRecord = _configuration.HasBefore
+            && operation is SqliteChangeOperation.Update or SqliteChangeOperation.Delete
+            && before is not null
+                ? SqlValue.Blob(SqliteRecordCodec.Encode(before))
+                : SqlValue.Null;
+        var afterRecord = _configuration.HasAfter
+            && operation is SqliteChangeOperation.Insert or SqliteChangeOperation.Update
+            && after is not null
+                ? SqlValue.Blob(SqliteRecordCodec.Encode(after))
+                : SqlValue.Null;
+        var updates = _configuration.HasUpdates
+            && operation == SqliteChangeOperation.Update
+            && before is not null
+            && after is not null
+                ? SqlValue.Blob(EncodeUpdateRecord(before, after))
+                : SqlValue.Null;
+        Append(
+            context,
+            ChangeType(operation),
+            SqlValue.Text(tableName),
+            SqlValue.Integer(rowId),
+            beforeRecord,
+            afterRecord,
+            updates);
+    }
+
+    internal void RecordSchemaChanges(
+        EmbeddedDatabase.QueryContext context,
+        EmbeddedDatabase.SchemaCatalog before,
+        EmbeddedDatabase.SchemaCatalog after,
+        ParsedStatement statement)
+    {
+        var oldRows = EnumerateSchemaRows(before).ToDictionary(row => row.Key, StringComparer.Ordinal);
+        var newRows = EnumerateSchemaRows(after).ToDictionary(row => row.Key, StringComparer.Ordinal);
+        foreach (var key in oldRows.Keys.Union(newRows.Keys).OrderBy(key => key, StringComparer.Ordinal))
+        {
+            if (!ShouldCaptureSchemaKey(statement, key))
+                continue;
+            oldRows.TryGetValue(key, out var oldRow);
+            newRows.TryGetValue(key, out var newRow);
+            if (oldRow.Row is not null
+                && newRow.Row is not null
+                && oldRow.Row.SequenceEqual(newRow.Row))
+            {
+                continue;
+            }
+
+            if (oldRow.Row is null)
+            {
+                Append(
+                    context,
+                    1,
+                    SqlValue.Text("sqlite_schema"),
+                    SqlValue.Integer(newRow.RowId),
+                    SqlValue.Null,
+                    EncodeAfter(newRow.Row!),
+                    SqlValue.Null);
+            }
+            else if (newRow.Row is null)
+            {
+                Append(
+                    context,
+                    -1,
+                    SqlValue.Text("sqlite_schema"),
+                    SqlValue.Integer(oldRow.RowId),
+                    EncodeBefore(oldRow.Row),
+                    SqlValue.Null,
+                    SqlValue.Null);
+            }
+            else
+            {
+                Append(
+                    context,
+                    0,
+                    SqlValue.Text("sqlite_schema"),
+                    SqlValue.Integer(newRow.RowId),
+                    EncodeBefore(oldRow.Row),
+                    EncodeAfter(newRow.Row),
+                    EncodeUpdates(oldRow.Row, newRow.Row));
+            }
+        }
+    }
+
+    internal bool CompleteAutocommit(EmbeddedDatabase.QueryContext context)
+    {
+        if (!_statementEligible || _configuration.Version != ChangeDataCaptureVersion.V2)
+            return false;
+
+        Append(context, 2, SqlValue.Null, SqlValue.Null, SqlValue.Null, SqlValue.Null, SqlValue.Null);
+        ResetTransaction();
+        return true;
+    }
+
+    internal bool CompleteExplicitTransaction(
+        IReadOnlyDictionary<string, EmbeddedTable> tables,
+        MvStore? concurrentStore,
+        MvccTxId? concurrentTxId)
+    {
+        if (_configuration.Version != ChangeDataCaptureVersion.V2 || !_hasCapturedRows)
+            return false;
+
+        Append(tables, concurrentStore, concurrentTxId, 2, SqlValue.Null, SqlValue.Null, SqlValue.Null, SqlValue.Null, SqlValue.Null);
+        ResetTransaction();
+        return true;
+    }
+
+    private void Append(
+        EmbeddedDatabase.QueryContext context,
+        long changeType,
+        SqlValue tableName,
+        SqlValue id,
+        SqlValue before,
+        SqlValue after,
+        SqlValue updates)
+        => Append(
+            context.Tables,
+            context.ConcurrentMvStore,
+            context.ConcurrentMvccTxId,
+            changeType,
+            tableName,
+            id,
+            before,
+            after,
+            updates);
+
+    private void Append(
+        IReadOnlyDictionary<string, EmbeddedTable> tables,
+        MvStore? concurrentStore,
+        MvccTxId? concurrentTxId,
+        long changeType,
+        SqlValue tableName,
+        SqlValue id,
+        SqlValue before,
+        SqlValue after,
+        SqlValue updates)
+    {
+        if (!tables.TryGetValue(_configuration.Table, out var cdcTable))
+            throw new EmbeddedSqlException($"no such table: {_configuration.Table}");
+        if (!cdcTable.HasRowid || !cdcTable.IsAutoIncrement)
+            throw new EmbeddedSqlException($"CDC table '{_configuration.Table}' has an unsupported schema");
+
+        var changeId = AllocateChangeId(tables, cdcTable, concurrentStore);
+        var transactionId = _configuration.Version == ChangeDataCaptureVersion.V2
+            ? GetOrSetTransactionId(changeId)
+            : -1;
+        SqlValue[] row = _configuration.Version switch
+        {
+            ChangeDataCaptureVersion.V1 =>
+            [
+                SqlValue.Null,
+                SqlValue.Integer(DateTimeOffset.UtcNow.ToUnixTimeSeconds()),
+                SqlValue.Integer(changeType),
+                tableName,
+                id,
+                before,
+                after,
+                updates,
+            ],
+            ChangeDataCaptureVersion.V2 =>
+            [
+                SqlValue.Null,
+                SqlValue.Integer(DateTimeOffset.UtcNow.ToUnixTimeSeconds()),
+                SqlValue.Integer(transactionId),
+                SqlValue.Integer(changeType),
+                tableName,
+                id,
+                before,
+                after,
+                updates,
+            ],
+            _ => throw new InvalidOperationException($"Unknown CDC version {_configuration.Version}."),
+        };
+        if (cdcTable.ColumnDefinitions.Length != row.Length)
+            throw new EmbeddedSqlException($"CDC table '{_configuration.Table}' has an unsupported schema");
+
+        if (cdcTable.RowidAliasColumnIndex >= 0)
+            row[cdcTable.RowidAliasColumnIndex] = SqlValue.Integer(changeId);
+        cdcTable.Rows.Add(row);
+        cdcTable.RowIds.Add(changeId);
+        if (concurrentStore is { } store && concurrentTxId is { } txId)
+        {
+            store.Insert(
+                txId,
+                new MvccRowId(store.GetOrCreateTableId(_configuration.Table), changeId),
+                row);
+        }
+
+        if (changeType != 2)
+            _hasCapturedRows = true;
+    }
+
+    private long AllocateChangeId(
+        IReadOnlyDictionary<string, EmbeddedTable> tables,
+        EmbeddedTable cdcTable,
+        MvStore? concurrentStore)
+    {
+        var allocator = new EmbeddedDatabase.AutoIncrementStatementState();
+        var tracker = allocator.GetTracker(_configuration.Table, cdcTable, tables);
+        var largest = cdcTable.RowIds.Count == 0 ? 0 : cdcTable.RowIds.Max();
+        long changeId;
+        if (concurrentStore is { } store)
+        {
+            changeId = store.AllocateRowId(
+                store.GetOrCreateTableId(_configuration.Table),
+                minimumExclusive: largest);
+            tracker.Observe(changeId);
+        }
+        else
+        {
+            changeId = tracker.NextRowId(cdcTable.RowIds.Count != 0, largest);
+        }
+
+        _ = allocator.Commit(tables);
+        return changeId;
+    }
+
+    private long GetOrSetTransactionId(long candidate)
+    {
+        if (_transactionId < 0)
+            _transactionId = candidate;
+        return _transactionId;
+    }
+
+    private SqlValue EncodeBefore(IReadOnlyList<SqlValue> row)
+        => _configuration.HasBefore ? SqlValue.Blob(SqliteRecordCodec.Encode(row)) : SqlValue.Null;
+
+    private SqlValue EncodeAfter(IReadOnlyList<SqlValue> row)
+        => _configuration.HasAfter ? SqlValue.Blob(SqliteRecordCodec.Encode(row)) : SqlValue.Null;
+
+    private SqlValue EncodeUpdates(IReadOnlyList<SqlValue> before, IReadOnlyList<SqlValue> after)
+        => _configuration.HasUpdates
+            ? SqlValue.Blob(EncodeUpdateRecord(before, after))
+            : SqlValue.Null;
+
+    private bool IsCaptureableStatement(ParsedStatement statement)
+    {
+        var target = TryGetTargetName(statement);
+        if (target is not null && IsExcludedTable(target))
+            return false;
+
+        return statement is InsertStatement or UpdateStatement or DeleteStatement or WithDmlStatement
+            || EmbeddedDatabase.MayChangeSchema(statement);
+    }
+
+    private static bool ShouldCaptureSchemaKey(ParsedStatement statement, string key)
+    {
+        return statement switch
+        {
+            DropTableStatement drop => key.Equals("table:" + drop.Name, StringComparison.OrdinalIgnoreCase),
+            CreateTableStatement create => key.Equals("table:" + create.Name, StringComparison.OrdinalIgnoreCase),
+            CreateVirtualTableStatement create => key.Equals("table:" + create.Name, StringComparison.OrdinalIgnoreCase),
+            CreateTableAsSelectStatement create => key.Equals("table:" + create.Name, StringComparison.OrdinalIgnoreCase),
+            DropIndexStatement drop => key.Equals("index:" + drop.Name, StringComparison.OrdinalIgnoreCase),
+            CreateIndexStatement create => key.Equals("index:" + create.Name, StringComparison.OrdinalIgnoreCase),
+            DropViewStatement drop => key.Equals("view:" + drop.Name, StringComparison.OrdinalIgnoreCase),
+            CreateViewStatement create => key.Equals("view:" + create.Name, StringComparison.OrdinalIgnoreCase),
+            DropTriggerStatement drop => key.Equals("trigger:" + drop.Name, StringComparison.OrdinalIgnoreCase),
+            CreateTriggerStatement create => key.Equals("trigger:" + create.Name, StringComparison.OrdinalIgnoreCase),
+            _ => true,
+        };
+    }
+
+    private bool IsExcludedTable(string table)
+        => string.Equals(table, _configuration.Table, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(table, ChangeDataCaptureConfiguration.VersionTableName, StringComparison.OrdinalIgnoreCase);
+
+    private static string? TryGetTargetName(ParsedStatement statement)
+    {
+        return statement switch
+        {
+            InsertStatement insert => insert.TableName,
+            UpdateStatement update => update.TableName,
+            DeleteStatement delete => delete.TableName,
+            WithDmlStatement with => TryGetTargetName(with.Dml),
+            CreateTableStatement create => create.Name,
+            CreateVirtualTableStatement create => create.Name,
+            CreateTableAsSelectStatement create => create.Name,
+            DropTableStatement drop => drop.Name,
+            CreateIndexStatement create => create.TableName,
+            DropIndexStatement drop => drop.Name,
+            CreateViewStatement create => create.Name,
+            DropViewStatement drop => drop.Name,
+            CreateTriggerStatement create => create.TableName,
+            DropTriggerStatement drop => drop.Name,
+            AlterTableAddColumnStatement alter => alter.TableName,
+            AlterTableRenameStatement alter => alter.TableName,
+            AlterTableRenameColumnStatement alter => alter.TableName,
+            AlterTableAlterColumnStatement alter => alter.TableName,
+            AlterTableDropColumnStatement alter => alter.TableName,
+            _ => null,
+        };
+    }
+
+    private static SqlValue[]? TryFindRow(EmbeddedTable table, long rowId)
+    {
+        var index = table.RowIds.IndexOf(rowId);
+        return index >= 0 && index < table.Rows.Count ? table.Rows[index].ToArray() : null;
+    }
+
+    private static long ChangeType(SqliteChangeOperation operation) => operation switch
+    {
+        SqliteChangeOperation.Insert => 1,
+        SqliteChangeOperation.Update => 0,
+        SqliteChangeOperation.Delete => -1,
+        _ => throw new InvalidOperationException($"Unknown CDC operation {operation}."),
+    };
+
+    private static byte[] EncodeUpdateRecord(IReadOnlyList<SqlValue> before, IReadOnlyList<SqlValue> after)
+    {
+        var count = Math.Min(before.Count, after.Count);
+        var values = new SqlValue[count * 2];
+        for (var index = 0; index < count; index++)
+        {
+            var changed = !before[index].Equals(after[index]);
+            values[index] = SqlValue.Integer(changed ? 1 : 0);
+            values[count + index] = changed ? after[index] : SqlValue.Null;
+        }
+
+        return SqliteRecordCodec.Encode(values);
+    }
+
+    private IEnumerable<SchemaRow> EnumerateSchemaRows(EmbeddedDatabase.SchemaCatalog catalog)
+    {
+        long rowId = 0;
+        foreach (var table in catalog.Tables)
+        {
+            var tableIsCapturable = !IsExcludedSchemaTable(table.Key);
+            var tableRowId = ++rowId;
+
+            if (tableIsCapturable)
+            {
+                yield return new SchemaRow(
+                    "table:" + table.Key,
+                    tableRowId,
+                    [
+                        SqlValue.Text("table"),
+                        SqlValue.Text(table.Key),
+                        SqlValue.Text(table.Key),
+                        SqlValue.Integer(0),
+                        SqlValue.Text(table.Value.Sql ?? EmbeddedDatabase.BuildCreateTableSql(table.Key, table.Value)),
+                    ]);
+            }
+            foreach (var index in table.Value.Indexes
+                         .Where(index => index.Origin == EmbeddedIndexOrigin.Explicit)
+                         .OrderBy(index => index.Name, StringComparer.OrdinalIgnoreCase))
+            {
+                var indexRowId = ++rowId;
+                if (!tableIsCapturable)
+                    continue;
+                yield return new SchemaRow(
+                    "index:" + index.Name,
+                    indexRowId,
+                    [
+                        SqlValue.Text("index"),
+                        SqlValue.Text(index.Name),
+                        SqlValue.Text(table.Key),
+                        SqlValue.Integer(0),
+                        SqlValue.Text(index.Sql ?? string.Empty),
+                    ]);
+            }
+        }
+
+        foreach (var view in catalog.Views.OrderBy(entry => entry.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            yield return new SchemaRow(
+                "view:" + view.Key,
+                ++rowId,
+                [
+                    SqlValue.Text("view"),
+                    SqlValue.Text(view.Key),
+                    SqlValue.Text(view.Key),
+                    SqlValue.Integer(0),
+                    SqlValue.Text(view.Value.Sql),
+                ]);
+        }
+
+        foreach (var trigger in catalog.Triggers
+                     .OrderBy(entry => entry.Value.DeclarationOrder)
+                     .ThenBy(entry => entry.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            yield return new SchemaRow(
+                "trigger:" + trigger.Key,
+                ++rowId,
+                [
+                    SqlValue.Text("trigger"),
+                    SqlValue.Text(trigger.Key),
+                    SqlValue.Text(trigger.Value.TableName),
+                    SqlValue.Integer(0),
+                    SqlValue.Text(trigger.Value.Sql),
+                ]);
+        }
+    }
+
+    private bool IsExcludedSchemaTable(string tableName)
+        => IsExcludedTable(tableName)
+            || tableName.StartsWith("sqlite_", StringComparison.OrdinalIgnoreCase)
+            || EmbeddedDatabase.IsAutoIncrementSequenceBackingTable(tableName);
+
+    private readonly record struct SchemaRow(string Key, long RowId, SqlValue[]? Row);
+}
+
+public sealed partial class EmbeddedConnection
+{
+    private ExecutionResult ExecutePragmaCaptureDataChangesConnection(
+        PragmaCaptureDataChangesConnectionStatement statement)
+    {
+        if (statement.Schema is not null
+            && !statement.Schema.Equals("main", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new EmbeddedSqlException("CDC tables must be in the main database");
+        }
+
+        if (statement.Value is null)
+        {
+            return _changeDataCapture is { } session
+                ? new ExecutionResult(
+                    ["capture_data_changes_conn", "table_name", "version"],
+                    [[
+                        SqlValue.Text(session.Configuration.ModeName),
+                        SqlValue.Text(session.Configuration.Table),
+                        SqlValue.Text(session.Configuration.VersionName),
+                    ]],
+                    0)
+                : new ExecutionResult(
+                    ["capture_data_changes_conn", "table_name", "version"],
+                    [[SqlValue.Text("off"), SqlValue.Null, SqlValue.Null]],
+                    0);
+        }
+
+        var requested = ChangeDataCaptureConfiguration.Parse(
+            statement.Value,
+            ChangeDataCaptureVersion.V2);
+        if (requested is null)
+        {
+            _changeDataCapture = null;
+            return ExecutionResult.Empty;
+        }
+
+        if (_changeDataCapture is { } active)
+        {
+            _changeDataCapture = active.Reconfigure(
+                requested with { Version = active.Configuration.Version });
+            return ExecutionResult.Empty;
+        }
+
+        var ownsProvisioningTransaction = _transactionDatabases is null;
+        if (ownsProvisioningTransaction)
+            BeginTransaction(openedBySavepoint: false, TransactionMode.Deferred);
+
+        try
+        {
+            var beforeProvisioning = CurrentMainCatalog();
+            var cdcTableExisted = beforeProvisioning.Tables.ContainsKey(requested.Table);
+            ExecuteCdcProvisioningSql(BuildCdcCreateTableSql(requested));
+            ExecuteCdcProvisioningSql(
+                $"CREATE TABLE IF NOT EXISTS {SqlIdentifierFormatter.Quote(ChangeDataCaptureConfiguration.VersionTableName)} " +
+                "(table_name TEXT PRIMARY KEY, version TEXT NOT NULL)");
+
+            var catalog = CurrentMainCatalog();
+            var actualVersion = ReadCdcVersion(catalog, requested.Table);
+            if (actualVersion is null)
+            {
+                var initialVersion = cdcTableExisted
+                    ? ChangeDataCaptureVersion.V1
+                    : ChangeDataCaptureVersion.V2;
+                ExecuteCdcProvisioningSql(
+                    $"INSERT OR IGNORE INTO {SqlIdentifierFormatter.Quote(ChangeDataCaptureConfiguration.VersionTableName)} " +
+                    $"(table_name, version) VALUES ({SqlLiteral(requested.Table)}, {SqlLiteral(VersionName(initialVersion))})");
+                actualVersion = ReadCdcVersion(CurrentMainCatalog(), requested.Table)
+                    ?? throw new EmbeddedSqlException("CDC version initialization did not persist");
+            }
+
+            if (ownsProvisioningTransaction)
+                CommitTransaction();
+            _changeDataCapture = new ChangeDataCaptureSession(requested with { Version = actualVersion.Value });
+            return ExecutionResult.Empty;
+        }
+        catch
+        {
+            if (ownsProvisioningTransaction && _transactionDatabases is not null)
+                ResetTransactionState();
+            throw;
+        }
+    }
+
+    private EmbeddedDatabase.SchemaCatalog CurrentMainCatalog()
+        => GetTransactionState(_database)?.Catalog ?? _database.SnapshotCatalog();
+
+    private void ExecuteCdcProvisioningSql(string sql)
+    {
+        var previousSuppression = _suppressUpdateHook;
+        _suppressUpdateHook = true;
+        try
+        {
+            Execute(
+                SqlParser.Parse(sql, SqlParameterMap.Parse(sql)),
+                [],
+                CancellationToken.None);
+        }
+        finally
+        {
+            _suppressUpdateHook = previousSuppression;
+        }
+    }
+
+    private static string BuildCdcCreateTableSql(ChangeDataCaptureConfiguration configuration)
+    {
+        var columns = configuration.Version switch
+        {
+            ChangeDataCaptureVersion.V1 =>
+                "change_id INTEGER PRIMARY KEY AUTOINCREMENT, change_time INTEGER, change_type INTEGER, table_name TEXT, id, before BLOB, after BLOB, updates BLOB",
+            ChangeDataCaptureVersion.V2 =>
+                "change_id INTEGER PRIMARY KEY AUTOINCREMENT, change_time INTEGER, change_txn_id INTEGER, change_type INTEGER, table_name TEXT, id, before BLOB, after BLOB, updates BLOB",
+            _ => throw new InvalidOperationException($"Unknown CDC version {configuration.Version}."),
+        };
+        return $"CREATE TABLE IF NOT EXISTS {SqlIdentifierFormatter.Quote(configuration.Table)} ({columns})";
+    }
+
+    private static ChangeDataCaptureVersion? ReadCdcVersion(
+        EmbeddedDatabase.SchemaCatalog catalog,
+        string tableName)
+    {
+        if (!catalog.Tables.TryGetValue(ChangeDataCaptureConfiguration.VersionTableName, out var versions))
+            return null;
+
+        for (var index = 0; index < versions.Rows.Count; index++)
+        {
+            var row = versions.Rows[index];
+            if (row.Length < 2
+                || row[0].Kind != SqlValueKind.Text
+                || !string.Equals(row[0].AsText(), tableName, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (row[1].Kind != SqlValueKind.Text)
+                throw new EmbeddedSqlException("unexpected CDC version");
+            return row[1].AsText() switch
+            {
+                "v1" => ChangeDataCaptureVersion.V1,
+                "v2" => ChangeDataCaptureVersion.V2,
+                _ => throw new EmbeddedSqlException($"unexpected CDC version: {row[1].AsText()}"),
+            };
+        }
+
+        return null;
+    }
+
+    private static string VersionName(ChangeDataCaptureVersion version)
+        => version == ChangeDataCaptureVersion.V1 ? "v1" : "v2";
+
+    private static string SqlLiteral(string value)
+        => "'" + value.Replace("'", "''", StringComparison.Ordinal) + "'";
+}

--- a/src/Ahtola.Core/EmbeddedDatabase.Triggers.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.Triggers.cs
@@ -1083,7 +1083,12 @@ public sealed partial class EmbeddedDatabase
             [deletedRow]);
         if (table.HasRowid)
             RecordBlobMutation(tableName, deletedRowId);
-        context.ReportRowChange(SqliteChangeOperation.Delete, tableName, table, deletedRowId);
+        context.ReportRowChange(
+            SqliteChangeOperation.Delete,
+            tableName,
+            table,
+            deletedRowId,
+            deletedRow);
     }
 
     private void AppendReturningRow(

--- a/src/Ahtola.Core/EmbeddedDatabase.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.cs
@@ -638,7 +638,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
         IReadOnlyDictionary<string, EmbeddedTable>? ConcurrentBaseTables = null,
         ConcurrentMvccIdentityTracker? ConcurrentMvccIdentityTracker = null,
         SqliteTextEncoding MvccTextEncoding = SqliteTextEncoding.Utf8,
-        IReadOnlyDictionary<string, VirtualTableDefinition>? VirtualTables = null)
+        IReadOnlyDictionary<string, VirtualTableDefinition>? VirtualTables = null,
+        ChangeDataCaptureSession? ChangeDataCapture = null)
     {
         /// <summary>
         /// Row-loop checkpoint. It honors cooperative cancellation exactly as before and
@@ -658,9 +659,19 @@ public sealed partial class EmbeddedDatabase : IDisposable
         /// Concurrent MVCC transactions also mirror INSERT/DELETE/UPDATE into the version
         /// store here (including trigger-body and multi-row inserts).
         /// </summary>
-        internal void ReportRowChange(SqliteChangeOperation operation, string tableName, EmbeddedTable table, long rowId)
+        internal void ReportRowChange(
+            SqliteChangeOperation operation,
+            string tableName,
+            EmbeddedTable table,
+            long rowId,
+            SqlValue[]? before = null,
+            SqlValue[]? after = null,
+            bool recordChangeDataCapture = true,
+            bool recordMvcc = true,
+            bool reportUpdateHook = true)
         {
-            if (table.HasRowid
+            if (recordMvcc
+                && table.HasRowid
                 && ConcurrentMvStore is { } store
                 && ConcurrentMvccTxId is { } txId
                 && !tableName.StartsWith("sqlite_", StringComparison.OrdinalIgnoreCase))
@@ -714,14 +725,18 @@ public sealed partial class EmbeddedDatabase : IDisposable
                         }
                 }
             }
-            else if (ConcurrentMvStore is { } typedStore
+            else if (recordMvcc
+                && ConcurrentMvStore is { } typedStore
                 && ConcurrentMvccTxId is { } typedTxId
                 && !tableName.StartsWith("sqlite_", StringComparison.OrdinalIgnoreCase))
             {
                 ReportWithoutRowidMvccChange(typedStore, typedTxId, operation, tableName, table, rowId);
             }
 
-            if (Hooks?.RowChanged is not { } rowChanged || !table.HasRowid)
+            if (recordChangeDataCapture)
+                ChangeDataCapture?.RecordRow(this, operation, tableName, table, rowId, before, after);
+
+            if (!reportUpdateHook || Hooks?.RowChanged is not { } rowChanged || !table.HasRowid)
                 return;
             if (tableName.StartsWith("sqlite_", StringComparison.OrdinalIgnoreCase))
                 return;
@@ -1365,7 +1380,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
         ManagedStatementHooks? hooks = null,
         bool ignoreCheckConstraints = false,
         Func<string?, string?, ExecutionResult>? executeTableList = null,
-        IReadOnlyDictionary<string, EmbeddedTable>? externalTables = null)
+        IReadOnlyDictionary<string, EmbeddedTable>? externalTables = null,
+        ChangeDataCaptureSession? changeDataCapture = null)
     {
         var result = ExecuteCore(
             statement,
@@ -1381,7 +1397,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
             hooks,
             ignoreCheckConstraints,
             executeTableList,
-            externalTables);
+            externalTables,
+            changeDataCapture);
 
         RecordChangeCounters(statement, result);
         return result;
@@ -1414,7 +1431,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
         ManagedStatementHooks? hooks = null,
         bool ignoreCheckConstraints = false,
         Func<string?, string?, ExecutionResult>? executeTableList = null,
-        IReadOnlyDictionary<string, EmbeddedTable>? externalTables = null)
+        IReadOnlyDictionary<string, EmbeddedTable>? externalTables = null,
+        ChangeDataCaptureSession? changeDataCapture = null)
     {
         ThrowIfRecursiveTriggerCallbackReentry();
         if (RequiresRecursiveTriggerStack(
@@ -1436,7 +1454,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 hooks,
                 ignoreCheckConstraints,
                 executeTableList,
-                externalTables));
+                externalTables,
+                changeDataCapture));
         }
 
         cancellationToken.ThrowIfCancellationRequested();
@@ -1482,7 +1501,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
                                 hooks,
                                 ignoreCheckConstraints,
                                 executeTableList,
-                                externalTables);
+                                externalTables,
+                                changeDataCapture: changeDataCapture);
                         }
                         catch (EmbeddedConflictFailException)
                         {
@@ -1550,7 +1570,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
                                 hooks,
                                 ignoreCheckConstraints,
                                 executeTableList,
-                                externalTables);
+                                externalTables,
+                                changeDataCapture: changeDataCapture);
                         }
                         catch (EmbeddedConflictFailException)
                         {
@@ -1590,7 +1611,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
                             hooks,
                             ignoreCheckConstraints,
                             executeTableList,
-                            externalTables);
+                            externalTables,
+                            changeDataCapture: changeDataCapture);
 
                     var working = new SchemaCatalog(_tables, _views, _triggers, _virtualTables).Clone();
                     ExecutionResult result;
@@ -1611,7 +1633,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
                             hooks,
                             ignoreCheckConstraints,
                             executeTableList,
-                            externalTables);
+                            externalTables,
+                            changeDataCapture: changeDataCapture);
                     }
                     catch (EmbeddedConflictFailException)
                     {
@@ -1708,7 +1731,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 ConcurrentMvccTxId: outer.ConcurrentMvccTxId,
                 ConcurrentBaseTables: outer.ConcurrentBaseTables,
                 ConcurrentMvccIdentityTracker: outer.ConcurrentMvccIdentityTracker,
-                MvccTextEncoding: outer.MvccTextEncoding);
+                MvccTextEncoding: outer.MvccTextEncoding,
+                ChangeDataCapture: outer.ChangeDataCapture);
             return statement switch
             {
                 InsertStatement insert => ExecuteDmlWithAutoIncrementState(
@@ -3602,7 +3626,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
         Func<string?, string?, ExecutionResult>? executeTableList = null,
         IReadOnlyDictionary<string, EmbeddedTable>? externalTables = null,
         MvStore? concurrentMvStore = null,
-        MvccTxId? concurrentMvccTxId = null)
+        MvccTxId? concurrentMvccTxId = null,
+        ChangeDataCaptureSession? changeDataCapture = null)
     {
         ThrowIfRecursiveTriggerCallbackReentry();
         if (RequiresRecursiveTriggerStack(
@@ -3627,13 +3652,18 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 executeTableList,
                 externalTables,
                 concurrentMvStore,
-                concurrentMvccTxId));
+                concurrentMvccTxId,
+                changeDataCapture));
         }
 
         cancellationToken.ThrowIfCancellationRequested();
         if (_readOnly && MayMutate(statement))
             throw new EmbeddedSqlException("attempt to write a readonly database");
 
+        var cdcSchemaBefore = changeDataCapture is not null
+            && MayChangeSchema(statement)
+                ? catalog.Clone()
+                : null;
         var tables = CreateExecutionTables(catalog.Tables, externalTables);
         var context = new QueryContext(
             tables,
@@ -3658,9 +3688,10 @@ public sealed partial class EmbeddedDatabase : IDisposable
             ConcurrentBaseTables: concurrentMvStore is null ? null : CloneTablesShallow(catalog.Tables),
             ConcurrentMvccIdentityTracker: concurrentMvStore is null ? null : new ConcurrentMvccIdentityTracker(),
             MvccTextEncoding: GetTextEncoding(),
-            VirtualTables: catalog.VirtualTables);
+            VirtualTables: catalog.VirtualTables,
+            ChangeDataCapture: changeDataCapture);
         EnsureConcurrentMvccDmlTargetIsSupported(statement, tables, context);
-        return statement switch
+        var result = statement switch
         {
             CreateTableStatement create => ExecuteCreateTable(create, catalog, cancellationToken),
             CreateVirtualTableStatement createVirtual => ExecuteCreateVirtualTable(
@@ -3740,6 +3771,12 @@ public sealed partial class EmbeddedDatabase : IDisposable
             RollbackToSavepointStatement => ExecutionResult.Empty,
             _ => throw new EmbeddedSqlException($"Unsupported statement type {statement.GetType().Name}."),
         };
+        if (cdcSchemaBefore is not null && result.Changed)
+            changeDataCapture!.RecordSchemaChanges(context, cdcSchemaBefore, catalog, statement);
+        if (!inTransaction && changeDataCapture?.CompleteAutocommit(context) == true && !result.Changed)
+            result = result with { Changed = true };
+
+        return result;
     }
 
     private static ExecutionResult ExecutePragmaTableInfo(
@@ -4625,6 +4662,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
             }
 
             tables.Remove(statement.Name);
+            RemoveChangeDataCaptureVersion(tables, statement.Name);
             if (table.IsAutoIncrement)
             {
                 DeleteSqliteSequenceRows(tables, table.Name);
@@ -4651,6 +4689,29 @@ public sealed partial class EmbeddedDatabase : IDisposable
             .ToArray();
         foreach (var trigger in orphaned)
             catalog.Triggers.Remove(trigger);
+    }
+
+    private static void RemoveChangeDataCaptureVersion(
+        IReadOnlyDictionary<string, EmbeddedTable> tables,
+        string tableName)
+    {
+        if (tableName.Equals(ChangeDataCaptureConfiguration.VersionTableName, StringComparison.OrdinalIgnoreCase)
+            || !tables.TryGetValue(ChangeDataCaptureConfiguration.VersionTableName, out var versions))
+        {
+            return;
+        }
+
+        for (var index = versions.Rows.Count - 1; index >= 0; index--)
+        {
+            var row = versions.Rows[index];
+            if (row.Length != 0
+                && row[0].Kind == SqlValueKind.Text
+                && string.Equals(row[0].AsText(), tableName, StringComparison.Ordinal))
+            {
+                versions.Rows.RemoveAt(index);
+                versions.RowIds.RemoveAt(index);
+            }
+        }
     }
 
     private static void EnsureSqliteSequenceTable(SchemaCatalog catalog)
@@ -9288,11 +9349,14 @@ public sealed partial class EmbeddedDatabase : IDisposable
                     TriggerMutationKind.Update,
                     updatePlan);
                 ApplyUpsertRows(table, updatedRows, updatedRowIds);
-                updateContext.ReportRowChange(
-                    SqliteChangeOperation.Update,
+                ReportUpdateChange(
+                    updateContext,
                     statement.TableName,
                     table,
-                    updatedRowIds[conflictPosition]);
+                    originalRowId,
+                    updatedRowIds[conflictPosition],
+                    originalRows[conflictPosition],
+                    updatedRows[conflictPosition]);
                 ValidateForeignKeysAfterUpdate(
                     updateContext,
                     statement.TableName,
@@ -12233,8 +12297,62 @@ public sealed partial class EmbeddedDatabase : IDisposable
 
         // SQLite reports the post-update rowid, so an UPDATE that rewrites an INTEGER PRIMARY
         // KEY notifies with the new value rather than the one the row had before.
-        foreach (var rowId in updatedRowIds)
-            context.ReportRowChange(SqliteChangeOperation.Update, tableName, table, rowId);
+        for (var index = 0; index < updatedRowIds.Length; index++)
+        {
+            var position = updatedPositions[index];
+            ReportUpdateChange(
+                context,
+                tableName,
+                table,
+                table.HasRowid ? originalRowIds[index] : updatedRowIds[index],
+                updatedRowIds[index],
+                originalRowSnapshot[position],
+                postUpdateRowSnapshot[position]);
+        }
+    }
+
+    private static void ReportUpdateChange(
+        QueryContext context,
+        string tableName,
+        EmbeddedTable table,
+        long oldRowId,
+        long newRowId,
+        SqlValue[] before,
+        SqlValue[] after)
+    {
+        if (table.HasRowid && oldRowId != newRowId)
+        {
+            context.ReportRowChange(
+                SqliteChangeOperation.Delete,
+                tableName,
+                table,
+                oldRowId,
+                before,
+                reportUpdateHook: false);
+            context.ReportRowChange(
+                SqliteChangeOperation.Insert,
+                tableName,
+                table,
+                newRowId,
+                after: after,
+                reportUpdateHook: false);
+            context.ReportRowChange(
+                SqliteChangeOperation.Update,
+                tableName,
+                table,
+                newRowId,
+                recordChangeDataCapture: false,
+                recordMvcc: false);
+            return;
+        }
+
+        context.ReportRowChange(
+            SqliteChangeOperation.Update,
+            tableName,
+            table,
+            newRowId,
+            before,
+            after);
     }
 
     // Foreign-key checks run against the complete post-statement image, but only inspect
@@ -13759,7 +13877,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
                     SqliteChangeOperation.Delete,
                     statement.TableName,
                     table,
-                    selectedRowId);
+                    selectedRowId,
+                    deletedRow);
                 deletedRows.Add(deletedRow);
                 deletedRowIds.Add(selectedRowId);
                 if (afterTriggers.Count > 0)
@@ -13999,8 +14118,15 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 RecordBlobMutation(statement.TableName, rowId);
         }
 
-        foreach (var rowId in deletedRowIds)
-            context.ReportRowChange(SqliteChangeOperation.Delete, statement.TableName, table, rowId);
+        for (var index = 0; index < deletedRowIds.Count; index++)
+        {
+            context.ReportRowChange(
+                SqliteChangeOperation.Delete,
+                statement.TableName,
+                table,
+                deletedRowIds[index],
+                deletedRows[index]);
+        }
         if (statement.Returning is not null)
             return returningResult!;
 
@@ -20352,7 +20478,7 @@ out bool hasReturning)
             GetRowId = index => index < table.RowIds.Count ? table.RowIds[index] : index + 1,
             MutateRow = index =>
             {
-                var original = table.Rows[index];
+                var original = table.Rows[index].ToArray();
                 var rowid = index < table.RowIds.Count ? table.RowIds[index] : index + 1;
                 var (updated, newRowid) = BuildUpdatedRow(statement, table, plan, original, rowid, parameters, context);
                 newRows[index] = updated;
@@ -20449,6 +20575,7 @@ out bool hasReturning)
 
         var rowCount = table.Rows.Count;
         var deleted = new bool[rowCount];
+        var deletedRows = new Dictionary<long, SqlValue[]>();
         var returningRows = hasReturning ? new List<SqlValue[]>(rowCount) : null;
         var returningRowIds = hasReturning ? new List<long>(rowCount) : null;
         var writeTarget = new VdbeWriteTarget
@@ -20474,6 +20601,7 @@ out bool hasReturning)
                     if (index < deleted.Length && deleted[index])
                     {
                         deletedRowIds.Add(rowId);
+                        deletedRows[rowId] = table.Rows[index].ToArray();
                         continue;
                     }
                     keptRows.Add(table.Rows[index]);
@@ -20490,7 +20618,8 @@ out bool hasReturning)
                         SqliteChangeOperation.Delete,
                         statement.TableName,
                         table,
-                        deletedRowId);
+                        deletedRowId,
+                        deletedRows[deletedRowId]);
                 }
 
                 return (long?)null;
@@ -20682,7 +20811,14 @@ out bool hasReturning)
                 table.Rows[index] = updated;
                 if (table.HasRowid)
                     table.RowIds[index] = newRowid;
-                context.ReportRowChange(SqliteChangeOperation.Update, statement.TableName, table, newRowid);
+                ReportUpdateChange(
+                    context,
+                    statement.TableName,
+                    table,
+                    rowid,
+                    newRowid,
+                    original,
+                    updated);
                 return new VdbeRowMutation(updated, newRowid);
             },
             Commit = () =>
@@ -20781,11 +20917,18 @@ out bool hasReturning)
                     if (position < 0)
                         return new VdbeRowMutation(new SqlValue[table.Columns.Length], sourceRowIds[index]);
 
-                    var updated = (SqlValue[])table.Rows[position].Clone();
+                    var original = table.Rows[position].ToArray();
+                    var updated = (SqlValue[])original.Clone();
                     for (var key = 0; key < childColumns.Length; key++)
                         updated[childColumns[key]] = setNull ? SqlValue.Null : newValues[key];
                     table.Rows[position] = updated;
-                    context.ReportRowChange(SqliteChangeOperation.Update, tableName, table, sourceRowIds[index]);
+                    context.ReportRowChange(
+                        SqliteChangeOperation.Update,
+                        tableName,
+                        table,
+                        sourceRowIds[index],
+                        original,
+                        updated);
                     _totalChanges++;
                     return new VdbeRowMutation(updated, sourceRowIds[index]);
                 },
@@ -21071,11 +21214,18 @@ out bool hasReturning)
                     if (position < 0)
                         return new VdbeRowMutation(new SqlValue[table.Columns.Length], sourceRowIds[index]);
 
-                    var updated = (SqlValue[])table.Rows[position].Clone();
+                    var original = table.Rows[position].ToArray();
+                    var updated = (SqlValue[])original.Clone();
                     foreach (var column in childColumns)
                         updated[column] = SqlValue.Null;
                     table.Rows[position] = updated;
-                    context.ReportRowChange(SqliteChangeOperation.Update, tableName, table, sourceRowIds[index]);
+                    context.ReportRowChange(
+                        SqliteChangeOperation.Update,
+                        tableName,
+                        table,
+                        sourceRowIds[index],
+                        original,
+                        updated);
                     _totalChanges++;
                     return new VdbeRowMutation(updated, sourceRowIds[index]);
                 },
@@ -21095,9 +21245,10 @@ out bool hasReturning)
         if (position < 0)
             return false;
 
+        var deletedRow = table.Rows[position].ToArray();
         table.Rows.RemoveAt(position);
         table.RowIds.RemoveAt(position);
-        context.ReportRowChange(SqliteChangeOperation.Delete, tableName, table, rowId);
+        context.ReportRowChange(SqliteChangeOperation.Delete, tableName, table, rowId, deletedRow);
         if (countAsCascade)
             _totalChanges++;
         return true;
@@ -41561,7 +41712,7 @@ out bool hasReturning)
     }
 }
 
-public sealed class EmbeddedConnection : IDisposable
+public sealed partial class EmbeddedConnection : IDisposable
 {
     private const int MaximumAttachedDatabases = 10;
     private const char UnqualifiedSchemaMarker = '\0';
@@ -41602,6 +41753,8 @@ public sealed class EmbeddedConnection : IDisposable
     private bool _tempInitialized;
     private readonly Dictionary<EmbeddedDatabase, int> _pendingPageSizes = [];
     private readonly ManagedConnectionHooks _hooks = new();
+    private ChangeDataCaptureSession? _changeDataCapture;
+    private bool _suppressUpdateHook;
     private bool _insideHookCallback;
     private bool _disposed;
     private TimeSpan _busyTimeout = TimeSpan.Zero;
@@ -42558,7 +42711,7 @@ public sealed class EmbeddedConnection : IDisposable
         var schema = ResolveSchemaName(database);
         return new ManagedStatementHooks
         {
-            RowChanged = updateHook is null
+            RowChanged = updateHook is null || _suppressUpdateHook
                 ? null
                 : (operation, table, rowId) => InvokeHook(
                     () => updateHook(new SqliteRowChange(operation, schema, table, rowId))),
@@ -42696,6 +42849,8 @@ public sealed class EmbeddedConnection : IDisposable
         _mvccGcThreshold = DefaultMvccGcThreshold;
         _tempInitialized = false;
         _pendingPageSizes.Clear();
+        _changeDataCapture = null;
+        _suppressUpdateHook = false;
         _hooks.UpdateHook = null;
         _hooks.CommitHook = null;
         _hooks.RollbackHook = null;
@@ -42972,6 +43127,8 @@ public sealed class EmbeddedConnection : IDisposable
                 return ExecutePragmaDeferForeignKeys(deferForeignKeys);
             case PragmaRecursiveTriggersStatement recursiveTriggers:
                 return ExecutePragmaRecursiveTriggers(recursiveTriggers);
+            case PragmaCaptureDataChangesConnectionStatement captureDataChanges:
+                return ExecutePragmaCaptureDataChangesConnection(captureDataChanges);
             case PragmaHeaderIntegerStatement headerInteger:
                 return ExecutePragmaHeaderInteger(headerInteger, cancellationToken);
             case PragmaJournalModeStatement journalMode:
@@ -43039,6 +43196,9 @@ public sealed class EmbeddedConnection : IDisposable
                 EmbeddedDatabase.SchemaCatalog? statementCatalog = null;
                 HashSet<EmbeddedDatabase.ForeignKeyViolation>? deferredBefore = null;
                 var tempTriggers = CreateTempTriggerBridge(routed.Database, out var tempTriggerSession);
+                var changeDataCapture = _changeDataCapture;
+                changeDataCapture?.BeginStatement(routed.Statement);
+                var changeDataCaptureSnapshot = changeDataCapture?.Snapshot();
                 var pendingTempTriggerRewrite = PrepareTempTriggerTableRename(routed, cancellationToken)
                     ?? PrepareTempTriggerColumnRename(routed, cancellationToken);
                 ValidateTempTriggersAfterDropColumn(routed, cancellationToken);
@@ -43087,7 +43247,8 @@ public sealed class EmbeddedConnection : IDisposable
                                 ignoreCheckConstraints: _ignoreCheckConstraints,
                                 executeTableList: ExecutePragmaTableList,
                                 concurrentMvStore: concurrentStore,
-                                concurrentMvccTxId: concurrentTxId);
+                                concurrentMvccTxId: concurrentTxId,
+                                changeDataCapture: changeDataCapture);
                         }
                         else if (transactionState is null)
                         {
@@ -43108,7 +43269,8 @@ public sealed class EmbeddedConnection : IDisposable
                                     CreateStatementHooks(routed.Database, includeCommitGate: true),
                                     ignoreCheckConstraints: _ignoreCheckConstraints,
                                     executeTableList: ExecutePragmaTableList,
-                                    externalTables: routed.ExternalTables);
+                                    externalTables: routed.ExternalTables,
+                                    changeDataCapture: changeDataCapture);
                             }
                             catch (Exception failure)
                                 when (failure is not EmbeddedConflictFailException
@@ -43145,7 +43307,8 @@ public sealed class EmbeddedConnection : IDisposable
                                 executeTableList: ExecutePragmaTableList,
                                 externalTables: routed.ExternalTables,
                                 concurrentMvStore: concurrentStore,
-                                concurrentMvccTxId: concurrentTxId);
+                                concurrentMvccTxId: concurrentTxId,
+                                changeDataCapture: changeDataCapture);
                             if (EmbeddedDatabase.MayMutate(routed.Statement))
                                 cancellationToken.ThrowIfCancellationRequested();
                             // The catalog overload used for transactional statements does not
@@ -43216,6 +43379,8 @@ public sealed class EmbeddedConnection : IDisposable
                 }
                 catch (EmbeddedConflictRollbackException exception)
                 {
+                    if (changeDataCaptureSnapshot is { } snapshot)
+                        changeDataCapture?.Restore(snapshot);
                     if (exception.LastInsertRowId is { } rolledBackInsertRowId)
                         _lastInsertRowId = rolledBackInsertRowId;
                     if (_transactionDatabases is not null)
@@ -43228,6 +43393,8 @@ public sealed class EmbeddedConnection : IDisposable
                 }
                 catch (EmbeddedStatementAbortException exception)
                 {
+                    if (changeDataCaptureSnapshot is { } snapshot)
+                        changeDataCapture?.Restore(snapshot);
                     _lastInsertRowId = exception.LastInsertRowId;
                     RollbackConcurrentStatementSavepoint(
                         concurrentStore,
@@ -43238,6 +43405,8 @@ public sealed class EmbeddedConnection : IDisposable
                 }
                 catch (EmbeddedStatementFailureException exception)
                 {
+                    if (changeDataCaptureSnapshot is { } snapshot)
+                        changeDataCapture?.Restore(snapshot);
                     _lastInsertRowId = exception.LastInsertRowId;
                     RollbackConcurrentStatementSavepoint(
                         concurrentStore,
@@ -43301,6 +43470,8 @@ public sealed class EmbeddedConnection : IDisposable
 
                     if (!exception.PreserveChanges)
                     {
+                        if (changeDataCaptureSnapshot is { } snapshot)
+                            changeDataCapture?.Restore(snapshot);
                         RollbackConcurrentStatementSavepoint(
                             concurrentStore,
                             concurrentTxId,
@@ -43318,6 +43489,8 @@ public sealed class EmbeddedConnection : IDisposable
                 }
                 catch (OperationCanceledException)
                 {
+                    if (changeDataCaptureSnapshot is { } snapshot)
+                        changeDataCapture?.Restore(snapshot);
                     RollbackConcurrentStatementSavepoint(
                         concurrentStore,
                         concurrentTxId,
@@ -43332,6 +43505,8 @@ public sealed class EmbeddedConnection : IDisposable
                 }
                 catch
                 {
+                    if (changeDataCaptureSnapshot is { } snapshot)
+                        changeDataCapture?.Restore(snapshot);
                     RollbackConcurrentStatementSavepoint(
                         concurrentStore,
                         concurrentTxId,
@@ -46049,6 +46224,7 @@ Func<string, ParsedStatement> rewrite)
         foreach (var pair in mvccTxs)
             _mvccTransactions[pair.Key] = pair.Value;
         _savepoints.Clear();
+        _changeDataCapture?.StartTransaction();
     }
 
     /// <summary>
@@ -46316,6 +46492,16 @@ Func<string, ParsedStatement> rewrite)
             throw new InvalidOperationException("No managed transaction is active.");
 
         ValidateDeferredForeignKeys();
+        if (_changeDataCapture is { } changeDataCapture
+            && _transactionDatabases.TryGetValue(_database, out var cdcState))
+        {
+            TryGetConcurrentMvccScope(_database, out var cdcStore, out var cdcTxId);
+            if (changeDataCapture.CompleteExplicitTransaction(cdcState.Catalog.Tables, cdcStore, cdcTxId))
+            {
+                cdcState.HasChanges = true;
+                _transactionWriteDatabase = _database;
+            }
+        }
         var changed = _transactionDatabases
             .Where(pair => pair.Value.HasChanges)
             .ToArray();
@@ -47214,6 +47400,8 @@ Func<string, ParsedStatement> rewrite)
             return ["defer_foreign_keys"];
         if (statement is PragmaRecursiveTriggersStatement { Enabled: null })
             return ["recursive_triggers"];
+        if (statement is PragmaCaptureDataChangesConnectionStatement { Value: null })
+            return ["capture_data_changes_conn", "table_name", "version"];
         if (statement is PragmaHeaderIntegerStatement { Value: null } headerInteger)
         {
             return headerInteger.Kind switch
@@ -47304,7 +47492,8 @@ Func<string, ParsedStatement> rewrite)
                     pair.Value.ForceFullCatalogRewrite,
                     new HashSet<EmbeddedDatabase.ForeignKeyViolation>(
                         pair.Value.PendingDeferredViolations))),
-            _transactionWriteDatabase));
+            _transactionWriteDatabase,
+            _changeDataCapture?.Snapshot()));
     }
 
     private void ReleaseSavepoint(string name)
@@ -47348,6 +47537,11 @@ Func<string, ParsedStatement> rewrite)
             state.PendingDeferredViolations.UnionWith(savedState.PendingDeferredViolations);
         }
         _transactionWriteDatabase = savepoint.WriteDatabase;
+        if (_changeDataCapture is { } changeDataCapture
+            && savepoint.ChangeDataCapture is { } changeDataCaptureSnapshot)
+        {
+            changeDataCapture.Restore(changeDataCaptureSnapshot);
+        }
 
         // Undo concurrent version-store ops after the named mark (Turso MVCC savepoints).
         foreach (var (database, txId) in _mvccTransactions)
@@ -47399,6 +47593,7 @@ Func<string, ParsedStatement> rewrite)
         }
 
         _savepoints.Clear();
+        _changeDataCapture?.ResetTransaction();
         _deferForeignKeys = false;
         ReleaseTransactionWriteReservations();
         if (transactionDatabases is not null)
@@ -47411,7 +47606,8 @@ Func<string, ParsedStatement> rewrite)
     private sealed record SavepointEntry(
         string Name,
         IReadOnlyDictionary<EmbeddedDatabase, SavepointDatabaseState> Databases,
-        EmbeddedDatabase? WriteDatabase);
+        EmbeddedDatabase? WriteDatabase,
+        ChangeDataCaptureTransactionSnapshot? ChangeDataCapture);
 
     private sealed record SavepointDatabaseState(
         EmbeddedDatabase.SchemaCatalog Catalog,

--- a/src/Ahtola.Core/Parsing/SqlAst.cs
+++ b/src/Ahtola.Core/Parsing/SqlAst.cs
@@ -307,6 +307,14 @@ internal sealed record PragmaDeferForeignKeysStatement(bool? Enabled, string? Sc
 
 internal sealed record PragmaRecursiveTriggersStatement(bool? Enabled, string? Schema = null) : ParsedStatement;
 
+/// <summary>
+/// Turso's connection-scoped public change-data-capture configuration. A null
+/// value queries the active configuration; otherwise it is <c>mode[,table]</c>.
+/// </summary>
+internal sealed record PragmaCaptureDataChangesConnectionStatement(
+    string? Value,
+    string? Schema = null) : ParsedStatement;
+
 internal enum PragmaHeaderIntegerKind
 {
     SchemaVersion,

--- a/src/Ahtola.Core/Parsing/SqlAuthorization.cs
+++ b/src/Ahtola.Core/Parsing/SqlAuthorization.cs
@@ -260,6 +260,9 @@ internal static class SqlAuthorization
                 PragmaForeignKeysStatement pragma => ("foreign_keys", Flag(pragma.Enabled)),
                 PragmaDeferForeignKeysStatement pragma => ("defer_foreign_keys", Flag(pragma.Enabled)),
                 PragmaRecursiveTriggersStatement pragma => ("recursive_triggers", Flag(pragma.Enabled)),
+                PragmaCaptureDataChangesConnectionStatement pragma => (
+                    "capture_data_changes_conn",
+                    pragma.Value),
                 PragmaSynchronousStatement pragma => ("synchronous", pragma.Value),
                 PragmaLockingModeStatement pragma => ("locking_mode", pragma.Value),
                 PragmaAutoVacuumStatement pragma => ("auto_vacuum", pragma.Value),

--- a/src/Ahtola.Core/Parsing/SqlParser.cs
+++ b/src/Ahtola.Core/Parsing/SqlParser.cs
@@ -257,6 +257,13 @@ internal sealed class SqlParser
             return new PragmaDeferForeignKeysStatement(ParseOptionalPragmaBoolean(name), schema);
         if (name.Equals("recursive_triggers", StringComparison.OrdinalIgnoreCase))
             return new PragmaRecursiveTriggersStatement(ParseOptionalPragmaBoolean(name), schema);
+        if (name.Equals("capture_data_changes_conn", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("unstable_capture_data_changes_conn", StringComparison.OrdinalIgnoreCase))
+        {
+            return new PragmaCaptureDataChangesConnectionStatement(
+                ParseOptionalPragmaCaptureDataChangesValue(name),
+                schema);
+        }
         if (name.Equals("schema_version", StringComparison.OrdinalIgnoreCase))
         {
             return new PragmaHeaderIntegerStatement(
@@ -657,6 +664,36 @@ internal sealed class SqlParser
     }
 
     private string ParsePragmaMode(string name)
+    {
+        var token = _lexer.Current;
+        if (token.Kind is not (TokenKind.Identifier or TokenKind.String))
+            throw Error($"Invalid value for PRAGMA {name}.");
+
+        _lexer.Next();
+        return token.Text;
+    }
+
+    private string? ParseOptionalPragmaCaptureDataChangesValue(string name)
+    {
+        if (_lexer.Current.Kind is TokenKind.Semicolon or TokenKind.End)
+            return null;
+
+        var parenthesized = !Consume(TokenKind.Equal);
+        if (parenthesized)
+            Expect(TokenKind.LeftParen);
+
+        var mode = ParsePragmaCaptureDataChangesPart(name);
+        string? table = null;
+        if (Consume(TokenKind.Comma))
+            table = ParsePragmaCaptureDataChangesPart(name);
+
+        if (parenthesized)
+            Expect(TokenKind.RightParen);
+
+        return table is null ? mode : mode + "," + table;
+    }
+
+    private string ParsePragmaCaptureDataChangesPart(string name)
     {
         var token = _lexer.Current;
         if (token.Kind is not (TokenKind.Identifier or TokenKind.String))

--- a/src/Ahtola.Tests/ManagedChangeDataCaptureTests.cs
+++ b/src/Ahtola.Tests/ManagedChangeDataCaptureTests.cs
@@ -1,0 +1,384 @@
+using AwesomeAssertions;
+using Ahtola.Core;
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Tests;
+
+public sealed class ManagedChangeDataCaptureTests
+{
+    [Test]
+    public void CdcPragmaCreatesThePinnedV2SchemaAndCapturesAutocommitRows()
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE data(id INTEGER PRIMARY KEY, value TEXT)");
+
+        ColumnNames(connection, "PRAGMA capture_data_changes_conn;").Should()
+            .Equal("capture_data_changes_conn", "table_name", "version");
+        ReadRows(connection, "PRAGMA capture_data_changes_conn;").Should()
+            .ContainSingle()
+            .Which.Should().Equal(SqlValue.Text("off"), SqlValue.Null, SqlValue.Null);
+
+        Execute(connection, "PRAGMA capture_data_changes_conn('full')");
+        ReadRows(connection, "PRAGMA capture_data_changes_conn;").Should()
+            .ContainSingle()
+            .Which.Should().Equal(
+                SqlValue.Text("full"),
+                SqlValue.Text("turso_cdc"),
+                SqlValue.Text("v2"));
+
+        Execute(connection, "INSERT INTO data VALUES (7, 'seven')");
+
+        var rows = ReadRows(
+            connection,
+            "SELECT change_id, change_txn_id, change_type, table_name, id, before, after, updates FROM turso_cdc ORDER BY change_id");
+        rows.Should().HaveCount(2);
+        rows[0][0].Should().Be(SqlValue.Integer(1));
+        rows[0][1].Should().Be(SqlValue.Integer(1));
+        rows[0][2].Should().Be(SqlValue.Integer(1));
+        rows[0][3].Should().Be(SqlValue.Text("data"));
+        rows[0][4].Should().Be(SqlValue.Integer(7));
+        rows[0][5].Should().Be(SqlValue.Null);
+        SqliteRecordCodec.Decode(rows[0][6].AsBlob().Span).Should()
+            .Equal(SqlValue.Integer(7), SqlValue.Text("seven"));
+        rows[0][7].Should().Be(SqlValue.Null);
+
+        rows[1].Should().Equal(
+            SqlValue.Integer(2),
+            SqlValue.Integer(1),
+            SqlValue.Integer(2),
+            SqlValue.Null,
+            SqlValue.Null,
+            SqlValue.Null,
+            SqlValue.Null,
+            SqlValue.Null);
+        ReadRows(connection, "SELECT table_name, version FROM turso_cdc_version").Should()
+            .ContainSingle()
+            .Which.Should().Equal(SqlValue.Text("turso_cdc"), SqlValue.Text("v2"));
+    }
+
+    [Test]
+    public void CdcModesUsePinnedBeforeAfterAndFullUpdateRecordShapes()
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE data(id INTEGER PRIMARY KEY, value TEXT)");
+        Execute(connection, "INSERT INTO data VALUES (1, 'before')");
+        Execute(connection, "PRAGMA capture_data_changes_conn('full')");
+
+        Execute(connection, "UPDATE data SET value = 'after' WHERE id = 1");
+
+        var row = ReadRows(
+                connection,
+                "SELECT before, after, updates FROM turso_cdc WHERE change_type = 0")
+            .Should().ContainSingle()
+            .Which;
+        SqliteRecordCodec.Decode(row[0].AsBlob().Span).Should()
+            .Equal(SqlValue.Integer(1), SqlValue.Text("before"));
+        SqliteRecordCodec.Decode(row[1].AsBlob().Span).Should()
+            .Equal(SqlValue.Integer(1), SqlValue.Text("after"));
+        SqliteRecordCodec.Decode(row[2].AsBlob().Span).Should().Equal(
+            SqlValue.Integer(0),
+            SqlValue.Integer(1),
+            SqlValue.Null,
+            SqlValue.Text("after"));
+    }
+
+    [Test]
+    public void CdcSavepointRollbackDiscardsRowsAndKeepsOneOuterCommitBoundary()
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE data(id INTEGER PRIMARY KEY)");
+        Execute(connection, "PRAGMA capture_data_changes_conn('id')");
+
+        Execute(connection, "BEGIN");
+        Execute(connection, "INSERT INTO data VALUES (1)");
+        Execute(connection, "SAVEPOINT inner");
+        Execute(connection, "INSERT INTO data VALUES (2)");
+        Execute(connection, "ROLLBACK TO inner");
+        Execute(connection, "COMMIT");
+
+        var rows = ReadRows(
+            connection,
+            "SELECT change_type, id, change_txn_id FROM turso_cdc ORDER BY change_id");
+        rows.Should().HaveCount(2);
+        rows[0].Should().Equal(SqlValue.Integer(1), SqlValue.Integer(1), SqlValue.Integer(1));
+        rows[1].Should().Equal(SqlValue.Integer(2), SqlValue.Null, SqlValue.Integer(1));
+    }
+
+    [Test]
+    public void FullCdcCapturesSchemaChangesWithoutCapturingItsOwnSetup()
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, "PRAGMA capture_data_changes_conn('full')");
+
+        Execute(connection, "CREATE TABLE products(id INTEGER PRIMARY KEY, name TEXT)");
+
+        var rows = ReadRows(
+            connection,
+            "SELECT change_type, table_name, after FROM turso_cdc ORDER BY change_id");
+        rows.Should().HaveCount(2);
+        rows[0][0].Should().Be(SqlValue.Integer(1));
+        rows[0][1].Should().Be(SqlValue.Text("sqlite_schema"));
+        SqliteRecordCodec.Decode(rows[0][2].AsBlob().Span)[1].Should().Be(SqlValue.Text("products"));
+        rows[1][0].Should().Be(SqlValue.Integer(2));
+    }
+
+    [Test]
+    public void IdCdcCapturesSchemaRowsAndACommitBoundaryWithoutRowPayloads()
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, "PRAGMA capture_data_changes_conn('id')");
+
+        Execute(connection, "CREATE TABLE products(id INTEGER PRIMARY KEY)");
+
+        var rows = ReadRows(
+            connection,
+            "SELECT change_type, table_name, before, after, updates FROM turso_cdc ORDER BY change_id");
+        rows.Should().HaveCount(2);
+        rows[0].Should().Equal(
+            SqlValue.Integer(1),
+            SqlValue.Text("sqlite_schema"),
+            SqlValue.Null,
+            SqlValue.Null,
+            SqlValue.Null);
+        rows[1][0].Should().Be(SqlValue.Integer(2));
+    }
+
+    [Test]
+    public void UpdatingAnIntegerPrimaryKeyEmitsPinnedDeleteAndInsertCdcRows()
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE data(id INTEGER PRIMARY KEY, value TEXT)");
+        Execute(connection, "INSERT INTO data VALUES (1, 'value')");
+        Execute(connection, "PRAGMA capture_data_changes_conn('full')");
+
+        Execute(connection, "UPDATE data SET id = 2 WHERE id = 1");
+
+        var rows = ReadRows(
+            connection,
+            "SELECT change_type, id, before, after FROM turso_cdc WHERE change_type != 2 ORDER BY change_id");
+        rows.Should().HaveCount(2);
+        rows[0][0].Should().Be(SqlValue.Integer(-1));
+        rows[0][1].Should().Be(SqlValue.Integer(1));
+        SqliteRecordCodec.Decode(rows[0][2].AsBlob().Span).Should()
+            .Equal(SqlValue.Integer(1), SqlValue.Text("value"));
+        rows[0][3].Should().Be(SqlValue.Null);
+        rows[1][0].Should().Be(SqlValue.Integer(1));
+        rows[1][1].Should().Be(SqlValue.Integer(2));
+        rows[1][2].Should().Be(SqlValue.Null);
+        SqliteRecordCodec.Decode(rows[1][3].AsBlob().Span).Should()
+            .Equal(SqlValue.Integer(2), SqlValue.Text("value"));
+    }
+
+    [Test]
+    public void CdcInternalRowsDoNotNotifyThePublicUpdateHookAndPoolResetDisablesCapture()
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE data(id INTEGER PRIMARY KEY)");
+        var changes = new List<SqliteRowChange>();
+        connection.Hooks.UpdateHook = changes.Add;
+
+        Execute(connection, "PRAGMA unstable_capture_data_changes_conn('id')");
+        Execute(connection, "INSERT INTO data VALUES (1)");
+
+        changes.Should().ContainSingle()
+            .Which.Should().Be(new SqliteRowChange(SqliteChangeOperation.Insert, "main", "data", 1));
+        connection.ResetForPooling();
+        ReadRows(connection, "PRAGMA capture_data_changes_conn;").Should()
+            .ContainSingle()
+            .Which.Should().Equal(SqlValue.Text("off"), SqlValue.Null, SqlValue.Null);
+    }
+
+    [Test]
+    public void CdcTracksNestedTriggerAndForeignKeyMutationsWithoutRecursingIntoItsTable()
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, "PRAGMA foreign_keys = ON");
+        Execute(connection, "CREATE TABLE parent(id INTEGER PRIMARY KEY)");
+        Execute(connection, "CREATE TABLE child(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id) ON DELETE CASCADE)");
+        Execute(connection, "CREATE TABLE audit(id INTEGER PRIMARY KEY)");
+        Execute(connection, "CREATE TRIGGER parent_audit AFTER INSERT ON parent BEGIN INSERT INTO audit VALUES (NEW.id); END");
+        Execute(connection, "PRAGMA capture_data_changes_conn('id')");
+
+        Execute(connection, "INSERT INTO parent VALUES (1)");
+        Execute(connection, "INSERT INTO child VALUES (2, 1)");
+        Execute(connection, "DELETE FROM parent WHERE id = 1");
+
+        var rows = ReadRows(
+            connection,
+            "SELECT change_type, table_name, id FROM turso_cdc WHERE change_type != 2 ORDER BY change_id");
+        ContainsRow(rows, SqlValue.Integer(1), SqlValue.Text("parent"), SqlValue.Integer(1)).Should().BeTrue();
+        ContainsRow(rows, SqlValue.Integer(1), SqlValue.Text("audit"), SqlValue.Integer(1)).Should().BeTrue();
+        ContainsRow(rows, SqlValue.Integer(1), SqlValue.Text("child"), SqlValue.Integer(2)).Should().BeTrue();
+        ContainsRow(rows, SqlValue.Integer(-1), SqlValue.Text("parent"), SqlValue.Integer(1)).Should().BeTrue();
+        ContainsRow(rows, SqlValue.Integer(-1), SqlValue.Text("child"), SqlValue.Integer(2)).Should().BeTrue();
+        ReadRows(connection, "SELECT count(*) FROM turso_cdc").Should().ContainSingle()
+            .Which.Should().Equal(SqlValue.Integer(8));
+    }
+
+    [Test]
+    public void CdcFailureDoesNotLeakARejectedStatementIntoTheNextTransactionBoundary()
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE data(id INTEGER PRIMARY KEY, value TEXT UNIQUE)");
+        Execute(connection, "PRAGMA capture_data_changes_conn('id')");
+        Execute(connection, "INSERT INTO data VALUES (1, 'one')");
+
+        Assert.Throws<EmbeddedSqlException>(() => Execute(connection, "INSERT INTO data VALUES (2, 'one')"));
+        Execute(connection, "INSERT INTO data VALUES (3, 'three')");
+
+        var rows = ReadRows(
+            connection,
+            "SELECT change_id, change_txn_id, change_type, id FROM turso_cdc ORDER BY change_id");
+        rows.Should().HaveCount(4);
+        rows[0].Should().Equal(SqlValue.Integer(1), SqlValue.Integer(1), SqlValue.Integer(1), SqlValue.Integer(1));
+        rows[1].Should().Equal(SqlValue.Integer(2), SqlValue.Integer(1), SqlValue.Integer(2), SqlValue.Null);
+        rows[2].Should().Equal(SqlValue.Integer(3), SqlValue.Integer(3), SqlValue.Integer(1), SqlValue.Integer(3));
+        rows[3].Should().Equal(SqlValue.Integer(4), SqlValue.Integer(3), SqlValue.Integer(2), SqlValue.Null);
+    }
+
+    [Test]
+    public void ExistingUnversionedCdcTableIsPinnedToV1WithoutCommitRecords()
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE data(id INTEGER PRIMARY KEY)");
+        Execute(
+            connection,
+            "CREATE TABLE turso_cdc(change_id INTEGER PRIMARY KEY AUTOINCREMENT, change_time INTEGER, change_type INTEGER, table_name TEXT, id, before BLOB, after BLOB, updates BLOB)");
+
+        Execute(connection, "PRAGMA capture_data_changes_conn('after')");
+        Execute(connection, "INSERT INTO data VALUES (1)");
+
+        ReadRows(connection, "PRAGMA capture_data_changes_conn;").Should().ContainSingle()
+            .Which.Should().Equal(
+                SqlValue.Text("after"),
+                SqlValue.Text("turso_cdc"),
+                SqlValue.Text("v1"));
+        var rows = ReadRows(connection, "SELECT * FROM turso_cdc");
+        rows.Should().ContainSingle();
+        rows[0][2].Should().Be(SqlValue.Integer(1));
+        SqliteRecordCodec.Decode(rows[0][6].AsBlob().Span).Should().Equal(SqlValue.Integer(1));
+        ReadRows(connection, "SELECT version FROM turso_cdc_version WHERE table_name = 'turso_cdc'")
+            .Should().ContainSingle()
+            .Which.Should().Equal(SqlValue.Text("v1"));
+    }
+
+    [Test]
+    public void DroppingACdcTableCleansUpItsVersionEntry()
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, "PRAGMA capture_data_changes_conn('id')");
+
+        Execute(connection, "DROP TABLE turso_cdc");
+
+        ReadRows(connection, "SELECT count(*) FROM turso_cdc_version").Should().ContainSingle()
+            .Which.Should().Equal(SqlValue.Integer(0));
+    }
+
+    [Test]
+    public void ReconfiguringCdcInsideATransactionKeepsThePinnedV2Boundary()
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE data(id INTEGER PRIMARY KEY)");
+        Execute(connection, "PRAGMA capture_data_changes_conn('id')");
+
+        Execute(connection, "BEGIN");
+        Execute(connection, "INSERT INTO data VALUES (1)");
+        Execute(connection, "PRAGMA capture_data_changes_conn('full')");
+        Execute(connection, "INSERT INTO data VALUES (2)");
+        Execute(connection, "COMMIT");
+
+        var rows = ReadRows(
+            connection,
+            "SELECT change_txn_id, change_type FROM turso_cdc ORDER BY change_id");
+        rows.Should().HaveCount(3);
+        rows[0].Should().Equal(SqlValue.Integer(1), SqlValue.Integer(1));
+        rows[1].Should().Equal(SqlValue.Integer(1), SqlValue.Integer(1));
+        rows[2].Should().Equal(SqlValue.Integer(1), SqlValue.Integer(2));
+    }
+
+    [Test]
+    public void FailedCdcProvisioningRollsBackItsNewTargetTable()
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE turso_cdc_version(other TEXT)");
+
+        Assert.Throws<EmbeddedSqlException>(() => Execute(connection, "PRAGMA capture_data_changes_conn('id')"));
+
+        ReadRows(connection, "SELECT count(*) FROM sqlite_schema WHERE name = 'turso_cdc'").Should()
+            .ContainSingle()
+            .Which.Should().Equal(SqlValue.Integer(0));
+        ReadRows(connection, "PRAGMA capture_data_changes_conn;").Should().ContainSingle()
+            .Which.Should().Equal(SqlValue.Text("off"), SqlValue.Null, SqlValue.Null);
+    }
+
+    [Test]
+    public void ConcurrentMvccCommitPublishesTheSourceAndItsCdcBoundaryAtomically()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("cdc-mvcc.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE data(id INTEGER PRIMARY KEY)");
+        ReadRows(connection, "PRAGMA journal_mode = mvcc").Should().ContainSingle()
+            .Which.Should().Equal(SqlValue.Text("mvcc"));
+        Execute(connection, "PRAGMA capture_data_changes_conn('id')");
+
+        Execute(connection, "BEGIN CONCURRENT");
+        Execute(connection, "INSERT INTO data VALUES (42)");
+        Execute(connection, "COMMIT");
+
+        ReadRows(connection, "SELECT id FROM data").Should().ContainSingle()
+            .Which.Should().Equal(SqlValue.Integer(42));
+        var rows = ReadRows(
+            connection,
+            "SELECT change_type, id, change_txn_id FROM turso_cdc ORDER BY change_id");
+        rows.Should().HaveCount(2);
+        rows[0].Should().Equal(SqlValue.Integer(1), SqlValue.Integer(42), SqlValue.Integer(1));
+        rows[1].Should().Equal(SqlValue.Integer(2), SqlValue.Null, SqlValue.Integer(1));
+    }
+
+    private static void Execute(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        statement.Step().Should().Be(StatementStepResult.Done);
+    }
+
+    private static string[] ColumnNames(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        var names = new string[statement.GetColumnCount()];
+        for (var index = 0; index < names.Length; index++)
+            names[index] = statement.GetColumnName(index);
+        return names;
+    }
+
+    private static List<SqlValue[]> ReadRows(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        var rows = new List<SqlValue[]>();
+        while (statement.Step() == StatementStepResult.Row)
+        {
+            var row = new SqlValue[statement.GetColumnCount()];
+            for (var index = 0; index < row.Length; index++)
+                row[index] = statement.GetValue(index);
+            rows.Add(row);
+        }
+
+        return rows;
+    }
+
+    private static bool ContainsRow(IEnumerable<SqlValue[]> rows, params SqlValue[] expected)
+        => rows.Any(row => row.SequenceEqual(expected));
+}


### PR DESCRIPTION
## Summary
- Add per-connection `PRAGMA capture_data_changes_conn` and its unstable alias, with pinned Turso v0.7.2 V1/V2 target-table provisioning and version tracking.
- Capture DML, schema changes, savepoint/rollback boundaries, triggers, foreign-key actions, INTEGER PRIMARY KEY rewrites, and MVCC commits into regular queryable CDC tables.
- Keep public CDC separate from the private managed-replica journal by suppressing internal CDC hook notifications.
- Update the Turso gap inventory and add CDC regression coverage.

## Validation
- `pwsh ./scripts/Invoke-ManagedTestSuite.ps1 -Framework net10.0 -Filter "FullyQualifiedName~ManagedChangeDataCaptureTests" -MinimumExecutedTests 1`
- Coupled CDC/pragma/hook/trigger/FK/MVCC suites (225 passing)
- `pwsh ./build.ps1 test` (4,417 passing managed tests; package and consumer gates passed)