### PR TITLE
Reject remote encryption over insecure HTTP

### DIFF
--- a/src/Ahtola.Data/AhtolaRemoteClient.cs
+++ b/src/Ahtola.Data/AhtolaRemoteClient.cs
@@ -45,7 +45,10 @@ internal sealed partial class AhtolaRemoteClient : IDisposable
         _pipelineUri = CreatePipelineUri(endpoint);
         _authToken = string.IsNullOrWhiteSpace(authToken) ? null : authToken;
         _remoteEncryptionKey = remoteEncryption?.Base64Key;
-        ValidateAuthTokenTransport(_pipelineUri, _authToken);
+        AhtolaRemoteTransportSecurity.Validate(
+            _pipelineUri,
+            _authToken,
+            remoteEncryptionConfigured: _remoteEncryptionKey is not null);
         _disposeHttpClient = disposeHttpClient;
     }
 
@@ -328,18 +331,6 @@ internal sealed partial class AhtolaRemoteClient : IDisposable
         {
             throw new AhtolaException($"Unable to parse remote response: {ex.Message}");
         }
-    }
-
-    private static void ValidateAuthTokenTransport(Uri endpoint, string? authToken)
-    {
-        if (authToken is null
-            || endpoint.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
-            || endpoint.IsLoopback)
-        {
-            return;
-        }
-
-        throw new InvalidOperationException("Auth Token requires an HTTPS remote Ahtola URL unless the host is localhost or loopback.");
     }
 
     private static RemoteStatement BuildStatement(string sql, AhtolaParameterCollection parameters, bool wantRows)
@@ -652,7 +643,10 @@ internal sealed partial class AhtolaRemoteClient : IDisposable
         if (!string.IsNullOrWhiteSpace(response.BaseUrl))
         {
             var pipelineUri = CreatePipelineUri(new Uri(_pipelineUri, response.BaseUrl));
-            ValidateAuthTokenTransport(pipelineUri, _authToken);
+            AhtolaRemoteTransportSecurity.Validate(
+                pipelineUri,
+                _authToken,
+                remoteEncryptionConfigured: _remoteEncryptionKey is not null);
             _pipelineUri = pipelineUri;
         }
 

--- a/src/Ahtola.Data/AhtolaRemoteClient.cs
+++ b/src/Ahtola.Data/AhtolaRemoteClient.cs
@@ -27,7 +27,13 @@ internal sealed partial class AhtolaRemoteClient : IDisposable
         Uri endpoint,
         string? authToken,
         AhtolaRemoteEncryptionOptions? remoteEncryption = null)
-        : this(new HttpClient(), endpoint, authToken, remoteEncryption, disposeHttpClient: true)
+        : this(
+            AhtolaRemoteTransportSecurity.CreateRedirectSafeHttpClient(),
+            endpoint,
+            authToken,
+            remoteEncryption,
+            disposeHttpClient: true,
+            automaticRedirectsDisabled: true)
     {
     }
 
@@ -36,7 +42,8 @@ internal sealed partial class AhtolaRemoteClient : IDisposable
         Uri endpoint,
         string? authToken,
         AhtolaRemoteEncryptionOptions? remoteEncryption = null,
-        bool disposeHttpClient = false)
+        bool disposeHttpClient = false,
+        bool automaticRedirectsDisabled = false)
     {
         ArgumentNullException.ThrowIfNull(httpClient);
         ArgumentNullException.ThrowIfNull(endpoint);
@@ -48,6 +55,9 @@ internal sealed partial class AhtolaRemoteClient : IDisposable
         AhtolaRemoteTransportSecurity.Validate(
             _pipelineUri,
             _authToken,
+            remoteEncryptionConfigured: _remoteEncryptionKey is not null);
+        AhtolaRemoteTransportSecurity.ValidateRedirectContract(
+            automaticRedirectsDisabled,
             remoteEncryptionConfigured: _remoteEncryptionKey is not null);
         _disposeHttpClient = disposeHttpClient;
     }
@@ -271,19 +281,15 @@ internal sealed partial class AhtolaRemoteClient : IDisposable
         var json = JsonSerializer.Serialize(
             request,
             AhtolaRemoteJsonContext.Default.RemotePipelineRequest);
-        using var content = new StringContent(json, Encoding.UTF8, "application/json");
-        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, _pipelineUri)
-        {
-            Content = content,
-        };
-
-        if (_authToken is not null)
-            httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _authToken);
-        if (_remoteEncryptionKey is not null)
-            httpRequest.Headers.TryAddWithoutValidation(EncryptionKeyHeaderName, _remoteEncryptionKey);
-
-        using var response = await _httpClient
-            .SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, effectiveCancellationToken)
+        using var response = await AhtolaRemoteTransportSecurity
+            .SendAsync(
+                _httpClient,
+                _pipelineUri,
+                requestUri => CreatePipelineHttpRequest(requestUri, json),
+                _authToken,
+                remoteEncryptionConfigured: _remoteEncryptionKey is not null,
+                HttpCompletionOption.ResponseHeadersRead,
+                effectiveCancellationToken)
             .ConfigureAwait(false);
 
         var body = await response.Content.ReadAsStringAsync(effectiveCancellationToken).ConfigureAwait(false);
