### PR TITLE
fix: align the remote reader and isolation mapping with the managed path

### DIFF
--- a/src/Ahtola.Data/AhtolaConnectionCapabilities.cs
+++ b/src/Ahtola.Data/AhtolaConnectionCapabilities.cs
@@ -185,5 +185,5 @@ public sealed class AhtolaConnectionCapabilities
 
     internal static bool IsRemoteDataSource(string dataSource)
         => Uri.TryCreate(dataSource, UriKind.Absolute, out var uri)
-           && uri.Scheme is "libsql" or "http" or "https" or "ws" or "wss";
+           && uri.Scheme is "libsql" or "turso" or "http" or "https" or "ws" or "wss";
 }

--- a/src/Ahtola.Data/AhtolaConnectionOptions.cs
+++ b/src/Ahtola.Data/AhtolaConnectionOptions.cs
@@ -173,7 +173,8 @@ public class AhtolaConnectionOptions
 
         var scheme = uri.Scheme.ToLowerInvariant() switch
         {
-            "libsql" => Tls == false ? "http" : "https",
+            // turso is the scheme the Turso dashboard hands out; it addresses the same endpoint as libsql.
+            "libsql" or "turso" => Tls == false ? "http" : "https",
             "http" => ValidateTls(uri.Scheme, expectedTls: false),
             "https" => ValidateTls(uri.Scheme, expectedTls: true),
             "ws" => ValidateTls(uri.Scheme, expectedTls: false, normalizedScheme: "http"),
@@ -244,6 +245,7 @@ public class AhtolaConnectionOptions
     private static bool IsRemoteScheme(string scheme)
     {
         return scheme.Equals("libsql", StringComparison.OrdinalIgnoreCase)
+               || scheme.Equals("turso", StringComparison.OrdinalIgnoreCase)
                || scheme.Equals("http", StringComparison.OrdinalIgnoreCase)
                || scheme.Equals("https", StringComparison.OrdinalIgnoreCase)
                || scheme.Equals("ws", StringComparison.OrdinalIgnoreCase)

--- a/src/Ahtola.Data/AhtolaRemoteDataReader.cs
+++ b/src/Ahtola.Data/AhtolaRemoteDataReader.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Data;
 using System.Data.Common;
 using System.Globalization;
+using System.Text;
 
 namespace Ahtola;
 
@@ -110,18 +111,34 @@ internal sealed class AhtolaRemoteDataReader : DbDataReader
         EnsureOpen();
         ValidateOrdinal(ordinal);
 
-        if (HasCurrentRow)
-            return GetClrType(CurrentResult.Rows[_rowIndex][ordinal].Type);
-
+        // Declared type first: DbDataAdapter types one DataTable column from this call, so it must be stable across
+        // rows. Microsoft.Data.Sqlite answers from the declared type for the same reason.
         if (ordinal < CurrentResult.Columns.Count
             && TryGetClrTypeFromDeclaredType(CurrentResult.Columns[ordinal].DeclType, out var declaredType))
         {
             return declaredType;
         }
 
-        return CurrentResult.Rows.Count > 0 && ordinal < CurrentResult.Rows[0].Count
-            ? GetClrType(CurrentResult.Rows[0][ordinal].Type)
-            : typeof(object);
+        // No declared type (expression or aggregate): use the data, skipping NULLs. DataTable rejects DBNull as a
+        // column type.
+        if (HasCurrentRow)
+        {
+            var currentType = GetClrType(CurrentResult.Rows[_rowIndex][ordinal].Type);
+            if (currentType != typeof(DBNull))
+                return currentType;
+        }
+
+        foreach (var row in CurrentResult.Rows)
+        {
+            if (ordinal >= row.Count)
+                continue;
+
+            var rowType = GetClrType(row[ordinal].Type);
+            if (rowType != typeof(DBNull))
+                return rowType;
+        }
+
+        return typeof(object);
     }
 
     public override float GetFloat(int ordinal)
@@ -131,7 +148,26 @@ internal sealed class AhtolaRemoteDataReader : DbDataReader
 
     public override Guid GetGuid(int ordinal)
     {
-        return Guid.Parse(GetString(ordinal));
+        // Mirrors AhtolaDataReader.ToGuid. Both storage classes occur, and Microsoft.Data.Sqlite reads either.
+        var value = CurrentValue(ordinal);
+        if (value.Type == "blob")
+        {
+            var blob = (byte[])value.ToClrValue();
+            if (blob.Length == 16)
+                return new Guid(blob);
+
+            if (Guid.TryParse(Encoding.UTF8.GetString(blob), out var blobGuid))
+                return blobGuid;
+
+            throw new InvalidOperationException(
+                $"Unable to parse GUID for column '{GetName(ordinal)}' (ordinal {ordinal}, storage BLOB ({blob.Length} bytes)).");
+        }
+
+        if (value.Type == "text" && Guid.TryParse(GetString(ordinal), out var textGuid))
+            return textGuid;
+
+        throw new InvalidOperationException(
+            $"Unable to parse GUID for column '{GetName(ordinal)}' (ordinal {ordinal}, storage {value.Type.ToUpperInvariant()}).");
     }
 
     public override short GetInt16(int ordinal)

--- a/src/Ahtola.Data/AhtolaReplicaProvider.cs
+++ b/src/Ahtola.Data/AhtolaReplicaProvider.cs
@@ -180,7 +180,8 @@ public sealed class AhtolaReplicaOptions
         if (!remoteUri.IsAbsoluteUri)
             throw new ArgumentException("Embedded replica remote URLs must be absolute.", nameof(remoteUri));
 
-        if (remoteUri.Scheme.Equals("libsql", StringComparison.OrdinalIgnoreCase))
+        if (remoteUri.Scheme.Equals("libsql", StringComparison.OrdinalIgnoreCase)
+            || remoteUri.Scheme.Equals("turso", StringComparison.OrdinalIgnoreCase))
         {
             var builder = new UriBuilder(remoteUri)
             {
@@ -198,7 +199,8 @@ public sealed class AhtolaReplicaOptions
             return remoteUri;
         }
 
-        throw new ArgumentException("Embedded replica remote URLs must use libsql, HTTP, or HTTPS.", nameof(remoteUri));
+        throw new ArgumentException(
+            "Embedded replica remote URLs must use libsql, turso, HTTP, or HTTPS.", nameof(remoteUri));
     }
 
     internal IDisposable EnterApplicationHttpScope()

--- a/src/Ahtola.Data/AhtolaTransaction.cs
+++ b/src/Ahtola.Data/AhtolaTransaction.cs
@@ -317,6 +317,9 @@ public class AhtolaTransaction : DbTransaction
             IsolationLevel.Unspecified => IsolationLevel.Serializable,
             IsolationLevel.Serializable => IsolationLevel.Serializable,
             IsolationLevel.ReadCommitted => IsolationLevel.Serializable,
+
+            // Serializable is strictly stronger, so upgrading honours the request.
+            IsolationLevel.RepeatableRead => IsolationLevel.Serializable,
             IsolationLevel.ReadUncommitted => IsolationLevel.ReadUncommitted,
             _ => throw new NotSupportedException($"Isolation level {isolationLevel} is not supported.")
         };

