### PR TITLE
Wire managed replica bootstrap/pull to remote-encryption semantics

### DIFF
--- a/src/Ahtola.Data/AhtolaRemoteClient.cs
+++ b/src/Ahtola.Data/AhtolaRemoteClient.cs
@@ -8,7 +8,12 @@ namespace Ahtola;
 
 internal sealed partial class AhtolaRemoteClient : IDisposable
 {
-    private const string EncryptionKeyHeaderName = "x-turso-encryption-key";
+    /// <summary>
+    /// HTTP header used to convey the remote encryption key alongside a push/pull request. Also
+    /// used by <see cref="ManagedReplicaBootstrapper"/>'s raw HTTP bootstrap/pull requests so both
+    /// paths speak the identical remote-encryption wire protocol.
+    /// </summary>
+    internal const string EncryptionKeyHeaderName = "x-turso-encryption-key";
 
     private readonly HttpClient _httpClient;
     private readonly string? _authToken;

--- a/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
+++ b/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Text;
 using Ahtola.Core;
+using Ahtola.Core.Storage;
 
 namespace Ahtola;
 
@@ -71,7 +72,7 @@ internal static class ManagedReplicaBootstrapper
         try
         {
             var (revision, protocol) = await DownloadDatabaseAsync(options, stagingPath, cancellationToken).ConfigureAwait(false);
-            ValidateStagedDatabase(stagingPath);
+            ValidateStagedDatabase(stagingPath, options.RemoteEncryption);
 
             ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.BootstrapStagedDatabase);
             cancellationToken.ThrowIfCancellationRequested();
@@ -80,7 +81,7 @@ internal static class ManagedReplicaBootstrapper
 
             ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.BootstrapDatabasePublished);
             cancellationToken.ThrowIfCancellationRequested();