@@ -318,6 +324,20 @@ internal sealed partial class AhtolaRemoteClient : IDisposable
         var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         timeout.CancelAfter(TimeSpan.FromSeconds(commandTimeout));
         return timeout;
+    }
+
+    private HttpRequestMessage CreatePipelineHttpRequest(Uri requestUri, string json)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, requestUri)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+
+        if (_authToken is not null)
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _authToken);
+        if (_remoteEncryptionKey is not null)
+            request.Headers.TryAddWithoutValidation(EncryptionKeyHeaderName, _remoteEncryptionKey);
+        return request;
     }
 
     internal static T DeserializeRemoteResult<T>(JsonElement result)

--- a/src/Ahtola.Data/AhtolaRemoteTransportSecurity.cs
+++ b/src/Ahtola.Data/AhtolaRemoteTransportSecurity.cs
@@ -1,0 +1,30 @@
+namespace Ahtola;
+
+internal static class AhtolaRemoteTransportSecurity
+{
+    public static void Validate(
+        Uri endpoint,
+        string? authToken,
+        bool remoteEncryptionConfigured)
+    {
+        ArgumentNullException.ThrowIfNull(endpoint);
+
+        if (endpoint.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+            || endpoint.IsLoopback)
+        {
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(authToken))
+        {
+            throw new InvalidOperationException(
+                "Auth Token requires an HTTPS remote Ahtola URL unless the host is localhost or loopback.");
+        }
+
+        if (remoteEncryptionConfigured)
+        {
+            throw new InvalidOperationException(
+                "Remote encryption requires an HTTPS remote Ahtola URL unless the host is localhost or loopback.");
+        }
+    }
+}

--- a/src/Ahtola.Data/AhtolaRemoteTransportSecurity.cs
+++ b/src/Ahtola.Data/AhtolaRemoteTransportSecurity.cs
@@ -2,6 +2,8 @@ namespace Ahtola;
 
 internal static class AhtolaRemoteTransportSecurity
 {
+    private const int MaximumRedirects = 5;
+
     public static void Validate(
         Uri endpoint,
         string? authToken,
@@ -26,5 +28,98 @@ internal static class AhtolaRemoteTransportSecurity
             throw new InvalidOperationException(
                 "Remote encryption requires an HTTPS remote Ahtola URL unless the host is localhost or loopback.");
         }
+    }
+
+    public static void ValidateRedirectContract(
+        bool automaticRedirectsDisabled,
+        bool remoteEncryptionConfigured)
+    {
+        if (remoteEncryptionConfigured && !automaticRedirectsDisabled)
+        {
+            throw new InvalidOperationException(
+                "Remote encryption requires an HTTP transport that guarantees automatic redirects are disabled.");
+        }
+    }
+
+    public static HttpClient CreateRedirectSafeHttpClient()
+        => new(new HttpClientHandler { AllowAutoRedirect = false });
+
+    public static async Task<HttpResponseMessage> SendAsync(
+        HttpClient client,
+        Uri initialUri,
+        Func<Uri, HttpRequestMessage> requestFactory,
+        string? authToken,
+        bool remoteEncryptionConfigured,
+        HttpCompletionOption completionOption,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        ArgumentNullException.ThrowIfNull(initialUri);
+        ArgumentNullException.ThrowIfNull(requestFactory);
+
+        var requestUri = initialUri;
+        for (var redirectCount = 0; ; redirectCount++)
+        {
+            Validate(requestUri, authToken, remoteEncryptionConfigured);
+
+            using var request = requestFactory(requestUri);
+            var response = await client
+                .SendAsync(request, completionOption, cancellationToken)
+                .ConfigureAwait(false);
+            if (!IsRedirect(response.StatusCode))
+                return response;
+
+            using (response)
+            {
+                if (response.StatusCode is not (System.Net.HttpStatusCode.TemporaryRedirect
+                    or System.Net.HttpStatusCode.PermanentRedirect))
+                {
+                    throw new InvalidOperationException(
+                        "Remote Ahtola requests follow only HTTP 307 and 308 redirects so the request method and body are preserved.");
+                }
+
+                var location = response.Headers.Location
+                    ?? throw new InvalidOperationException(
+                        "The remote Ahtola redirect response did not include a Location header.");
+
+                if (redirectCount >= MaximumRedirects)
+                {
+                    throw new InvalidOperationException(
+                        $"The remote Ahtola request exceeded the maximum of {MaximumRedirects} redirects.");
+                }
+
+                var destination = location.IsAbsoluteUri ? location : new Uri(requestUri, location);
+                Validate(destination, authToken, remoteEncryptionConfigured);
+                ValidateRedirectOrigin(
+                    requestUri,
+                    destination,
+                    credentialsConfigured: !string.IsNullOrWhiteSpace(authToken) || remoteEncryptionConfigured);
+                requestUri = destination;
+            }
+        }
+    }
+
+    private static bool IsRedirect(System.Net.HttpStatusCode statusCode)
+        => statusCode is System.Net.HttpStatusCode.MovedPermanently
+            or System.Net.HttpStatusCode.Redirect
+            or System.Net.HttpStatusCode.SeeOther
+            or System.Net.HttpStatusCode.TemporaryRedirect
+            or System.Net.HttpStatusCode.PermanentRedirect;
+
+    private static void ValidateRedirectOrigin(
+        Uri source,
+        Uri destination,
+        bool credentialsConfigured)
+    {
+        if (!credentialsConfigured
+            || source.Scheme.Equals(destination.Scheme, StringComparison.OrdinalIgnoreCase)
+                && source.IdnHost.Equals(destination.IdnHost, StringComparison.OrdinalIgnoreCase)
+                && source.Port == destination.Port)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            "Credential-bearing remote Ahtola requests cannot redirect to a different origin.");
     }
 }

