### PR TITLE
feat: add bounded managed sorter spill

### DIFF
--- a/src/Ahtola.Core/EmbeddedDatabase.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.cs
@@ -639,7 +639,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
         ConcurrentMvccIdentityTracker? ConcurrentMvccIdentityTracker = null,
         SqliteTextEncoding MvccTextEncoding = SqliteTextEncoding.Utf8,
         IReadOnlyDictionary<string, VirtualTableDefinition>? VirtualTables = null,
-        ChangeDataCaptureSession? ChangeDataCapture = null)
+        ChangeDataCaptureSession? ChangeDataCapture = null,
+        VdbeExecutionOptions? VdbeExecutionOptions = null)
     {
         /// <summary>
         /// Row-loop checkpoint. It honors cooperative cancellation exactly as before and
@@ -1381,7 +1382,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
         bool ignoreCheckConstraints = false,
         Func<string?, string?, ExecutionResult>? executeTableList = null,
         IReadOnlyDictionary<string, EmbeddedTable>? externalTables = null,
-        ChangeDataCaptureSession? changeDataCapture = null)
+        ChangeDataCaptureSession? changeDataCapture = null,
+        VdbeExecutionOptions? vdbeExecutionOptions = null)
     {
         var result = ExecuteCore(
             statement,
@@ -1398,7 +1400,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
             ignoreCheckConstraints,
             executeTableList,
             externalTables,
-            changeDataCapture);
+            changeDataCapture,
+            vdbeExecutionOptions);
 
         RecordChangeCounters(statement, result);
         return result;
@@ -1432,7 +1435,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
         bool ignoreCheckConstraints = false,
         Func<string?, string?, ExecutionResult>? executeTableList = null,
         IReadOnlyDictionary<string, EmbeddedTable>? externalTables = null,
-        ChangeDataCaptureSession? changeDataCapture = null)
+        ChangeDataCaptureSession? changeDataCapture = null,
+        VdbeExecutionOptions? vdbeExecutionOptions = null)
     {
         ThrowIfRecursiveTriggerCallbackReentry();
         if (RequiresRecursiveTriggerStack(
@@ -1455,7 +1459,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 ignoreCheckConstraints,
                 executeTableList,
                 externalTables,
-                changeDataCapture));
+                changeDataCapture,
+                vdbeExecutionOptions));
         }
 
         cancellationToken.ThrowIfCancellationRequested();
@@ -1502,7 +1507,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
                                 ignoreCheckConstraints,
                                 executeTableList,
                                 externalTables,
-                                changeDataCapture: changeDataCapture);
+                                changeDataCapture: changeDataCapture,
+                                vdbeExecutionOptions: vdbeExecutionOptions);
                         }
                         catch (EmbeddedConflictFailException)
                         {
@@ -1571,7 +1577,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
                                 ignoreCheckConstraints,
                                 executeTableList,
                                 externalTables,
-                                changeDataCapture: changeDataCapture);
+                                changeDataCapture: changeDataCapture,
+                                vdbeExecutionOptions: vdbeExecutionOptions);
                         }
                         catch (EmbeddedConflictFailException)
                         {
@@ -1612,7 +1619,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
                             ignoreCheckConstraints,
                             executeTableList,
                             externalTables,
-                            changeDataCapture: changeDataCapture);
+                            changeDataCapture: changeDataCapture,
+                            vdbeExecutionOptions: vdbeExecutionOptions);
 
                     var working = new SchemaCatalog(_tables, _views, _triggers, _virtualTables).Clone();
                     ExecutionResult result;
@@ -1634,7 +1642,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
                             ignoreCheckConstraints,
                             executeTableList,
                             externalTables,
-                            changeDataCapture: changeDataCapture);
+                            changeDataCapture: changeDataCapture,
+                            vdbeExecutionOptions: vdbeExecutionOptions);
                     }
                     catch (EmbeddedConflictFailException)
                     {
@@ -2027,7 +2036,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
         long lastInsertRowId,
         bool foreignKeysEnabled,
         bool recursiveTriggersEnabled,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        VdbeExecutionOptions? vdbeExecutionOptions = null)
     {
         lock (_gate)
         {
@@ -2038,7 +2048,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 lastInsertRowId,
                 foreignKeysEnabled,
                 recursiveTriggersEnabled,
-                cancellationToken);
+                cancellationToken,
+                vdbeExecutionOptions);
         }
     }
 
@@ -2049,7 +2060,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
         long lastInsertRowId,
         bool foreignKeysEnabled,
         bool recursiveTriggersEnabled,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        VdbeExecutionOptions? vdbeExecutionOptions = null)
     {
         var context = new QueryContext(
             catalog.Tables,
@@ -2059,7 +2071,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
             LastInsertRowId: lastInsertRowId,
             ForeignKeysEnabled: foreignKeysEnabled,
             RecursiveTriggersEnabled: recursiveTriggersEnabled,
-            CancellationToken: cancellationToken);
+            CancellationToken: cancellationToken,
+            VdbeExecutionOptions: vdbeExecutionOptions);
         var result = MaterializeQueryResult(ExecuteQuery(statement, parameters, context, outerRow: null));
         var affinities = DescribeQueryAffinities(
             statement,
@@ -3627,7 +3640,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
         IReadOnlyDictionary<string, EmbeddedTable>? externalTables = null,
         MvStore? concurrentMvStore = null,
         MvccTxId? concurrentMvccTxId = null,
-        ChangeDataCaptureSession? changeDataCapture = null)
+        ChangeDataCaptureSession? changeDataCapture = null,
+        VdbeExecutionOptions? vdbeExecutionOptions = null)
     {
         ThrowIfRecursiveTriggerCallbackReentry();
         if (RequiresRecursiveTriggerStack(
@@ -3653,7 +3667,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 externalTables,
                 concurrentMvStore,
                 concurrentMvccTxId,
-                changeDataCapture));
+                changeDataCapture,
+                vdbeExecutionOptions));
         }
 
         cancellationToken.ThrowIfCancellationRequested();
@@ -3689,7 +3704,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
             ConcurrentMvccIdentityTracker: concurrentMvStore is null ? null : new ConcurrentMvccIdentityTracker(),
             MvccTextEncoding: GetTextEncoding(),
             VirtualTables: catalog.VirtualTables,
-            ChangeDataCapture: changeDataCapture);
+            ChangeDataCapture: changeDataCapture,
+            VdbeExecutionOptions: vdbeExecutionOptions);
         EnsureConcurrentMvccDmlTargetIsSupported(statement, tables, context);
         var result = statement switch
         {
@@ -10572,7 +10588,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
     {
         if (CanRouteInsertThroughCompiler(statement, context)
             && TryCompileInsert(statement, parameters, context, out var compiled, out var columns, out var hasReturning))
-            return RunCompiledDml(compiled, columns, hasReturning, parameters);
+            return RunCompiledDml(compiled, columns, hasReturning, parameters, context.VdbeExecutionOptions);
 
         return PerformInsertEvaluated(statement, parameters, context);
     }
@@ -11508,12 +11524,13 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 foreignKeyCompiled,
                 foreignKeyColumns,
                 foreignKeyHasReturning,
-                parameters);
+                parameters,
+                context.VdbeExecutionOptions);
         }
 
         if (CanRouteUpdateThroughCompiler(statement, context)
             && TryCompileUpdate(statement, parameters, context, out var compiled, out var columns, out var hasReturning))