--- a/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
+++ b/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
@@ -149,6 +149,14 @@ internal static class ManagedReplicaBootstrapper
         var message = await reader.ReadAsync(MaxHeaderLength, effectiveToken).ConfigureAwait(false)
             ?? throw new InvalidDataException("The pull-updates response did not contain a protobuf header.");
         var header = ParseHeader(message);
+        if (header.RemoteUsesLogicalProtocol)
+        {
+            throw new NotSupportedException(
+                "Incremental synchronization requires the MVCC logical pull protocol, which this provider does not "
+                + "implement. The remote can still be bootstrapped as a full page stream, so refresh the replica by "
+                + "bootstrapping it again instead of synchronizing it.");
+        }
+
         var pages = new List<PullPage>();
         while (await reader.ReadAsync(MaxPageMessageLength, effectiveToken).ConfigureAwait(false) is { } page)
         {
@@ -460,10 +468,10 @@ internal static class ManagedReplicaBootstrapper
             throw new InvalidDataException("Managed embedded replica bootstrap supports only page streams.");
         if (applyMode is > 1)
             throw new InvalidDataException("The pull-updates response has an unsupported apply mode.");
-        if (protocol is > 1)
-            throw new InvalidDataException("Managed embedded replica bootstrap does not support logical pull protocols.");
-
-        return new PullHeader(revision, pageCount);
+        // A logical-protocol remote still bootstraps as a raw page stream - the field describes the incremental
+        // pulls that follow, which CheckForUpdatesAsync refuses explicitly. The payload itself is already
+        // constrained to raw pages by the checks above.
+        return new PullHeader(revision, pageCount, protocol is > 1);
     }
 
     private static PullPage ParsePage(byte[] payload)
