### PR TITLE
Add chunked managed replica bootstrap

### DIFF
--- a/src/Ahtola.Data/AhtolaReplicaProvider.cs
+++ b/src/Ahtola.Data/AhtolaReplicaProvider.cs
@@ -121,7 +121,9 @@ public sealed class AhtolaReplicaOptions
     public long? PushOperationsThreshold { get; init; }
 
     /// <summary>
-    /// Gets or initializes the bootstrap pull chunk target in bytes.
+    /// Gets or initializes the target size in bytes for each initial bootstrap pull.
+    /// The target is rounded up to complete 4 KiB pages, and the complete database
+    /// image is staged eagerly before it is published.
     /// </summary>
     public long? PullBytesThreshold { get; init; }
 

--- a/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
+++ b/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Text;
@@ -894,23 +895,97 @@ internal static class ManagedReplicaBootstrapper
         string stagingPath,
         CancellationToken cancellationToken)
     {
-        using var timeout = CreateTimeout(options.HttpPolicy.RequestTimeout, cancellationToken);
-        var effectiveCancellationToken = timeout?.Token ?? cancellationToken;
         using var scope = options.EnterApplicationHttpScope();
         using var client = options.HttpPolicy.MessageHandler is { } handler
             ? new HttpClient(handler, disposeHandler: false)
             : new HttpClient();
         client.Timeout = Timeout.InfiniteTimeSpan;
+        var authToken = string.IsNullOrWhiteSpace(options.AuthToken) ? null : options.AuthToken;
+        var chunkPages = options.PullBytesThreshold is { } threshold
+            ? Math.Min(checked((ulong)((threshold - 1) / PageSize + 1)), uint.MaxValue)
+            : (ulong?)null;
+
+        await using (var staging = new FileStream(
+            stagingPath,
+            FileMode.CreateNew,
+            FileAccess.ReadWrite,
+            FileShare.None,
+            bufferSize: PageSize,
+            FileOptions.Asynchronous | FileOptions.WriteThrough))
+        {
+            var firstSelector = chunkPages is { } firstChunkPages
+                ? CreatePageRangeSelector(0, checked((uint)firstChunkPages))
+                : [];
+            var header = await PullBootstrapChunkAsync(
+                    client,
+                    options,
+                    authToken,
+                    staging,
+                    CreateBootstrapPullRequest(
+                        serverRevision: null,
+                        options.LongPollTimeout,
+                        firstSelector),
+                    expectedHeader: null,
+                    requestedStart: 0,
+                    requestedEnd: chunkPages,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            if (chunkPages is { } pagesPerChunk)
+            {
+                if (header.DatabasePages > uint.MaxValue)
+                    throw new InvalidDataException("The remote database is too large for chunked page selection.");
+
+                var start = pagesPerChunk;
+                while (start < header.DatabasePages)
+                {
+                    var end = Math.Min(start + pagesPerChunk, header.DatabasePages);
+                    var selector = CreatePageRangeSelector(checked((uint)start), checked((uint)end));
+                    _ = await PullBootstrapChunkAsync(
+                            client,
+                            options,
+                            authToken,
+                            staging,
+                            CreateBootstrapPullRequest(
+                                header.Revision,
+                                longPollTimeout: null,
+                                selector),
+                            header,
+                            start,
+                            end,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                    start = end;
+                }
+            }
+
+            await staging.FlushAsync(cancellationToken).ConfigureAwait(false);
+            staging.Flush(flushToDisk: true);
+            return (header.Revision, header.Protocol);
+        }
+    }
+
+    private static async Task<PullHeader> PullBootstrapChunkAsync(
+        HttpClient client,
+        AhtolaReplicaOptions options,
+        string? authToken,
+        FileStream staging,
+        byte[] requestPayload,
+        PullHeader? expectedHeader,
+        ulong requestedStart,
+        ulong? requestedEnd,
+        CancellationToken cancellationToken)
+    {
         using var request = new HttpRequestMessage(HttpMethod.Post, CreatePullUpdatesUri(options.RemoteUri));
-        request.Content = new ByteArrayContent(CreateInitialPullRequest(options.LongPollTimeout));
+        request.Content = new ByteArrayContent(requestPayload);
         request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/protobuf");
         request.Headers.TryAddWithoutValidation("Accept-Encoding", "application/protobuf");
-
-        var authToken = string.IsNullOrWhiteSpace(options.AuthToken) ? null : options.AuthToken;
         ValidateAuthTokenTransport(request.RequestUri!, authToken);
         if (authToken is not null)
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", authToken);
 
+        using var timeout = CreateTimeout(options.HttpPolicy.RequestTimeout, cancellationToken);
+        var effectiveCancellationToken = timeout?.Token ?? cancellationToken;
         using var response = await client.SendAsync(
             request,
             HttpCompletionOption.ResponseHeadersRead,
@@ -928,37 +1003,108 @@ internal static class ManagedReplicaBootstrapper
                 "Managed embedded replica bootstrap requires a raw page stream; the server returned an MVCC logical-log stream.");
         }
 
-        var databaseLength = checked((long)header.DatabasePages * PageSize);
-        var receivedPages = new HashSet<ulong>();
-        await using (var staging = new FileStream(
-            stagingPath,
-            FileMode.CreateNew,
-            FileAccess.ReadWrite,
-            FileShare.None,
-            bufferSize: PageSize,
-            FileOptions.Asynchronous | FileOptions.WriteThrough))
+        if (expectedHeader is { } expected
+            && (header.Revision != expected.Revision
+                || header.DatabasePages != expected.DatabasePages
+                || header.ApplyMode != expected.ApplyMode
+                || header.Protocol != expected.Protocol))
         {
-            staging.SetLength(databaseLength);
-            while (await reader.ReadAsync(MaxPageMessageLength, effectiveCancellationToken).ConfigureAwait(false) is { } pagePayload)
-            {
-                var page = ParsePage(pagePayload);
-                if (page.PageId >= header.DatabasePages)
-                    throw new InvalidDataException("The pull-updates response contains a page outside the declared database size.");
-                if (!receivedPages.Add(page.PageId))
-                    throw new InvalidDataException("The pull-updates response contains a duplicate page.");
-
-                staging.Position = checked((long)page.PageId * PageSize);
-                await staging.WriteAsync(page.Data, effectiveCancellationToken).ConfigureAwait(false);
-            }
-
-            if ((ulong)receivedPages.Count != header.DatabasePages)
-                throw new InvalidDataException("The pull-updates response did not contain every database page exactly once.");
-
-            await staging.FlushAsync(effectiveCancellationToken).ConfigureAwait(false);
-            staging.Flush(flushToDisk: true);
+            throw new InvalidDataException(
+                "A chunked bootstrap response did not match the initial database revision and shape.");
         }
 
-        return (header.Revision, header.Protocol);
+        if (expectedHeader is null)
+            staging.SetLength(checked((long)header.DatabasePages * PageSize));
+
+        var expectedEnd = Math.Min(requestedEnd ?? header.DatabasePages, header.DatabasePages);
+        var receivedPages = new HashSet<ulong>();
+        while (await reader.ReadAsync(MaxPageMessageLength, effectiveCancellationToken).ConfigureAwait(false) is { } pagePayload)
+        {
+            var page = ParsePage(pagePayload);
+            if (page.PageId < requestedStart || page.PageId >= expectedEnd)
+                throw new InvalidDataException("The pull-updates response contains a page outside the requested bootstrap range.");
+            if (!receivedPages.Add(page.PageId))
+                throw new InvalidDataException("The pull-updates response contains a duplicate page.");
+
+            staging.Position = checked((long)page.PageId * PageSize);
+            await staging.WriteAsync(page.Data, effectiveCancellationToken).ConfigureAwait(false);
+        }
+
+        if ((ulong)receivedPages.Count != expectedEnd - requestedStart)
+        {
+            throw new InvalidDataException(
+                "The pull-updates response did not contain every requested database page exactly once.");
+        }
+
+        return header;
+    }
+
+    private static byte[] CreatePageRangeSelector(uint startInclusive, uint endExclusive)
+    {
+        if (startInclusive >= endExclusive)
+            throw new ArgumentOutOfRangeException(nameof(endExclusive), endExclusive, "The page range must not be empty.");
+
+        const uint serialCookie = 12347;
+        var firstKey = startInclusive >> 16;
+        var lastKey = (endExclusive - 1) >> 16;
+        var containerCount = checked((int)(lastKey - firstKey + 1));
+        var runBitmapLength = (containerCount + 7) / 8;
+        var hasOffsets = containerCount >= 4;
+        var headerLength = checked(
+            sizeof(uint)
+            + runBitmapLength
+            + containerCount * (sizeof(ushort) * 2)
+            + (hasOffsets ? containerCount * sizeof(uint) : 0));
+        var result = new byte[checked(headerLength + containerCount * (sizeof(ushort) * 3))];
+        BinaryPrimitives.WriteUInt32LittleEndian(
+            result,
+            serialCookie | checked((uint)(containerCount - 1) << 16));
+
+        for (var index = 0; index < containerCount; index++)
+            result[sizeof(uint) + index / 8] |= checked((byte)(1 << (index % 8)));
+
+        var descriptionsOffset = sizeof(uint) + runBitmapLength;
+        for (var index = 0; index < containerCount; index++)
+        {
+            var key = checked((ushort)(firstKey + (uint)index));
+            var runStart = index == 0 ? checked((ushort)(startInclusive & ushort.MaxValue)) : (ushort)0;
+            var runEnd = index == containerCount - 1
+                ? checked((ushort)((endExclusive - 1) & ushort.MaxValue))
+                : ushort.MaxValue;
+            var descriptionOffset = descriptionsOffset + index * (sizeof(ushort) * 2);
+            BinaryPrimitives.WriteUInt16LittleEndian(result.AsSpan(descriptionOffset), key);
+            BinaryPrimitives.WriteUInt16LittleEndian(
+                result.AsSpan(descriptionOffset + sizeof(ushort)),
+                checked((ushort)(runEnd - runStart)));
+        }
+
+        var containersOffset = headerLength;
+        if (hasOffsets)
+        {
+            var offsetsOffset = descriptionsOffset + containerCount * (sizeof(ushort) * 2);
+            for (var index = 0; index < containerCount; index++)
+            {
+                BinaryPrimitives.WriteUInt32LittleEndian(
+                    result.AsSpan(offsetsOffset + index * sizeof(uint)),
+                    checked((uint)(containersOffset + index * (sizeof(ushort) * 3))));
+            }
+        }
+
+        for (var index = 0; index < containerCount; index++)
+        {
+            var runStart = index == 0 ? checked((ushort)(startInclusive & ushort.MaxValue)) : (ushort)0;
+            var runEnd = index == containerCount - 1
+                ? checked((ushort)((endExclusive - 1) & ushort.MaxValue))
+                : ushort.MaxValue;
+            var containerOffset = containersOffset + index * (sizeof(ushort) * 3);
+            BinaryPrimitives.WriteUInt16LittleEndian(result.AsSpan(containerOffset), 1);
+            BinaryPrimitives.WriteUInt16LittleEndian(result.AsSpan(containerOffset + sizeof(ushort)), runStart);
+            BinaryPrimitives.WriteUInt16LittleEndian(
+                result.AsSpan(containerOffset + sizeof(ushort) * 2),
+                checked((ushort)(runEnd - runStart)));
+        }
+
+        return result;
     }
 
 
@@ -1239,7 +1385,23 @@ internal static class ManagedReplicaBootstrapper
     }
 
     private static byte[] CreateInitialPullRequest(TimeSpan? longPollTimeout)