-            var tableMap = RebuildTableMapFromSchema(options.Path);
+            var tableMap = RebuildTableMapFromSchema(options.Path, options.RemoteEncryption);
             await WriteMetadataAsync(
                 metadataStagingPath,
                 metadataPath,
@@ -113,10 +114,11 @@ internal static class ManagedReplicaBootstrapper
     /// apply path (bootstrap, incremental pages, replace-base), where no logical schema identity
     /// operations are decoded but a future logical pull may depend on an existing map.
     /// </summary>
-    private static IReadOnlyDictionary<ulong, string> RebuildTableMapFromSchema(string databasePath)
+    private static IReadOnlyDictionary<ulong, string> RebuildTableMapFromSchema(
+        string databasePath, AhtolaRemoteEncryptionOptions? remoteEncryption)
     {
-        using var database = ManagedDatabaseAdapter.Open(databasePath);
-        var connection = database.Connect();
+        using var opened = ManagedReplicaEncryption.OpenDatabase(databasePath, remoteEncryption);
+        var connection = opened.Database.Connect();
         using var statement = connection.Prepare(
             "SELECT rootpage, name FROM sqlite_schema WHERE type = 'table' AND rootpage != 0");
         var map = new Dictionary<ulong, string>();
@@ -330,6 +332,16 @@ internal static class ManagedReplicaBootstrapper
         ArgumentNullException.ThrowIfNull(pendingLocalChanges);
         ManagedReplicaSupportMatrix.ValidateOptions(options);
         var requestLogical = metadata.Protocol == RemotePullProtocol.MvccLogical;
+        if (requestLogical && options.RemoteEncryption is not null)
+        {
+            // Mirrors Turso's ensure_logical_mvcc_pull_supported: the MVCC logical pull protocol
+            // and remote encryption are not a supported combination, so this must fail closed
+            // before ever sending the request rather than silently downgrading to page mode.
+            throw new NotSupportedException(
+                "Managed embedded replica synchronization does not support the MVCC logical pull "
+                + "protocol combined with remote encryption.");
+        }
+
         if (!requestLogical)
         {
             // A non-logical (page) protocol client can only ever receive a Pages response for
@@ -362,6 +374,8 @@ internal static class ManagedReplicaBootstrapper
         ValidateAuthTokenTransport(request.RequestUri!, token);
         if (token is not null)
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        if (options.RemoteEncryption is { } remoteEncryption)
+            request.Headers.TryAddWithoutValidation(AhtolaRemoteClient.EncryptionKeyHeaderName, remoteEncryption.Base64Key);
         var effectiveToken = timeout?.Token ?? cancellationToken;
         using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, effectiveToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
@@ -821,7 +835,7 @@ internal static class ManagedReplicaBootstrapper
                 staging.Flush(flushToDisk: true);
             }
 
-            ValidateStagedDatabase(stagingPath);
+            ValidateStagedDatabase(stagingPath, options.RemoteEncryption);
             ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.IncrementalApplyStagedDatabase);
             cancellationToken.ThrowIfCancellationRequested();
             File.Replace(stagingPath, options.Path, backupPath, ignoreMetadataErrors: false);
@@ -831,8 +845,8 @@ internal static class ManagedReplicaBootstrapper
 
             if (header.ApplyMode == PullApplyMode.ReplaceBase && pendingLocalChanges.Count > 0)
             {
-                using var database = ManagedDatabaseAdapter.Open(options.Path);
-                var connection = database.Connect();
+                using var opened = ManagedReplicaEncryption.OpenDatabase(options.Path, options.RemoteEncryption);
+                var connection = opened.Database.Connect();
                 ExecuteNonQuery(connection, "BEGIN IMMEDIATE");
                 try
                 {
@@ -855,7 +869,7 @@ internal static class ManagedReplicaBootstrapper
             // freshly detected protocol is recorded too, so a protocol-2 remote that answered this
             // particular pull with Pages (e.g. Pages+ReplaceBase) still enables a logical request
             // on the next pull rather than sticking to pages forever.
-            var tableMap = RebuildTableMapFromSchema(options.Path);
+            var tableMap = RebuildTableMapFromSchema(options.Path, options.RemoteEncryption);
             await WriteMetadataAsync(
                     metadataStagingPath,
                     metadataPath,
@@ -910,6 +924,8 @@ internal static class ManagedReplicaBootstrapper
         ValidateAuthTokenTransport(request.RequestUri!, authToken);
         if (authToken is not null)
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", authToken);
+        if (options.RemoteEncryption is { } remoteEncryption)
+            request.Headers.TryAddWithoutValidation(AhtolaRemoteClient.EncryptionKeyHeaderName, remoteEncryption.Base64Key);
 
         using var response = await client.SendAsync(
             request,
@@ -926,6 +942,18 @@ internal static class ManagedReplicaBootstrapper
         {
             throw new InvalidDataException(
                 "Managed embedded replica bootstrap requires a raw page stream; the server returned an MVCC logical-log stream.");
+        }
+
+        if (options.RemoteEncryption is not null && header.Protocol == RemotePullProtocol.MvccLogical)
+        {
+            // Fail closed as soon as the remote's advertised protocol is known, before ever
+            // installing a bootstrap image that would require an unsupported MVCC-logical
+            // catch-up pull later (see CheckForUpdatesAsync's matching guard). Mirrors Turso's
+            // ensure_logical_mvcc_pull_supported: MVCC logical pull and remote encryption are not
+            // a supported combination.
+            throw new NotSupportedException(
+                "Managed embedded replica bootstrap does not support a remote that advertises the "
+                + "MVCC logical pull protocol combined with remote encryption.");
         }
 
         var databaseLength = checked((long)header.DatabasePages * PageSize);
@@ -962,18 +990,23 @@ internal static class ManagedReplicaBootstrapper
     }
 
 
-    private static void ValidateStagedDatabase(string stagingPath)
+    private static void ValidateStagedDatabase(string stagingPath, AhtolaRemoteEncryptionOptions? remoteEncryption)
     {
-        using (var stream = new FileStream(stagingPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+        if (remoteEncryption is null)
         {
+            using var stream = new FileStream(stagingPath, FileMode.Open, FileAccess.Read, FileShare.Read);
             Span<byte> header = stackalloc byte[SqliteHeader.Length];
             stream.ReadExactly(header);
             if (!header.SequenceEqual(SqliteHeader))
                 throw new InvalidDataException("The bootstrapped page stream does not contain a SQLite database header.");
         }
 
-        using var database = ManagedDatabaseAdapter.Open(stagingPath);
-        _ = database.Connect();
+        // For an encrypted stream, page 1 begins with the Ahtola encrypted-page magic rather than
+        // the plaintext SQLite header, so the plaintext pre-check above is skipped: opening below
+        // exercises the storage layer's own encrypted-header/reserved-byte validation instead
+        // (see SqlitePageStore.OpenCore/OpenWithCodec), which fails closed on any mismatch.
+        using var opened = ManagedReplicaEncryption.OpenDatabase(stagingPath, remoteEncryption);
+        _ = opened.Database.Connect();
     }
 
     private static async Task WriteMetadataAsync(

--- a/src/Ahtola.Data/ManagedReplicaConnectionHost.cs
+++ b/src/Ahtola.Data/ManagedReplicaConnectionHost.cs
@@ -11,6 +11,7 @@ namespace Ahtola;
 internal sealed class ManagedReplicaConnectionHost : IDisposable
 {
     private IManagedDatabaseAdapter? _database;
+    private AhtolaEncryptionFileSystem? _encryptionFileSystem;
     private ManagedReplicaBootstrapper.ManagedReplicaMetadata? _metadata;
     private readonly AhtolaReplicaOptions _options;
     private readonly ManagedReplicaSyncRegistry.Entry _syncEntry;
@@ -26,12 +27,14 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
 
     private ManagedReplicaConnectionHost(
         IManagedDatabaseAdapter database,
+        AhtolaEncryptionFileSystem? encryptionFileSystem,
         ManagedReplicaBootstrapper.ManagedReplicaMetadata? metadata,
         AhtolaReplicaOptions options,
         ManagedReplicaChangeJournal changeJournal,
         ManagedReplicaSyncRegistry.Entry syncEntry)
     {
         _database = database;
+        _encryptionFileSystem = encryptionFileSystem;
         _metadata = metadata;
         _options = options;
         _changeJournal = changeJournal;
@@ -268,12 +271,13 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
         AhtolaReplicaOptions options,
         ManagedReplicaSyncRegistry.Entry syncEntry)
     {
-        var database = OpenDatabase(options.Path);
+        var (database, encryptionFileSystem) = OpenDatabase(options);
         try
         {
             _ = database.Connect();
             return new ManagedReplicaConnectionHost(
                 database,
+                encryptionFileSystem,
                 ManagedReplicaBootstrapper.LoadMetadata(options.Path),
                 options,
                 ManagedReplicaChangeJournal.Open(options.Path),
@@ -283,21 +287,30 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
         catch
         {
             database.Dispose();
+            encryptionFileSystem?.Dispose();
             throw;
         }
     }
 
-    private static IManagedDatabaseAdapter OpenDatabase(string path)
+    /// <summary>
+    /// Opens the managed database at <paramref name="options"/>'s path, wiring in remote
+    /// encryption (see <see cref="ManagedReplicaEncryption.OpenDatabase"/>) when configured. The
+    /// returned file system, if any, must be kept alive and disposed alongside the database for
+    /// as long as it remains open -- it is consulted on every subsequent page read/write, not
+    /// only at open time.
+    /// </summary>
+    private static (IManagedDatabaseAdapter Database, AhtolaEncryptionFileSystem? FileSystem) OpenDatabase(
+        AhtolaReplicaOptions options)
     {
-        var database = ManagedDatabaseAdapter.Open(path);
+        var opened = ManagedReplicaEncryption.OpenDatabase(options.Path, options.RemoteEncryption);
         try
         {
-            _ = database.Connect();
-            return database;
+            _ = opened.Database.Connect();
+            return (opened.Database, opened.FileSystem);
         }
         catch
         {
-            database.Dispose();
+            opened.Dispose();
             throw;
         }
     }
@@ -460,6 +473,8 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
             ReleaseSqlTransactionOperation();
             var database = Interlocked.Exchange(ref _database, null);
             database?.Dispose();
+            var encryptionFileSystem = Interlocked.Exchange(ref _encryptionFileSystem, null);
+            encryptionFileSystem?.Dispose();
         }
         finally
         {
@@ -473,11 +488,12 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
         var database = Interlocked.Exchange(ref _database, null)
             ?? throw new ObjectDisposedException(nameof(ManagedReplicaConnectionHost));
         database.Dispose();
+        Interlocked.Exchange(ref _encryptionFileSystem, null)?.Dispose();
     }
 
     internal void ReopenAfterPublication()
     {
-        var database = OpenDatabase(_options.Path);
+        var (database, encryptionFileSystem) = OpenDatabase(_options);
         try
         {
             var changeJournal = ManagedReplicaChangeJournal.Open(_options.Path);
@@ -485,11 +501,14 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
             if (Interlocked.CompareExchange(ref _database, database, null) is not null)
                 throw new InvalidOperationException("Managed embedded replica host reopened more than once.");
             _changeJournal = changeJournal;
+            _encryptionFileSystem = encryptionFileSystem;
             database = null!;
+            encryptionFileSystem = null;
         }
         finally
         {
             database?.Dispose();
+            encryptionFileSystem?.Dispose();
         }
     }
 

--- a/src/Ahtola.Data/ManagedReplicaEncryption.cs
+++ b/src/Ahtola.Data/ManagedReplicaEncryption.cs
@@ -1,0 +1,120 @@
+using System.Security.Cryptography;
+using Ahtola.Core;
+using Ahtola.Core.Storage;
+
+namespace Ahtola;
+
+/// <summary>
+/// Bridges <see cref="AhtolaRemoteEncryptionOptions"/> (the Cloud replica wire configuration) to
+/// the managed storage engine's own <see cref="AhtolaEncryptionOptions"/>/<see cref="AhtolaEncryptionFileSystem"/>,
+/// so managed replica bootstrap/pull opens an encrypted database page stream the same way
+/// <see cref="AhtolaConnection"/> opens any other encrypted managed database -- reusing the
+/// storage layer's existing encrypted-header and reserved-byte validation instead of
+/// duplicating it. Mirrors Turso's <c>remote_encryption_key</c> plumbing in
+/// <c>database_sync_engine.rs</c>: only the AES-GCM cipher family the managed engine actually
+/// implements (<see cref="AhtolaEncryptionCipher.Aes128Gcm"/>/<see cref="AhtolaEncryptionCipher.Aes256Gcm"/>)
+/// is supported; every other remote cipher fails closed rather than being silently accepted or
+/// weakened.
+/// </summary>
+internal static class ManagedReplicaEncryption
+{
+    /// <summary>
+    /// Throws <see cref="NotSupportedException"/> unless <paramref name="cipher"/> is one of the
+    /// AES-GCM variants the managed storage engine implements. Called eagerly from
+    /// <see cref="ManagedReplicaSupportMatrix.ValidateOptions"/> so an unsupported cipher fails
+    /// before any network request, not partway through a bootstrap.
+    /// </summary>
+    public static void EnsureSupportedCipher(AhtolaRemoteEncryptionCipher cipher)
+    {
+        if (cipher is not (AhtolaRemoteEncryptionCipher.Aes128Gcm or AhtolaRemoteEncryptionCipher.Aes256Gcm))
+        {
+            throw new NotSupportedException(
+                $"Managed embedded replicas support remote encryption ciphers Aes128Gcm and Aes256Gcm only; "
+                + $"'{cipher}' is not implemented by the managed storage engine.");
+        }
+    }
+
+    /// <summary>
+    /// Maps a validated <see cref="AhtolaRemoteEncryptionOptions"/> to the managed storage
+    /// engine's own <see cref="AhtolaEncryptionOptions"/>. The returned instance owns a copy of
+    /// the decoded key and must be disposed by the caller once it is no longer needed.
+    /// </summary>
+    public static AhtolaEncryptionOptions CreateManagedOptions(AhtolaRemoteEncryptionOptions remoteEncryption)
+    {
+        ArgumentNullException.ThrowIfNull(remoteEncryption);
+        EnsureSupportedCipher(remoteEncryption.Cipher);
+
+        byte[] key;
+        try
+        {
+            key = Convert.FromBase64String(remoteEncryption.Base64Key);
+        }
+        catch (FormatException exception)
+        {
+            throw new ArgumentException(
+                "The remote encryption key is not valid base64.", nameof(remoteEncryption), exception);
+        }
+
+        try
+        {
+            // AhtolaRemoteEncryptionCipher.Aes128Gcm/Aes256Gcm share their names with
+            // AhtolaEncryptionCipher's members, so the Enum-accepting constructor resolves them
+            // directly; any other (already-rejected) cipher would throw there too as a backstop.
+            return new AhtolaEncryptionOptions(remoteEncryption.Cipher, key);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(key);
+        }
+    }
+
+    /// <summary>
+    /// Opens a managed database at <paramref name="path"/>, wiring in
+    /// <paramref name="remoteEncryption"/> when configured so the storage layer performs its
+    /// existing encrypted-header/reserved-byte validation on open. Returns both the database and
+    /// the (possibly null) encryption file system backing it; the caller owns disposing both --
+    /// for a long-lived database the file system must be kept alive and disposed alongside it,
+    /// since it is consulted on every subsequent page read/write, not only at open time.
+    /// </summary>
+    public static ManagedReplicaOpenedDatabase OpenDatabase(string path, AhtolaRemoteEncryptionOptions? remoteEncryption)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+
+        if (remoteEncryption is null)
+            return new ManagedReplicaOpenedDatabase(ManagedDatabaseAdapter.Open(path), null);
+
+        AhtolaEncryptionFileSystem? fileSystem = null;
+        IManagedDatabaseAdapter? database = null;
+        try
+        {
+            using var managedOptions = CreateManagedOptions(remoteEncryption);
+            fileSystem = new AhtolaEncryptionFileSystem(PhysicalFileSystem.Instance, managedOptions);
+            database = ManagedDatabaseAdapter.OpenFile(path, fileSystem, readOnly: false, foreignReadOnly: false);
+            return new ManagedReplicaOpenedDatabase(database, fileSystem);
+        }
+        catch
+        {
+            database?.Dispose();
+            fileSystem?.Dispose();
+            throw;
+        }
+    }
+}
+
+/// <summary>
+/// Pairs a managed database adapter with the (possibly null) <see cref="AhtolaEncryptionFileSystem"/>
+/// backing it so both are disposed together. See <see cref="ManagedReplicaEncryption.OpenDatabase"/>.
+/// </summary>
+internal readonly struct ManagedReplicaOpenedDatabase(IManagedDatabaseAdapter database, AhtolaEncryptionFileSystem? fileSystem)
+    : IDisposable
+{
+    public IManagedDatabaseAdapter Database { get; } = database;
+
+    public AhtolaEncryptionFileSystem? FileSystem { get; } = fileSystem;
+
+    public void Dispose()
+    {
+        Database.Dispose();
+        FileSystem?.Dispose();
+    }
+}

--- a/src/Ahtola.Data/ManagedReplicaSupportMatrix.cs
+++ b/src/Ahtola.Data/ManagedReplicaSupportMatrix.cs
@@ -22,9 +22,6 @@ internal static class ManagedReplicaSupportMatrix
         }
 
         if (options.RemoteEncryption is not null)
-        {
-            throw new NotSupportedException(
-                "Managed embedded replicas do not support encrypted remote page streams.");
-        }
+            ManagedReplicaEncryption.EnsureSupportedCipher(options.RemoteEncryption.Cipher);
     }
 }

--- a/src/Ahtola.Tests/ManagedEmbeddedReplicaConnectionTests.cs
+++ b/src/Ahtola.Tests/ManagedEmbeddedReplicaConnectionTests.cs
@@ -18,6 +18,11 @@ public sealed class ManagedEmbeddedReplicaConnectionTests
     private const int LogicalApplyCheckpointedBoundary = (int)ManagedReplicaDurableBoundary.LogicalApplyCheckpointed;
     private const int LogicalApplyMetadataPublishedBoundary = (int)ManagedReplicaDurableBoundary.LogicalApplyMetadataPublished;
 
+    // 32-byte (AES-256-GCM) hex keys used to build genuinely encrypted replica fixtures; mirrors
+    // ManagedEncryptedFileOpenContractTests' Aes256Key/WrongAes256Key pair.
+    private const string ReplicaEncryptionKeyHex = "202122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F";
+    private const string ReplicaEncryptionWrongKeyHex = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
+
     [Test]
     public void ReplicaOptionsNormalizeLibsqlUrlsToHttps()
     {
@@ -2152,7 +2157,7 @@ public sealed class ManagedEmbeddedReplicaConnectionTests
         }
     }
 
-    [TestCase(UnsupportedReplicaMode.RemoteEncryption)]
+    [TestCase(UnsupportedReplicaMode.UnsupportedEncryptionCipher)]
     [TestCase(UnsupportedReplicaMode.PartialPrefix)]
     [TestCase(UnsupportedReplicaMode.PartialQuery)]
     [TestCase(UnsupportedReplicaMode.ChunkedBootstrap)]
@@ -2172,6 +2177,195 @@ public sealed class ManagedEmbeddedReplicaConnectionTests
             File.Exists(path).Should().BeFalse();
             File.Exists(path + ".ahtola-replica-meta").Should().BeFalse();
             File.Exists(path + ManagedReplicaChangeJournal.Suffix).Should().BeFalse();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public void CreateReplicaBootstrapsAnEncryptedRemoteDatabaseWithNonzeroReservedBytes()
+    {
+        // The source database is genuinely AES-256-GCM encrypted (28 reserved bytes per page;
+        // page 1 begins with the "AHTLA" header rather than plaintext SQLite magic). Bootstrap
+        // must materialize it using the storage layer's own encrypted-header/reserved-byte
+        // treatment (see ManagedReplicaEncryption.OpenDatabase) instead of the previous blanket
+        // "remote encryption is unsupported" rejection, and must forward the remote encryption
+        // key as an HTTP header on the pull request (mirrors Turso's remote_encryption_key).
+        var path = NewReplicaPath("managed-replica-encrypted-bootstrap");
+        var sourcePath = path + ".source";
+        var image = CreateEncryptedDatabaseImage(sourcePath, ReplicaEncryptionKeyHex, marker: 77);
+        image.AsSpan(0, 5).ToArray().Should().Equal(
+            "AHTLA"u8.ToArray(), "the fixture must be genuinely encrypted, not merely labeled as such");
+
+        var receivedEncryptionKeys = new List<string?>();
+        var handler = new PullUpdatesHandler(
+            CreatePullResponse("revision-42", image),
+            request => receivedEncryptionKeys.Add(
+                request.Headers.TryGetValues(AhtolaRemoteClient.EncryptionKeyHeaderName, out var values)
+                    ? values.FirstOrDefault()
+                    : null));
+        var options = CreateEncryptedOptions(path, handler, ReplicaEncryptionKeyHex);
+
+        try
+        {
+            using (var connection = AhtolaConnection.CreateReplica(options))
+            {
+                connection.Open();
+
+                ReadBootstrapMarker(connection).Should().Be(77);
+                handler.CallCount.Should().Be(1);
+                receivedEncryptionKeys.Should().ContainSingle().Which.Should().Be(options.RemoteEncryption!.Base64Key);
+            }
+
+            File.ReadAllBytes(path).AsSpan(0, 5).ToArray().Should().Equal(
+                "AHTLA"u8.ToArray(), "the bootstrapped local file must remain encrypted at rest");
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public void CreateReplicaRejectsAnEncryptedRemoteDatabaseWhenTheConfiguredKeyDoesNotMatch()
+    {
+        // A wrong (but valid-length) key cannot authenticate the AES-GCM tag on page 1, so the
+        // storage layer's decrypt path must fail closed rather than silently accepting
+        // corrupted plaintext; the failed bootstrap must also roll back completely.
+        var path = NewReplicaPath("managed-replica-encrypted-wrong-key");
+        var sourcePath = path + ".source";
+        var image = CreateEncryptedDatabaseImage(sourcePath, ReplicaEncryptionKeyHex);
+
+        var handler = new PullUpdatesHandler(CreatePullResponse("revision-42", image));
+        var options = CreateEncryptedOptions(path, handler, ReplicaEncryptionWrongKeyHex);
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(options);
+            Assert.Throws<InvalidDataException>(() => connection.Open())!
+                .Message.Should().Contain("failed authentication");
+
+            handler.CallCount.Should().Be(1);
+            File.Exists(path).Should().BeFalse(
+                "a failed bootstrap must roll back rather than leave a database that cannot be decrypted with the configured key");
+            File.Exists(path + ".ahtola-replica-meta").Should().BeFalse();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public void CreateReplicaRejectsAPlaintextPageStreamWhenRemoteEncryptionIsConfigured()
+    {
+        // The remote's page stream is ordinary plaintext SQLite pages (reserved bytes = 0), but
+        // the replica is configured to expect an AES-256-GCM encrypted stream. The storage
+        // layer must detect that mismatch and fail closed (SqlitePageStore rejects a plaintext
+        // SQLite header when encryption was requested, refusing any plaintext fallback) rather
+        // than silently accepting an unencrypted page 1 as if it had already been decrypted --
+        // bootstrap must enforce the correct reserved-byte/header treatment rather than
+        // trusting the caller's RemoteEncryption configuration blindly.
+        var path = NewReplicaPath("managed-replica-plaintext-with-encryption-configured");
+        var sourcePath = path + ".source";
+        var image = CreateDatabaseImage(sourcePath);
+
+        var handler = new PullUpdatesHandler(CreatePullResponse("revision-42", image));
+        var options = CreateEncryptedOptions(path, handler, ReplicaEncryptionKeyHex);
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(options);
+            Assert.Throws<InvalidDataException>(() => connection.Open())!
+                .Message.Should().Contain("plaintext SQLite header");
+
+            handler.CallCount.Should().Be(1);
+            File.Exists(path).Should().BeFalse();
+            File.Exists(path + ".ahtola-replica-meta").Should().BeFalse();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public void CreateReplicaRejectsAnMvccLogicalRemoteAdvertisedDuringBootstrapWhenRemoteEncryptionIsConfigured()
+    {
+        // protocol: 2 advertises the MVCC logical pull protocol that would govern any later
+        // incremental pull (see CreateReplicaBootstrapsRawPagesFromALogicalProtocolRemote); the
+        // managed engine does not support combining that protocol with remote encryption
+        // (mirrors Turso's ensure_logical_mvcc_pull_supported), so bootstrap must fail closed
+        // before ever installing local state that would need an unsupported logical catch-up.
+        var path = NewReplicaPath("managed-replica-mvcc-encryption-bootstrap-reject");
+        var sourcePath = path + ".source";
+        var image = CreateDatabaseImage(sourcePath);
+
+        var handler = new PullUpdatesHandler(CreatePullResponse("revision-42", image, protocol: 2));
+        var options = CreateEncryptedOptions(path, handler, ReplicaEncryptionKeyHex);
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(options);
+            Assert.Throws<NotSupportedException>(() => connection.Open())!
+                .Message.Should().Contain("MVCC logical pull protocol combined with remote encryption");
+
+            handler.CallCount.Should().Be(
+                1, "the guard must fire from the bootstrap download itself, before any catch-up request");
+            File.Exists(path).Should().BeFalse();
+            File.Exists(path + ".ahtola-replica-meta").Should().BeFalse();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task CheckForUpdatesRejectsAnMvccLogicalMetadataProtocolWhenRemoteEncryptionIsConfigured()
+    {
+        // Establishes a replica whose stored metadata already records the MVCC logical pull
+        // protocol via a normal, unencrypted bootstrap (protocol: 2, matching
+        // CreateReplicaBootstrapsRawPagesFromALogicalProtocolRemote), then drives
+        // CheckForUpdatesAsync directly with RemoteEncryption configured against that same
+        // metadata. Mirrors Turso's ensure_logical_mvcc_pull_supported: this is the SECOND,
+        // independent guard (CheckForUpdatesAsync's own, not the bootstrap-time one in
+        // DownloadDatabaseAsync) -- it must fail closed as soon as a logical pull would be
+        // requested against an encrypted remote, without relying solely on the bootstrap-time
+        // check above.
+        var path = NewReplicaPath("managed-replica-mvcc-encryption-checkforupdates-reject");
+        var sourcePath = path + ".source";
+        var image = CreateDatabaseImage(sourcePath);
+
+        var handler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", image, protocol: 2),
+            CreateLogicalPullResponse("revision-42", body: []), // fresh-bootstrap catch-up: nothing new
+        ]);
+        var options = CreateOptions(path, handler);
+
+        try
+        {
+            ManagedReplicaBootstrapper.ManagedReplicaMetadata metadata;
+            using (var connection = AhtolaConnection.CreateReplica(options))
+            {
+                connection.Open();
+                metadata = ManagedReplicaBootstrapper.LoadMetadata(path)!.Value;
+            }
+
+            metadata.Protocol.Should().Be(
+                RemotePullProtocol.MvccLogical, "the fresh bootstrap above must have recorded an MVCC logical protocol");
+
+            var encryptedOptions = CreateEncryptedOptions(path, handler, ReplicaEncryptionKeyHex);
+
+            Func<Task> checkForUpdates = () => ManagedReplicaBootstrapper.CheckForUpdatesAsync(
+                encryptedOptions, metadata, new AhtolaSyncOptions(), [], CancellationToken.None);
+            await checkForUpdates.Should().ThrowAsync<NotSupportedException>()
+                .WithMessage("*MVCC logical pull protocol combined with remote encryption*");
+
+            handler.CallCount.Should().Be(2, "the guard must fail before any additional network request");
         }
         finally
         {
@@ -3278,14 +3472,17 @@ public sealed class ManagedEmbeddedReplicaConnectionTests
         var options = CreateOptions(path, handler);
         return mode switch
         {
-            UnsupportedReplicaMode.RemoteEncryption => new AhtolaReplicaOptions(
+            UnsupportedReplicaMode.UnsupportedEncryptionCipher => new AhtolaReplicaOptions(
                 path,
                 options.RemoteUri,
                 options.AuthToken)
             {
+                // Aes128Gcm/Aes256Gcm are supported by the managed engine (see
+                // ManagedReplicaEncryption); this mode instead exercises an unimplemented cipher
+                // to prove it still fails closed via ManagedReplicaSupportMatrix.ValidateOptions.
                 RemoteEncryption = new AhtolaRemoteEncryptionOptions(
                     "c2VjcmV0",
-                    AhtolaRemoteEncryptionCipher.Aes256Gcm),
+                    AhtolaRemoteEncryptionCipher.ChaCha20Poly1305),
                 HttpPolicy = options.HttpPolicy,
             },
             UnsupportedReplicaMode.PartialPrefix => new AhtolaReplicaOptions(
@@ -3315,6 +3512,48 @@ public sealed class ManagedEmbeddedReplicaConnectionTests
             _ => throw new ArgumentOutOfRangeException(nameof(mode)),
         };
     }
+
+    private static string ManagedEncryptionConnectionString(string path, string hexKey)
+        => $"Data Source={path};Local Provider=Managed;Encryption Cipher=Aes256Gcm;Encryption Key={hexKey}";
+
+    /// <summary>
+    /// Builds a genuinely AES-256-GCM encrypted source database image (28 reserved bytes per
+    /// page; page 1 begins with the "AHTLA" header, not the plaintext SQLite magic) for feeding
+    /// through <see cref="CreatePullResponse"/> in encrypted-bootstrap tests.
+    /// </summary>
+    private static void CreateEncryptedInitializedDatabase(string path, string hexKey, int marker)
+    {
+        using var connection = new AhtolaConnection(ManagedEncryptionConnectionString(path, hexKey));
+        connection.Open();
+        connection.ExecuteNonQuery("CREATE TABLE bootstrap_marker(value INTEGER NOT NULL);");
+        connection.ExecuteNonQuery($"INSERT INTO bootstrap_marker VALUES ({marker});");
+    }
+
+    private static byte[] CreateEncryptedDatabaseImage(string path, string hexKey, int marker = 42)
+    {
+        try
+        {
+            CreateEncryptedInitializedDatabase(path, hexKey, marker);
+            return File.ReadAllBytes(path);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    private static AhtolaReplicaOptions CreateEncryptedOptions(
+        string path,
+        HttpMessageHandler handler,
+        string hexKey,
+        AhtolaRemoteEncryptionCipher cipher = AhtolaRemoteEncryptionCipher.Aes256Gcm)
+        => new(path, new Uri("https://example.test/cluster"), authToken: "token-42")
+        {
+            LongPollTimeout = TimeSpan.FromSeconds(3),
+            HttpPolicy = new AhtolaSyncHttpPolicy(handler),
+            RemoteEncryption = new AhtolaRemoteEncryptionOptions(
+                Convert.ToBase64String(Convert.FromHexString(hexKey)), cipher),
+        };
 
     private static void DeleteReplicaFiles(string path)
     {
@@ -3526,7 +3765,7 @@ public sealed class ManagedEmbeddedReplicaConnectionTests
 
     public enum UnsupportedReplicaMode
     {
-        RemoteEncryption,
+        UnsupportedEncryptionCipher,
         PartialPrefix,
         PartialQuery,
         ChunkedBootstrap,


### PR DESCRIPTION
## Summary

Follow-up gap #3 after merged PR #24: the managed embedded replica bootstrapper (`ManagedReplicaBootstrapper`/`ManagedReplicaConnectionHost`) previously rejected any `AhtolaReplicaOptions` with `RemoteEncryption` configured outright. This wires it to Turso's Rust `database_sync_engine.rs` semantics instead — `remote_encryption_key`, `reserved_bytes`, and `ensure_logical_mvcc_pull_supported` (pinned `turso-src` v0.7.2).

## Changes

- **`ManagedReplicaEncryption.cs`** (new): centralizes cipher validation and opens a staged/local database through the existing `AhtolaPageEncryption`/`AhtolaEncryptionFileSystem` storage machinery, so encrypted remote page streams are materialized with correct reserved-byte/header treatment instead of being hard-rejected.
- **`ManagedReplicaSupportMatrix.cs`**: no longer blanket-rejects `RemoteEncryption`; only genuinely unsupported cipher configurations remain rejected.
- **`ManagedReplicaBootstrapper.cs`**: threads the remote encryption key as an outgoing HTTP header (`AhtolaRemoteClient.EncryptionKeyHeaderName`); validates staged databases via the storage layer's own encrypted-header checks (`ValidateStagedDatabase`), so mismatched keys/plaintext streams fail closed with the storage layer's own diagnostics. Two independent fail-closed guards enforce `ensure_logical_mvcc_pull_supported`:
  - `DownloadDatabaseAsync` rejects a bootstrap-time MVCC-logical protocol advertisement combined with `RemoteEncryption`, before any page is written.
  - `CheckForUpdatesAsync` rejects a stored MVCC-logical metadata protocol combined with `RemoteEncryption`, before issuing any further pull request.
- **`ManagedReplicaConnectionHost.cs`**: threads an `AhtolaEncryptionFileSystem` through open/close/reopen-after-publication so encrypted replicas decrypt transparently on ordinary connection use after bootstrap.

No native/P-Invoke/Rust dependencies were added — all encryption reuses existing pure-managed `Ahtola.Core` storage primitives (`AhtolaPageEncryption`, `AhtolaEncryptionFileSystem`).

## Tests

Five new focused tests added to `ManagedEmbeddedReplicaConnectionTests.cs`:

1. `CreateReplicaBootstrapsAnEncryptedRemoteDatabaseWithNonzeroReservedBytes` — successful bootstrap of a genuinely AES-256-GCM encrypted remote database (28 reserved bytes/page), asserting the outgoing encryption-key HTTP header and that the local file remains encrypted at rest.
2. `CreateReplicaRejectsAnEncryptedRemoteDatabaseWhenTheConfiguredKeyDoesNotMatch` — wrong-key rejection (`InvalidDataException`/"failed authentication") with full rollback.
3. `CreateReplicaRejectsAPlaintextPageStreamWhenRemoteEncryptionIsConfigured` — plaintext remote page stream vs. configured encryption fails closed rather than silently trusting caller config.
4. `CreateReplicaRejectsAnMvccLogicalRemoteAdvertisedDuringBootstrapWhenRemoteEncryptionIsConfigured` — bootstrap-time MVCC-logical + `RemoteEncryption` rejection (`NotSupportedException`), before any catch-up request.
5. `CheckForUpdatesRejectsAnMvccLogicalMetadataProtocolWhenRemoteEncryptionIsConfigured` — the independent `CheckForUpdatesAsync`-time guard, exercised directly against real bootstrap-produced metadata.

Also fixes a pre-existing regression in an existing unsupported-mode test that assumed `RemoteEncryption` + `Aes256Gcm` was universally unsupported (renamed to `UnsupportedEncryptionCipher`, now using `ChaCha20Poly1305` as the actually-unsupported cipher).

### Evidence

```
pwsh ./scripts/Invoke-ManagedTestSuite.ps1 -Framework net10.0 `
  -Filter "FullyQualifiedName~ManagedEmbeddedReplicaConnectionTests" -MinimumExecutedTests 50
# Passed! - Failed: 0, Passed: 89, Skipped: 0, Total: 89

pwsh ./scripts/Invoke-ManagedTestSuite.ps1 -Framework net10.0 `
  -Filter "FullyQualifiedName~Ahtola.Tests.Managed" -MinimumExecutedTests 100
# Passed! - Failed: 0, Passed: 1967, Skipped: 46, Total: 2013

pwsh ./build.ps1 format-check
# clean for all files touched by this change (one pre-existing, unrelated
# formatting drift in VdbeDmlFkEmissionTests.cs on master, not modified here)
```