### PR TITLE
Add read-only CDC↔managed-replica bridge (PeekPendingChangeCapture)

### DIFF
--- a/src/Ahtola.Data/AhtolaConnection.cs
+++ b/src/Ahtola.Data/AhtolaConnection.cs
@@ -566,6 +566,29 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
                 "Local replica changes are available only for managed embedded replica connections."))
             .ReadLocalChanges(maximumChanges);
 
+    /// <summary>
+    /// Returns a read-only snapshot of this managed embedded replica connection's currently
+    /// pending (not yet pushed) local changes, projected into Ahtola's public change-data-capture
+    /// row contract (the same row shape as the real <c>turso_cdc</c> table). This performs no
+    /// network I/O, never writes a real CDC table, and never advances the push acknowledgement
+    /// watermark: calling it repeatedly, or interleaving it with an unrelated push, has no effect
+    /// on either. See <see cref="AhtolaReplicaChangeRow"/> for the exact per-row guarantees and
+    /// documented limitations (transaction grouping, delete pre-image requirements, and
+    /// "after"-image reconstruction for rows superseded later in the same pending batch).
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The connection is not a managed embedded replica connection.
+    /// </exception>
+    /// <exception cref="AhtolaReplicaChangeCaptureException">
+    /// The pending batch contains an entry that cannot be safely represented in the
+    /// change-data-capture row contract (a schema/DDL change, or a delete with no captured
+    /// pre-image).
+    /// </exception>
+    public AhtolaReplicaChangeCaptureBatch PeekPendingChangeCapture()
+        => (_managedReplicaHost ?? throw new InvalidOperationException(
+                "Pending change-data-capture is available only for managed embedded replica connections."))
+            .PeekPendingChangeCapture();
+
     void ILocalReaderConnection.ReaderOpened(IConnectionOwnedReader reader)
     {
         lock (_readerLock)

--- a/src/Ahtola.Data/AhtolaReplicaChangeCapture.cs
+++ b/src/Ahtola.Data/AhtolaReplicaChangeCapture.cs
@@ -1,0 +1,100 @@
+namespace Ahtola;
+
+/// <summary>
+/// The kind of row-level operation a projected replica change-data-capture row represents,
+/// numbered to match the <c>change_type</c> column of Ahtola's real <c>turso_cdc</c> table
+/// (Delete = -1, Update = 0, Insert = 1). The real table also uses <c>2</c> as an
+/// autocommit/explicit-transaction-boundary marker row with no table/id/image data; that marker
+/// has no equivalent here because the private replica journal does not persist transaction
+/// boundaries (see <see cref="AhtolaReplicaChangeRow.ChangeTransactionId"/>).
+/// </summary>
+public enum AhtolaReplicaChangeType
+{
+    /// <summary>The row was deleted.</summary>
+    Delete = -1,
+
+    /// <summary>The row was updated.</summary>
+    Update = 0,
+
+    /// <summary>The row was inserted.</summary>
+    Insert = 1,
+}
+
+/// <summary>
+/// A single row of Ahtola's public change-data-capture row contract (the same shape as a row of
+/// the real <c>turso_cdc</c> table), projected read-only from a managed embedded replica
+/// connection's still-pending local change journal. See
+/// <see cref="AhtolaConnection.PeekPendingChangeCapture"/>.
+/// </summary>
+/// <param name="ChangeId">
+/// The change's position in the pending journal, matching the <c>change_id</c> column. Strictly
+/// increasing and gap-free across one <see cref="AhtolaReplicaChangeCaptureBatch"/>, and stable
+/// across repeated peeks as long as nothing has been pushed/acknowledged.
+/// </param>
+/// <param name="ChangeTransactionId">
+/// Matches the real <c>change_txn_id</c> column's contract for a single-row transaction (a
+/// transaction's rows share the id of its first change). The private replica journal does not
+/// persist which local SQL transaction a committed row belonged to once reloaded from disk, so
+/// this bridge cannot recover multi-row grouping: every row reports its own <see cref="ChangeId"/>
+/// here, i.e. it is always represented as if it were the sole row of its own transaction. Do not
+/// use this field to detect that two rows were part of the same original local transaction.
+/// </param>
+/// <param name="ChangeType">The row operation, matching the <c>change_type</c> column.</param>
+/// <param name="TableName">The affected table, matching the <c>table_name</c> column.</param>
+/// <param name="RowId">The affected row's rowid, matching the <c>id</c> column.</param>
+/// <param name="Before">
+/// The row's pre-image as an encoded SQLite record, matching the <c>before</c> column, or
+/// <see langword="null"/> when not applicable (insert, or update — see remarks). Always
+/// non-null for delete: a delete whose pre-image was not captured (only possible for a change
+/// journal written by a pre-v4 journal format) makes the whole peek fail closed with
+/// <see cref="AhtolaReplicaChangeCaptureException"/> instead of returning a misleadingly empty row.
+/// </param>
+/// <param name="After">
+/// The row's post-image as an encoded SQLite record, matching the <c>after</c> column, or
+/// <see langword="null"/> when not applicable (delete) or not safely reconstructable. An
+/// insert/update's "after" image is reconstructed by reading the row's current live state, which
+/// is only correct when no later pending change in the same batch touches the same
+/// (<see cref="TableName"/>, <see cref="RowId"/>) key again; when a later change supersedes it,
+/// this is left <see langword="null"/> (the row degrades to id-only image availability) rather
+/// than returning stale or fabricated data.
+/// </param>
+/// <remarks>
+/// <c>updates</c> (the real CDC table's packed all-columns-changed column, only ever populated in
+/// "full" capture mode) has no equivalent here: it requires both the before- and after-images of
+/// an update simultaneously, and the private replica journal never captures an update's
+/// pre-image. There is intentionally no property for it.
+/// </remarks>
+public sealed record AhtolaReplicaChangeRow(
+    long ChangeId,
+    long ChangeTransactionId,
+    AhtolaReplicaChangeType ChangeType,
+    string TableName,
+    long RowId,
+    byte[]? Before,
+    byte[]? After);
+
+/// <summary>
+/// A read-only snapshot of a managed embedded replica connection's currently pending (not yet
+/// pushed) local changes, projected into Ahtola's public change-data-capture row contract. See
+/// <see cref="AhtolaConnection.PeekPendingChangeCapture"/>.
+/// </summary>
+/// <param name="FirstChangeId">The first pending row's <see cref="AhtolaReplicaChangeRow.ChangeId"/>, or the next unassigned change id when there are no pending rows.</param>
+/// <param name="AcknowledgementWatermark">
+/// The exclusive change-id boundary a genuine push may later acknowledge, identical to the
+/// underlying journal's push watermark. Peeking this batch never advances it and has no other
+/// side effect: it is a pure read of already-durable state, so acknowledging a later push is
+/// unaffected by, and cannot be corrupted by, having peeked it first.
+/// </param>
+/// <param name="Rows">The pending rows, in strictly increasing <see cref="AhtolaReplicaChangeRow.ChangeId"/> order.</param>
+public sealed record AhtolaReplicaChangeCaptureBatch(
+    long FirstChangeId,
+    long AcknowledgementWatermark,
+    IReadOnlyList<AhtolaReplicaChangeRow> Rows);
+
+/// <summary>
+/// Indicates that a still-pending managed embedded replica local change cannot be safely
+/// represented as a row in Ahtola's public change-data-capture contract. Peeking pending
+/// change-data-capture fails closed rather than silently omitting or approximating the
+/// unrepresentable entry; see <see cref="AhtolaConnection.PeekPendingChangeCapture"/>.
+/// </summary>
+public sealed class AhtolaReplicaChangeCaptureException(string message) : AhtolaException(message);

--- a/src/Ahtola.Data/ManagedReplicaChangeCaptureProjector.cs
+++ b/src/Ahtola.Data/ManagedReplicaChangeCaptureProjector.cs
@@ -1,0 +1,115 @@
+using Ahtola.Core;
+using Ahtola.Core.Storage;
+
+namespace Ahtola;
+
+/// <summary>
+/// Projects a managed embedded replica connection's still-pending local change journal batch
+/// (<see cref="ReplicaLocalChangeBatch"/>) into Ahtola's public change-data-capture row contract
+/// (<see cref="AhtolaReplicaChangeRow"/>). This is a pure, read-only adapter: it never writes to
+/// a real <c>turso_cdc</c> table, never appends to the replica change journal, and never
+/// acknowledges its watermark. See <see cref="AhtolaConnection.PeekPendingChangeCapture"/> for
+/// the public entry point and the exact guarantees/limitations documented on
+/// <see cref="AhtolaReplicaChangeRow"/>.
+/// </summary>
+internal static class ManagedReplicaChangeCaptureProjector
+{
+    public static AhtolaReplicaChangeCaptureBatch Project(
+        IManagedConnectionAdapter connection,
+        ReplicaLocalChangeBatch batch)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+
+        var changes = batch.Changes;
+        foreach (var change in changes)
+        {
+            if (change.Kind == ReplicaLocalChangeKind.Schema)
+            {
+                throw new AhtolaReplicaChangeCaptureException(
+                    "The pending managed embedded replica change journal contains a schema "
+                    + "(DDL) change, which has no row-level before/after image and cannot be "
+                    + "represented in the change-data-capture row contract. Push the pending "
+                    + "changes before peeking pending change-data-capture.");
+            }
+        }
+
+        // The live row for an insert/update is only guaranteed to reflect that specific change's
+        // own result when no later pending change touches the same (table, rowid) key again.
+        // This must be computed against the full pending batch (never a caller-truncated slice)
+        // or a later change outside the analyzed window could silently make an "after" image
+        // look correct when it is actually stale.
+        var lastSequenceByKey = new Dictionary<(string Table, long RowId), long>();
+        foreach (var change in changes)
+        {
+            var key = (change.Table, change.RowId);
+            if (!lastSequenceByKey.TryGetValue(key, out var existing) || change.Sequence > existing)
+                lastSequenceByKey[key] = change.Sequence;
+        }
+
+        var rows = new List<AhtolaReplicaChangeRow>(changes.Count);
+        foreach (var change in changes)
+            rows.Add(ProjectRow(connection, change, lastSequenceByKey));
+
+        return new AhtolaReplicaChangeCaptureBatch(batch.FirstSequence, batch.Watermark, rows);
+    }
+
+    private static AhtolaReplicaChangeRow ProjectRow(
+        IManagedConnectionAdapter connection,
+        ReplicaLocalChange change,
+        IReadOnlyDictionary<(string Table, long RowId), long> lastSequenceByKey)
+    {
+        var changeType = change.Operation switch
+        {
+            SqliteChangeOperation.Insert => AhtolaReplicaChangeType.Insert,
+            SqliteChangeOperation.Update => AhtolaReplicaChangeType.Update,
+            SqliteChangeOperation.Delete => AhtolaReplicaChangeType.Delete,
+            _ => throw new AhtolaReplicaChangeCaptureException(
+                $"Managed embedded replica change journal has an entry for table "
+                + $"'{change.Table}' with an unrecognized operation "
+                + $"({change.Operation}) that cannot be represented in the "
+                + "change-data-capture row contract."),
+        };
+
+        byte[]? before = null;
+        byte[]? after = null;
+
+        if (change.Operation == SqliteChangeOperation.Delete)
+        {
+            before = change.BeforeRecord
+                ?? throw new AhtolaReplicaChangeCaptureException(
+                    "Managed embedded replica change journal has a delete entry for table "
+                    + $"'{change.Table}' (rowid {change.RowId}) with no captured before-image. "
+                    + "This happens only for entries written by an older journal format that "
+                    + "did not capture delete pre-images; push the pending changes to advance "
+                    + "past it before peeking pending change-data-capture.");
+        }
+        else
+        {
+            // An earlier touch to the same key has since been overwritten locally by a later
+            // pending change: the live row no longer reflects this entry's own result, so its
+            // "after" image cannot be safely reconstructed. Rather than fabricate stale data,
+            // this row degrades to id-only image availability (before/after both null), which
+            // matches the real CDC contract's "id" capture mode for that row.
+            var isFinalTouch = lastSequenceByKey.TryGetValue((change.Table, change.RowId), out var lastSequence)
+                && lastSequence == change.Sequence;
+            if (isFinalTouch)
+            {
+                var values = ManagedReplicaLogicalReplayer.TryCaptureCurrentRowValues(
+                    connection,
+                    change.Table,
+                    change.RowId);
+                if (values is not null)
+                    after = SqliteRecordCodec.Encode(values);
+            }
+        }
+
+        return new AhtolaReplicaChangeRow(
+            ChangeId: change.Sequence,
+            ChangeTransactionId: change.Sequence,
+            ChangeType: changeType,
+            TableName: change.Table,
+            RowId: change.RowId,
+            Before: before,
+            After: after);
+    }
+}