-            return RunCompiledDml(compiled, columns, hasReturning, parameters);
+            return RunCompiledDml(compiled, columns, hasReturning, parameters, context.VdbeExecutionOptions);
 
         return PerformUpdateEvaluated(statement, parameters, context);
     }
@@ -13989,12 +14006,13 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 foreignKeyCompiled,
                 foreignKeyColumns,
                 foreignKeyHasReturning,
-                parameters);
+                parameters,
+                context.VdbeExecutionOptions);
         }
 
         if (CanCompilePlainDelete(context)
             && TryCompileDelete(statement, parameters, context, out var compiled, out var columns, out var hasReturning))
-            return RunCompiledDml(compiled, columns, hasReturning, parameters);
+            return RunCompiledDml(compiled, columns, hasReturning, parameters, context.VdbeExecutionOptions);
 
         return PerformDeleteEvaluated(statement, parameters, context);
     }
@@ -14892,7 +14910,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 compiled,
                 columns,
                 BuildValuesBinding(compiled.ParameterIndices ?? [], parameters),
-                context.CancellationToken);
+                context.CancellationToken,
+                context.VdbeExecutionOptions);
         }
 
         return ExecuteSelect(select, parameters, context, outerRow);
@@ -20261,10 +20280,12 @@ public sealed partial class EmbeddedDatabase : IDisposable
         CompiledSelect compiled,
         string[] columns,
         VdbeParameterBinding? parameterBinding,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        VdbeExecutionOptions? executionOptions = null)
     {
-        using var runtime = new ResumableStatement(
+        using var runtime = ResumableStatement.CreateWithExecutionOptions(
             compiled.Program,
+            executionOptions ?? VdbeExecutionOptions.Default,
             compiled.CursorSources,
             parameterBinding: parameterBinding);
         var rows = new List<SqlValue[]>();
@@ -20289,10 +20310,12 @@ public sealed partial class EmbeddedDatabase : IDisposable
         CompiledDml compiled,
         string[] columns,
         bool hasReturning,
-        SqlValue[] parameters)
+        SqlValue[] parameters,
+        VdbeExecutionOptions? executionOptions = null)
     {
-        using var runtime = new ResumableStatement(
+        using var runtime = ResumableStatement.CreateWithExecutionOptions(
             compiled.Program,
+            executionOptions ?? VdbeExecutionOptions.Default,
             compiled.CursorSources,
             compiled.RuntimeWriteTargets,
             BuildValuesBinding(compiled.ParameterIndices ?? [], parameters));
@@ -24438,7 +24461,8 @@ out bool hasReturning)
             return RunCompiledProgram(
                 compiledCompound,
                 compoundColumns,
-                BuildValuesBinding(compiledCompound.ParameterIndices ?? [], parameters));
+                BuildValuesBinding(compiledCompound.ParameterIndices ?? [], parameters),
+                executionOptions: context.VdbeExecutionOptions);
         }
 
         var first = ExecuteCompoundTerm(statement.Terms[0], parameters, context, outerRow);
@@ -41777,6 +41801,33 @@ public sealed partial class EmbeddedConnection : IDisposable
         }
     }
 
+    private VdbeExecutionOptions CreateVdbeExecutionOptions(EmbeddedDatabase database)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+        if (_tempStore == 2)
+        {
+            return new VdbeExecutionOptions(
+                new InMemoryFileSystem(),
+                long.MaxValue,
+                temporaryDirectory: "ahtola-memory-sorter");
+        }
+
+        var cacheSize = _cacheSizes.GetValueOrDefault(database, -2000);
+        Int128 bytes = cacheSize < 0
+            ? (Int128)(cacheSize == long.MinValue ? long.MaxValue : -cacheSize) * 1024
+            : (Int128)cacheSize * database.GetPageSize();
+        var budget = bytes <= 0
+            ? 1L
+            : bytes >= long.MaxValue
+                ? long.MaxValue
+                : (long)bytes;
+
+        return new VdbeExecutionOptions(
+            PhysicalFileSystem.Instance,
+            budget,
+            temporaryDirectory: Path.GetTempPath());
+    }
+
     /// <summary>
     /// Tracks one outer statement's use of connection-private temp triggers. Temp triggers live in
     /// a separate in-memory database, so firing one for a main-schema table means handing it to the
@@ -43188,6 +43239,7 @@ public sealed partial class EmbeddedConnection : IDisposable
                     throw new EmbeddedSqlException("attempt to write a readonly database");
 
                 var routed = RouteStatement(statement);
+                var vdbeExecutionOptions = CreateVdbeExecutionOptions(routed.Database);
                 // A reader-excluding EXCLUSIVE transaction on another connection blocks
                 // this statement outright, which is what SQLite's EXCLUSIVE lock does
                 // under a rollback journal.
@@ -43248,7 +43300,8 @@ public sealed partial class EmbeddedConnection : IDisposable
                                 executeTableList: ExecutePragmaTableList,
                                 concurrentMvStore: concurrentStore,
                                 concurrentMvccTxId: concurrentTxId,
-                                changeDataCapture: changeDataCapture);
+                                changeDataCapture: changeDataCapture,
+                                vdbeExecutionOptions: vdbeExecutionOptions);
                         }
                         else if (transactionState is null)
                         {
@@ -43270,7 +43323,8 @@ public sealed partial class EmbeddedConnection : IDisposable
                                     ignoreCheckConstraints: _ignoreCheckConstraints,
                                     executeTableList: ExecutePragmaTableList,
                                     externalTables: routed.ExternalTables,
-                                    changeDataCapture: changeDataCapture);
+                                    changeDataCapture: changeDataCapture,
+                                    vdbeExecutionOptions: vdbeExecutionOptions);
                             }
                             catch (Exception failure)
                                 when (failure is not EmbeddedConflictFailException
@@ -43308,7 +43362,8 @@ public sealed partial class EmbeddedConnection : IDisposable
                                 externalTables: routed.ExternalTables,
                                 concurrentMvStore: concurrentStore,
                                 concurrentMvccTxId: concurrentTxId,
-                                changeDataCapture: changeDataCapture);
+                                changeDataCapture: changeDataCapture,
+                                vdbeExecutionOptions: vdbeExecutionOptions);
                             if (EmbeddedDatabase.MayMutate(routed.Statement))
                                 cancellationToken.ThrowIfCancellationRequested();
                             // The catalog overload used for transactional statements does not
@@ -43909,6 +43964,7 @@ public sealed partial class EmbeddedConnection : IDisposable
         var sourceQuery = source.Statement as QueryStatement
             ?? throw new InvalidOperationException("CREATE TABLE AS SELECT routing did not return a query.");
         var sourceState = GetTransactionState(source.Database);
+        var vdbeExecutionOptions = CreateVdbeExecutionOptions(source.Database);
         var materialization = sourceState is null
             ? source.Database.MaterializeCreateTableAs(
                 sourceQuery,
@@ -43916,7 +43972,8 @@ public sealed partial class EmbeddedConnection : IDisposable
                 _lastInsertRowId,
                 _foreignKeys,
                 _recursiveTriggers,
-                cancellationToken)
+                cancellationToken,
+                vdbeExecutionOptions)
             : source.Database.MaterializeCreateTableAs(
                 sourceQuery,
                 parameters,
@@ -43924,7 +43981,8 @@ public sealed partial class EmbeddedConnection : IDisposable
                 _lastInsertRowId,
                 _foreignKeys,
                 _recursiveTriggers,
-                cancellationToken);
+                cancellationToken,
+                vdbeExecutionOptions);
         cancellationToken.ThrowIfCancellationRequested();
         if (ReferenceEquals(source.Database, _tempDatabase))
             _tempInitialized = true;