-        => CreatePullRequest(clientRevision: null, longPollTimeout, requestLogicalProtocol: false);
+        => CreatePullRequest(
+            serverRevision: null,
+            clientRevision: null,
+            longPollTimeout,
+            requestLogicalProtocol: false,
+            serverPagesSelector: []);
+
+    private static byte[] CreateBootstrapPullRequest(
+        string? serverRevision,
+        TimeSpan? longPollTimeout,
+        byte[] serverPagesSelector)
+        => CreatePullRequest(
+            serverRevision,
+            clientRevision: null,
+            longPollTimeout,
+            requestLogicalProtocol: false,
+            serverPagesSelector);
 
     /// <summary>
     /// Builds a <c>PullUpdatesReqProtoBody</c> request. <paramref name="clientRevision"/> is
@@ -1250,7 +1412,33 @@ internal static class ManagedReplicaBootstrapper
     /// </summary>
     private static byte[] CreatePullRequest(string? clientRevision, TimeSpan? longPollTimeout, bool requestLogicalProtocol)
     {
-        var request = new List<byte>(clientRevision is null ? 6 : clientRevision.Length + 12);
+        return CreatePullRequest(
+            serverRevision: null,
+            clientRevision,
+            longPollTimeout,
+            requestLogicalProtocol,
+            serverPagesSelector: []);
+    }
+
+    private static byte[] CreatePullRequest(
+        string? serverRevision,
+        string? clientRevision,
+        TimeSpan? longPollTimeout,
+        bool requestLogicalProtocol,
+        byte[] serverPagesSelector)
+    {
+        var request = new List<byte>(
+            (serverRevision?.Length ?? 0)
+            + (clientRevision?.Length ?? 0)
+            + serverPagesSelector.Length
+            + 18);
+        if (!string.IsNullOrEmpty(serverRevision))
+        {
+            var revision = StrictUtf8.GetBytes(serverRevision);
+            WriteVarint(request, 2u << 3 | 2);
+            WriteVarint(request, checked((ulong)revision.Length));
+            request.AddRange(revision);
+        }
         if (!string.IsNullOrEmpty(clientRevision))
         {
             var revision = StrictUtf8.GetBytes(clientRevision);
@@ -1262,6 +1450,12 @@ internal static class ManagedReplicaBootstrapper
         {
             WriteVarint(request, 4u << 3);
             WriteVarint(request, checked((ulong)timeout.TotalMilliseconds));
+        }
+        if (serverPagesSelector.Length != 0)
+        {
+            WriteVarint(request, 5u << 3 | 2);
+            WriteVarint(request, checked((ulong)serverPagesSelector.Length));
+            request.AddRange(serverPagesSelector);
         }
         if (requestLogicalProtocol)
         {

--- a/src/Ahtola.Data/ManagedReplicaSupportMatrix.cs
+++ b/src/Ahtola.Data/ManagedReplicaSupportMatrix.cs
@@ -15,12 +15,6 @@ internal static class ManagedReplicaSupportMatrix
                 "Managed embedded replicas support only a complete raw 4 KiB page bootstrap; partial, query, and lazy bootstrap are not supported.");
         }
 
-        if (options.PullBytesThreshold is not null)
-        {
-            throw new NotSupportedException(
-                "Managed embedded replicas support only a single complete raw 4 KiB page bootstrap; chunked bootstrap is not supported.");
-        }
-
         if (options.RemoteEncryption is not null)
         {
             throw new NotSupportedException(

--- a/src/Ahtola.Tests/ManagedEmbeddedReplicaConnectionTests.cs
+++ b/src/Ahtola.Tests/ManagedEmbeddedReplicaConnectionTests.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using System.Buffers.Binary;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
@@ -482,6 +483,125 @@ public sealed class ManagedEmbeddedReplicaConnectionTests
         finally
         {
             DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task ChunkedBootstrapPullsExactPageRangesAndMatchesOneShotImage()
+    {
+        var sourcePath = NewReplicaPath("managed-replica-chunked-bootstrap-source");
+        var oneShotPath = NewReplicaPath("managed-replica-one-shot-bootstrap");
+        var chunkedPath = NewReplicaPath("managed-replica-chunked-bootstrap");
+        try
+        {
+            CreateInitializedDatabase(sourcePath);
+            using (var source = new AhtolaConnection($"Data Source={sourcePath};Local Provider=Managed"))
+            {
+                source.Open();
+                source.ExecuteNonQuery("CREATE TABLE bootstrap_payload(value BLOB NOT NULL);");
+                source.ExecuteNonQuery("INSERT INTO bootstrap_payload VALUES (zeroblob(20000));");
+            }
+
+            var databaseImage = File.ReadAllBytes(sourcePath);
+            var pageCount = checked(databaseImage.Length / 4096);
+            pageCount.Should().BeGreaterThan(4);
+            const int pagesPerChunk = 2;
+            var expectedRequestCount = (pageCount + pagesPerChunk - 1) / pagesPerChunk;
+            var chunkResponses = Enumerable.Range(0, expectedRequestCount)
+                .Select(index =>
+                {
+                    var start = index * pagesPerChunk;
+                    var end = Math.Min(start + pagesPerChunk, pageCount);
+                    return CreatePullResponseForPageRange("revision-42", databaseImage, start, end);
+                })
+                .ToArray();
+            var capturedRequests = new List<BootstrapPullRequest>();
+            var chunkedHandler = new PullUpdatesHandler(
+                chunkResponses,
+                request => capturedRequests.Add(
+                    ReadBootstrapPullRequest(request.Content!.ReadAsByteArrayAsync().GetAwaiter().GetResult())));
+            var oneShotHandler = new PullUpdatesHandler(CreatePullResponse("revision-42", databaseImage));
+
+            await ManagedReplicaBootstrapper.BootstrapAsync(
+                CreateOptions(oneShotPath, oneShotHandler),
+                CancellationToken.None);
+            await ManagedReplicaBootstrapper.BootstrapAsync(
+                new AhtolaReplicaOptions(
+                    chunkedPath,
+                    new Uri("https://example.test/cluster"),
+                    authToken: "token-42")
+                {
+                    PullBytesThreshold = 4097,
+                    HttpPolicy = new AhtolaSyncHttpPolicy(chunkedHandler),
+                },
+                CancellationToken.None);
+
+            chunkedHandler.CallCount.Should().Be(expectedRequestCount);
+            capturedRequests.Should().HaveCount(expectedRequestCount);
+            for (var index = 0; index < capturedRequests.Count; index++)
+            {
+                var start = index * pagesPerChunk;
+                var end = Math.Min(start + pagesPerChunk, pageCount);
+                capturedRequests[index].ServerRevision.Should().Be(index == 0 ? null : "revision-42");
+                capturedRequests[index].SelectedPages.Should().Equal(
+                    Enumerable.Range(start, end - start).Select(page => checked((uint)page)));
+            }
+
+            File.ReadAllBytes(chunkedPath).Should().Equal(databaseImage);
+            File.ReadAllBytes(chunkedPath).Should().Equal(File.ReadAllBytes(oneShotPath));
+        }
+        finally
+        {
+            DeleteReplicaFiles(sourcePath);
+            DeleteReplicaFiles(oneShotPath);
+            DeleteReplicaFiles(chunkedPath);
+        }
+    }
+
+    [Test]
+    public void ChunkedBootstrapFailureDoesNotPublishPartialState()
+    {
+        var sourcePath = NewReplicaPath("managed-replica-chunked-bootstrap-failure-source");
+        var replicaPath = NewReplicaPath("managed-replica-chunked-bootstrap-failure");
+        try
+        {
+            CreateInitializedDatabase(sourcePath);
+            using (var source = new AhtolaConnection($"Data Source={sourcePath};Local Provider=Managed"))
+            {
+                source.Open();
+                source.ExecuteNonQuery("CREATE TABLE bootstrap_payload(value BLOB NOT NULL);");
+                source.ExecuteNonQuery("INSERT INTO bootstrap_payload VALUES (zeroblob(12000));");
+            }
+
+            var databaseImage = File.ReadAllBytes(sourcePath);
+            (databaseImage.Length / 4096).Should().BeGreaterThan(1);
+            var handler = new PullUpdatesHandler(
+                CreatePullResponseForPageRange("revision-42", databaseImage, startPage: 0, endPage: 1));
+            var options = new AhtolaReplicaOptions(
+                replicaPath,
+                new Uri("https://example.test/cluster"),
+                authToken: null)
+            {
+                PullBytesThreshold = 4096,
+                HttpPolicy = new AhtolaSyncHttpPolicy(handler),
+            };
+
+            Assert.ThrowsAsync<InvalidOperationException>(
+                () => ManagedReplicaBootstrapper.BootstrapAsync(options, CancellationToken.None));
+
+            File.Exists(replicaPath).Should().BeFalse();
+            File.Exists(replicaPath + ".ahtola-replica-meta").Should().BeFalse();
+            var directory = Path.GetDirectoryName(replicaPath)!;
+            Directory.GetFiles(
+                    directory,
+                    $".{Path.GetFileName(replicaPath)}.bootstrap-*.tmp")
+                .Should()
+                .BeEmpty();
+        }
+        finally
+        {
+            DeleteReplicaFiles(sourcePath);
+            DeleteReplicaFiles(replicaPath);
         }
     }
 
@@ -2155,7 +2275,6 @@ public sealed class ManagedEmbeddedReplicaConnectionTests
     [TestCase(UnsupportedReplicaMode.RemoteEncryption)]
     [TestCase(UnsupportedReplicaMode.PartialPrefix)]
     [TestCase(UnsupportedReplicaMode.PartialQuery)]
-    [TestCase(UnsupportedReplicaMode.ChunkedBootstrap)]
     public void CreateReplicaRejectsUnsupportedModesBeforeOpeningOrMutatingLocalState(
         UnsupportedReplicaMode mode)
     {
@@ -3304,14 +3423,6 @@ public sealed class ManagedEmbeddedReplicaConnectionTests
                 PartialBootstrap = AhtolaPartialBootstrapOptions.QueryPages("SELECT 1"),
                 HttpPolicy = options.HttpPolicy,
             },
-            UnsupportedReplicaMode.ChunkedBootstrap => new AhtolaReplicaOptions(
-                path,
-                options.RemoteUri,
-                options.AuthToken)
-            {
-                PullBytesThreshold = 4096,
-                HttpPolicy = options.HttpPolicy,
-            },
             _ => throw new ArgumentOutOfRangeException(nameof(mode)),
         };
     }
@@ -3374,6 +3485,110 @@ public sealed class ManagedEmbeddedReplicaConnectionTests
             WriteDelimitedMessage(response, page);
         }
         return response.ToArray();
+    }
+
+    private static byte[] CreatePullResponseForPageRange(
+        string revision,
+        byte[] databaseImage,
+        int startPage,
+        int endPage)
+    {
+        var pageCount = checked(databaseImage.Length / 4096);
+        startPage.Should().BeGreaterThanOrEqualTo(0);
+        endPage.Should().BeGreaterThan(startPage).And.BeLessThanOrEqualTo(pageCount);
+        var response = new List<byte>(
+            CreatePullResponse(
+                revision,
+                [],
+                declaredPages: checked((ulong)pageCount)));
+        for (var pageId = startPage; pageId < endPage; pageId++)
+        {
+            var page = new List<byte>();
+            if (pageId != 0)
+                WriteVarintField(page, 1, checked((ulong)pageId));
+            WriteLengthDelimitedField(
+                page,
+                2,
+                databaseImage.AsSpan(pageId * 4096, 4096));
+            WriteDelimitedMessage(response, page);
+        }
+
+        return response.ToArray();
+    }
+
+    private static BootstrapPullRequest ReadBootstrapPullRequest(byte[] payload)
+    {
+        string? serverRevision = null;
+        byte[]? selector = null;
+        var offset = 0;
+        while (offset < payload.Length)
+        {
+            var key = ReadVarint(payload, ref offset);
+            var field = checked((int)(key >> 3));
+            switch (key & 7)
+            {
+                case 0:
+                    _ = ReadVarint(payload, ref offset);
+                    break;
+                case 2:
+                    var length = checked((int)ReadVarint(payload, ref offset));
+                    var value = payload.AsSpan(offset, length);
+                    offset += length;
+                    if (field == 2)
+                        serverRevision = Encoding.UTF8.GetString(value);
+                    else if (field == 5)
+                        selector = value.ToArray();
+                    break;
+                default:
+                    throw new InvalidOperationException("Unsupported test protobuf wire type.");
+            }
+        }
+
+        selector.Should().NotBeNull();
+        return new BootstrapPullRequest(serverRevision, DecodeRoaringPageSelector(selector!));
+    }
+
+    private static IReadOnlyList<uint> DecodeRoaringPageSelector(byte[] selector)
+    {
+        const ushort serialCookie = 12347;
+        var offset = 0;
+        var cookie = BinaryPrimitives.ReadUInt32LittleEndian(selector.AsSpan(offset));
+        offset += sizeof(uint);
+        checked((ushort)(cookie & ushort.MaxValue)).Should().Be(serialCookie);
+        var containerCount = checked((int)(cookie >> 16) + 1);
+        var runBitmap = selector.AsSpan(offset, (containerCount + 7) / 8);
+        offset += runBitmap.Length;
+        var keys = new ushort[containerCount];
+        for (var index = 0; index < containerCount; index++)
+        {
+            keys[index] = BinaryPrimitives.ReadUInt16LittleEndian(selector.AsSpan(offset));
+            offset += sizeof(ushort);
+            _ = BinaryPrimitives.ReadUInt16LittleEndian(selector.AsSpan(offset));
+            offset += sizeof(ushort);
+        }
+
+        if (containerCount >= 4)
+            offset += containerCount * sizeof(uint);
+
+        var pages = new List<uint>();
+        for (var index = 0; index < containerCount; index++)
+        {
+            (runBitmap[index / 8] & (1 << (index % 8))).Should().NotBe(0);
+            var runCount = BinaryPrimitives.ReadUInt16LittleEndian(selector.AsSpan(offset));
+            offset += sizeof(ushort);
+            for (var run = 0; run < runCount; run++)
+            {
+                var start = BinaryPrimitives.ReadUInt16LittleEndian(selector.AsSpan(offset));
+                offset += sizeof(ushort);
+                var additionalValues = BinaryPrimitives.ReadUInt16LittleEndian(selector.AsSpan(offset));
+                offset += sizeof(ushort);
+                for (var value = 0; value <= additionalValues; value++)
+                    pages.Add(((uint)keys[index] << 16) | checked((uint)(start + value)));
+            }
+        }
+
+        offset.Should().Be(selector.Length);
+        return pages;
     }
 
     private static byte[] BuildLogicalLogRangeMessage(
@@ -3529,8 +3744,11 @@ public sealed class ManagedEmbeddedReplicaConnectionTests
         RemoteEncryption,
         PartialPrefix,
         PartialQuery,
-        ChunkedBootstrap,
     }
+
+    private readonly record struct BootstrapPullRequest(
+        string? ServerRevision,
+        IReadOnlyList<uint> SelectedPages);
 
     public enum PullResponseFramingFailure
     {


### PR DESCRIPTION
## Summary
- enable the existing `PullBytesThreshold` option for managed embedded replicas
- mirror Turso v0.7.2's bounded eager bootstrap loop with contiguous portable RoaringBitmap page selectors and revision-pinned follow-up pulls
- assemble and validate every chunk in the existing staging file before atomic database and metadata publication
- add deterministic request-range, byte-equivalence, and partial-failure cleanup coverage

Upstream reference: `turso-src/sync/engine/src/database_sync_operations.rs` (`bootstrap_db_file_v1`, `pull_chunk_into_file`, and `page_range_bitmap`).

## Validation
- `ManagedEmbeddedReplicaConnectionTests` on `net10.0`: 85 passed
- chunked bootstrap tests on `net8.0`, `net9.0`, and `net10.0`: 2 passed per framework
- changed-file `dotnet format --verify-no-changes`: passed
- `pwsh ./build.ps1 validate-project-closure`: passed

The repository-wide format command remains blocked by existing formatting findings outside this change; all changed files pass the formatter.