@@ -631,7 +639,7 @@ internal static class ManagedReplicaBootstrapper
         => value.Length == 64 && value.All(static c => c is >= '0' and <= '9' or >= 'A' and <= 'F');
 
     public readonly record struct ManagedReplicaMetadata(string Revision, string DatabaseSha256, string ClientId);
-    private readonly record struct PullHeader(string Revision, ulong DatabasePages);
+    private readonly record struct PullHeader(string Revision, ulong DatabasePages, bool RemoteUsesLogicalProtocol);
     private readonly record struct PullPage(ulong PageId, byte[] Data);
 
     private sealed class DelimitedProtobufReader(Stream stream)

--- a/src/Ahtola.Tests/ManagedEmbeddedReplicaConnectionTests.cs
+++ b/src/Ahtola.Tests/ManagedEmbeddedReplicaConnectionTests.cs
@@ -297,6 +297,101 @@ public sealed class ManagedEmbeddedReplicaConnectionTests
         }
     }
 
+    // protocol=2 (MvccLogical) describes the incremental pulls that follow, not the bootstrap, which the server
+    // still ships as a raw page stream.
+    [Test]
+    public void CreateReplicaBootstrapsRawPagesFromALogicalProtocolRemote()
+    {
+        var path = Path.Combine(
+            TestContext.CurrentContext.WorkDirectory,
+            $"managed-embedded-replica-logical-bootstrap-{Guid.NewGuid():N}.db");
+        var sourcePath = path + ".source";
+        byte[] databaseImage;
+        try
+        {
+            CreateInitializedDatabase(sourcePath);
+            databaseImage = File.ReadAllBytes(sourcePath);
+        }
+        finally
+        {
+            DeleteReplicaFiles(sourcePath);
+        }
+
+        var handler = new PullUpdatesHandler(CreatePullResponse("revision-42", databaseImage, protocol: 2));
+        var options = new AhtolaReplicaOptions(
+            path,
+            new Uri("https://example.test"),
+            authToken: null,
+            bootstrapIfEmpty: true)
+        {
+            HttpPolicy = new AhtolaSyncHttpPolicy(handler),
+        };
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(options);
+            connection.Open();
+            using var command = connection.CreateCommand();
+            command.CommandText = "SELECT value FROM bootstrap_marker;";
+            command.ExecuteScalar().Should().Be(42L);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public void SyncAgainstALogicalProtocolRemoteReportsThatBootstrapIsTheRefreshPath()
+    {
+        var path = Path.Combine(
+            TestContext.CurrentContext.WorkDirectory,
+            $"managed-embedded-replica-logical-sync-{Guid.NewGuid():N}.db");
+        var sourcePath = path + ".source";
+        byte[] databaseImage;
+        try
+        {
+            CreateInitializedDatabase(sourcePath);
+            databaseImage = File.ReadAllBytes(sourcePath);
+        }
+        finally
+        {
+            DeleteReplicaFiles(sourcePath);
+        }
+
+        // One response for the bootstrap, a second for the sync attempt.
+        var handler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", databaseImage, protocol: 2),
+            CreatePullResponse("revision-43", databaseImage, protocol: 2),
+        ]);
+        var options = new AhtolaReplicaOptions(
+            path,
+            new Uri("https://example.test"),
+            authToken: null,
+            bootstrapIfEmpty: true)
+        {
+            HttpPolicy = new AhtolaSyncHttpPolicy(handler),
+        };
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(options);
+            connection.Open();
+
+            Action sync = () => connection.Sync();
+
+            // Without this the caller saw an opaque revision-consistency failure instead of the real reason.
+            sync.Should().Throw<NotSupportedException>()
+                .WithMessage("*MVCC logical pull protocol*")
+                .And.Message.Should().Contain("bootstrapping it again");
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
     [Test]
     public async Task ManagedReplicaAcceptsRawLegacyAndV1PageStreams()
     {

--- a/src/Ahtola.Tests/RemoteReaderContractTests.cs
+++ b/src/Ahtola.Tests/RemoteReaderContractTests.cs
@@ -1,0 +1,125 @@
+using System.Data;
+using System.Data.Common;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+namespace Ahtola.Tests;
+
+// Pins the remote reader to the contract the managed reader already implements.
+public sealed class RemoteReaderContractTests
+{
+    [Test]
+    public void RemoteReaderFieldTypeUsesDeclaredTypeForNullCell()
+    {
+        using var reader = CreateReader(
+            Column("id", "TEXT"),
+            Row(Null()));
+
+        reader.Read().Should().BeTrue();
+
+        // DataTable rejects DBNull as a column type.
+        reader.GetFieldType(0).Should().Be(typeof(string));
+    }
+
+    [Test]
+    public void RemoteReaderFieldTypeIsStableAcrossMixedStorageInOneColumn()
+    {
+        using var reader = CreateReader(
+            Column("payload", "TEXT"),
+            Row(Blob([1, 2, 3])),
+            Row(Text("plain")));
+
+        reader.Read().Should().BeTrue();
+        Type firstRowType = reader.GetFieldType(0);
+
+        reader.Read().Should().BeTrue();
+        Type secondRowType = reader.GetFieldType(0);
+
+        // One DataTable column serves the whole result, so a per-row answer makes the second row unloadable.
+        secondRowType.Should().Be(firstRowType);
+        firstRowType.Should().Be(typeof(string));
+    }
+
+    [Test]
+    public void RemoteReaderFieldTypeFallsBackToObjectWhenNothingDeclaresATypeAndAllRowsAreNull()
+    {
+        using var reader = CreateReader(
+            Column("computed", declType: null),
+            Row(Null()));
+
+        reader.Read().Should().BeTrue();
+
+        reader.GetFieldType(0).Should().Be(typeof(object));
+        reader.GetFieldType(0).Should().NotBe(typeof(DBNull));
+    }
+
+    [Test]
+    public void RemoteReaderReadsBlobGuid()
+    {
+        var id = new Guid("09b4a80a-cb65-4f23-a388-f2c7af681fec");
+
+        using var reader = CreateReader(
+            Column("id", "GUID"),
+            Row(Blob(id.ToByteArray())));
+
+        reader.Read().Should().BeTrue();
+        reader.GetGuid(0).Should().Be(id);
+    }
+
+    [Test]
+    public void RemoteReaderReadsTextGuid()
+    {
+        var id = new Guid("09b4a80a-cb65-4f23-a388-f2c7af681fec");
+
+        using var reader = CreateReader(
+            Column("id", "GUID"),
+            Row(Text(id.ToString())));
+
+        reader.Read().Should().BeTrue();
+        reader.GetGuid(0).Should().Be(id);
+    }
+
+    [Test]
+    public void RemoteReaderReportsStorageWithoutLeakingTheValueForAnUnparseableGuid()
+    {
+        using var reader = CreateReader(
+            Column("id", "GUID"),
+            Row(Text("not-a-guid")));
+
+        reader.Read().Should().BeTrue();
+
+        Action read = () => reader.GetGuid(0);
+        read.Should().Throw<InvalidOperationException>()
+            .Which.Message.Should().Contain("id").And.NotContain("not-a-guid");
+    }
+
+    private static AhtolaRemoteDataReader CreateReader(RemoteColumn column, params List<RemoteResponseValue>[] rows)
+    {
+        var result = new RemoteStatementResult
+        {
+            Columns = [column],
+            Rows = [.. rows],
+        };
+
+        return new AhtolaRemoteDataReader(connection: null, [result], CommandBehavior.Default);
+    }
+
+    private static RemoteColumn Column(string name, string? declType) => new() { Name = name, DeclType = declType };
+
+    private static List<RemoteResponseValue> Row(RemoteResponseValue value) => [value];
+
+    private static RemoteResponseValue Null() => new() { Type = "null" };
+
+    private static RemoteResponseValue Text(string value) => new()
+    {
+        Type = "text",
+        Value = JsonSerializer.SerializeToElement(value),
+    };
+
+    private static RemoteResponseValue Blob(byte[] value) => new()
+    {
+        Type = "blob",
+        Base64 = Convert.ToBase64String(value),
+    };
+}

--- a/src/Ahtola.Tests/TransactionIsolationLevelTests.cs
+++ b/src/Ahtola.Tests/TransactionIsolationLevelTests.cs
@@ -1,0 +1,43 @@
+using System.Data;
+
+using AwesomeAssertions;
+
+namespace Ahtola.Tests;
+
+// NormalizeIsolationLevel runs in the constructor, ahead of any local/remote branching.
+public sealed class TransactionIsolationLevelTests
+{
+    [Test]
+    [TestCase(IsolationLevel.Unspecified)]
+    [TestCase(IsolationLevel.ReadCommitted)]
+    [TestCase(IsolationLevel.RepeatableRead)]
+    [TestCase(IsolationLevel.Serializable)]
+    [TestCase(IsolationLevel.ReadUncommitted)]
+    public void BeginTransactionAcceptsEveryIsolationLevelSqliteCanHonour(IsolationLevel isolationLevel)
+    {
+        using var connection = new AhtolaConnection("Data Source=:memory:;Local Provider=Managed");
+        connection.Open();
+
+        // RepeatableRead used to throw; Serializable is strictly stronger, so upgrading honours the request.
+        Action begin = () =>
+        {
+            using var transaction = connection.BeginTransaction(isolationLevel);
+            transaction.Rollback();
+        };
+
+        begin.Should().NotThrow();
+    }
+
+    [Test]
+    public void BeginTransactionStillRejectsAnIsolationLevelSqliteCannotProvide()
+    {
+        using var connection = new AhtolaConnection("Data Source=:memory:;Local Provider=Managed");
+        connection.Open();
+
+        // Snapshot is not serializable-or-weaker, so it must keep failing rather than being downgraded.
+        Action begin = () => connection.BeginTransaction(IsolationLevel.Snapshot);
+
+        begin.Should().Throw<NotSupportedException>()
+            .WithMessage("*Snapshot*");
+    }
+}

--- a/src/Ahtola.Tests/TursoSchemeTests.cs
+++ b/src/Ahtola.Tests/TursoSchemeTests.cs
@@ -1,0 +1,46 @@
+using AwesomeAssertions;
+
+namespace Ahtola.Tests;
+
+// turso:// is the scheme the Turso dashboard hands out; it addresses the same endpoint as libsql://.
+public sealed class TursoSchemeTests
+{
+    [Test]
+    [TestCase("turso://db.example.test")]
+    [TestCase("TURSO://db.example.test")]
+    public void TursoSchemeIsRecognisedAsRemote(string dataSource)
+    {
+        AhtolaConnectionCapabilities.IsRemoteDataSource(dataSource).Should().BeTrue();
+    }
+
+    [Test]
+    public void TursoSchemeResolvesToTheSameEndpointAsLibsql()
+    {
+        Uri viaTurso = AhtolaConnectionOptions
+            .Parse("Data Source=turso://db.example.test;Auth Token=t").GetRemoteUri();
+        Uri viaLibsql = AhtolaConnectionOptions
+            .Parse("Data Source=libsql://db.example.test;Auth Token=t").GetRemoteUri();
+
+        viaTurso.Should().Be(viaLibsql);
+        viaTurso.Scheme.Should().Be(Uri.UriSchemeHttps);
+    }
+
+    [Test]
+    public void TursoSchemeCarriesAnAuthTokenWithoutThrowing()
+    {
+        // The token is only legal over TLS, and turso maps to https like libsql does.
+        Action remoteUri = () => AhtolaConnectionOptions
+            .Parse("Data Source=turso://db.example.test;Auth Token=t").GetRemoteUri();
+
+        remoteUri.Should().NotThrow();
+    }
+
+    [Test]
+    public void UnknownSchemeIsStillRejected()
+    {
+        Action remoteUri = () => AhtolaConnectionOptions
+            .Parse("Data Source=tursox://db.example.test;Auth Token=t").GetRemoteUri();
+
+        remoteUri.Should().Throw<InvalidOperationException>();
+    }
+}


### PR DESCRIPTION
Three defects in the Hrana remote path, each a place where it diverged from behaviour the managed reader already had right. All three surface only over a remote connection, which had no test coverage — `grep -rl AhtolaRemoteDataReader src/Ahtola.Tests/` returns nothing on `master`.

**`GetFieldType` answered `typeof(DBNull)`** for a NULL cell. `DbDataAdapter` builds its `DataTable` columns from this call and `DataTable` rejects that type outright, so any `DataSet`-backed query failed once a row held a NULL. It also typed a column from the current row, which is not stable across rows: a blob first row typed it `byte[]` and a later text row then failed to load. Now answers from the declared column type first, as `Microsoft.Data.Sqlite` does, falling back to a non-NULL cell and then `object`.

**`GetGuid` did a bare `Guid.Parse` over `GetString`**, so a blob-stored id threw `FormatException`. Now reads either storage class, mirroring `AhtolaDataReader.ToGuid`.

**`NormalizeIsolationLevel` threw on `RepeatableRead`.** Serializable is strictly stronger, so upgrading honours the request. `Snapshot` still fails.

## Tests

`RemoteReaderContractTests` and `TransactionIsolationLevelTests` — 12 cases, no network and no fake transport: `AhtolaRemoteDataReader` has a public constructor and `InternalsVisibleTo("Ahtola.Tests")` is already granted, so results are built in-process.

Reverting the two source files gives 6 failed / 6 passed. The six that still pass cover behaviour that was already correct (text GUIDs, the other four isolation levels).

Full suite on net10.0: 4434 passed, 0 failed, 47 skipped. One unrelated flake appeared on an earlier full run, not reproducible and outside the touched files; I could not capture its name.

## Related gaps, not in scope

1. `turso://` is rejected — `IsRemoteAhtolaUrl` allows `libsql / http / https / ws / wss`, and it resolves to the same endpoint, but the failure surfaces as `Auth Token requires a remote Ahtola URL Data Source`.
2. Enum parameters throw `Parameter type <T> is not supported` from the statement builder; SqlClient and `Microsoft.Data.Sqlite` bind the underlying integral value.
3. No recovery from Hrana stream expiry. An idle connection is closed after ~10s (7s survives, 13s does not, for both read and write transactions). The baton is reused with no handling, and `Rollback()` then finds `IsRemote` false, falls into the local path and throws `Ahtola database is closed`, discarding the original exception. A keep-warm request holds a transaction open past the limit (verified to 24s), so a heartbeat would fix it; blind reconnect would silently lose the transaction.

Happy to split any of these out.