--- a/src/Ahtola.Core/Execution/ResumableStatement.cs
+++ b/src/Ahtola.Core/Execution/ResumableStatement.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Runtime.ExceptionServices;
 using System.Text;
 using Ahtola.Core.Parsing;
+using Ahtola.Core.Storage;
 
 namespace Ahtola.Core.Execution;
 
@@ -57,6 +58,7 @@ public sealed class ResumableStatement : IDisposable
     private readonly IReadOnlyList<VdbeCursorSource?>? _cursorSources;
     private readonly IReadOnlyList<VdbeWriteTarget?>? _writeTargets;
     private readonly IReadOnlyList<VdbeVirtualTableBinding?>? _virtualTableBindings;
+    private readonly VdbeExecutionOptions _executionOptions;
     private readonly VdbeTransactionContext _transaction;
     private readonly bool _ownsTransaction;
     private VdbeParameterBinding? _binding;
@@ -74,8 +76,49 @@ public sealed class ResumableStatement : IDisposable
         VdbeParameterBinding? parameterBinding = null,
         VdbeTransactionContext? sharedTransaction = null,
         IReadOnlyList<VdbeVirtualTableBinding?>? virtualTableBindings = null)
+        : this(
+            program,
+            cursorSources,
+            writeTargets,
+            parameterBinding,
+            sharedTransaction,
+            virtualTableBindings,
+            VdbeExecutionOptions.Default)
+    {
+    }
+
+    /// <summary>
+    /// Creates a statement with explicit temporary execution resources without changing
+    /// the legacy constructor's positional parameter contract.
+    /// </summary>
+    public static ResumableStatement CreateWithExecutionOptions(
+        VdbeProgram program,
+        VdbeExecutionOptions executionOptions,
+        IReadOnlyList<VdbeCursorSource?>? cursorSources = null,
+        IReadOnlyList<VdbeWriteTarget?>? writeTargets = null,
+        VdbeParameterBinding? parameterBinding = null,
+        VdbeTransactionContext? sharedTransaction = null,
+        IReadOnlyList<VdbeVirtualTableBinding?>? virtualTableBindings = null)
+        => new(
+            program,
+            cursorSources,
+            writeTargets,
+            parameterBinding,
+            sharedTransaction,
+            virtualTableBindings,
+            executionOptions);
+
+    internal ResumableStatement(
+        VdbeProgram program,
+        IReadOnlyList<VdbeCursorSource?>? cursorSources,
+        IReadOnlyList<VdbeWriteTarget?>? writeTargets,
+        VdbeParameterBinding? parameterBinding,
+        VdbeTransactionContext? sharedTransaction,
+        IReadOnlyList<VdbeVirtualTableBinding?>? virtualTableBindings,
+        VdbeExecutionOptions executionOptions)
     {
         ArgumentNullException.ThrowIfNull(program);
+        ArgumentNullException.ThrowIfNull(executionOptions);
         if (cursorSources is not null && cursorSources.Count != program.CursorCount)
         {
             throw new ArgumentException(
@@ -120,6 +163,7 @@ public sealed class ResumableStatement : IDisposable
         _cursorSources = cursorSources;
         _writeTargets = writeTargets;
         _virtualTableBindings = virtualTableBindings;
+        _executionOptions = executionOptions;
         _binding = parameterBinding;
         _ownsTransaction = sharedTransaction is null;
         _transaction = sharedTransaction ?? new VdbeTransactionContext();
@@ -869,7 +913,7 @@ public sealed class ResumableStatement : IDisposable
                 case SorterInsertInstruction sorterInsert:
                     {
                         var runtime = RequireOpenSorter(sorterInsert.Sorter);
-                        runtime.Insert(ReadRegisters(sorterInsert.Record));
+                        runtime.Insert(ReadRegisters(sorterInsert.Record), cancellationToken);
                         AdvanceInstructionPointer();
                         break;
                     }
@@ -894,7 +938,7 @@ public sealed class ResumableStatement : IDisposable
                 case SorterNextInstruction sorterNext:
                     {
                         var runtime = RequireOpenSorter(sorterNext.Sorter);
-                        if (runtime.MoveNext())
+                        if (runtime.MoveNext(cancellationToken))
                             _instructionPointer = sorterNext.LoopTarget;
                         else
                             AdvanceInstructionPointer();
@@ -1561,7 +1605,9 @@ public sealed class ResumableStatement : IDisposable
                 && subprogram!.State != ResumableStatementState.Yielded))
         {
             subprogram?.Dispose();
-            subprogram = instruction.Subprogram.CreateRuntime(CreateSubprogramBinding(instruction));
+            subprogram = instruction.Subprogram.CreateRuntime(
+                CreateSubprogramBinding(instruction),
+                _executionOptions);
             _subprogramStatements[instructionOffset] = subprogram;
         }
         else if (subprogram!.State == ResumableStatementState.Yielded)
@@ -1612,7 +1658,8 @@ public sealed class ResumableStatement : IDisposable
         _sorters[instruction.Sorter.Index] = new SorterRuntime(
             instruction.Comparer,
             instruction.ColumnCount,
-            instruction.BufferRowCapacity);
+            instruction.BufferRowCapacity,
+            _executionOptions);
     }
 
     private void CloseSorter(Sorter sorter)
@@ -1630,11 +1677,26 @@ public sealed class ResumableStatement : IDisposable
     // temp file, even when the program ends mid-drain or is aborted.
     private void DisposeAllSorters()
     {
+        Exception? cleanupFailure = null;
         for (var index = 0; index < _sorters.Length; index++)
         {
-            _sorters[index]?.Dispose();
-            _sorters[index] = null;
+            var sorter = _sorters[index];
+            if (sorter is null)
+                continue;
+
+            try
+            {
+                sorter.Dispose();
+                _sorters[index] = null;
+            }
+            catch (Exception exception)
+            {
+                cleanupFailure ??= exception;
+            }
         }
+
+        if (cleanupFailure is not null)
+            ExceptionDispatchInfo.Capture(cleanupFailure).Throw();
     }
 
     private void DisposeAllJoinCursors()
@@ -2449,7 +2511,10 @@ public sealed class ResumableStatement : IDisposable
         private readonly VdbeRowComparer _comparer;
         private readonly int _columnCount;
         private readonly int _bufferRowCapacity;
+        private readonly long _bufferMemoryLimitBytes;
+        private readonly VdbeExecutionOptions _executionOptions;
         private readonly List<SqlValue[]> _rows = [];
+        private long _bufferedBytes;
         private SorterSpill? _spill;
         private bool _sorted;
         private int _position = -1;
@@ -2458,17 +2523,23 @@ public sealed class ResumableStatement : IDisposable
         private SqlValue[]? _pending;
         private int _pendingRunIndex;
 
-        public SorterRuntime(VdbeRowComparer comparer, int columnCount, int bufferRowCapacity)
+        public SorterRuntime(
+            VdbeRowComparer comparer,
+            int columnCount,
+            int bufferRowCapacity,
+            VdbeExecutionOptions executionOptions)
         {
             _comparer = comparer;
             _columnCount = columnCount;
+            _executionOptions = executionOptions;
             // 0 means "no spill" (the historical in-memory default). Treat anything
             // non-positive the same way so a stray negative capacity can never force a
             // single-row spill loop.
             _bufferRowCapacity = bufferRowCapacity > 0 ? bufferRowCapacity : int.MaxValue;
+            _bufferMemoryLimitBytes = executionOptions.SorterMemoryLimitBytes;
         }
 
