### PR TITLE
fix: treat omitted proto3 scalars in a logical-log range as zero

### DIFF
--- a/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
+++ b/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
@@ -1135,10 +1135,14 @@ internal static class ManagedReplicaBootstrapper
             }
         }
 
-        if (generation is null || startOffset is null || endOffset is null)
-            throw new InvalidDataException("The MVCC logical-log range is missing required fields.");
-
-        return new ManagedReplicaLogicalLogRange(generation.Value, startOffset.Value, endOffset.Value, startsWithHeader, crcSeed);
+        // generation, start_offset and end_offset are non-optional proto3 scalars, so the server omits them at
+        // zero. A first range starts at offset 0 and carries no tag 2 at all.
+        return new ManagedReplicaLogicalLogRange(
+            generation ?? 0,
+            startOffset ?? 0,
+            endOffset ?? 0,
+            startsWithHeader,
+            crcSeed);
     }
 
     private static PullPage ParsePage(byte[] payload)

--- a/src/Ahtola.Tests/ManagedEmbeddedReplicaConnectionTests.cs
+++ b/src/Ahtola.Tests/ManagedEmbeddedReplicaConnectionTests.cs
@@ -1221,6 +1221,62 @@ public sealed class ManagedEmbeddedReplicaConnectionTests
         }
     }
 
+
+    // A real server omits non-optional proto3 scalars at zero, so a first range carries no start_offset field.
+    [Test]
+    public void LogicalSyncAcceptsARangeThatOmitsItsProto3DefaultFields()
+    {
+        var path = NewReplicaPath("managed-replica-logical-proto3-defaults");
+        var image = CreateDatabaseImage(path + ".source");
+
+        var salt = 778UL;
+        var logHeader = Lml3TestBuilder.BuildHeader(salt);
+        var crc = Lml3TestBuilder.HeaderSeedCrc(salt);
+        var schemaRecord = Lml3TestBuilder.SchemaRecord("table", "widgets", 5, "CREATE TABLE widgets(id INTEGER PRIMARY KEY, name TEXT)");
+        var schemaOp = Lml3TestBuilder.BuildRecoveryOp(0, 0, -1, Lml3TestBuilder.UpsertTablePayload(1, schemaRecord));
+        var rowRecord = Core.Storage.SqliteRecordCodec.Encode([Core.SqlValue.Null, Core.SqlValue.Text("bob")]);
+        var rowOp = Lml3TestBuilder.BuildRecoveryOp(0, 0, -2, Lml3TestBuilder.UpsertTablePayload(9, rowRecord));
+        var portableTxn = Lml3TestBuilder.BuildPortableLogicalTxn(1, 1, ["widgets"], [(-2, 0)]);
+        var extRecord = Lml3TestBuilder.BuildExtensionRecord(Lml3TestBuilder.PortableChangesExtensionType, Lml3TestBuilder.Delimited(portableTxn));
+        var frame = Lml3TestBuilder.BuildFrame(ref crc, schemaOp.Concat(rowOp).ToArray(), opCount: 2, extensionBlock: extRecord);
+        var logicalBody = logHeader.Concat(frame).ToArray();
+
+        // start_offset is 0, so it is absent from the wire entirely.
+        var rangeMessage = BuildLogicalLogRangeMessage(
+            1, 0, (ulong)logicalBody.Length, startsWithHeader: true, omitProto3Defaults: true);
+
+        var handler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", image, protocol: 2),
+            CreateLogicalPullResponse("revision-42", body: []),
+            CreateLogicalPullResponse("revision-43", logicalBody, rangeMessages: [rangeMessage]),
+        ]);
+        var options = new AhtolaReplicaOptions(
+            path,
+            new Uri("https://example.test"),
+            authToken: null,
+            bootstrapIfEmpty: true)
+        {
+            HttpPolicy = new AhtolaSyncHttpPolicy(handler),
+        };
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(options);
+            connection.Open();
+
+            var result = connection.Sync(new AhtolaSyncOptions());
+
+            result.Outcome.Should().Be(AhtolaSyncOutcome.RemoteChangesApplied);
+            using var command = connection.CreateCommand();
+            command.CommandText = "SELECT name FROM widgets WHERE id = 9;";
+            command.ExecuteScalar().Should().Be("bob");
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
     [Test]
     public async Task LogicalSyncRequestBytesIncludeClientRevisionAndLogicalStreamKind()
     {
@@ -3195,12 +3251,16 @@ public sealed class ManagedEmbeddedReplicaConnectionTests
     }
 
     private static byte[] BuildLogicalLogRangeMessage(
-        ulong generation, ulong startOffset, ulong endOffset, bool startsWithHeader, byte[]? crcSeed = null)
+        ulong generation, ulong startOffset, ulong endOffset, bool startsWithHeader, byte[]? crcSeed = null,
+        bool omitProto3Defaults = false)
     {
         var range = new List<byte>();
-        WriteVarintField(range, 1, generation);
-        WriteVarintField(range, 2, startOffset);
-        WriteVarintField(range, 3, endOffset);
+        if (!omitProto3Defaults || generation != 0)
+            WriteVarintField(range, 1, generation);
+        if (!omitProto3Defaults || startOffset != 0)
+            WriteVarintField(range, 2, startOffset);
+        if (!omitProto3Defaults || endOffset != 0)
+            WriteVarintField(range, 3, endOffset);
         if (startsWithHeader)
             WriteVarintField(range, 4, 1);
         if (crcSeed is not null)


### PR DESCRIPTION
`MvccLogicalLogRangeProto` declares `generation`, `start_offset` and `end_offset` as non-optional proto3 scalars:

```rust
#[prost(uint64, tag = "1")] pub generation: u64,
#[prost(uint64, tag = "2")] pub start_offset: u64,
#[prost(uint64, tag = "3")] pub end_offset: u64,
#[prost(bytes, optional, tag = "5")] pub crc_seed: Option<Vec<u8>>,
```

proto3 omits non-optional scalars from the wire when they equal zero, so a range starting at offset 0 arrives with no tag 2 at all. `ParseLogicalLogRange` required all three to be present and threw `The MVCC logical-log range is missing required fields.`

Since the first range of a logical pull starts at offset 0, this rejected the first sync against any remote using the logical protocol — the replica could not be established. Absence now reads as zero. `crc_seed` is the only optional field upstream and was already handled that way.

## Why the existing tests missed it

`BuildLogicalLogRangeMessage` unconditionally emitted tags 1, 2 and 3, so no test ever produced the encoding a server actually sends. It now takes `omitProto3Defaults`, mirroring the existing `omitDefaultPageId` on `CreatePullResponse`.

Added `LogicalSyncAcceptsARangeThatOmitsItsProto3DefaultFields`, which fails on `master` and passes with this change. `ManagedEmbeddedReplicaConnectionTests`: 82/82.

## Verified against a live remote

Bootstrap, then a write through a separate remote connection, then `Sync()`:

- bootstrap 15.4 s
- local read 46 ms
- delta pull **1.75 s**, replica converged on the remote write

Before this change the same sequence failed at `AhtolaConnection.Open()` with the error above.