### PR TITLE
Request raw replica page encoding

### DIFF
--- a/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
+++ b/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
@@ -1242,7 +1242,10 @@ internal static class ManagedReplicaBootstrapper
         => CreatePullRequest(clientRevision: null, longPollTimeout, requestLogicalProtocol: false);
 
     /// <summary>
-    /// Builds a <c>PullUpdatesReqProtoBody</c> request. <paramref name="clientRevision"/> is
+    /// Builds a <c>PullUpdatesReqProtoBody</c> request. Tag 1 (<c>encoding</c>) is explicitly
+    /// emitted as <c>PageUpdatesEncodingReq.Raw</c> (0), even though that is the proto3 default,
+    /// so the wire request negotiates the only page encoding this managed client supports.
+    /// <paramref name="clientRevision"/> is
     /// always emitted (tag 3) whenever it is non-empty, independent of whether a long-poll
     /// timeout is configured: the server cannot compute an incremental diff without it. Setting
     /// <paramref name="requestLogicalProtocol"/> encodes tag 8 (<c>stream_kind</c>) as
@@ -1250,7 +1253,9 @@ internal static class ManagedReplicaBootstrapper
     /// </summary>
     private static byte[] CreatePullRequest(string? clientRevision, TimeSpan? longPollTimeout, bool requestLogicalProtocol)
     {
-        var request = new List<byte>(clientRevision is null ? 6 : clientRevision.Length + 12);
+        var request = new List<byte>(clientRevision is null ? 8 : clientRevision.Length + 14);
+        WriteVarint(request, 1u << 3);
+        WriteVarint(request, 0); // PageUpdatesEncodingReq::Raw
         if (!string.IsNullOrEmpty(clientRevision))
         {
             var revision = StrictUtf8.GetBytes(clientRevision);

--- a/src/Ahtola.Tests/ManagedEmbeddedReplicaConnectionTests.cs
+++ b/src/Ahtola.Tests/ManagedEmbeddedReplicaConnectionTests.cs
@@ -455,7 +455,8 @@ public sealed class ManagedEmbeddedReplicaConnectionTests
             request.Content!.Headers.ContentType!.MediaType.Should().Be("application/protobuf");
 
             var fields = ReadVarintFields(request.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult());
-            fields.Should().ContainSingle();
+            fields.Should().HaveCount(2);
+            fields[1].Should().Be(0, "the bootstrap must explicitly request PageUpdatesEncodingReq.Raw");
             fields[4].Should().Be(3000);
         });
         var options = new AhtolaReplicaOptions(
@@ -1401,8 +1402,9 @@ public sealed class ManagedEmbeddedReplicaConnectionTests
         request =>
         {
             var bytes = request.Content!.ReadAsByteArrayAsync().GetAwaiter().GetResult();
-            if (bytes.Length > 0)
-                capturedRequests.Add(ReadFields(bytes));
+            var fields = ReadFields(bytes);
+            if (fields.ContainsKey(3))
+                capturedRequests.Add(fields);
         });
         var options = new AhtolaReplicaOptions(path, new Uri("https://example.test"), authToken: null)
         {
@@ -1412,7 +1414,7 @@ public sealed class ManagedEmbeddedReplicaConnectionTests
         try
         {
             using var connection = AhtolaConnection.CreateReplica(options);
-            connection.Open(); // bootstrap (no revision, empty request) + fresh-bootstrap catch-up
+            connection.Open(); // bootstrap (raw encoding only, no revision) + fresh-bootstrap catch-up
             await connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None).ConfigureAwait(false);
 
             // The fresh-bootstrap catch-up and the explicit Sync() both know the remote is
@@ -1422,6 +1424,8 @@ public sealed class ManagedEmbeddedReplicaConnectionTests
             capturedRequests.Should().HaveCount(2);
             foreach (var fields in capturedRequests)
             {
+                fields[1].Number.Should().Be(0,
+                    "logical incremental pulls must still request raw encoding for any page fallback");
                 fields[3].Text.Should().Be("revision-42");
                 fields[8].Number.Should().Be(1);
             }
@@ -2649,7 +2653,7 @@ public sealed class ManagedEmbeddedReplicaConnectionTests
     }
 
     [Test]
-    public async Task SyncAsyncReportsUpToDateForTheStoredRevision()
+    public async Task SyncAsyncRequestsRawEncodingAndReportsUpToDateForTheStoredRevision()
     {
         var path = NewReplicaPath("managed-embedded-replica-up-to-date");
         var image = CreateDatabaseImage(path + ".source");
@@ -2658,14 +2662,16 @@ public sealed class ManagedEmbeddedReplicaConnectionTests
                 CreatePullResponse("revision-42", [], declaredPages: 1),
             ], request =>
             {
-                if (request.Content!.Headers.ContentLength == 0)
-                    return;
-                var fields = ReadFields(request.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult());
+                var fields = ReadFields(request.Content!.ReadAsByteArrayAsync().GetAwaiter().GetResult());
                 if (!fields.ContainsKey(3))
                 {
+                    fields[1].Number.Should().Be(0,
+                        "the initial pull must explicitly request PageUpdatesEncodingReq.Raw");
                     fields[4].Number.Should().Be(3000);
                     return;
                 }
+                fields[1].Number.Should().Be(0,
+                    "incremental pulls must explicitly request PageUpdatesEncodingReq.Raw");
                 fields[3].Text.Should().Be("revision-42");
                 fields[4].Number.Should().Be(3000);
             });


### PR DESCRIPTION
## Summary
- explicitly encode `PullUpdatesReqProtoBody.encoding` at protobuf tag 1 as `PageUpdatesEncodingReq.Raw` (`0`) for bootstrap and incremental pulls
- keep fail-closed raw response validation, including zstd rejection
- assert raw encoding on page and logical incremental request paths

Mirrors the pinned Turso v0.7.2 contract in `sync/engine/src/server_proto.rs` and `database_sync_operations.rs`.

## Tests
- `pwsh ./scripts/Invoke-ManagedTestSuite.ps1 -Framework net10.0 -Filter "FullyQualifiedName~ManagedEmbeddedReplicaConnectionTests" -MinimumExecutedTests 1` (84 passed)
- `dotnet format Ahtola.slnx --verify-no-changes --no-restore --include "src\Ahtola.Data\ManagedReplicaBootstrapper.cs" "src\Ahtola.Tests\ManagedEmbeddedReplicaConnectionTests.cs"`