-        public void Insert(SqlValue[] record)
+        public void Insert(SqlValue[] record, CancellationToken cancellationToken)
         {
             if (_sorted)
                 throw new InvalidOperationException("Cannot insert into a sorter after it has been sorted.");
@@ -2478,16 +2549,16 @@ public sealed class ResumableStatement : IDisposable
                     $"Sorter stores {_columnCount}-column records but received {record.Length} values.");
             }
 
-            _rows.Add(record);
-
-            // Spill when the in-memory buffer exceeds the capacity. Each run is stably
-            // sorted before flushing so the k-way merge over runs is globally stable.
-            if (_rows.Count > _bufferRowCapacity && _bufferRowCapacity != int.MaxValue)
+            var recordBytes = EstimateRecordBytes(record);
+            if (_rows.Count > 0
+                && (_rows.Count >= _bufferRowCapacity
+                    || _bufferedBytes > _bufferMemoryLimitBytes - recordBytes))
             {
-                _spill ??= new SorterSpill(_columnCount);
-                _spill.WriteRun(SortBufferedRows(CancellationToken.None), CancellationToken.None);
-                _rows.Clear();
+                FlushBuffered(cancellationToken);
             }
+
+            _rows.Add(record);
+            _bufferedBytes = checked(_bufferedBytes + recordBytes);
         }
 
         // Sorts the buffered records and positions on the first one. Returns false (and
@@ -2498,10 +2569,9 @@ public sealed class ResumableStatement : IDisposable
 
             // Flush the final partial buffer as one more run so Sort always drains from
             // the spill when any runs exist. An empty tail is skipped (no zero-row run).
-            if (_spill is not null && _rows.Count > 0)
+            if ((_spill is not null || _bufferedBytes > _bufferMemoryLimitBytes) && _rows.Count > 0)
             {
-                _spill.WriteRun(SortBufferedRows(cancellationToken), cancellationToken);
-                _rows.Clear();
+                FlushBuffered(cancellationToken);
             }
 
             if (_spill is not null)
@@ -2513,6 +2583,10 @@ public sealed class ResumableStatement : IDisposable
                     return false;
                 }
 
+                _spill.ConsolidateRuns(
+                    _comparer,
+                    _executionOptions.SorterMergeFanIn,
+                    cancellationToken);
                 StartMerge(cancellationToken);
                 _position = 0;
                 return true;
@@ -2552,7 +2626,7 @@ public sealed class ResumableStatement : IDisposable
         }
 
         // Advances to the next ordered record, returning whether one remains.
-        public bool MoveNext()
+        public bool MoveNext(CancellationToken cancellationToken)
         {
             if (!_sorted)
                 throw new InvalidOperationException("Sorter must be sorted before advancing.");
@@ -2563,7 +2637,7 @@ public sealed class ResumableStatement : IDisposable
             // drops the run association and would emit at most one record per run.
             if (_merge is not null)
             {
-                if (_readers![_pendingRunIndex].TryReadNext(out var next))
+                if (_readers![_pendingRunIndex].TryReadNext(out var next, cancellationToken))
                     _merge.Enqueue(_pendingRunIndex, new MergeKey(next, _pendingRunIndex, _comparer));
 
                 if (!_merge.TryDequeue(out _pendingRunIndex, out var key))
@@ -2630,7 +2704,7 @@ public sealed class ResumableStatement : IDisposable
                 cancellationToken.ThrowIfCancellationRequested();
                 var reader = _spill.OpenRunReader(runIndex);
                 _readers[runIndex] = reader;
-                if (reader.TryReadNext(out var first))
+                if (reader.TryReadNext(out var first, cancellationToken))
                     _merge.Enqueue(runIndex, new MergeKey(first, runIndex, _comparer));
             }
 
@@ -2656,8 +2730,38 @@ public sealed class ResumableStatement : IDisposable
             _spill?.Dispose();
             _spill = null;
             _rows.Clear();
+            _bufferedBytes = 0;
             _merge = null;
             _pending = null;
+        }
+
+        private void FlushBuffered(CancellationToken cancellationToken)
+        {
+            if (_rows.Count == 0)
+                return;
+
+            _spill ??= new SorterSpill(_columnCount, _executionOptions);
+            _spill.WriteRun(SortBufferedRows(cancellationToken), cancellationToken);
+            _rows.Clear();
+            _bufferedBytes = 0;
+        }
+
+        private static long EstimateRecordBytes(SqlValue[] record)
+        {
+            long total = 0;
+            foreach (var value in record)
+            {
+                total = checked(total + value.Kind switch
+                {
+                    SqlValueKind.Null => 1,
+                    SqlValueKind.Integer or SqlValueKind.Real => 9,
+                    SqlValueKind.Text => 5L + Encoding.UTF8.GetByteCount(value.AsText()),
+                    SqlValueKind.Blob => 5L + value.AsBlob().Length,
+                    _ => throw new InvalidOperationException($"Unknown SQL value kind {value.Kind}."),
+                });
+            }
+
+            return total;
         }
 
         // Heap priority: orders by the row comparer, then by RunIndex so equal-key rows
@@ -2685,27 +2789,23 @@ public sealed class ResumableStatement : IDisposable
         }
     }
 