--- a/src/Ahtola.Data/AhtolaReplicaProvider.cs
+++ b/src/Ahtola.Data/AhtolaReplicaProvider.cs
@@ -138,6 +138,11 @@ public sealed class AhtolaReplicaOptions
 
     internal void Validate()
     {
+        AhtolaRemoteTransportSecurity.Validate(
+            RemoteUri,
+            AuthToken,
+            remoteEncryptionConfigured: RemoteEncryption is not null);
+
         if (LongPollTimeout is { } longPollTimeout
             && (longPollTimeout < TimeSpan.FromMilliseconds(1)
                 || longPollTimeout.TotalMilliseconds > int.MaxValue))

--- a/src/Ahtola.Data/AhtolaReplicaProvider.cs
+++ b/src/Ahtola.Data/AhtolaReplicaProvider.cs
@@ -138,9 +138,13 @@ public sealed class AhtolaReplicaOptions
 
     internal void Validate()
     {
+        ArgumentNullException.ThrowIfNull(HttpPolicy);
         AhtolaRemoteTransportSecurity.Validate(
             RemoteUri,
             AuthToken,
+            remoteEncryptionConfigured: RemoteEncryption is not null);
+        AhtolaRemoteTransportSecurity.ValidateRedirectContract(
+            HttpPolicy.MessageHandler is null || HttpPolicy.MessageHandlerDisablesAutomaticRedirects,
             remoteEncryptionConfigured: RemoteEncryption is not null);
 
         if (LongPollTimeout is { } longPollTimeout
@@ -176,8 +180,6 @@ public sealed class AhtolaReplicaOptions
             throw new InvalidOperationException(
                 "PullBytesThreshold cannot be combined with query partial bootstrap because the server selects the query page set.");
         }
-        ArgumentNullException.ThrowIfNull(HttpPolicy);
-        ArgumentNullException.ThrowIfNull(HttpPolicy);
     }
 
     private static Uri NormalizeRemoteUri(Uri remoteUri)

--- a/src/Ahtola.Data/AhtolaSyncOptions.cs
+++ b/src/Ahtola.Data/AhtolaSyncOptions.cs
@@ -220,6 +220,13 @@ public sealed class AhtolaSyncHttpPolicy
     public HttpMessageHandler? MessageHandler { get; }
 
     /// <summary>
+    /// Gets or initializes whether <see cref="MessageHandler"/> is guaranteed not to follow HTTP
+    /// redirects internally. Set this only for handlers that return redirect responses to Ahtola,
+    /// which validates and follows supported redirects itself.
+    /// </summary>
+    public bool MessageHandlerDisablesAutomaticRedirects { get; init; }
+
+    /// <summary>
     /// Gets whether the connection owns and disposes <see cref="MessageHandler"/>.
     /// </summary>
     public bool DisposeMessageHandler { get; }
@@ -228,6 +235,17 @@ public sealed class AhtolaSyncHttpPolicy
     /// Gets the per-request HTTP timeout.
     /// </summary>
     public TimeSpan RequestTimeout { get; }
+
+    internal HttpClient CreateHttpClient(bool remoteEncryptionConfigured)
+    {
+        var automaticRedirectsDisabled = MessageHandler is null || MessageHandlerDisablesAutomaticRedirects;
+        AhtolaRemoteTransportSecurity.ValidateRedirectContract(
+            automaticRedirectsDisabled,
+            remoteEncryptionConfigured);
+        return MessageHandler is null
+            ? AhtolaRemoteTransportSecurity.CreateRedirectSafeHttpClient()
+            : new HttpClient(MessageHandler, disposeHandler: false);
+    }
 
     internal HttpMessageHandler? ClaimMessageHandlerOwnership()
     {

--- a/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
+++ b/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
@@ -362,21 +362,20 @@ internal static class ManagedReplicaBootstrapper
         var payload = CreatePullRequest(metadata.Revision, options.LongPollTimeout, requestLogical);
         using var timeout = CreateTimeout(options.HttpPolicy.RequestTimeout, cancellationToken);
         using var scope = options.EnterApplicationHttpScope();
-        using var client = options.HttpPolicy.MessageHandler is { } handler ? new HttpClient(handler, false) : new HttpClient();
+        using var client = options.HttpPolicy.CreateHttpClient(options.RemoteEncryption is not null);
         client.Timeout = Timeout.InfiniteTimeSpan;
-        using var request = new HttpRequestMessage(HttpMethod.Post, CreatePullUpdatesUri(options.RemoteUri))
-        {
-            Content = new ByteArrayContent(payload),
-        };
-        request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/protobuf");
-        request.Headers.TryAddWithoutValidation("Accept-Encoding", "application/protobuf");
         var token = string.IsNullOrWhiteSpace(options.AuthToken) ? null : options.AuthToken;
-        if (token is not null)
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-        if (options.RemoteEncryption is { } remoteEncryption)
-            request.Headers.TryAddWithoutValidation(AhtolaRemoteClient.EncryptionKeyHeaderName, remoteEncryption.Base64Key);
         var effectiveToken = timeout?.Token ?? cancellationToken;
-        using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, effectiveToken).ConfigureAwait(false);
+        using var response = await AhtolaRemoteTransportSecurity
+            .SendAsync(
+                client,
+                CreatePullUpdatesUri(options.RemoteUri),
+                requestUri => CreatePullUpdatesHttpRequest(requestUri, payload, token, options.RemoteEncryption),
+                token,
+                remoteEncryptionConfigured: options.RemoteEncryption is not null,
+                HttpCompletionOption.ResponseHeadersRead,
+                effectiveToken)
+            .ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
         await using var stream = await response.Content.ReadAsStreamAsync(effectiveToken).ConfigureAwait(false);
         var reader = new DelimitedProtobufReader(stream);
@@ -910,24 +909,24 @@ internal static class ManagedReplicaBootstrapper
         using var timeout = CreateTimeout(options.HttpPolicy.RequestTimeout, cancellationToken);
         var effectiveCancellationToken = timeout?.Token ?? cancellationToken;
         using var scope = options.EnterApplicationHttpScope();
-        using var client = options.HttpPolicy.MessageHandler is { } handler
-            ? new HttpClient(handler, disposeHandler: false)
-            : new HttpClient();
+        using var client = options.HttpPolicy.CreateHttpClient(options.RemoteEncryption is not null);
         client.Timeout = Timeout.InfiniteTimeSpan;
-        using var request = new HttpRequestMessage(HttpMethod.Post, CreatePullUpdatesUri(options.RemoteUri));
-        request.Content = new ByteArrayContent(CreateInitialPullRequest(options.LongPollTimeout));
-        request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/protobuf");
-        request.Headers.TryAddWithoutValidation("Accept-Encoding", "application/protobuf");
+        var payload = CreateInitialPullRequest(options.LongPollTimeout);
         var authToken = string.IsNullOrWhiteSpace(options.AuthToken) ? null : options.AuthToken;
-        if (authToken is not null)
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", authToken);
-        if (options.RemoteEncryption is { } remoteEncryption)
-            request.Headers.TryAddWithoutValidation(AhtolaRemoteClient.EncryptionKeyHeaderName, remoteEncryption.Base64Key);
-
-        using var response = await client.SendAsync(
-            request,
-            HttpCompletionOption.ResponseHeadersRead,
-            effectiveCancellationToken).ConfigureAwait(false);
+        using var response = await AhtolaRemoteTransportSecurity
+            .SendAsync(
+                client,
+                CreatePullUpdatesUri(options.RemoteUri),
+                requestUri => CreatePullUpdatesHttpRequest(
+                    requestUri,
+                    payload,
+                    authToken,
+                    options.RemoteEncryption),
+                authToken,
+                remoteEncryptionConfigured: options.RemoteEncryption is not null,
+                HttpCompletionOption.ResponseHeadersRead,
+                effectiveCancellationToken)
+            .ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
         await using var stream = await response.Content.ReadAsStreamAsync(effectiveCancellationToken).ConfigureAwait(false);
@@ -1325,6 +1324,30 @@ internal static class ManagedReplicaBootstrapper
         var source = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         source.CancelAfter(timeout);
         return source;
+    }
+
+    private static HttpRequestMessage CreatePullUpdatesHttpRequest(
+        Uri requestUri,
+        byte[] payload,
+        string? authToken,
+        AhtolaRemoteEncryptionOptions? remoteEncryption)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, requestUri)
+        {
+            Content = new ByteArrayContent(payload),
+        };
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/protobuf");
+        request.Headers.TryAddWithoutValidation("Accept-Encoding", "application/protobuf");
+        if (authToken is not null)
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", authToken);
+        if (remoteEncryption is not null)
+        {
+            request.Headers.TryAddWithoutValidation(
+                AhtolaRemoteClient.EncryptionKeyHeaderName,
+                remoteEncryption.Base64Key);
+        }
+
+        return request;
     }
 
     private static void DeleteIfExists(string path)