--- a/src/Ahtola.Data/ManagedReplicaConnectionHost.cs
+++ b/src/Ahtola.Data/ManagedReplicaConnectionHost.cs
@@ -101,6 +101,14 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
     public void AcknowledgeLocalChanges(long watermark)
         => _changeJournal.Acknowledge(watermark);
 
+    /// <summary>
+    /// Projects the entire currently pending local change batch into Ahtola's public
+    /// change-data-capture row contract. Pure read: it does not acknowledge the journal
+    /// watermark, so it has no effect on a subsequent push.
+    /// </summary>
+    public AhtolaReplicaChangeCaptureBatch PeekPendingChangeCapture()
+        => ManagedReplicaChangeCaptureProjector.Project(Database.Connection, _changeJournal.ReadBatch(int.MaxValue));
+
     public void StatementStarted(string sql)
     {
         ArgumentNullException.ThrowIfNull(sql);

--- a/src/Ahtola.Data/ManagedReplicaLogicalReplayer.cs
+++ b/src/Ahtola.Data/ManagedReplicaLogicalReplayer.cs
@@ -334,7 +334,13 @@ internal static class ManagedReplicaLogicalReplayer
         return SqliteRecordCodec.Decode(change.BeforeRecord);
     }
 
-    private static IReadOnlyList<SqlValue>? TryCaptureCurrentRowValues(
+    /// <summary>
+    /// Reads a table's current row values by rowid, or <see langword="null"/> when the row is
+    /// not currently present (including tables with no accessible rowid). Shared with
+    /// <see cref="ManagedReplicaChangeCaptureProjector"/>, which uses the same live-read
+    /// technique to reconstruct an "after" image for the public change-data-capture bridge.
+    /// </summary>
+    internal static IReadOnlyList<SqlValue>? TryCaptureCurrentRowValues(
         IManagedConnectionAdapter connection,
         string tableName,
         long rowId)

--- a/src/Ahtola.Tests/ManagedReplicaChangeCaptureBridgeTests.cs
+++ b/src/Ahtola.Tests/ManagedReplicaChangeCaptureBridgeTests.cs
@@ -1,0 +1,356 @@
+using AwesomeAssertions;
+using Ahtola.Core;
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Tests;
+
+/// <summary>
+/// Covers <see cref="ManagedReplicaChangeCaptureProjector"/> and the public
+/// <see cref="AhtolaConnection.PeekPendingChangeCapture"/> entry point: the read-only bridge that
+/// projects a managed embedded replica's still-pending local change journal into Ahtola's public
+/// change-data-capture row contract. These tests prove the bridge agrees with the real
+/// <c>turso_cdc</c> table for the fields it can represent, documents where it intentionally
+/// cannot (an update's before-image, multi-row transaction grouping), fails closed for
+/// unrepresentable entries instead of guessing, and that peeking is side-effect-free: it can
+/// never corrupt, or be corrupted by, a genuine push's acknowledgement.
+/// </summary>
+public sealed class ManagedReplicaChangeCaptureBridgeTests
+{
+    [Test]
+    public void ProjectAgreesWithRealChangeDataCaptureForDistinctInsertUpdateDeleteRows()
+    {
+        using var database = ManagedDatabaseAdapter.Open(":memory:");
+        var connection = database.Connect();
+
+        Exec(connection, "CREATE TABLE t(id INTEGER PRIMARY KEY, value TEXT)");
+        Exec(connection, "PRAGMA capture_data_changes_conn('full')");
+
+        // Pre-existing state the pending batch under test does NOT reference: only present so
+        // the update/delete below have a row to act on. These generate their own real CDC rows,
+        // so every comparison below targets its row by (change_type, id) rather than a blanket
+        // "the next N rows" ordering assumption.
+        Exec(connection, "INSERT INTO t VALUES (2, 'seed2')");
+        Exec(connection, "INSERT INTO t VALUES (3, 'seed3')");
+
+        // The three journal-tracked operations under test, each touching a distinct rowid
+        // exactly once so none of them hits the "superseded touch" after-image degradation.
+        Exec(connection, "INSERT INTO t VALUES (1, 'a')");
+        Exec(connection, "UPDATE t SET value = 'c2' WHERE id = 2");
+        var beforeDelete = SqliteRecordCodec.Encode(
+            ManagedReplicaLogicalReplayer.TryCaptureCurrentRowValues(connection, "t", 3)!);
+        Exec(connection, "DELETE FROM t WHERE id = 3");
+
+        var batch = new ReplicaLocalChangeBatch(
+            FirstSequence: 1,
+            Watermark: 4,
+            Changes:
+            [
+                ReplicaLocalChange.Row(SqliteChangeOperation.Insert, "main", "t", 1) with { Sequence = 1 },
+                ReplicaLocalChange.Row(SqliteChangeOperation.Update, "main", "t", 2) with { Sequence = 2 },
+                ReplicaLocalChange.Row(SqliteChangeOperation.Delete, "main", "t", 3, beforeDelete) with { Sequence = 3 },
+            ]);
+
+        var projected = ManagedReplicaChangeCaptureProjector.Project(connection, batch);
+
+        projected.FirstChangeId.Should().Be(1);
+        projected.AcknowledgementWatermark.Should().Be(4);
+        projected.Rows.Should().HaveCount(3);
+
+        var insertRow = projected.Rows[0];
+        var insertCdc = SingleCdcRow(connection, changeType: 1, id: 1);
+        insertRow.ChangeId.Should().Be(1);
+        insertRow.ChangeTransactionId.Should().Be(insertRow.ChangeId);
+        insertRow.ChangeType.Should().Be(AhtolaReplicaChangeType.Insert);
+        insertRow.TableName.Should().Be(AsText(insertCdc[3]));
+        insertRow.RowId.Should().Be(AsInteger(insertCdc[4]));
+        insertRow.Before.Should().BeNull();
+        insertCdc[5].Should().Be(SqlValue.Null, "a real insert row never has a before-image either");
+        DecodeAfter(insertRow).Should().Equal(SqliteRecordCodec.Decode(AsBlob(insertCdc[6]).Span));
+
+        var updateRow = projected.Rows[1];
+        var updateCdc = SingleCdcRow(connection, changeType: 0, id: 2);
+        updateRow.ChangeId.Should().Be(2);
+        updateRow.ChangeTransactionId.Should().Be(updateRow.ChangeId);
+        updateRow.ChangeType.Should().Be(AhtolaReplicaChangeType.Update);
+        updateRow.TableName.Should().Be(AsText(updateCdc[3]));
+        updateRow.RowId.Should().Be(AsInteger(updateCdc[4]));
+        // Documented, deliberate divergence: the private replica journal never captures an
+        // update's pre-image, while the real turso_cdc row does. Both sides are asserted so this
+        // simplification stays a proven, intentional gap rather than an untested one.
+        updateRow.Before.Should().BeNull();
+        updateCdc[5].Should().NotBe(SqlValue.Null, "the real CDC row DOES capture the update's before-image");
+        DecodeAfter(updateRow).Should().Equal(SqliteRecordCodec.Decode(AsBlob(updateCdc[6]).Span));
+
+        var deleteRow = projected.Rows[2];
+        var deleteCdc = SingleCdcRow(connection, changeType: -1, id: 3);
+        deleteRow.ChangeId.Should().Be(3);
+        deleteRow.ChangeTransactionId.Should().Be(deleteRow.ChangeId);
+        deleteRow.ChangeType.Should().Be(AhtolaReplicaChangeType.Delete);
+        deleteRow.TableName.Should().Be(AsText(deleteCdc[3]));
+        deleteRow.RowId.Should().Be(AsInteger(deleteCdc[4]));
+        deleteRow.After.Should().BeNull();
+        deleteCdc[6].Should().Be(SqlValue.Null, "a real delete row never has an after-image either");
+        SqliteRecordCodec.Decode(deleteRow.Before!).Should().Equal(SqliteRecordCodec.Decode(AsBlob(deleteCdc[5]).Span));
+    }
+
+    [Test]
+    public void ProjectDegradesSupersededTouchAfterImageToNullInsteadOfStaleData()
+    {
+        using var database = ManagedDatabaseAdapter.Open(":memory:");
+        var connection = database.Connect();
+
+        Exec(connection, "CREATE TABLE t(id INTEGER PRIMARY KEY, value TEXT)");
+        // Only the FINAL live value is ever present; if the earlier touch's "after" were
+        // reconstructed from live state it would silently show this final value instead, so
+        // asserting it stays null is what actually proves the guard works.
+        Exec(connection, "INSERT INTO t VALUES (5, 'final')");
+
+        var batch = new ReplicaLocalChangeBatch(
+            FirstSequence: 1,
+            Watermark: 3,
+            Changes:
+            [
+                ReplicaLocalChange.Row(SqliteChangeOperation.Insert, "main", "t", 5) with { Sequence = 1 },
+                ReplicaLocalChange.Row(SqliteChangeOperation.Update, "main", "t", 5) with { Sequence = 2 },
+            ]);
+
+        var projected = ManagedReplicaChangeCaptureProjector.Project(connection, batch);
+
+        projected.Rows.Should().HaveCount(2);
+        projected.Rows[0].After.Should().BeNull("a later pending change in the same batch touches the same row again");
+        projected.Rows[1].After.Should().NotBeNull("this is the last touch to the row, so live state safely reflects it");
+        SqliteRecordCodec.Decode(projected.Rows[1].After!).Should()
+            .Equal(SqlValue.Integer(5), SqlValue.Text("final"));
+    }
+
+    [Test]
+    public void ProjectFailsClosedForADeleteWithNoCapturedBeforeImage()
+    {
+        using var database = ManagedDatabaseAdapter.Open(":memory:");
+        var connection = database.Connect();
+
+        Exec(connection, "CREATE TABLE t(id INTEGER PRIMARY KEY, value TEXT)");
+        Exec(connection, "INSERT INTO t VALUES (1, 'x')");
+        Exec(connection, "DELETE FROM t WHERE id = 1");
+
+        var batch = new ReplicaLocalChangeBatch(
+            FirstSequence: 1,
+            Watermark: 2,
+            Changes: [ReplicaLocalChange.Row(SqliteChangeOperation.Delete, "main", "t", 1) with { Sequence = 1 }]);
+
+        Action act = () => ManagedReplicaChangeCaptureProjector.Project(connection, batch);
+
+        act.Should().Throw<AhtolaReplicaChangeCaptureException>()
+            .WithMessage("*no captured before-image*");
+    }
+
+    [Test]
+    public void ProjectFailsClosedWhenTheBatchContainsASchemaChangeAnywhereEvenAlongsideValidRowChanges()
+    {
+        using var database = ManagedDatabaseAdapter.Open(":memory:");
+        var connection = database.Connect();
+
+        Exec(connection, "CREATE TABLE t(id INTEGER PRIMARY KEY, value TEXT)");
+        Exec(connection, "INSERT INTO t VALUES (1, 'a')");
+
+        // The schema entry is deliberately NOT first, proving the whole batch is scanned rather
+        // than only its head.
+        var batch = new ReplicaLocalChangeBatch(
+            FirstSequence: 1,
+            Watermark: 3,
+            Changes:
+            [
+                ReplicaLocalChange.Row(SqliteChangeOperation.Insert, "main", "t", 1) with { Sequence = 1 },
+                ReplicaLocalChange.Schema("CREATE TABLE u(v INTEGER)") with { Sequence = 2 },
+            ]);
+
+        Action act = () => ManagedReplicaChangeCaptureProjector.Project(connection, batch);
+
+        act.Should().Throw<AhtolaReplicaChangeCaptureException>()
+            .WithMessage("*schema*");
+    }
+
+    [Test]
+    public void AcknowledgingAnEarlierWatermarkLeavesLaterPendingRowsUncorrupted()
+    {
+        using var database = ManagedDatabaseAdapter.Open(":memory:");
+        var connection = database.Connect();
+        Exec(connection, "CREATE TABLE t(id INTEGER PRIMARY KEY, value TEXT)");
+        // Final live state matching each pending change's own result (neither key is touched
+        // twice, so both remain eligible for after-image reconstruction).
+        Exec(connection, "INSERT INTO t VALUES (1, 'v2')");
+        Exec(connection, "INSERT INTO t VALUES (2, 'v3')");
+
+        var journalPath = Path.Combine(
+            TestContext.CurrentContext.WorkDirectory,
+            $"cdc-bridge-ack-{Guid.NewGuid():N}.db");
+        try
+        {
+            var journal = ManagedReplicaChangeJournal.Open(journalPath);
+            journal.AppendCommitted(
+            [
+                ReplicaLocalChange.Row(SqliteChangeOperation.Update, "main", "t", 1),
+                ReplicaLocalChange.Row(SqliteChangeOperation.Insert, "main", "t", 2),
+            ]);
+
+            var firstPeek = ManagedReplicaChangeCaptureProjector.Project(connection, journal.ReadBatch(int.MaxValue));
+            firstPeek.FirstChangeId.Should().Be(1);
+            firstPeek.AcknowledgementWatermark.Should().Be(3);
+            firstPeek.Rows.Should().HaveCount(2);
+            firstPeek.Rows[0].ChangeId.Should().Be(1);
+            firstPeek.Rows[0].ChangeType.Should().Be(AhtolaReplicaChangeType.Update);
+            SqliteRecordCodec.Decode(firstPeek.Rows[0].After!).Should().Equal(SqlValue.Integer(1), SqlValue.Text("v2"));
+            firstPeek.Rows[1].ChangeId.Should().Be(2);
+            firstPeek.Rows[1].ChangeType.Should().Be(AhtolaReplicaChangeType.Insert);
+            SqliteRecordCodec.Decode(firstPeek.Rows[1].After!).Should().Equal(SqlValue.Integer(2), SqlValue.Text("v3"));
+
+            // Peeking again before any acknowledgement must be perfectly repeatable: it is a
+            // pure read, so it cannot itself be the thing that "uses up" or mutates the journal.
+            // Compared structurally (not via record equality) since "after" images are freshly
+            // re-encoded byte[] instances on every call and byte[] uses reference equality.
+            var repeatPeek = ManagedReplicaChangeCaptureProjector.Project(connection, journal.ReadBatch(int.MaxValue));
+            repeatPeek.Should().BeEquivalentTo(firstPeek);
+
+            // A genuine push now acknowledges only the first (already-delivered) change.
+            journal.Acknowledge(2);
+
+            var secondPeek = ManagedReplicaChangeCaptureProjector.Project(connection, journal.ReadBatch(int.MaxValue));
+            secondPeek.Rows.Should().ContainSingle();
+            var remaining = secondPeek.Rows[0];
+            // The surviving row keeps its original change id: acknowledging a prefix never
+            // renumbers what is left, and the row's content is byte-for-byte identical to what
+            // the pre-ack peek already reported for it.
+            remaining.ChangeId.Should().Be(firstPeek.Rows[1].ChangeId);
+            remaining.ChangeType.Should().Be(firstPeek.Rows[1].ChangeType);
+            remaining.TableName.Should().Be(firstPeek.Rows[1].TableName);
+            remaining.RowId.Should().Be(firstPeek.Rows[1].RowId);
+            SqliteRecordCodec.Decode(remaining.After!).Should()
+                .Equal(SqliteRecordCodec.Decode(firstPeek.Rows[1].After!));
+            secondPeek.FirstChangeId.Should().Be(2);
+            secondPeek.AcknowledgementWatermark.Should().Be(3, "no new changes were appended after the ack");
+        }
+        finally
+        {
+            var sidecar = journalPath + ManagedReplicaChangeJournal.Suffix;
+            if (File.Exists(sidecar))
+                File.Delete(sidecar);
+        }
+    }
+
+    [Test]
+    public void PublicPeekPendingChangeCaptureProjectsCommittedLocalMutationsEndToEnd()
+    {
+        var path = NewReplicaPath("cdc-bridge-peek");
+        try
+        {
+            using (var setup = new AhtolaConnection($"Data Source={path};Local Provider=Managed"))
+            {
+                setup.Open();
+                setup.ExecuteNonQuery("CREATE TABLE t(id INTEGER PRIMARY KEY, value TEXT)");
+                setup.ExecuteNonQuery("INSERT INTO t VALUES (2, 'seed2')");
+            }
+
+            using var replica = AhtolaConnection.CreateReplica(
+                new AhtolaReplicaOptions(path, new Uri("https://example.test"), authToken: null));
+            replica.Open();
+
+            replica.ExecuteNonQuery("INSERT INTO t VALUES (1, 'a')");
+            replica.ExecuteNonQuery("UPDATE t SET value = 'c2' WHERE id = 2");
+
+            var peek = replica.PeekPendingChangeCapture();
+
+            peek.FirstChangeId.Should().Be(1);
+            peek.AcknowledgementWatermark.Should().Be(3);
+            peek.Rows.Should().HaveCount(2);
+
+            var insertRow = peek.Rows[0];
+            insertRow.ChangeId.Should().Be(1);
+            insertRow.ChangeTransactionId.Should().Be(1);
+            insertRow.ChangeType.Should().Be(AhtolaReplicaChangeType.Insert);
+            insertRow.TableName.Should().Be("t");
+            insertRow.RowId.Should().Be(1);
+            insertRow.Before.Should().BeNull();
+            SqliteRecordCodec.Decode(insertRow.After!).Should().Equal(SqlValue.Integer(1), SqlValue.Text("a"));
+
+            var updateRow = peek.Rows[1];
+            updateRow.ChangeId.Should().Be(2);
+            updateRow.ChangeType.Should().Be(AhtolaReplicaChangeType.Update);
+            updateRow.TableName.Should().Be("t");
+            updateRow.RowId.Should().Be(2);
+            updateRow.Before.Should().BeNull("the private replica journal never captures an update's pre-image");
+            SqliteRecordCodec.Decode(updateRow.After!).Should().Equal(SqlValue.Integer(2), SqlValue.Text("c2"));
+
+            // Peeking performs no network I/O and never advances the push watermark: reading it
+            // again reports the exact same pending batch (structurally, not via record equality
+            // — "after" images are freshly re-encoded byte[] instances on every call).
+            replica.PeekPendingChangeCapture().Should().BeEquivalentTo(peek);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public void PeekPendingChangeCaptureThrowsForNonReplicaConnections()
+    {
+        using var connection = new AhtolaConnection("Data Source=:memory:;Local Provider=Managed");
+        connection.Open();
+
+        Action act = () => connection.PeekPendingChangeCapture();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*managed embedded replica connections*");
+    }
+
+    // --- helpers ---
+
+    private static void Exec(IManagedConnectionAdapter connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        statement.Step();
+    }
+
+    private static SqlValue[] SingleCdcRow(IManagedConnectionAdapter connection, int changeType, long id)
+    {
+        using var statement = connection.Prepare(
+            "SELECT change_id, change_txn_id, change_type, table_name, id, before, after "
+            + "FROM turso_cdc WHERE change_type = ? AND id = ?");
+        statement.Bind(1, SqlValue.Integer(changeType));
+        statement.Bind(2, SqlValue.Integer(id));
+        statement.Step().Should().Be(StatementStepResult.Row);
+        var row = new SqlValue[statement.GetColumnCount()];
+        for (var i = 0; i < row.Length; i++)
+            row[i] = statement.GetValue(i);
+        statement.Step().Should().Be(StatementStepResult.Done, "exactly one real CDC row should match this filter");
+        return row;
+    }
+
+    private static string AsText(SqlValue value) => value.AsText();
+
+    private static long AsInteger(SqlValue value) => value.AsInteger();
+
+    private static ReadOnlyMemory<byte> AsBlob(SqlValue value) => value.AsBlob();
+
+    private static SqlValue[] DecodeAfter(AhtolaReplicaChangeRow row) => SqliteRecordCodec.Decode(row.After!);
+
+    private static string NewReplicaPath(string prefix)
+        => Path.Combine(TestContext.CurrentContext.WorkDirectory, $"{prefix}-{Guid.NewGuid():N}.db");
+
+    private static void DeleteReplicaFiles(string path)
+    {
+        foreach (var file in new[]
+                 {
+                     path,
+                     path + "-wal",
+                     path + "-shm",
+                     path + "-journal",
+                     path + ".ahtola-replica-meta",
+                     path + ManagedReplicaChangeJournal.Suffix,
+                 })
+        {
+            if (File.Exists(file))
+                File.Delete(file);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up gap #8 after #24: a safe, **read-only** public bridge between the private managed embedded replica change journal (`ManagedReplicaChangeJournal` / `ReplicaLocalChange`) and Ahtola's public change-data-capture row contract (the `turso_cdc` table shape).

Scope is deliberately narrow for this first PR:
- **Projection only** — pending private replica journal entries are *projected* into the public CDC row contract on read.
- **No dual-write** — nothing is written to a real `turso_cdc` table.
- **No external-CDC-as-push-source** — this does not make externally-appended CDC rows a push source; the journal remains the sole source of truth for pushes.
- **No acknowledgement** — peeking never advances the journal's push watermark and has no side effects.

## Public API

- `AhtolaConnection.PeekPendingChangeCapture()` → `AhtolaReplicaChangeCaptureBatch` (managed embedded replica connections only; throws `InvalidOperationException` otherwise).
- `AhtolaReplicaChangeRow` (`ChangeId`, `ChangeTransactionId`, `ChangeType`, `TableName`, `RowId`, `Before`, `After`) and `AhtolaReplicaChangeCaptureBatch` (`FirstChangeId`, `AcknowledgementWatermark`, `Rows`) — public records mirroring `change_id`/`change_txn_id`/`change_type`/`table_name`/`id`/`before`/`after`.
- `AhtolaReplicaChangeCaptureException` for fail-closed cases.

## Design decisions (documented on the types themselves)

| Concern | Decision |
| --- | --- |
| Operation IDs/order | `ChangeId` = journal `Sequence`, strictly increasing and gap-free per batch. |
| Transactions | `ChangeTransactionId` = `ChangeId` (always self-referencing) — the private journal doesn't persist which local SQL transaction a row belonged to once reloaded from disk, so multi-row transaction grouping cannot be recovered. Every row is represented as the sole row of its own transaction. |
| Acknowledgement watermark | `AcknowledgementWatermark` mirrors the journal's push watermark exactly; peeking never advances it. |
| Delete pre-image | Required. A legacy pre-v4 journal delete entry with no captured before-image fails the whole peek closed (`AhtolaReplicaChangeCaptureException`) instead of returning a misleading empty row. |
| Schema/DDL entries | Any schema change anywhere in the pending batch fails the whole peek closed — it has no row-level image and cannot be represented. |
| Insert/Update after-image | Reconstructed from live row state, only when no *later* pending change in the same batch touches the same `(table, rowid)` key again. A superseded touch degrades to `before`/`after` both `null` (id-only) rather than returning stale data. |
| `updates` column | No equivalent — it requires an update's pre-image, which the journal never captures. |

## Tests

`ManagedReplicaChangeCaptureBridgeTests` (7 new tests):
1. Projected rows agree field-for-field with the real `turso_cdc` table for distinct insert/update/delete rows on the same connection.
2. A row superseded by a later touch in the same batch degrades its `after` image to `null` instead of stale data.
3. Fails closed for a delete entry with no captured before-image.
4. Fails closed when the batch contains a schema change anywhere, including alongside otherwise-valid row changes.
5. Acknowledging an earlier watermark leaves later pending rows correctly projected; a repeated peek is unaffected (proves acking a push doesn't corrupt CDC semantics).
6. End-to-end smoke test through the public `AhtolaConnection` API on a real `CreateReplica` connection.
7. Guards against non-replica connections.

## Verification

```
dotnet build src\Ahtola.Data\Ahtola.Data.csproj -c Debug -f net10.0      # 0 warnings/errors
dotnet build src\Ahtola.Tests\Ahtola.Tests.csproj -c Debug -f net10.0    # 0 warnings/errors

pwsh ./scripts/Invoke-ManagedTestSuite.ps1 -Framework net10.0 \
  -Filter "FullyQualifiedName~ManagedReplicaChangeCaptureBridgeTests" -MinimumExecutedTests 7
# Passed! 7/7

pwsh ./scripts/Invoke-ManagedTestSuite.ps1 -Framework net10.0 \
  -Filter "FullyQualifiedName~ManagedChangeDataCaptureTests|FullyQualifiedName~ManagedEmbeddedReplicaConnectionTests|FullyQualifiedName~ManagedReplicaLogicalReplayerTests" \
  -MinimumExecutedTests 50
# Passed! 149/149 (no regressions from promoting TryCaptureCurrentRowValues to internal)

dotnet format Ahtola.slnx --no-restore --verify-no-changes --include <touched/new files>
# clean (a pre-existing, unrelated whitespace issue elsewhere in AhtolaConnection.cs predates this change)

pwsh ./build.ps1 validate-project-closure   # passes — no native/Rust references introduced
```

## Also in this PR

`ManagedReplicaLogicalReplayer.TryCaptureCurrentRowValues` is promoted from `private` to `internal` so the projector can reuse the same live-row capture logic as the replay path, avoiding duplicated reflection-free row-reading code.

## Non-goals (left for future gaps)

- Dual-writing to a real `turso_cdc` table from local mutations.
- Recovering multi-row transaction boundaries in the private journal.
- Treating externally-appended CDC rows as a push source.
- Exposing acknowledgement/watermark-advance through the public API (peeking stays read-only by design).