-    // Backing store for spilled sorter runs: one temp file holding any number of sorted
-    // runs concatenated end-to-end. DeleteOnClose makes the OS reclaim the file on
-    // dispose/close, so a sorter that is abandoned mid-drain cannot leak a temp file.
+    // Backing store for spilled sorter runs: one transient IFileSystem file holding
+    // concatenated runs. Every handle is explicitly disposed before DeleteFile so the
+    // cleanup path works uniformly on Windows, Unix, and InMemoryFileSystem.
     private sealed class SorterSpill : IDisposable
     {
         private readonly int _columnCount;
-        private readonly FileStream _stream;
+        private readonly IFileSystem _fileSystem;
+        private readonly string _path;
+        private readonly IFile _file;
         private readonly List<(long Offset, int RowCount)> _runs = [];
         private long _writePosition;
 
-        public SorterSpill(int columnCount)
+        public SorterSpill(int columnCount, VdbeExecutionOptions executionOptions)
         {
             _columnCount = columnCount;
-            var path = Path.Combine(Path.GetTempPath(), "Ahtola-sorter-" + Path.GetRandomFileName());
-            _stream = new FileStream(
-                path,
-                FileMode.Create,
-                FileAccess.ReadWrite,
-                FileShare.None,
-                bufferSize: 8192,
-                FileOptions.DeleteOnClose);
+            _fileSystem = executionOptions.TemporaryFileSystem;
+            (_path, _file) = CreateFile(executionOptions);
         }
 
         public int RunCount => _runs.Count;
@@ -2715,60 +2815,189 @@ public sealed class ResumableStatement : IDisposable
         public void WriteRun(List<SqlValue[]> sorted, CancellationToken cancellationToken)
         {
             var offset = _writePosition;
-            Span<byte> header = stackalloc byte[8];
-            foreach (var row in sorted)
+            try
             {
-                cancellationToken.ThrowIfCancellationRequested();
-                for (var column = 0; column < _columnCount; column++)
-                    WriteValue(_stream, row[column], header);
-            }
+                Span<byte> header = stackalloc byte[8];
+                foreach (var row in sorted)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    for (var column = 0; column < _columnCount; column++)
+                        WriteValue(_file, ref _writePosition, row[column], header);
+                }
 
-            _stream.Flush();
-            _runs.Add((offset, sorted.Count));
-            _writePosition = _stream.Position;
+                _file.FlushToDisk();
+                _runs.Add((offset, sorted.Count));
+            }
+            catch
+            {
+                _file.SetLength(offset);
+                _writePosition = offset;
+                throw;
+            }
+        }
+
+        public void ConsolidateRuns(
+            VdbeRowComparer comparer,
+            int maximumFanIn,
+            CancellationToken cancellationToken)
+        {
+            while (_runs.Count > maximumFanIn)
+            {
+                var passOffset = _writePosition;
+                try
+                {
+                    var consolidated = new List<(long Offset, int RowCount)>();
+                    for (var start = 0; start < _runs.Count; start += maximumFanIn)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        var count = Math.Min(maximumFanIn, _runs.Count - start);
+                        if (count == 1)
+                        {
+                            consolidated.Add(_runs[start]);
+                            continue;
+                        }
+
+                        consolidated.Add(MergeRunGroup(
+                            _runs.GetRange(start, count),
+                            comparer,
+                            cancellationToken));
+                    }
+
+                    _runs.Clear();
+                    _runs.AddRange(consolidated);
+                }
+                catch
+                {
+                    _file.SetLength(passOffset);
+                    _writePosition = passOffset;
+                    throw;
+                }
+            }
+        }
+
+        private (long Offset, int RowCount) MergeRunGroup(
+            IReadOnlyList<(long Offset, int RowCount)> inputs,
+            VdbeRowComparer comparer,
+            CancellationToken cancellationToken)
+        {
+            var offset = _writePosition;
+            var readers = new RunReader[inputs.Count];
+            try
+            {
+                var heap = new PriorityQueue<int, SpillMergeKey>(SpillMergeKey.Comparer);
+                for (var index = 0; index < inputs.Count; index++)
+                {
+                    var input = inputs[index];
+                    var reader = new RunReader(_file, input.Offset, input.RowCount, _columnCount);
+                    readers[index] = reader;
+                    if (reader.TryReadNext(out var row, cancellationToken))
+                        heap.Enqueue(index, new SpillMergeKey(row, index, comparer));
+                }
+
+                var rowsWritten = 0;
+                Span<byte> header = stackalloc byte[8];
+                while (heap.TryDequeue(out var readerIndex, out var key))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    for (var column = 0; column < _columnCount; column++)
+                        WriteValue(_file, ref _writePosition, key.Record[column], header);
+                    rowsWritten = checked(rowsWritten + 1);
+
+                    if (readers[readerIndex].TryReadNext(out var next, cancellationToken))
+                        heap.Enqueue(readerIndex, new SpillMergeKey(next, readerIndex, comparer));
+                }
+
+                _file.FlushToDisk();
+                return (offset, rowsWritten);
+            }
+            catch
+            {
+                _file.SetLength(offset);
+                _writePosition = offset;
+                throw;
+            }
+            finally
+            {
+                foreach (var reader in readers)
+                    reader?.Dispose();
+            }
         }
 
         public RunReader OpenRunReader(int runIndex)
         {
             var (offset, rowCount) = _runs[runIndex];
-            return new RunReader(_stream, offset, rowCount, _columnCount);
+            return new RunReader(_file, offset, rowCount, _columnCount);
         }
 
-        public void Dispose() => _stream.Dispose();
+        public void Dispose()
+        {
+            try
+            {
+                _file.Dispose();
+            }
+            finally
+            {
+                _fileSystem.DeleteFile(_path);
+            }
+        }
 
-        private static void WriteValue(FileStream stream, SqlValue value, Span<byte> header)
+        private static (string Path, IFile File) CreateFile(VdbeExecutionOptions executionOptions)
+        {
+            for (var attempt = 0; attempt < 16; attempt++)
+            {
+                var path = Path.Combine(
+                    executionOptions.TemporaryDirectory,
+                    "ahtola-sorter-" + Guid.NewGuid().ToString("N") + ".run");
+                try
+                {
+                    var fileSystem = executionOptions.TemporaryFileSystem;
+                    var file = fileSystem is ITemporaryFileSystem temporaryFileSystem
+                        ? temporaryFileSystem.OpenTemporaryFile(path)
+                        : fileSystem.OpenFile(path, FileOpenMode.CreateNew);
+                    return (path, file);
+                }
+                catch (IOException) when (executionOptions.TemporaryFileSystem.FileExists(path))
+                {
+                    // Extremely unlikely name collision: select another statement-local name.
+                }
+            }
+
+            throw new IOException("Unable to allocate a unique temporary sorter run file.");
+        }
+
+        private static void WriteValue(IFile file, ref long position, SqlValue value, Span<byte> header)
         {
             switch (value.Kind)
             {
                 case SqlValueKind.Null:
-                    stream.WriteByte(0x00);
+                    WriteByte(file, ref position, 0x00);
                     break;
                 case SqlValueKind.Integer:
-                    stream.WriteByte(0x01);
+                    WriteByte(file, ref position, 0x01);
                     BinaryPrimitives.WriteInt64LittleEndian(header, value.AsInteger());
-                    stream.Write(header);
+                    Write(file, ref position, header);
                     break;
                 case SqlValueKind.Real:
-                    stream.WriteByte(0x02);
+                    WriteByte(file, ref position, 0x02);
                     BinaryPrimitives.WriteDoubleLittleEndian(header, value.AsReal());
-                    stream.Write(header);
+                    Write(file, ref position, header);
                     break;
                 case SqlValueKind.Text:
                     {
                         var bytes = Encoding.UTF8.GetBytes(value.AsText());
-                        stream.WriteByte(value.IsJson ? (byte)0x83 : (byte)0x03);
+                        WriteByte(file, ref position, value.IsJson ? (byte)0x83 : (byte)0x03);
                         BinaryPrimitives.WriteInt32LittleEndian(header, bytes.Length);
-                        stream.Write(header[..4]);
-                        stream.Write(bytes);
+                        Write(file, ref position, header[..4]);
+                        Write(file, ref position, bytes);
                         break;
                     }
                 case SqlValueKind.Blob:
                     {
                         var bytes = value.AsBlob().ToArray();
-                        stream.WriteByte(0x04);
+                        WriteByte(file, ref position, 0x04);
                         BinaryPrimitives.WriteInt32LittleEndian(header, bytes.Length);
-                        stream.Write(header[..4]);
-                        stream.Write(bytes);
+                        Write(file, ref position, header[..4]);
+                        Write(file, ref position, bytes);
                         break;
                     }
                 default:
@@ -2776,19 +3005,50 @@ public sealed class ResumableStatement : IDisposable
             }
         }
 