--- a/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
+++ b/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
@@ -371,7 +371,6 @@ internal static class ManagedReplicaBootstrapper
         request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/protobuf");
         request.Headers.TryAddWithoutValidation("Accept-Encoding", "application/protobuf");
         var token = string.IsNullOrWhiteSpace(options.AuthToken) ? null : options.AuthToken;
-        ValidateAuthTokenTransport(request.RequestUri!, token);
         if (token is not null)
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         if (options.RemoteEncryption is { } remoteEncryption)
@@ -919,9 +918,7 @@ internal static class ManagedReplicaBootstrapper
         request.Content = new ByteArrayContent(CreateInitialPullRequest(options.LongPollTimeout));
         request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/protobuf");
         request.Headers.TryAddWithoutValidation("Accept-Encoding", "application/protobuf");
-
         var authToken = string.IsNullOrWhiteSpace(options.AuthToken) ? null : options.AuthToken;
-        ValidateAuthTokenTransport(request.RequestUri!, authToken);
         if (authToken is not null)
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", authToken);
         if (options.RemoteEncryption is { } remoteEncryption)
@@ -1328,18 +1325,6 @@ internal static class ManagedReplicaBootstrapper
         var source = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         source.CancelAfter(timeout);
         return source;
-    }
-
-    private static void ValidateAuthTokenTransport(Uri endpoint, string? authToken)
-    {
-        if (authToken is null
-            || endpoint.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
-            || endpoint.IsLoopback)
-        {
-            return;
-        }
-
-        throw new InvalidOperationException("Auth Token requires an HTTPS remote Ahtola URL unless the host is localhost or loopback.");
     }
 
     private static void DeleteIfExists(string path)

