### PR TITLE
Fix CDC bridge correctness blockers in PeekPendingChangeCapture

### DIFF
--- a/src/Ahtola.Data/AhtolaConnection.cs
+++ b/src/Ahtola.Data/AhtolaConnection.cs
@@ -580,9 +580,12 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
     /// The connection is not a managed embedded replica connection.
     /// </exception>
     /// <exception cref="AhtolaReplicaChangeCaptureException">
-    /// The pending batch contains an entry that cannot be safely represented in the
+    /// Either a local transaction is currently open on this connection (peeking while a
+    /// transaction is in progress could observe not-yet-committed writes, or writes the
+    /// transaction later rolls back, and silently bake them into the projected row), or the
+    /// pending batch contains an entry that cannot be safely represented in the
     /// change-data-capture row contract (a schema/DDL change, or a delete with no captured
-    /// pre-image).
+    /// pre-image). Commit or roll back an open transaction and peek again.
     /// </exception>
     public AhtolaReplicaChangeCaptureBatch PeekPendingChangeCapture()
         => (_managedReplicaHost ?? throw new InvalidOperationException(

--- a/src/Ahtola.Data/AhtolaReplicaChangeCapture.cs
+++ b/src/Ahtola.Data/AhtolaReplicaChangeCapture.cs
@@ -48,6 +48,9 @@ public enum AhtolaReplicaChangeType
 /// non-null for delete: a delete whose pre-image was not captured (only possible for a change
 /// journal written by a pre-v4 journal format) makes the whole peek fail closed with
 /// <see cref="AhtolaReplicaChangeCaptureException"/> instead of returning a misleadingly empty row.
+/// This is always an independent copy of the change journal's own stored buffer, never an alias
+/// to it: mutating the returned array cannot corrupt the journal's still-durable state or a
+/// later delete replay that decodes the same underlying entry.
 /// </param>
 /// <param name="After">
 /// The row's post-image as an encoded SQLite record, matching the <c>after</c> column, or
@@ -56,7 +59,10 @@ public enum AhtolaReplicaChangeType
 /// is only correct when no later pending change in the same batch touches the same
 /// (<see cref="TableName"/>, <see cref="RowId"/>) key again; when a later change supersedes it,
 /// this is left <see langword="null"/> (the row degrades to id-only image availability) rather
-/// than returning stale or fabricated data.
+/// than returning stale or fabricated data. Includes every column declared on the table in
+/// declaration order — including VIRTUAL and STORED generated columns — matching the real
+/// <c>turso_cdc</c> row's full in-memory row image, not the narrower subset a schema
+/// introspection limited to storable columns would report.
 /// </param>
 /// <remarks>
 /// <c>updates</c> (the real CDC table's packed all-columns-changed column, only ever populated in
@@ -93,8 +99,9 @@ public sealed record AhtolaReplicaChangeCaptureBatch(
 
 /// <summary>
 /// Indicates that a still-pending managed embedded replica local change cannot be safely
-/// represented as a row in Ahtola's public change-data-capture contract. Peeking pending
-/// change-data-capture fails closed rather than silently omitting or approximating the
-/// unrepresentable entry; see <see cref="AhtolaConnection.PeekPendingChangeCapture"/>.
+/// represented as a row in Ahtola's public change-data-capture contract, or that the whole peek
+/// cannot be safely performed right now (a local transaction is open). Peeking pending
+/// change-data-capture fails closed rather than silently omitting, approximating, or projecting
+/// not-yet-committed state; see <see cref="AhtolaConnection.PeekPendingChangeCapture"/>.
 /// </summary>
 public sealed class AhtolaReplicaChangeCaptureException(string message) : AhtolaException(message);

--- a/src/Ahtola.Data/ManagedReplicaChangeCaptureProjector.cs
+++ b/src/Ahtola.Data/ManagedReplicaChangeCaptureProjector.cs
@@ -75,13 +75,20 @@ internal static class ManagedReplicaChangeCaptureProjector
 
         if (change.Operation == SqliteChangeOperation.Delete)
         {
-            before = change.BeforeRecord
+            var beforeRecord = change.BeforeRecord
                 ?? throw new AhtolaReplicaChangeCaptureException(
                     "Managed embedded replica change journal has a delete entry for table "
                     + $"'{change.Table}' (rowid {change.RowId}) with no captured before-image. "
                     + "This happens only for entries written by an older journal format that "
                     + "did not capture delete pre-images; push the pending changes to advance "
                     + "past it before peeking pending change-data-capture.");
+
+            // change.BeforeRecord is the change journal's own stored buffer (the same array
+            // instance is returned by every ReadBatch call until the entry is acknowledged), so
+            // it must be cloned before handing it to a caller: mutating the returned array must
+            // never corrupt the journal's still-durable state or a later delete replay that
+            // decodes the very same buffer.
+            before = (byte[])beforeRecord.Clone();
         }
         else
         {
@@ -94,12 +101,21 @@ internal static class ManagedReplicaChangeCaptureProjector
                 && lastSequence == change.Sequence;
             if (isFinalTouch)
             {
+                // includeGeneratedColumns: true so this "after" image includes VIRTUAL/STORED
+                // generated columns in table-declaration order, matching the real turso_cdc
+                // row's full in-memory row image instead of pragma_table_info's subset.
                 var values = ManagedReplicaLogicalReplayer.TryCaptureCurrentRowValues(
                     connection,
                     change.Table,
-                    change.RowId);
+                    change.RowId,
+                    includeGeneratedColumns: true);
                 if (values is not null)
+                {
+                    // SqliteRecordCodec.Encode always allocates a fresh, exactly-sized array
+                    // (never a cached/pooled buffer), so - unlike the before-image above - no
+                    // additional clone is needed here for caller-mutation isolation.
                     after = SqliteRecordCodec.Encode(values);
+                }
             }
         }
 

--- a/src/Ahtola.Data/ManagedReplicaConnectionHost.cs
+++ b/src/Ahtola.Data/ManagedReplicaConnectionHost.cs
@@ -106,8 +106,43 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
     /// change-data-capture row contract. Pure read: it does not acknowledge the journal
     /// watermark, so it has no effect on a subsequent push.
     /// </summary>
+    /// <exception cref="AhtolaReplicaChangeCaptureException">
+    /// A local transaction is currently open on this connection. Projecting an "after" image
+    /// while a transaction is in progress could observe writes that are not yet committed - or
+    /// that the transaction later rolls back - and silently bake them into the projected row as
+    /// if they were committed. Commit or roll back the open transaction first.
+    /// </exception>
     public AhtolaReplicaChangeCaptureBatch PeekPendingChangeCapture()
-        => ManagedReplicaChangeCaptureProjector.Project(Database.Connection, _changeJournal.ReadBatch(int.MaxValue));
+    {
+        // Held for the whole call so a concurrent publish's quiesce-and-close cannot interleave
+        // with it: EnterLocalOperation blocks that cycle from proceeding past its own "wait for
+        // zero active local operations" step until this lease is released, which is exactly what
+        // keeps CloseForPublication/ReopenAfterPublication (the database/journal generation
+        // swap) from running underneath this projection and mixing generations.
+        using var operation = EnterLocalOperation(CancellationToken.None);
+
+        lock (_changeGate)
+        {
+            if (_localTransactionActive)
+            {
+                throw new AhtolaReplicaChangeCaptureException(
+                    "Cannot peek pending change-data-capture while a local transaction is open "
+                    + "on this connection. Projecting an \"after\" image while a transaction is "
+                    + "in progress could observe not-yet-committed writes, or writes the "
+                    + "transaction later rolls back, and silently bake them into the projected "
+                    + "row as if they were committed. Commit or roll back the open transaction "
+                    + "before peeking pending change-data-capture.");
+            }
+        }
+
+        // Stable locals captured while the lease above is held, so both come from the same
+        // database/journal generation for the whole call: Database and _changeJournal are only
+        // ever swapped together, by CloseForPublication/ReopenAfterPublication, which that lease
+        // blocks for as long as it is held.
+        var database = Database;
+        var journal = _changeJournal;
+        return ManagedReplicaChangeCaptureProjector.Project(database.Connection, journal.ReadBatch(int.MaxValue));
+    }
 
     public void StatementStarted(string sql)
     {

--- a/src/Ahtola.Data/ManagedReplicaLogicalReplayer.cs
+++ b/src/Ahtola.Data/ManagedReplicaLogicalReplayer.cs
@@ -340,26 +340,75 @@ internal static class ManagedReplicaLogicalReplayer
     /// <see cref="ManagedReplicaChangeCaptureProjector"/>, which uses the same live-read
     /// technique to reconstruct an "after" image for the public change-data-capture bridge.
     /// </summary>
+    /// <param name="connection">The connection to read the row through.</param>
+    /// <param name="tableName">The table the rowid belongs to.</param>
+    /// <param name="rowId">The rowid to read.</param>
+    /// <param name="includeGeneratedColumns">
+    /// When <see langword="false"/> (the default, used by local-change replay), the column set
+    /// is <see cref="GetTableColumnsInfo"/>'s <c>pragma_table_info</c>-derived list, which
+    /// excludes VIRTUAL/STORED generated columns because replay builds a literal
+    /// <c>INSERT</c>/<c>UPDATE</c> statement naming each column explicitly, and a generated
+    /// column can never be assigned that way. When <see langword="true"/> (used only by the
+    /// change-data-capture bridge's "after" image reconstruction), every declared column -
+    /// generated or not - is read instead, matching the real <c>turso_cdc</c> row's full
+    /// in-memory row image (see <see cref="GetFullTableColumnNamesForChangeCapture"/>).
+    /// </param>
     internal static IReadOnlyList<SqlValue>? TryCaptureCurrentRowValues(
         IManagedConnectionAdapter connection,
         string tableName,
-        long rowId)
+        long rowId,
+        bool includeGeneratedColumns = false)
     {
         var info = GetTableColumnsInfo(connection, tableName);
         if (info.ColumnNames.Count == 0 || info.IsWithoutRowId || info.RowidReferenceName is not { } rowidReference)
             return null;
 
-        var columnList = string.Join(", ", info.ColumnNames.Select(QuoteIdentifier));
+        var columnNames = includeGeneratedColumns
+            ? GetFullTableColumnNamesForChangeCapture(connection, tableName)
+            : info.ColumnNames;
+        if (columnNames.Count == 0)
+            return null;
+
+        var columnList = string.Join(", ", columnNames.Select(QuoteIdentifier));
         using var statement = connection.Prepare(
             $"SELECT {columnList} FROM {QuoteIdentifier(tableName)} WHERE {QuoteIdentifier(rowidReference)} = ?");
         statement.Bind(1, SqlValue.Integer(rowId));
         if (statement.Step() != StatementStepResult.Row)
             return null;
 
-        var values = new SqlValue[info.ColumnNames.Count];
+        var values = new SqlValue[columnNames.Count];
         for (var i = 0; i < values.Length; i++)
             values[i] = statement.GetValue(i);
         return values;
+    }
+
+    /// <summary>
+    /// Returns every column of a table in declared order, including VIRTUAL and STORED
+    /// generated columns, which <see cref="GetTableColumnsInfo"/> deliberately excludes (see
+    /// <see cref="TryCaptureCurrentRowValues"/> for why). <c>pragma_table_xinfo</c> reports
+    /// every column - unlike <c>pragma_table_info</c>, which silently renumbers past generated
+    /// columns - with <c>hidden</c> distinguishing ordinary (0), VIRTUAL generated (2), and
+    /// STORED generated (3) columns; <c>hidden == 1</c> (a virtual-table shadow column) is
+    /// skipped defensively even though it cannot occur for an ordinary table.
+    /// </summary>
+    private static IReadOnlyList<string> GetFullTableColumnNamesForChangeCapture(
+        IManagedConnectionAdapter connection,
+        string tableName)
+    {
+        var columnNames = new List<string>();
+        using var statement = connection.Prepare(
+            "SELECT name, hidden FROM pragma_table_xinfo(?) ORDER BY cid");
+        statement.Bind(1, SqlValue.Text(tableName));
+        while (statement.Step() == StatementStepResult.Row)
+        {
+            var hidden = checked((int)statement.GetValue(1).AsInteger());
+            if (hidden == 1)
+                continue;
+
+            columnNames.Add(statement.GetValue(0).AsText());
+        }
+
+        return columnNames;
     }
 
     /// <summary>

--- a/src/Ahtola.Tests/ManagedReplicaChangeCaptureBridgeTests.cs
+++ b/src/Ahtola.Tests/ManagedReplicaChangeCaptureBridgeTests.cs
@@ -12,7 +12,14 @@ namespace Ahtola.Tests;
 /// <c>turso_cdc</c> table for the fields it can represent, documents where it intentionally
 /// cannot (an update's before-image, multi-row transaction grouping), fails closed for
 /// unrepresentable entries instead of guessing, and that peeking is side-effect-free: it can
-/// never corrupt, or be corrupted by, a genuine push's acknowledgement.
+/// never corrupt, or be corrupted by, a genuine push's acknowledgement. They also prove three
+/// further correctness properties the public contract depends on: a peek fails closed while a
+/// local transaction is open instead of risking an after-image built from not-yet-committed (or
+/// later rolled-back) writes; a peek can never race a concurrent publish into observing a torn
+/// or mixed database/journal generation; a returned before-image is always an independent copy
+/// the caller can freely mutate without corrupting the journal's own buffer; and an after-image
+/// includes virtual generated columns, matching the real <c>turso_cdc</c> row's full declared
+/// column set rather than <c>pragma_table_info</c>'s narrower, generated-column-excluding subset.
 /// </summary>
 public sealed class ManagedReplicaChangeCaptureBridgeTests
 {
@@ -301,6 +308,197 @@ public sealed class ManagedReplicaChangeCaptureBridgeTests
 
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("*managed embedded replica connections*");
+    }
+
+    [Test]
+    public void PeekPendingChangeCaptureThrowsWhileALocalTransactionIsOpenAndSucceedsAgainAfterRollback()
+    {
+        var path = NewReplicaPath("cdc-bridge-peek-txn-guard");
+        try
+        {
+            using (var setup = new AhtolaConnection($"Data Source={path};Local Provider=Managed"))
+            {
+                setup.Open();
+                setup.ExecuteNonQuery("CREATE TABLE t(id INTEGER PRIMARY KEY, value TEXT)");
+            }
+
+            using var replica = AhtolaConnection.CreateReplica(
+                new AhtolaReplicaOptions(path, new Uri("https://example.test"), authToken: null));
+            replica.Open();
+
+            replica.ExecuteNonQuery("INSERT INTO t VALUES (1, 'committed')");
+
+            replica.ExecuteNonQuery("BEGIN;");
+            replica.ExecuteNonQuery("INSERT INTO t VALUES (2, 'uncommitted')");
+
+            // A later write in this same still-open transaction (or a rollback of it) could
+            // otherwise silently change what an in-progress peek's after-image observed:
+            // rejecting outright while the transaction is open is what actually closes that
+            // hole, rather than merely documenting it.
+            Action act = () => replica.PeekPendingChangeCapture();
+
+            act.Should().Throw<AhtolaReplicaChangeCaptureException>()
+                .WithMessage("*transaction*");
+
+            replica.ExecuteNonQuery("ROLLBACK;");
+
+            // Rolling back must fully clear the guard rather than leaving it stuck closed, and
+            // the projected batch must reflect only the row committed before the transaction
+            // opened: the transaction's own insert was only ever staged pending its own commit,
+            // so it never reached the change journal and leaves nothing behind to filter out.
+            var peek = replica.PeekPendingChangeCapture();
+            peek.Rows.Should().ContainSingle();
+            var insertRow = peek.Rows[0];
+            insertRow.ChangeType.Should().Be(AhtolaReplicaChangeType.Insert);
+            insertRow.RowId.Should().Be(1);
+            SqliteRecordCodec.Decode(insertRow.After!).Should().Equal(SqlValue.Integer(1), SqlValue.Text("committed"));
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task PeekPendingChangeCaptureNeverRacesWithAConcurrentPublish()
+    {
+        var path = NewReplicaPath("cdc-bridge-peek-publish-race");
+        try
+        {
+            using (var setup = new AhtolaConnection($"Data Source={path};Local Provider=Managed"))
+            {
+                setup.Open();
+                setup.ExecuteNonQuery("CREATE TABLE t(id INTEGER PRIMARY KEY, value TEXT)");
+                setup.ExecuteNonQuery("INSERT INTO t VALUES (1, 'seed')");
+            }
+
+            // Bypasses AhtolaConnection to drive the host directly, matching how
+            // AhtolaConnection.CreateReplica(...) itself obtains one internally.
+            var host = ManagedReplicaConnectionHost.Open(
+                new AhtolaReplicaOptions(path, new Uri("https://example.test"), authToken: null));
+            try
+            {
+                using var stop = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
+                Exception? peekFailure = null;
+                Exception? publishFailure = null;
+
+                var peekLoop = Task.Run(() =>
+                {
+                    try
+                    {
+                        while (!stop.IsCancellationRequested)
+                            host.PeekPendingChangeCapture();
+                    }
+                    catch (Exception ex)
+                    {
+                        peekFailure = ex;
+                    }
+                });
+
+                var publishLoop = Task.Run(async () =>
+                {
+                    try
+                    {
+                        while (!stop.IsCancellationRequested)
+                        {
+                            // A real publish always closes and reopens the database/journal
+                            // generation, even when - as here - the staged operation itself
+                            // does nothing: this is exactly the generation swap a concurrent
+                            // peek must never observe torn or mixed.
+                            await host.QuiesceAndReopenAsync(_ => Task.CompletedTask, CancellationToken.None);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        publishFailure = ex;
+                    }
+                });
+
+                await Task.WhenAll(peekLoop, publishLoop);
+
+                peekFailure.Should().BeNull(
+                    "a concurrent publish must never surface a torn or mixed database/journal generation to a peek");
+                publishFailure.Should().BeNull("a concurrent peek must never interfere with a publish either");
+            }
+            finally
+            {
+                host.Dispose();
+            }
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public void ProjectDeepClonesTheDeleteBeforeImageInsteadOfAliasingTheJournalsBuffer()
+    {
+        using var database = ManagedDatabaseAdapter.Open(":memory:");
+        var connection = database.Connect();
+
+        // Stands in for the change journal's own stored before-image buffer: the real journal
+        // keeps returning this SAME array instance from ReadBatch until the entry is
+        // acknowledged, so this test proves Project() never hands that instance out directly.
+        var journalBuffer = new byte[] { 10, 20, 30, 40 };
+        var originalSnapshot = (byte[])journalBuffer.Clone();
+
+        var change = ReplicaLocalChange.Row(SqliteChangeOperation.Delete, "main", "t", 1, journalBuffer) with { Sequence = 1 };
+        var batch = new ReplicaLocalChangeBatch(FirstSequence: 1, Watermark: 2, Changes: [change]);
+
+        var projected = ManagedReplicaChangeCaptureProjector.Project(connection, batch);
+        var before = projected.Rows[0].Before!;
+
+        before.Should().NotBeSameAs(journalBuffer, "callers must receive an independent copy, never the journal's own buffer");
+        before.Should().Equal(journalBuffer);
+
+        // A caller mutating its own copy must never be able to reach back into, and corrupt,
+        // the journal's stored buffer - which a later, still-pending peek or an eventual push
+        // would otherwise observe as silently altered.
+        before[0] = unchecked((byte)(before[0] + 1));
+
+        journalBuffer.Should().Equal(originalSnapshot, "mutating the returned Before image must never corrupt the journal's own buffer");
+    }
+
+    [Test]
+    public void ProjectIncludesVirtualGeneratedColumnsInTheAfterImageMatchingRealChangeDataCapture()
+    {
+        using var database = ManagedDatabaseAdapter.Open(":memory:");
+        var connection = database.Connect();
+
+        Exec(
+            connection,
+            "CREATE TABLE t("
+            + "id INTEGER PRIMARY KEY, "
+            + "a INT, "
+            + "b INT, "
+            + "total INT GENERATED ALWAYS AS (a + b) VIRTUAL)");
+        Exec(connection, "PRAGMA capture_data_changes_conn('full')");
+
+        Exec(connection, "INSERT INTO t (id, a, b) VALUES (1, 3, 4)");
+
+        var batch = new ReplicaLocalChangeBatch(
+            FirstSequence: 1,
+            Watermark: 2,
+            Changes: [ReplicaLocalChange.Row(SqliteChangeOperation.Insert, "main", "t", 1) with { Sequence = 1 }]);
+
+        var projected = ManagedReplicaChangeCaptureProjector.Project(connection, batch);
+
+        projected.Rows.Should().ContainSingle();
+        var insertRow = projected.Rows[0];
+
+        // The real turso_cdc row is the ground truth: its after-image is built from the
+        // engine's full in-memory row and always includes generated columns, so the projected
+        // bridge row must match it exactly rather than pragma_table_info's narrower,
+        // generated-column-excluding subset.
+        var insertCdc = SingleCdcRow(connection, changeType: 1, id: 1);
+        DecodeAfter(insertRow).Should().Equal(SqliteRecordCodec.Decode(AsBlob(insertCdc[6]).Span));
+
+        DecodeAfter(insertRow).Should().Equal(
+            SqlValue.Integer(1),
+            SqlValue.Integer(3),
+            SqlValue.Integer(4),
+            SqlValue.Integer(7));
     }
 
     // --- helpers ---


### PR DESCRIPTION
Stacked correctness fix on top of #30 (`copilot/cdc-replica-bridge`). Addresses four review blockers in `PeekPendingChangeCapture` / the managed replica CDC bridge. This PR's diff is scoped only to these fixes and their tests.

## Fixes

1. **Reject peeking during an active transaction.** `PeekPendingChangeCapture()` now checks `_localTransactionActive` under `_changeGate` and throws `AhtolaReplicaChangeCaptureException` while a local transaction is open, instead of risking a projected after-image that observes writes made later in the same transaction (or that the transaction subsequently rolls back).
2. **Hold `EnterLocalOperation` and stable `Database`/journal references across the whole capture+projection.** This closes the window where a concurrent `PublishAsync`'s quiesce/close/reopen cycle (`CloseForPublication`/`ReopenAfterPublication`) could swap the database/journal generation mid-peek and cause the projector to read a torn or mixed pair.
3. **Deep-clone the delete before-image.** `change.BeforeRecord` is the change journal's own stored buffer instance (returned as the same array by every `ReadBatch` until acknowledged); `ManagedReplicaChangeCaptureProjector.Project` now clones it before returning it in the public `Before` record, so a caller mutating the array can never corrupt journal state.
4. **Include generated columns in the after-image's column order.** `TryCaptureCurrentRowValues` gained an `includeGeneratedColumns` parameter, and the CDC path now sources its column list from a new `GetFullTableColumnNamesForChangeCapture` helper (`pragma_table_xinfo`, ordered by `cid`) instead of `pragma_table_info`'s subset — matching the real `turso_cdc` row's full in-memory row image (which always includes VIRTUAL/STORED generated columns) instead of a narrower projection.

## Tests added (`ManagedReplicaChangeCaptureBridgeTests`)

- `PeekPendingChangeCaptureThrowsWhileALocalTransactionIsOpenAndSucceedsAgainAfterRollback` — asserts the guard fires while `BEGIN;` is open and clears cleanly after `ROLLBACK;`.
- `PeekPendingChangeCaptureNeverRacesWithAConcurrentPublish` — drives `PeekPendingChangeCapture()` and a no-op `QuiesceAndReopenAsync` publish cycle concurrently in tight loops for 500ms and asserts neither surfaces an exception.
- `ProjectDeepClonesTheDeleteBeforeImageInsteadOfAliasingTheJournalsBuffer` — asserts the returned `Before` array is not the same instance as the journal's buffer, and that mutating it doesn't affect the original.
- `ProjectIncludesVirtualGeneratedColumnsInTheAfterImageMatchingRealChangeDataCapture` — creates a table with a `VIRTUAL GENERATED ALWAYS AS` column, and asserts the projected after-image matches both the real `turso_cdc` row's after-image and the expected full tuple including the generated column. (Ahtola's engine rejects `STORED` generated columns outright, so only `VIRTUAL` is exercised; the production fix itself is not STORED/VIRTUAL-specific.)

## Test results (net10.0)

- Focused: `ManagedReplicaChangeCaptureBridgeTests` — **11/11 passed** (7 existing + 4 new).
- Replica + CDC group (`ManagedEmbeddedReplicaConnectionTests`, `ManagedReplicaChangeCaptureBridgeTests`, `ManagedReplicaLogicalReplayerTests`, `ManagedReplicaLogicalReplaySmokeTests`, `ManagedReplicaLml3DecoderTests`, `ManagedReplicaSchemaDdlTextTests`, `RemoteReplicationIndexTests`, `SqliteRemoteFacadeTests`, `ManagedChangeDataCaptureTests`) — **249/249 passed**.
- Full managed suite — **4738 passed, 0 failed, 47 skipped** (expected platform-specific/known-gap skips), 6m27s.
- `dotnet format` verified clean for every file touched by this diff. (The repo-wide `format-check` currently fails on four unrelated, pre-existing files — none touched here — left out of scope per the stacked-diff requirement.)

Base: `copilot/cdc-replica-bridge` (#30).