-        // Reads one run's records back one at a time from a shared FileStream. Each read
-        // seeks to the run's cursor so multiple readers can share the stream without a
-        // BinaryReader buffering conflict.
+        private static void WriteByte(IFile file, ref long position, byte value)
+        {
+            Span<byte> bytes = stackalloc byte[1] { value };
+            Write(file, ref position, bytes);
+        }
+
+        private static void Write(IFile file, ref long position, ReadOnlySpan<byte> source)
+        {
+            file.Write(position, source);
+            position = checked(position + source.Length);
+        }
+
+        private readonly struct SpillMergeKey
+        {
+            public readonly SqlValue[] Record;
+            public readonly int InputIndex;
+            private readonly VdbeRowComparer _comparer;
+
+            public SpillMergeKey(SqlValue[] record, int inputIndex, VdbeRowComparer comparer)
+            {
+                Record = record;
+                InputIndex = inputIndex;
+                _comparer = comparer;
+            }
+
+            public static IComparer<SpillMergeKey> Comparer { get; } =
+                Comparer<SpillMergeKey>.Create((left, right) =>
+                {
+                    var comparison = left._comparer(left.Record, right.Record);
+                    return comparison != 0 ? comparison : left.InputIndex.CompareTo(right.InputIndex);
+                });
+        }
+
+        // Reads one run's records back one at a time using positional IFile access. Multiple
+        // readers share the file safely because each carries its own explicit offset.
         public sealed class RunReader : IDisposable
         {
-            private readonly FileStream _stream;
+            private readonly IFile _file;
             private readonly int _columnCount;
             private long _position;
-            private int _rowsRead;
 
-            public RunReader(FileStream stream, long offset, int rowCount, int columnCount)
+            public RunReader(IFile file, long offset, int rowCount, int columnCount)
             {
-                _stream = stream;
+                _file = file;
                 _columnCount = columnCount;
                 _position = offset;
                 RowsRemaining = rowCount;
@@ -2796,7 +3056,7 @@ public sealed class ResumableStatement : IDisposable
 
             public int RowsRemaining { get; private set; }
 
-            public bool TryReadNext(out SqlValue[] row)
+            public bool TryReadNext(out SqlValue[] row, CancellationToken cancellationToken)
             {
                 if (RowsRemaining <= 0)
                 {
@@ -2804,29 +3064,36 @@ public sealed class ResumableStatement : IDisposable
                     return false;
                 }
 
-                _stream.Seek(_position, SeekOrigin.Begin);
-                row = new SqlValue[_columnCount];
-                Span<byte> header = stackalloc byte[8];
+                var rowStart = _position;
+                try
+                {
+                    row = new SqlValue[_columnCount];
+                    Span<byte> header = stackalloc byte[8];
 
-                for (var column = 0; column < _columnCount; column++)
-                    ReadValue(_stream, header, out row[column]);
+                    for (var column = 0; column < _columnCount; column++)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        ReadValue(_file, ref _position, header, out row[column]);
+                    }
 
-                _position = _stream.Position;
-                _rowsRead++;
-                RowsRemaining--;
-                return true;
+                    RowsRemaining--;
+                    return true;
+                }
+                catch
+                {
+                    _position = rowStart;
+                    throw;
+                }
             }
 
             public void Dispose()
             {
-                // The FileStream is shared (owned by SorterSpill); nothing to release here.
+                // The IFile is shared and owned by SorterSpill.
             }
 
-            private static void ReadValue(FileStream stream, Span<byte> header, out SqlValue value)
+            private static void ReadValue(IFile file, ref long position, Span<byte> header, out SqlValue value)
             {
-                var kindByte = stream.ReadByte();
-                if (kindByte < 0)
-                    throw new EndOfStreamException("Sorter spill stream ended mid-record.");
+                var kindByte = ReadByte(file, ref position);
 
                 var isJson = (kindByte & 0x80) != 0;
                 var kind = (SqlValueKind)(kindByte & 0x0F);
@@ -2836,26 +3103,30 @@ public sealed class ResumableStatement : IDisposable
                         value = SqlValue.Null;
                         break;
                     case SqlValueKind.Integer:
-                        ReadExact(stream, header[..8]);
+                        ReadExact(file, ref position, header[..8]);
                         value = SqlValue.Integer(BinaryPrimitives.ReadInt64LittleEndian(header));
                         break;
                     case SqlValueKind.Real:
-                        ReadExact(stream, header[..8]);
+                        ReadExact(file, ref position, header[..8]);
                         value = SqlValue.Real(BinaryPrimitives.ReadDoubleLittleEndian(header));
                         break;
                     case SqlValueKind.Text:
-                        ReadExact(stream, header[..4]);
+                        ReadExact(file, ref position, header[..4]);
                         var textLength = BinaryPrimitives.ReadInt32LittleEndian(header);
+                        if (textLength < 0)
+                            throw new InvalidDataException("Sorter spill text length is negative.");
                         var textBytes = new byte[textLength];
-                        ReadExact(stream, textBytes);
+                        ReadExact(file, ref position, textBytes);
                         var text = Encoding.UTF8.GetString(textBytes);
                         value = isJson ? SqlValue.JsonText(text) : SqlValue.Text(text);
                         break;
                     case SqlValueKind.Blob:
-                        ReadExact(stream, header[..4]);
+                        ReadExact(file, ref position, header[..4]);
                         var blobLength = BinaryPrimitives.ReadInt32LittleEndian(header);
+                        if (blobLength < 0)
+                            throw new InvalidDataException("Sorter spill blob length is negative.");
                         var blob = new byte[blobLength];
-                        ReadExact(stream, blob);
+                        ReadExact(file, ref position, blob);
                         value = SqlValue.Blob(blob);
                         break;
                     default:
@@ -2863,16 +3134,25 @@ public sealed class ResumableStatement : IDisposable
                 }
             }
 
-            private static void ReadExact(FileStream stream, Span<byte> buffer)
+            private static byte ReadByte(IFile file, ref long position)
+            {
+                Span<byte> value = stackalloc byte[1];
+                ReadExact(file, ref position, value);
+                return value[0];
+            }
+
+            private static void ReadExact(IFile file, ref long position, Span<byte> buffer)
             {
                 var total = 0;
                 while (total < buffer.Length)
                 {
-                    var read = stream.Read(buffer[total..]);
+                    var read = file.Read(checked(position + total), buffer[total..]);
                     if (read <= 0)
                         throw new EndOfStreamException("Sorter spill stream ended mid-record.");
                     total += read;
                 }
+
+                position = checked(position + total);
             }
         }
     }