--- a/src/Ahtola.Data/ManagedReplicaConnectionHost.cs
+++ b/src/Ahtola.Data/ManagedReplicaConnectionHost.cs
@@ -584,16 +584,15 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
             return new LocalPushResult(0, metadata);
 
         syncOptions.Progress?.Report(new AhtolaSyncProgress(AhtolaSyncProgressStage.Pushing));
-        using var client = replicaOptions.HttpPolicy.MessageHandler is { } handler
-            ? new HttpClient(handler, disposeHandler: false)
-            : new HttpClient();
+        using var client = replicaOptions.HttpPolicy.CreateHttpClient(replicaOptions.RemoteEncryption is not null);
         client.Timeout = Timeout.InfiniteTimeSpan;
         using var remote = new AhtolaRemoteClient(
             client,
             replicaOptions.RemoteUri,
             replicaOptions.AuthToken,
             replicaOptions.RemoteEncryption,
-            disposeHttpClient: false);
+            disposeHttpClient: false,
+            automaticRedirectsDisabled: true);
 
         await remote.PushReplicaChangesAsync(
                 batch,

--- a/src/Ahtola.Data/ManagedReplicaSupportMatrix.cs
+++ b/src/Ahtola.Data/ManagedReplicaSupportMatrix.cs
@@ -8,6 +8,7 @@ internal static class ManagedReplicaSupportMatrix
     public static void ValidateOptions(AhtolaReplicaOptions options)
     {
         ArgumentNullException.ThrowIfNull(options);
+        options.Validate();
 
         if (options.PartialBootstrap is not null)
         {

--- a/src/Ahtola.Tests/ManagedEmbeddedReplicaConnectionTests.cs
+++ b/src/Ahtola.Tests/ManagedEmbeddedReplicaConnectionTests.cs
@@ -2185,6 +2185,63 @@ public sealed class ManagedEmbeddedReplicaConnectionTests
     }
 
     [Test]
+    public async Task ReplicaEntryPointsRejectRemoteEncryptionOverNonLoopbackHttpBeforeRequestOrLocalMutation()
+    {
+        var path = NewReplicaPath("managed-replica-encryption-plaintext-http");
+        var handler = new PullUpdatesHandler(CreatePullResponse("unused", new byte[4096]));
+        var options = new AhtolaReplicaOptions(
+            path,
+            new Uri("http://database.example/cluster"),
+            authToken: null)
+        {
+            HttpPolicy = new AhtolaSyncHttpPolicy(handler),
+            RemoteEncryption = new AhtolaRemoteEncryptionOptions(
+                Convert.ToBase64String(Convert.FromHexString(ReplicaEncryptionKeyHex)),
+                AhtolaRemoteEncryptionCipher.Aes256Gcm),
+        };
+
+        try
+        {
+            var action = () => AhtolaConnection.CreateReplica(options);
+
+            action.Should().Throw<InvalidOperationException>()
+                .WithMessage(
+                    "Remote encryption requires an HTTPS remote Ahtola URL unless the host is localhost or loopback.");
+
+            Func<Task> bootstrap = () => ManagedReplicaBootstrapper.BootstrapAsync(
+                options,
+                CancellationToken.None);
+            await bootstrap.Should().ThrowAsync<InvalidOperationException>()
+                .WithMessage(
+                    "Remote encryption requires an HTTPS remote Ahtola URL unless the host is localhost or loopback.");
+
+            var metadata = new ManagedReplicaBootstrapper.ManagedReplicaMetadata(
+                "revision-42",
+                "unused",
+                "client-42",
+                RemotePullProtocol.Pages,
+                new Dictionary<ulong, string>());
+            Func<Task> incrementalPull = () => ManagedReplicaBootstrapper.CheckForUpdatesAsync(
+                options,
+                metadata,
+                new AhtolaSyncOptions(),
+                CancellationToken.None);
+            await incrementalPull.Should().ThrowAsync<InvalidOperationException>()
+                .WithMessage(
+                    "Remote encryption requires an HTTPS remote Ahtola URL unless the host is localhost or loopback.");
+
+            handler.CallCount.Should().Be(0);
+            File.Exists(path).Should().BeFalse();
+            File.Exists(path + ".ahtola-replica-meta").Should().BeFalse();
+            File.Exists(path + ManagedReplicaChangeJournal.Suffix).Should().BeFalse();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
     public void CreateReplicaBootstrapsAnEncryptedRemoteDatabaseWithNonzeroReservedBytes()
     {
         // The source database is genuinely AES-256-GCM encrypted (28 reserved bytes per page;

--- a/src/Ahtola.Tests/ManagedEmbeddedReplicaConnectionTests.cs
+++ b/src/Ahtola.Tests/ManagedEmbeddedReplicaConnectionTests.cs
@@ -3518,7 +3518,10 @@ public sealed class ManagedEmbeddedReplicaConnectionTests
             LongPollTimeout = TimeSpan.FromSeconds(3),
             SyncInterval = syncInterval,
             PushOperationsThreshold = pushOperationsThreshold,
-            HttpPolicy = new AhtolaSyncHttpPolicy(handler),
+            HttpPolicy = new AhtolaSyncHttpPolicy(handler)
+            {
+                MessageHandlerDisablesAutomaticRedirects = true,
+            },
         };
 
     private static AhtolaReplicaOptions CreateUnsupportedOptions(
@@ -3607,7 +3610,10 @@ public sealed class ManagedEmbeddedReplicaConnectionTests
         => new(path, new Uri("https://example.test/cluster"), authToken: "token-42")
         {
             LongPollTimeout = TimeSpan.FromSeconds(3),
-            HttpPolicy = new AhtolaSyncHttpPolicy(handler),
+            HttpPolicy = new AhtolaSyncHttpPolicy(handler)
+            {
+                MessageHandlerDisablesAutomaticRedirects = true,
+            },
             RemoteEncryption = new AhtolaRemoteEncryptionOptions(
                 Convert.ToBase64String(Convert.FromHexString(hexKey)), cipher),
         };

--- a/src/Ahtola.Tests/RemoteEncryptionContractTests.cs
+++ b/src/Ahtola.Tests/RemoteEncryptionContractTests.cs
@@ -26,6 +26,29 @@ public sealed class RemoteEncryptionContractTests
     }
 
     [Test]
+    public void ReplicaOptionsRejectEncryptionWhenInjectedTransportMayAutomaticallyRedirect()
+    {
+        using var handler = new CapturingHandler();
+        var options = new AhtolaReplicaOptions(
+            "replica.db",
+            new Uri("https://example.com"),
+            authToken: null)
+        {
+            HttpPolicy = new AhtolaSyncHttpPolicy(handler),
+            RemoteEncryption = new AhtolaRemoteEncryptionOptions(
+                "c2VjcmV0",
+                AhtolaRemoteEncryptionCipher.Aes256Gcm),
+        };
+
+        var action = () => options.Validate();
+
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage(
+                "Remote encryption requires an HTTP transport that guarantees automatic redirects are disabled.");
+        handler.CallCount.Should().Be(0);
+    }
+
+    [Test]
     public void RemoteConnectionsAcceptEncryptionSettings()
     {
         using var connection = new AhtolaConnection(
@@ -48,7 +71,8 @@ public sealed class RemoteEncryptionContractTests
             authToken: null,
             remoteEncryption: new AhtolaRemoteEncryptionOptions(
                 "c2VjcmV0",
-                AhtolaRemoteEncryptionCipher.Aes256Gcm));
+                AhtolaRemoteEncryptionCipher.Aes256Gcm),
+            automaticRedirectsDisabled: true);
 
         action.Should().Throw<InvalidOperationException>()
             .WithMessage(
@@ -68,7 +92,8 @@ public sealed class RemoteEncryptionContractTests
             authToken: null,
             remoteEncryption: new AhtolaRemoteEncryptionOptions(
                 "c2VjcmV0",
-                AhtolaRemoteEncryptionCipher.Aes256Gcm));
+                AhtolaRemoteEncryptionCipher.Aes256Gcm),
+            automaticRedirectsDisabled: true);
 
         Assert.ThrowsAsync<AhtolaException>(() => client.ExecuteAsync(
             "SELECT 1",
@@ -81,6 +106,130 @@ public sealed class RemoteEncryptionContractTests
         handler.EncryptionKey.Should().Be("c2VjcmV0");
         handler.CallCount.Should().Be(1);
     }
+
+    [Test]
+    public void RemoteClientRejectsEncryptionWhenInjectedTransportMayAutomaticallyRedirect()
+    {
+        using var handler = new CapturingHandler();
+        using var httpClient = new HttpClient(handler);
+
+        var action = () => new AhtolaRemoteClient(
+            httpClient,
+            new Uri("https://example.com"),
+            authToken: null,
+            remoteEncryption: new AhtolaRemoteEncryptionOptions(
+                "c2VjcmV0",
+                AhtolaRemoteEncryptionCipher.Aes256Gcm));
+
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage(
+                "Remote encryption requires an HTTP transport that guarantees automatic redirects are disabled.");
+        handler.CallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task RemoteClientBlocksLoopbackRedirectToNonLoopbackHttpBeforeLeakingEncryptionKey()
+    {
+        using var handler = new RedirectingHandler(
+            new Uri("http://database.example/v2/pipeline"),
+            HttpStatusCode.TemporaryRedirect);
+        using var httpClient = new HttpClient(handler);
+        using var client = CreateEncryptedRemoteClient(
+            httpClient,
+            new Uri("http://localhost"));
+
+        Func<Task> action = () => ExecuteAsync(client);
+
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage(
+                "Remote encryption requires an HTTPS remote Ahtola URL unless the host is localhost or loopback.");
+        handler.RequestUris.Should().ContainSingle();
+        handler.RequestUris[0].Host.Should().Be("localhost");
+        handler.EncryptionKeys.Should().ContainSingle().Which.Should().Be("c2VjcmV0");
+    }
+
+    [TestCase("http://localhost", "http://localhost/redirected")]
+    [TestCase("https://origin.example", "https://origin.example/redirected")]
+    public async Task RemoteClientFollowsAllowedRedirectsWithoutChangingPostBody(
+        string endpoint,
+        string destination)
+    {
+        using var handler = new RedirectingHandler(
+            new Uri(destination),
+            HttpStatusCode.TemporaryRedirect);
+        using var httpClient = new HttpClient(handler);
+        using var client = CreateEncryptedRemoteClient(httpClient, new Uri(endpoint));
+
+        Func<Task> action = () => ExecuteAsync(client);
+
+        await action.Should().ThrowAsync<AhtolaException>()
+            .WithMessage("Remote request failed with HTTP 500*");
+        handler.RequestUris.Should().HaveCount(2);
+        handler.RequestUris[1].Should().Be(new Uri(destination));
+        handler.Methods.Should().OnlyContain(method => method == HttpMethod.Post);
+        handler.Bodies.Should().HaveCount(2);
+        handler.Bodies[1].Should().Be(handler.Bodies[0]);
+        handler.EncryptionKeys.Should().OnlyContain(key => key == "c2VjcmV0");
+    }
+
+    [Test]
+    public async Task RemoteClientBlocksCrossOriginHttpsRedirectBeforeLeakingEncryptionKey()
+    {
+        using var handler = new RedirectingHandler(
+            new Uri("https://destination.example/v2/pipeline"),
+            HttpStatusCode.TemporaryRedirect);
+        using var httpClient = new HttpClient(handler);
+        using var client = CreateEncryptedRemoteClient(
+            httpClient,
+            new Uri("https://origin.example"));
+
+        Func<Task> action = () => ExecuteAsync(client);
+
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage(
+                "Credential-bearing remote Ahtola requests cannot redirect to a different origin.");
+        handler.RequestUris.Should().ContainSingle();
+        handler.RequestUris[0].Host.Should().Be("origin.example");
+        handler.EncryptionKeys.Should().ContainSingle().Which.Should().Be("c2VjcmV0");
+    }
+
+    [Test]
+    public async Task RemoteClientRejectsRedirectsThatWouldChangePostSemantics()
+    {
+        using var handler = new RedirectingHandler(
+            new Uri("https://destination.example/v2/pipeline"),
+            HttpStatusCode.Redirect);
+        using var httpClient = new HttpClient(handler);
+        using var client = CreateEncryptedRemoteClient(
+            httpClient,
+            new Uri("https://origin.example"));
+
+        Func<Task> action = () => ExecuteAsync(client);
+
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage(
+                "Remote Ahtola requests follow only HTTP 307 and 308 redirects so the request method and body are preserved.");
+        handler.RequestUris.Should().ContainSingle();
+    }
+
+    private static AhtolaRemoteClient CreateEncryptedRemoteClient(HttpClient httpClient, Uri endpoint)
+        => new(
+            httpClient,
+            endpoint,
+            authToken: null,
+            remoteEncryption: new AhtolaRemoteEncryptionOptions(
+                "c2VjcmV0",
+                AhtolaRemoteEncryptionCipher.Aes256Gcm),
+            automaticRedirectsDisabled: true);
+
+    private static Task<RemoteStatementResult> ExecuteAsync(AhtolaRemoteClient client)
+        => client.ExecuteAsync(
+            "SELECT 1",
+            new AhtolaParameterCollection(),
+            wantRows: true,
+            commandTimeout: 30,
+            closeAfter: true,
+            CancellationToken.None);
 
     private sealed class CapturingHandler : HttpMessageHandler
     {
@@ -100,6 +249,44 @@ public sealed class RemoteEncryptionContractTests
             {
                 Content = new StringContent("rejected", Encoding.UTF8, "text/plain"),
             });
+        }
+    }
+
+    private sealed class RedirectingHandler(Uri destination, HttpStatusCode redirectStatus)
+        : HttpMessageHandler
+    {
+        public List<string> Bodies { get; } = [];
+
+        public List<string?> EncryptionKeys { get; } = [];
+
+        public List<HttpMethod> Methods { get; } = [];
+
+        public List<Uri> RequestUris { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            RequestUris.Add(request.RequestUri!);
+            Methods.Add(request.Method);
+            Bodies.Add(await request.Content!.ReadAsStringAsync(cancellationToken));
+            EncryptionKeys.Add(
+                request.Headers.TryGetValues("x-turso-encryption-key", out var values)
+                    ? values.Single()
+                    : null);
+
+            if (RequestUris.Count == 1)
+            {
+                return new HttpResponseMessage(redirectStatus)
+                {
+                    Headers = { Location = destination },
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.InternalServerError)
+            {
+                Content = new StringContent("rejected", Encoding.UTF8, "text/plain"),
+            };
         }
     }
 }

--- a/src/Ahtola.Tests/RemoteEncryptionContractTests.cs
+++ b/src/Ahtola.Tests/RemoteEncryptionContractTests.cs
@@ -37,13 +37,34 @@ public sealed class RemoteEncryptionContractTests
     }
 
     [Test]