--- a/src/Ahtola.Core/Execution/VdbeExecutionOptions.cs
+++ b/src/Ahtola.Core/Execution/VdbeExecutionOptions.cs
@@ -1,0 +1,60 @@
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Core.Execution;
+
+/// <summary>
+/// Supplies statement-local execution resources to a <see cref="ResumableStatement"/>.
+/// </summary>
+/// <remarks>
+/// Sorter runs are transient execution artifacts. They use <see cref="TemporaryFileSystem"/>
+/// exclusively and are never part of the SQLite database, WAL, or catalog format.
+/// </remarks>
+public sealed class VdbeExecutionOptions
+{
+    /// <summary>
+    /// The default sorter memory budget, matching SQLite's default
+    /// <c>cache_size=-2000</c> (2 MiB).
+    /// </summary>
+    public const long DefaultSorterMemoryLimitBytes = 2L * 1024 * 1024;
+    public const int DefaultSorterMergeFanIn = 32;
+
+    /// <summary>
+    /// Creates execution resources for one or more statements.
+    /// </summary>
+    /// <param name="temporaryFileSystem">The backend that owns temporary sorter runs.</param>
+    /// <param name="sorterMemoryLimitBytes">The maximum buffered sorter payload before spilling.</param>
+    /// <param name="temporaryDirectory">The existing directory or logical path prefix for run files.</param>
+    /// <param name="sorterMergeFanIn">The maximum run heads retained by a merge pass.</param>
+    public VdbeExecutionOptions(
+        IFileSystem temporaryFileSystem,
+        long sorterMemoryLimitBytes = DefaultSorterMemoryLimitBytes,
+        string? temporaryDirectory = null,
+        int sorterMergeFanIn = DefaultSorterMergeFanIn)
+    {
+        ArgumentNullException.ThrowIfNull(temporaryFileSystem);
+        ArgumentOutOfRangeException.ThrowIfLessThan(sorterMemoryLimitBytes, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(sorterMergeFanIn, 2);
+
+        TemporaryFileSystem = temporaryFileSystem;
+        SorterMemoryLimitBytes = sorterMemoryLimitBytes;
+        SorterMergeFanIn = sorterMergeFanIn;
+        TemporaryDirectory = string.IsNullOrWhiteSpace(temporaryDirectory)
+            ? Path.GetTempPath()
+            : temporaryDirectory;
+    }
+
+    /// <summary>The file-system abstraction that stores transient sorter runs.</summary>
+    public IFileSystem TemporaryFileSystem { get; }
+
+    /// <summary>The maximum buffered sorter payload before an external run is written.</summary>
+    public long SorterMemoryLimitBytes { get; }
+
+    /// <summary>The maximum run heads retained by a single merge pass.</summary>
+    public int SorterMergeFanIn { get; }
+
+    /// <summary>The existing directory or logical path prefix used for temporary run names.</summary>
+    public string TemporaryDirectory { get; }
+
+    internal static VdbeExecutionOptions Default { get; } =
+        new(PhysicalFileSystem.Instance);
+}

--- a/src/Ahtola.Core/Execution/VdbeProgram.cs
+++ b/src/Ahtola.Core/Execution/VdbeProgram.cs
@@ -1418,14 +1418,24 @@ public sealed class VdbeSubprogram
 
     internal bool RequiresFreshRuntime => _dynamicWriteTargets is not null;
 
-    internal ResumableStatement CreateRuntime(VdbeParameterBinding? parameterBinding)
+    internal ResumableStatement CreateRuntime(
+        VdbeParameterBinding? parameterBinding,
+        VdbeExecutionOptions executionOptions)
     {
+        ArgumentNullException.ThrowIfNull(executionOptions);
         lock (_syncRoot)
         {
             var program = _program ?? throw new InvalidOperationException(
                 "The recursive VDBE subprogram was not resolved before execution.");
             var writeTargets = _dynamicWriteTargets?.Invoke(parameterBinding) ?? _writeTargets;
-            return new ResumableStatement(program, _cursorSources, writeTargets, parameterBinding);
+            return new ResumableStatement(
+                program,
+                _cursorSources,
+                writeTargets,
+                parameterBinding,
+                sharedTransaction: null,
+                virtualTableBindings: null,
+                executionOptions: executionOptions);
         }
     }
 }
@@ -1641,12 +1651,12 @@ public sealed record CloseCursorInstruction(Cursor Cursor) : VdbeInstruction
 
 /// <summary>Opens a sorter that materializes rows and orders them with
 /// <paramref name="Comparer"/> when <c>SorterSort</c> runs. <paramref name="ColumnCount"/>
-/// is the fixed width of every record the sorter stores. When the buffered row count
-/// exceeds <paramref name="BufferRowCapacity"/> (if positive), the sorter spills to a
-/// temp file and drains via a k-way merge so large <c>ORDER BY</c>/<c>DISTINCT</c>/
-/// <c>GROUP BY</c> result sets do not OOM — mirroring SQLite's external merge sort.
-/// The default <c>0</c> means no spill (in-memory only), preserving the historical
-/// behavior for every existing call site.</summary>
+/// is the fixed width of every record the sorter stores. The owning
+/// <see cref="ResumableStatement"/> spills buffered payloads at its
+/// <see cref="VdbeExecutionOptions.SorterMemoryLimitBytes"/> and drains through
+/// a k-way merge, so large <c>ORDER BY</c>/<c>GROUP BY</c> result sets do not
+/// materialize in memory. A positive <paramref name="BufferRowCapacity"/> is a
+/// stricter deterministic row-cap override used by opcode-level tests.</summary>
 public sealed record OpenSorterInstruction(
     Sorter Sorter,
     VdbeRowComparer Comparer,

--- a/src/Ahtola.Core/Storage/IFileSystem.cs
+++ b/src/Ahtola.Core/Storage/IFileSystem.cs
@@ -21,11 +21,13 @@ public enum FileOpenMode
 /// </summary>
 public enum FileSystemOperation
 {
-    Read,
-    Write,
-    SetLength,
-    FlushToDisk,
-    AtomicReplace,
+    Read = 0,
+    Write = 1,
+    SetLength = 2,
+    FlushToDisk = 3,
+    AtomicReplace = 4,
+    Open = 5,
+    Delete = 6,
 }
 
 /// <summary>
@@ -76,6 +78,16 @@ internal interface IAtomicFileSystem
         string sourcePath,
         string destinationPath,
         bool replaceEmptyDestination);
+}
+
+/// <summary>
+/// Optional temporary-file capability. Implementations that can ask the host to
+/// remove a file when its final handle closes expose it without leaking host I/O
+/// APIs into execution code.
+/// </summary>
+internal interface ITemporaryFileSystem
+{
+    IFile OpenTemporaryFile(string path);
 }
 
 /// <summary>

--- a/src/Ahtola.Core/Storage/InMemoryFileSystem.cs
+++ b/src/Ahtola.Core/Storage/InMemoryFileSystem.cs
@@ -132,6 +132,7 @@ public sealed class InMemoryFileSystem : IFileSystem, IAtomicFileSystem
         if (readOnly && mode == FileOpenMode.CreateNew)
             throw new ArgumentException("A newly created file cannot be opened read-only.", nameof(readOnly));
 
+        _faults?.BeforeOperation(FileSystemOperation.Open);
         lock (_gate)
         {
             var exists = _files.TryGetValue(path, out var store);
@@ -156,6 +157,7 @@ public sealed class InMemoryFileSystem : IFileSystem, IAtomicFileSystem
     public void DeleteFile(string path)
     {
         ArgumentException.ThrowIfNullOrEmpty(path);
+        _faults?.BeforeOperation(FileSystemOperation.Delete);
         lock (_gate)
             _files.Remove(path);
     }

--- a/src/Ahtola.Core/Storage/PhysicalFileSystem.cs
+++ b/src/Ahtola.Core/Storage/PhysicalFileSystem.cs
@@ -12,6 +12,7 @@ namespace Ahtola.Core.Storage;
 public sealed partial class PhysicalFileSystem :
     IFileSystem,
     IAtomicFileSystem,
+    ITemporaryFileSystem,
     ISqliteWalSharedMemoryFileSystem
 {
     private const uint ReplaceFileWriteThrough = 0x00000001;
@@ -36,6 +37,18 @@ public sealed partial class PhysicalFileSystem :
 
     public IFile OpenFile(string path, FileOpenMode mode, bool readOnly = false)
         => OpenFile(path, mode, readOnly, FileShare.Read);
+
+    IFile ITemporaryFileSystem.OpenTemporaryFile(string path)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        var handle = File.OpenHandle(
+            path,
+            FileMode.CreateNew,
+            FileAccess.ReadWrite,
+            FileShare.Read,
+            FileOptions.DeleteOnClose);
+        return new PhysicalFile(handle, readOnly: false);
+    }
 
     internal IFile OpenPagerFile(string path, FileOpenMode mode, bool readOnly = false)
         => OpenFile(path, mode, readOnly, FileShare.ReadWrite | FileShare.Delete);

--- a/src/Ahtola.Tests/SorterOpcodeExecutionTests.cs
+++ b/src/Ahtola.Tests/SorterOpcodeExecutionTests.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using Ahtola.Core;
 using Ahtola.Core.Execution;
+using Ahtola.Core.Storage;
 
 namespace Ahtola.Tests;
 
@@ -264,6 +265,115 @@ public class SorterOpcodeExecutionTests
     }
 
     [Test]