-    public void RemoteClientSendsEncryptionKeyHeader()
+    public void RemoteClientRejectsEncryptionOverNonLoopbackHttpWithoutAuthToken()
+    {
+        using var handler = new CapturingHandler();
+        using var httpClient = new HttpClient(handler);
+
+        var action = () => new AhtolaRemoteClient(
+            httpClient,
+            new Uri("http://database.example"),
+            authToken: null,
+            remoteEncryption: new AhtolaRemoteEncryptionOptions(
+                "c2VjcmV0",
+                AhtolaRemoteEncryptionCipher.Aes256Gcm));
+
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage(
+                "Remote encryption requires an HTTPS remote Ahtola URL unless the host is localhost or loopback.");
+        handler.CallCount.Should().Be(0);
+    }
+
+    [TestCase("https://example.com")]
+    [TestCase("http://localhost")]
+    public void RemoteClientAllowsEncryptionOverHttpsOrLoopbackHttp(string endpoint)
     {
         using var handler = new CapturingHandler();
         using var httpClient = new HttpClient(handler);
         using var client = new AhtolaRemoteClient(
             httpClient,
-            new Uri("https://example.com"),
+            new Uri(endpoint),
             authToken: null,
             remoteEncryption: new AhtolaRemoteEncryptionOptions(
                 "c2VjcmV0",
@@ -58,16 +79,20 @@ public sealed class RemoteEncryptionContractTests
             CancellationToken.None));
 
         handler.EncryptionKey.Should().Be("c2VjcmV0");
+        handler.CallCount.Should().Be(1);
     }
 
     private sealed class CapturingHandler : HttpMessageHandler
     {
+        public int CallCount { get; private set; }
+
         public string? EncryptionKey { get; private set; }
 
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
+            CallCount++;
             EncryptionKey = request.Headers.TryGetValues("x-turso-encryption-key", out var values)
                 ? values.Single()
                 : null;


### PR DESCRIPTION
## Summary
- centralize transport validation for auth tokens and remote encryption keys
- disable automatic redirects for default encryption-bearing clients and require an explicit no-auto-redirect contract for injected replica handlers
- manually follow only same-origin HTTP 307/308 redirects after validating every destination, rebuilding the original POST body on each hop
- reject non-loopback plaintext, cross-origin, method-changing, malformed, and excessive redirects before sending the encryption key
- apply the same redirect-safe sender to direct Hrana requests and managed replica bootstrap, incremental pull, and push paths

## Tests
- focused encryption transport and redirect tests: 13 passed
- managed replica tests: 208 passed
- `pwsh ./build.ps1 build`
- targeted `dotnet format --verify-no-changes` for all changed files

## Formatting note
`pwsh ./build.ps1 format-check` was also run; the repository-wide check still reports pre-existing whitespace failures in unchanged baseline files.