+    public void SorterUsesConfiguredByteBudgetAndCleansUpIFileSystemRuns()
+    {
+        var fileSystem = new TrackingFileSystem();
+        var options = new VdbeExecutionOptions(
+            fileSystem,
+            sorterMemoryLimitBytes: 1,
+            temporaryDirectory: "sorter-byte-budget");
+        var program = SingleColumnSorterProgram(AscendingFirstColumn, 3, 1, 2);
+
+        using (var statement = ResumableStatement.CreateWithExecutionOptions(program, options))
+        {
+            DrainRows(statement).Select(row => row[0].AsInteger()).Should().Equal(1, 2, 3);
+        }
+
+        fileSystem.Created.Should().NotBeEmpty();
+        fileSystem.Deleted.Should().BeEquivalentTo(fileSystem.Created);
+        fileSystem.Created.Should().OnlyContain(path => !fileSystem.FileExists(path));
+    }
+
+    [Test]
+    public void SorterConsolidatesManyRunsWithinConfiguredMergeFanIn()
+    {
+        var options = new VdbeExecutionOptions(
+            new InMemoryFileSystem(),
+            sorterMemoryLimitBytes: 1024,
+            temporaryDirectory: "sorter-fan-in",
+            sorterMergeFanIn: 2);
+        var values = Enumerable.Range(1, 40).Select(static value => (long)(41 - value)).ToArray();
+        var program = SingleColumnSpillSorterProgram(AscendingFirstColumn, 1, values);
+
+        using var statement = ResumableStatement.CreateWithExecutionOptions(program, options);
+
+        DrainRows(statement).Select(row => row[0].AsInteger()).Should().Equal(Enumerable.Range(1, 40).Select(static value => (long)value));
+    }
+
+    [Test]
+    public void SpillWriteFailureDeletesTheAllocatedIFileSystemRunOnDispose()
+    {
+        var faults = new DeterministicFaultInjector();
+        var backing = new InMemoryFileSystem(faults);
+        var fileSystem = new TrackingFileSystem(backing);
+        faults.FailNextAfter(FileSystemOperation.Open, FileSystemOperation.Write);
+        var options = new VdbeExecutionOptions(
+            fileSystem,
+            sorterMemoryLimitBytes: 1,
+            temporaryDirectory: "sorter-write-fault");
+        var program = SingleColumnSorterProgram(AscendingFirstColumn, 2, 1);
+        var statement = ResumableStatement.CreateWithExecutionOptions(program, options);
+
+        Assert.Throws<IOException>(() => statement.StepResumable());
+        faults.ClearScheduled();
+        DrainRows(statement).Select(row => row[0].AsInteger()).Should().Equal(1, 2);
+        statement.Dispose();
+
+        fileSystem.Created.Should().HaveCount(1);
+        fileSystem.Deleted.Should().BeEquivalentTo(fileSystem.Created);
+        fileSystem.FileExists(fileSystem.Created[0]).Should().BeFalse();
+    }
+
+    [Test]
+    public void SpillCancellationDeletesTheAllocatedIFileSystemRunOnDispose()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var fileSystem = new TrackingFileSystem();
+        VdbeRowComparer comparer = (left, right) =>
+        {
+            cancellation.Cancel();
+            return left[0].AsInteger().CompareTo(right[0].AsInteger());
+        };
+        var options = new VdbeExecutionOptions(
+            fileSystem,
+            sorterMemoryLimitBytes: 1024,
+            temporaryDirectory: "sorter-cancellation");
+        var statement = ResumableStatement.CreateWithExecutionOptions(
+            SingleColumnSpillSorterProgram(comparer, 2, 3, 2, 1),
+            options);
+
+        Assert.Throws<OperationCanceledException>(() => statement.StepResumable(cancellation.Token));
+        statement.Dispose();
+
+        fileSystem.Created.Should().HaveCount(1);
+        fileSystem.Deleted.Should().BeEquivalentTo(fileSystem.Created);
+    }
+
+    [Test]
+    public void SpillReadFailureDeletesTheAllocatedIFileSystemRunOnDispose()
+    {
+        var faults = new DeterministicFaultInjector();
+        var backing = new InMemoryFileSystem(faults);
+        var fileSystem = new TrackingFileSystem(backing);
+        faults.FailNext(FileSystemOperation.Read);
+        var options = new VdbeExecutionOptions(
+            fileSystem,
+            sorterMemoryLimitBytes: 1,
+            temporaryDirectory: "sorter-read-fault");
+        var statement = ResumableStatement.CreateWithExecutionOptions(
+            SingleColumnSorterProgram(AscendingFirstColumn, 3, 1, 2),
+            options);
+
+        Assert.Throws<IOException>(() => statement.StepResumable());
+        faults.ClearScheduled();
+        DrainRows(statement).Select(row => row[0].AsInteger()).Should().Equal(1, 2, 3);
+        statement.Dispose();
+
+        fileSystem.Created.Should().HaveCount(1);
+        fileSystem.Deleted.Should().BeEquivalentTo(fileSystem.Created);
+    }
+
+    [Test]
     public void ValidationRejectsMalformedSorterBytecode()
     {
         var comparer = AscendingFirstColumn;
@@ -464,6 +574,33 @@ public class SorterOpcodeExecutionTests
         instructions.Add(new HaltInstruction());
 
         return new VdbeProgram(registerCount: 1, cursorCount: 0, instructions, sorterCount: 1);
+    }
+
+    private sealed class TrackingFileSystem : IFileSystem
+    {
+        private readonly IFileSystem _inner;
+
+        public TrackingFileSystem(IFileSystem? inner = null) => _inner = inner ?? new InMemoryFileSystem();
+
+        public List<string> Created { get; } = [];
+
+        public List<string> Deleted { get; } = [];
+
+        public bool FileExists(string path) => _inner.FileExists(path);
+
+        public IFile OpenFile(string path, FileOpenMode mode, bool readOnly = false)
+        {
+            var file = _inner.OpenFile(path, mode, readOnly);
+            if (mode == FileOpenMode.CreateNew)
+                Created.Add(path);
+            return file;
+        }
+
+        public void DeleteFile(string path)
+        {
+            Deleted.Add(path);
+            _inner.DeleteFile(path);
+        }
     }
 
     private static List<SqlValue[]> RunToCompletion(VdbeProgram program, params VdbeCursorSource[] cursorSources)


### PR DESCRIPTION
## Summary
- Replace VDBE sorter `FileStream` spill handling with statement-owned `IFileSystem` resources, byte budgets, retry-safe cleanup, and bounded fan-in merge passes.
- Derive compiled execution resources from connection `cache_size` and `temp_store`, including CTAS; keep unsafe DISTINCT, compound-set, outer-join, and aggregate hash spill deferred.
- Add deterministic threshold, fan-in, cancellation, I/O fault, retry, and cleanup coverage.

## Validation
- `Invoke-ManagedTestSuite.ps1` sorter suite on net8.0, net9.0, net10.0
- Focused sorter integration suite on net10.0
- Full net10.0 managed suite (4,421 executed)
- `build.ps1 build -Framework net10.0`
- `build.ps1 validate-package`