### PR TITLE
Add browser WebAssembly support with OPFS persistence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,10 @@ jobs:
         shell: pwsh
         run: ./build.ps1 test-browser-js
 
+      - name: Test exact package version assertion
+        shell: pwsh
+        run: ./scripts/tests/Test-AssertExactPackageVersion.ps1
+
   build-test:
     name: Build and test (${{ matrix.os }})
     needs: lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,3 +301,52 @@ jobs:
           path: artifacts/powershell-modules/Devolutions.Ahtola.Sqlite/**
           if-no-files-found: error
           retention-days: 7
+
+  browser-smoke:
+    name: Browser smoke (${{ matrix.browser }})
+    needs: package
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        browser:
+          - firefox
+          - webkit
+    env:
+      PLAYWRIGHT_VERSION: 1.55.0
+      BROWSER_ENGINE: ${{ matrix.browser }}
+      PACKAGE_VERSION: 0.0.0-ci.${{ github.run_number }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Download packed packages
+        uses: actions/download-artifact@v8
+        with:
+          name: managed-packages
+          path: artifacts/managed-packages
+
+      - name: Install Playwright browser
+        shell: pwsh
+        run: |
+          npm install --no-save --no-package-lock "playwright@$env:PLAYWRIGHT_VERSION"
+          npx playwright install --with-deps $env:BROWSER_ENGINE
+
+      - name: Run packed browser smoke
+        shell: pwsh
+        run: |
+          ./scripts/Invoke-BrowserPackageConsumer.ps1 `
+            -PackageDirectory ./artifacts/managed-packages `
+            -PackageVersion $env:PACKAGE_VERSION `
+            -BrowserEngine $env:BROWSER_ENGINE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,11 @@ jobs:
             9.0.x
             10.0.x
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
       - name: Restore package roots
         shell: pwsh
         run: ./build.ps1 restore
@@ -50,6 +55,10 @@ jobs:
       - name: Validate managed project closure
         shell: pwsh
         run: ./build.ps1 validate-project-closure
+
+      - name: Test browser OPFS worker (Node)
+        shell: pwsh
+        run: ./build.ps1 test-browser-js
 
   build-test:
     name: Build and test (${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,7 @@ jobs:
           - firefox
           - webkit
     env:
-      PLAYWRIGHT_VERSION: 1.55.0
+      PLAYWRIGHT_VERSION: 1.62.1
       BROWSER_ENGINE: ${{ matrix.browser }}
       PACKAGE_VERSION: 0.0.0-ci.${{ github.run_number }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,14 @@ jobs:
 
       - name: Validate packaged consumer
         shell: pwsh
-        run: ./build.ps1 validate-package
+        run: ./build.ps1 validate-package -PackageVersion 0.0.0-ci.${{ github.run_number }}
+
+      - name: Assert exact CI package version
+        shell: pwsh
+        # Deterministic guard against the packaging steps above silently
+        # producing (or leaving behind) a different package version than the
+        # one this run is supposed to publish and validate end-to-end.
+        run: ./build.ps1 assert-package-version -PackageVersion 0.0.0-ci.${{ github.run_number }}
 
       - name: Validate packed browser consumer
         shell: pwsh
@@ -305,7 +312,6 @@ jobs:
   browser-smoke:
     name: Browser smoke (${{ matrix.browser }})
     needs: package
-    continue-on-error: true
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -345,8 +351,16 @@ jobs:
 
       - name: Run packed browser smoke
         shell: pwsh
+        # Playwright's bundled WebKit build does not implement the Origin
+        # Private File System API at all (verified directly against this
+        # pinned Playwright version), so it cannot pass this smoke test - a
+        # limitation of the test engine, not of Ahtola or real-world Safari/
+        # WebKit. Invoke-BrowserSmokeCheck.ps1 downgrades only that exact,
+        # structured capability gap to a notice; a FAIL for any other
+        # reason, a timeout, an unexpected exception, or a webkit capability
+        # that should be present still fails this step.
         run: |
-          ./scripts/Invoke-BrowserPackageConsumer.ps1 `
+          ./scripts/Invoke-BrowserSmokeCheck.ps1 `
             -PackageDirectory ./artifacts/managed-packages `
             -PackageVersion $env:PACKAGE_VERSION `
             -BrowserEngine $env:BROWSER_ENGINE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,15 @@ jobs:
             9.0.x
             10.0.x
 
+      - name: Setup Node.js for browser validation
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Install WebAssembly build tools
+        shell: pwsh
+        run: dotnet workload install wasm-tools --skip-manifest-update
+
       - name: Install PlatyPS
         shell: pwsh
         run: |
@@ -268,6 +277,14 @@ jobs:
       - name: Validate packaged consumer
         shell: pwsh
         run: ./build.ps1 validate-package
+
+      - name: Validate packed browser consumer
+        shell: pwsh
+        run: |
+          ./scripts/Invoke-BrowserPackageConsumer.ps1 `
+            -PackageDirectory ./artifacts/managed-packages `
+            -PackageVersion 0.0.0-ci.${{ github.run_number }} `
+            -RunAot
 
       - name: Upload nupkgs
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,11 @@ jobs:
             9.0.x
             10.0.x
 
+      - name: Setup Node.js for browser validation
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
       - name: Restore
         shell: pwsh
         run: ./build.ps1 restore
@@ -110,6 +115,13 @@ jobs:
       - name: Validate packed closure
         shell: pwsh
         run: ./build.ps1 validate-packed-closure
+
+      - name: Validate packed browser consumer
+        shell: pwsh
+        run: |
+          ./scripts/Invoke-BrowserPackageConsumer.ps1 `
+            -PackageDirectory ./artifacts/managed-packages `
+            -PackageVersion ${{ needs.preflight.outputs.version }}
 
       - name: Upload nupkgs
         uses: actions/upload-artifact@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,11 @@ a hard constraint when changing build/package configuration.
 ## Referencing the Turso source
 
 A read-only `turso-src` git submodule pins the upstream Turso Rust core at a
-specific release tag (currently `v0.7.2`, commit `046e9cbf6`) so agents can
-read the original Rust sources while porting or comparing behavior, without
-cloning ad hoc or guessing at API shape.
+specific release tag (currently `v0.8.0-pre.7`, commit `277ddd050`) so agents
+can read the original Rust sources while porting or comparing behavior,
+including the tagged browser WASM binding, without cloning ad hoc or guessing
+at API shape. Historical gap/MVCC contracts that explicitly name `v0.7.2`
+retain that version as their behavioral analysis baseline.
 
 ```powershell
 git submodule update --init --recursive      # first checkout / fresh clone

--- a/Ahtola.slnx
+++ b/Ahtola.slnx
@@ -2,6 +2,7 @@
   <Project Path="src/Ahtola.Core/Ahtola.Core.csproj" />
   <Project Path="src/Ahtola.Data/Ahtola.Data.csproj" />
   <Project Path="src/Ahtola.Data.Sqlite/Ahtola.Data.Sqlite.csproj" />
+  <Project Path="src/Ahtola.Data.Sqlite.Browser/Ahtola.Data.Sqlite.Browser.csproj" />
   <Project Path="src/Ahtola.EntityFrameworkCore.Sqlite/Ahtola.EntityFrameworkCore.Sqlite.csproj" />
     <Project Path="src/Devolutions.Ahtola.PowerShell/Devolutions.Ahtola.PowerShell.csproj" />
       <Project Path="src/Ahtola.Tests/Ahtola.Tests.csproj" />

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ or run.
 
 - [Install](#install) ([full guide](docs/dotnet-packages.md))
 - [Quick start](#quick-start)
+- [Browser WebAssembly](#browser-webassembly) ([deployment guide](docs/browser-wasm.md))
 - [PowerShell module](#powershell-module) ([full guide](docs/powershell-module.md))
 - [What this is good for](#what-this-is-good-for)
 - [Important limits](#important-limits)
@@ -27,6 +28,8 @@ or run.
 dotnet add package Devolutions.Ahtola.Data.Sqlite
 # optional EF Core provider (9.x on net8/net9, 10.x on net10):
 dotnet add package Devolutions.Ahtola.EntityFrameworkCore.Sqlite
+# optional Blazor/browser OPFS support:
+dotnet add package Devolutions.Ahtola.Data.Sqlite.Browser
 ```
 
 Targets: `net8.0`, `net9.0`, `net10.0`. No `net48` / .NET Framework assets.
@@ -35,6 +38,7 @@ Targets: `net8.0`, `net9.0`, `net10.0`. No `net48` / .NET Framework assets.
 | --- | --- | --- |
 | `Devolutions.Ahtola.Core` | Managed engine | [nuget.org](https://www.nuget.org/packages/Devolutions.Ahtola.Core) |
 | `Devolutions.Ahtola.Data.Sqlite` | ADO.NET provider + `Microsoft.Data.Sqlite`-compatible facade; embeds `Ahtola.Data` | [nuget.org](https://www.nuget.org/packages/Devolutions.Ahtola.Data.Sqlite) |
+| `Devolutions.Ahtola.Data.Sqlite.Browser` | Blazor/.NET WebAssembly data source with durable OPFS storage | [nuget.org](https://www.nuget.org/packages/Devolutions.Ahtola.Data.Sqlite.Browser) |
 | `Devolutions.Ahtola.EntityFrameworkCore.Sqlite` | EF Core provider (`UseAhtola`) | [nuget.org](https://www.nuget.org/packages/Devolutions.Ahtola.EntityFrameworkCore.Sqlite) |
 
 `Devolutions.Ahtola.Core` flows in transitively via `Devolutions.Ahtola.Data.Sqlite`
@@ -90,6 +94,40 @@ options.UseAhtola("Data Source=app.db");
 // Direct Turso/Hrana:
 options.UseAhtola("Data Source=turso://my-db.turso.io;Auth Token=" + authToken);
 ```
+
+## Browser WebAssembly
+
+`Devolutions.Ahtola.Data.Sqlite.Browser` stores local databases in the browser's
+Origin Private File System (OPFS). A dedicated module worker owns synchronous
+OPFS handles while .NET awaits its operations, so the browser event loop is
+never blocked on storage I/O.
+
+```csharp
+using Ahtola.Data.Sqlite.Browser;
+
+await using var dataSource = new AhtolaBrowserDataSource("my-app/main.db");
+await using var connection = await dataSource.OpenConnectionAsync();
+await using var command = connection.CreateCommand();
+command.CommandText = "CREATE TABLE IF NOT EXISTS items(id INTEGER PRIMARY KEY, name TEXT)";
+await command.ExecuteNonQueryAsync();
+```
+
+Browser-created connections are async-only. Use `OpenAsync`,
+`ExecuteReaderAsync`, `ReadAsync`, transaction async methods, `OpenBlobAsync`,
+`BackupDatabaseAsync`, `CloseAsync`, and `DisposeAsync`. The corresponding
+synchronous operations fail rather than blocking WebAssembly on an incomplete
+browser promise.
+
+The host must be a secure context and cross-origin isolated:
+
+```text
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Embedder-Policy: require-corp
+```
+
+The package supplies its worker and JavaScript modules through normal Razor
+static web assets. See [docs/browser-wasm.md](docs/browser-wasm.md) for complete
+deployment, EF Core, locking, lifetime, quota, and troubleshooting guidance.
 
 Common connection-string keywords: `Data Source`, `Mode`, `Cache`, `Pooling`,
 `Foreign Keys`, `Default Timeout` / `Command Timeout`, `Foreign Read Only`,

--- a/README.md
+++ b/README.md
@@ -126,8 +126,11 @@ Cross-Origin-Embedder-Policy: require-corp
 ```
 
 The package supplies its worker and JavaScript modules through normal Razor
-static web assets. See [docs/browser-wasm.md](docs/browser-wasm.md) for complete
-deployment, EF Core, locking, lifetime, quota, and troubleshooting guidance.
+static web assets. Browser OPFS files can use the same byte-compatible AHTLA
+AES-GCM format as desktop databases. See
+[docs/browser-wasm.md](docs/browser-wasm.md) for deployment and usage, and
+[docs/browser-encrypted-storage.md](docs/browser-encrypted-storage.md) for the
+encryption/durability design.
 
 Common connection-string keywords: `Data Source`, `Mode`, `Cache`, `Pooling`,
 `Foreign Keys`, `Default Timeout` / `Command Timeout`, `Foreign Read Only`,

--- a/README.md
+++ b/README.md
@@ -291,9 +291,10 @@ Treat Ahtola as SQLite-*compatible*, not a full SQLite replacement:
   build side). Full System-R DP join reordering and multi-index AND intersection
   are still deferred; OUTER JOIN order stays correctness-preserving. Prefer
   `ORDER BY` when order matters (`GROUP BY` is first-encounter order).
-- **File-backed platforms** — Windows, 64-bit Linux, and macOS. In-memory works
-  everywhere; other platforms (e.g. 32-bit Linux) throw
-  `PlatformNotSupportedException` on physical open. macOS uses POSIX
+- **File-backed platforms** — desktop physical files support Windows, 64-bit
+  Linux, and macOS. Browser WebAssembly uses the separate OPFS package and its
+  async-only data source; in-memory works everywhere. Other platforms (e.g.
+  32-bit Linux) throw `PlatformNotSupportedException` on physical open. macOS uses POSIX
   `fcntl(F_SETLK)` (process-associated locks, not Linux OFD); multi-engine
   claims on macOS need host verification.
 - **Multi-engine files (Stage 6)** — physical opens use SQLite main-file SHARED

--- a/build.ps1
+++ b/build.ps1
@@ -31,6 +31,7 @@ param(
                 'cloud-smoke',
                 'validate-project-closure',
                 'validate-packed-closure',
+                'assert-package-version',
                 'format-check'
             )]
             [string]$Task = 'build',
@@ -279,6 +280,33 @@ function Invoke-ValidatePackedClosure {
     Invoke-PwshScript -Path $ClosureValidator -Arguments @('-PackageDirectory', $outputAbsolute)
 }
 
+function Assert-ExactPackageVersion {
+    param(
+        [Parameter(Mandatory)][string]$Directory,
+        [Parameter(Mandatory)][string]$ExpectedVersion
+    )
+
+    $directoryAbsolute = Get-AbsolutePath $Directory
+    Write-Step "Asserting every package in $directoryAbsolute is exactly version $ExpectedVersion"
+    if (-not (Test-Path -LiteralPath $directoryAbsolute -PathType Container)) {
+        throw "Package directory '$directoryAbsolute' does not exist."
+    }
+
+    $nupkgs = @(Get-ChildItem -LiteralPath $directoryAbsolute -Filter '*.nupkg' -File)
+    if ($nupkgs.Count -eq 0) {
+        throw "No .nupkg files were found in '$directoryAbsolute'."
+    }
+
+    $suffix = ".$ExpectedVersion.nupkg"
+    $mismatched = @($nupkgs | Where-Object { -not $_.Name.EndsWith($suffix, [System.StringComparison]::OrdinalIgnoreCase) })
+    if ($mismatched.Count -gt 0) {
+        $names = ($mismatched | ForEach-Object { $_.Name }) -join ', '
+        throw "Expected every package in '$directoryAbsolute' to be version '$ExpectedVersion', but found: $names"
+    }
+
+    Write-Host "Verified $($nupkgs.Count) package(s) in '$directoryAbsolute' are exactly version '$ExpectedVersion'." -ForegroundColor Green
+}
+
 function Write-ConsumerNugetConfig {
     param(
         [Parameter(Mandatory)][string]$ConfigPath,
@@ -306,16 +334,43 @@ function Write-ConsumerNugetConfig {
 function Invoke-ValidatePackage {
     Assert-ManagedProjectClosure
 
-    $localVersion = '0.0.0-managed-local'
     $packageOutputAbsolute = Get-AbsolutePath $PackageOutput
+    $existingNupkgCount = if (Test-Path -LiteralPath $packageOutputAbsolute -PathType Container) {
+        @(Get-ChildItem -LiteralPath $packageOutputAbsolute -Filter '*.nupkg' -File -ErrorAction SilentlyContinue).Count
+    } else {
+        0
+    }
+    # When the caller already packed nupkgs at a specific version (as CI does
+    # before calling this task), validate those in place instead of deleting
+    # and repacking them under a throwaway local version: that repack used to
+    # silently orphan the intended CI-versioned artifacts, and any consumer
+    # that still asked for the original version - the browser smoke jobs, the
+    # final uploaded nupkg artifact - got a different package via NuGet's
+    # nearest-version fallback without any error.
+    $reuseExistingPackages = -not [string]::IsNullOrWhiteSpace($PackageVersion) -and $existingNupkgCount -gt 0
+
+    if ($reuseExistingPackages) {
+        Assert-ExactPackageVersion -Directory $packageOutputAbsolute -ExpectedVersion $PackageVersion
+        $localVersion = $PackageVersion
+        Write-Step "Validating existing $localVersion packages in $packageOutputAbsolute without repacking"
+    } else {
+        $localVersion = if ([string]::IsNullOrWhiteSpace($PackageVersion)) { '0.0.0-managed-local' } else { $PackageVersion }
+        Invoke-Pack -Version $localVersion -Output $packageOutputAbsolute
+    }
+
     $consumerOutputRoot = Get-AbsolutePath $PackageConsumerOutput
     $consumerNugetConfigAbsolute = Get-AbsolutePath $ConsumerNugetConfig
     $consumerProjectAbsolute = Get-AbsolutePath $ConsumerProject
     $consumerObj = Join-Path (Split-Path -Parent $consumerProjectAbsolute) 'obj'
     $consumerBin = Join-Path (Split-Path -Parent $consumerProjectAbsolute) 'bin'
     $globalPackages = Join-Path $packageOutputAbsolute '.nuget-packages'
+    # Reusing existing nupkgs (above) means this function no longer always
+    # wipes $packageOutputAbsolute first, so any global-packages cache left
+    # over from an earlier restore into the same folder must be cleared
+    # explicitly - otherwise a stale extracted package could shadow a nupkg
+    # that legitimately changed content under an unchanged version string.
+    Remove-PathIfExists $globalPackages
 
-    Invoke-Pack -Version $localVersion -Output $packageOutputAbsolute
     Invoke-ValidatePackedClosure -Output $packageOutputAbsolute
 
     Write-Step 'Validating packed consumer restore/build/run/publish'
@@ -504,6 +559,12 @@ switch ($Task) {
         'validate-browser-package' { Invoke-ValidateBrowserPackage }
         'validate-runtime' { Invoke-ValidateRuntime }
         'cloud-smoke' { Invoke-CloudSmoke }
+        'assert-package-version' {
+            if ([string]::IsNullOrWhiteSpace($PackageVersion)) {
+                throw "Task 'assert-package-version' requires -PackageVersion."
+            }
+            Assert-ExactPackageVersion -Directory $PackageOutput -ExpectedVersion $PackageVersion
+        }
         'test' { Invoke-Test }
         'format-check' { Invoke-FormatCheck }
         default { throw "Unknown task '$Task'" }

--- a/build.ps1
+++ b/build.ps1
@@ -12,6 +12,7 @@
     ./build.ps1 test
     ./build.ps1 pack -PackageVersion 0.1.0-preview.1
     ./build.ps1 validate-package
+    ./build.ps1 validate-browser-package
 #>
 [CmdletBinding()]
 param(
@@ -25,6 +26,7 @@ param(
                 'pack-powershell',
                 'test-powershell',
                 'validate-package',
+                'validate-browser-package',
                 'validate-runtime',
                 'cloud-smoke',
                 'validate-project-closure',
@@ -72,6 +74,7 @@ $PowerShellHelpMarkdown = Join-Path $RepoRoot "docs/powershell-help/$PowerShellM
 $PowerShellHelpBuilder = Join-Path $RepoRoot 'scripts/Build-PowerShellHelp.ps1'
 $PowerShellTestRunner = Join-Path $RepoRoot 'scripts/Invoke-PowerShellModuleTests.ps1'
 $ConsumerProject = './samples/ManagedPackageConsumer/ManagedPackageConsumer.csproj'
+$BrowserConsumerRunner = Join-Path $RepoRoot 'scripts/Invoke-BrowserPackageConsumer.ps1'
 $ConsumerNugetConfig = './samples/ManagedPackageConsumer/obj/managed-package-consumer.nuget.config'
 $ClosureValidator = Join-Path $RepoRoot 'scripts/Validate-ManagedPackageClosure.ps1'
 $TestRunner = Join-Path $RepoRoot 'scripts/Invoke-ManagedTestSuite.ps1'
@@ -135,7 +138,8 @@ function Assert-ManagedProjectClosure {
         (Join-Path $RepoRoot 'src/Ahtola.Data.Sqlite.Browser'),
         (Join-Path $RepoRoot 'src/Ahtola.EntityFrameworkCore.Sqlite'),
                 (Join-Path $RepoRoot 'src/Devolutions.Ahtola.PowerShell'),
-                (Join-Path $RepoRoot 'samples/ManagedPackageConsumer')
+                (Join-Path $RepoRoot 'samples/ManagedPackageConsumer'),
+                (Join-Path $RepoRoot 'samples/BrowserWasmConsumer')
             )
     foreach ($root in $projectRoots) {
         if (-not (Test-Path -LiteralPath $root -PathType Container)) {
@@ -367,6 +371,23 @@ function Invoke-ValidatePackage {
     }
 }
 
+function Invoke-ValidateBrowserPackage {
+    $localVersion = if ([string]::IsNullOrWhiteSpace($PackageVersion)) {
+        '0.0.0-browser-local'
+    } else {
+        $PackageVersion
+    }
+    Invoke-Pack -Version $localVersion -Output $PackageOutput
+    $arguments = @(
+        '-PackageDirectory', (Get-AbsolutePath $PackageOutput),
+        '-PackageVersion', $localVersion
+    )
+    if ($env:AHTOLA_BROWSER_AOT -eq '1') {
+        $arguments += '-RunAot'
+    }
+    Invoke-PwshScript -Path $BrowserConsumerRunner -Arguments $arguments
+}
+
 function Invoke-ValidateRuntime {
     Invoke-ValidatePackage
 
@@ -480,6 +501,7 @@ switch ($Task) {
         'validate-project-closure' { Assert-ManagedProjectClosure }
         'validate-packed-closure' { Invoke-ValidatePackedClosure }
         'validate-package' { Invoke-ValidatePackage }
+        'validate-browser-package' { Invoke-ValidateBrowserPackage }
         'validate-runtime' { Invoke-ValidateRuntime }
         'cloud-smoke' { Invoke-CloudSmoke }
         'test' { Invoke-Test }

--- a/build.ps1
+++ b/build.ps1
@@ -25,6 +25,7 @@ param(
         'pack',
                 'pack-powershell',
                 'test-powershell',
+                'test-browser-js',
                 'validate-package',
                 'validate-browser-package',
                 'validate-runtime',
@@ -51,7 +52,12 @@ param(
 
         # Floor for Pester module tests (test-powershell). Keep in sync with
         # tests/PowerShell/Devolutions.Ahtola.Sqlite/Module.Tests.ps1.
-        [int]$PowerShellMinimumExecutedTests = 34
+        [int]$PowerShellMinimumExecutedTests = 34,
+
+        # Floor for the Node-based browser OPFS worker/capability unit tests
+        # (test-browser-js). Keep in sync with the test() count under
+        # scripts/tests/browser-worker.
+        [int]$BrowserWorkerMinimumExecutedTests = 10
     )
 
 Set-StrictMode -Version Latest
@@ -244,6 +250,45 @@ function Invoke-Build {
                 throw "PowerShell module tests failed with exit code $LASTEXITCODE"
             }
         }
+
+function Invoke-TestBrowserJs {
+    param([int]$MinimumExecuted = $BrowserWorkerMinimumExecutedTests)
+
+    if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+        throw 'Browser worker JS tests require Node.js.'
+    }
+
+    $testDirectory = Join-Path $RepoRoot 'scripts/tests/browser-worker'
+    $testFiles = @(Get-ChildItem -LiteralPath $testDirectory -Filter '*.test.mjs' -File -ErrorAction SilentlyContinue |
+        ForEach-Object { $_.FullName })
+    if ($testFiles.Count -eq 0) {
+        throw "No browser worker JS test files were found under $testDirectory."
+    }
+
+    Write-Step "Running browser worker JS tests ($($testFiles.Count) file(s), min $MinimumExecuted)"
+    $output = @(& node --test @testFiles 2>&1)
+    $output | ForEach-Object { Write-Host $_ }
+    $exitCode = $LASTEXITCODE
+
+    $executed = 0
+    $summaryLine = $output | Where-Object { $_ -match '^\s*#\s*tests\s+(\d+)\s*$' } | Select-Object -Last 1
+    if ($summaryLine -and $summaryLine -match '(\d+)') {
+        $executed = [int]$Matches[1]
+    }
+
+    # dotnet test exits 0 for a run that silently discovered nothing, and
+    # Node's runner has the same failure mode if a test file throws during
+    # module load before registering any test() calls - so an explicit floor
+    # on the executed count is required, not just the process exit code.
+    if ($executed -lt $MinimumExecuted) {
+        throw "Browser worker JS tests executed only $executed test(s); expected at least $MinimumExecuted. A test file may have failed to load or register its tests."
+    }
+    if ($exitCode -ne 0) {
+        throw "Browser worker JS tests failed with exit code $exitCode."
+    }
+
+    Write-Host "Browser worker JS tests passed ($executed executed)." -ForegroundColor Green
+}
 
 function Invoke-Pack {
     param(
@@ -553,6 +598,7 @@ switch ($Task) {
     'pack' { Invoke-Pack }
         'pack-powershell' { Invoke-PackPowerShell }
         'test-powershell' { Invoke-TestPowerShell }
+        'test-browser-js' { Invoke-TestBrowserJs }
         'validate-project-closure' { Assert-ManagedProjectClosure }
         'validate-packed-closure' { Invoke-ValidatePackedClosure }
         'validate-package' { Invoke-ValidatePackage }

--- a/build.ps1
+++ b/build.ps1
@@ -59,6 +59,7 @@ $RepoRoot = $PSScriptRoot
 Set-Location -LiteralPath $RepoRoot
 
 $DataSqliteProject = './src/Ahtola.Data.Sqlite/Ahtola.Data.Sqlite.csproj'
+$BrowserDataSqliteProject = './src/Ahtola.Data.Sqlite.Browser/Ahtola.Data.Sqlite.Browser.csproj'
 $EfCoreProject = './src/Ahtola.EntityFrameworkCore.Sqlite/Ahtola.EntityFrameworkCore.Sqlite.csproj'
 $PowerShellProject = './src/Devolutions.Ahtola.PowerShell/Devolutions.Ahtola.PowerShell.csproj'
 $CoreProject = './src/Ahtola.Core/Ahtola.Core.csproj'
@@ -131,6 +132,7 @@ function Assert-ManagedProjectClosure {
         (Join-Path $RepoRoot 'src/Ahtola.Core'),
         (Join-Path $RepoRoot 'src/Ahtola.Data'),
         (Join-Path $RepoRoot 'src/Ahtola.Data.Sqlite'),
+        (Join-Path $RepoRoot 'src/Ahtola.Data.Sqlite.Browser'),
         (Join-Path $RepoRoot 'src/Ahtola.EntityFrameworkCore.Sqlite'),
                 (Join-Path $RepoRoot 'src/Devolutions.Ahtola.PowerShell'),
                 (Join-Path $RepoRoot 'samples/ManagedPackageConsumer')
@@ -155,6 +157,7 @@ function Assert-ManagedProjectClosure {
 function Invoke-Restore {
     Write-Step 'Restoring managed packages'
     Invoke-DotNet @('restore', $DataSqliteProject)
+    Invoke-DotNet @('restore', $BrowserDataSqliteProject)
     Invoke-DotNet @('restore', $EfCoreProject)
         Invoke-DotNet @('restore', $PowerShellProject)
 }
@@ -166,6 +169,7 @@ function Invoke-Build {
     Invoke-Restore
     Write-Step "Building managed packages ($BuildConfiguration)"
     Invoke-DotNet @('build', '--no-restore', '-c', $BuildConfiguration, $DataSqliteProject)
+    Invoke-DotNet @('build', '--no-restore', '-c', $BuildConfiguration, $BrowserDataSqliteProject)
     Invoke-DotNet @('build', '--no-restore', '-c', $BuildConfiguration, $EfCoreProject)
         Invoke-DotNet @('build', '--no-restore', '-c', $BuildConfiguration, $PowerShellProject)
 }
@@ -257,6 +261,7 @@ function Invoke-Pack {
 
     Invoke-DotNet ($packArgs + @($CoreProject))
     Invoke-DotNet ($packArgs + @($DataSqliteProject))
+    Invoke-DotNet ($packArgs + @($BrowserDataSqliteProject))
     Invoke-DotNet ($packArgs + @($EfCoreProject))
 
     Invoke-ValidatePackedClosure -Output $outputAbsolute

--- a/docs/browser-encrypted-storage.md
+++ b/docs/browser-encrypted-storage.md
@@ -55,10 +55,35 @@ transform. Files are classified by SQLite's naming conventions:
 
 | File | Treatment |
 | --- | --- |
-| database (`x.db`, attached, VACUUM temporaries) | every page encrypted |
+| database (`x.db`, attached, VACUUM targets) | every page encrypted |
 | `x.db-wal` | header plaintext; frame bodies encrypted; rolling checksums recomputed over the **encrypted** bytes |
 | `x.db-journal` | header plaintext; page records encrypted; per-record checksum recomputed over the **encrypted** page |
 | `x.db-shm` | passthrough — the WAL index is derived, rebuildable metadata |
+| `x.db-log` | rejected — see *MVCC* below |
+
+### Roles are tracked, not guessed from the suffix
+
+A filename suffix alone cannot decide this. A perfectly legal database can be
+named `notes-shm`, or attached as `archive-wal`, and treating it as a sidecar
+would corrupt it or — for `-shm` — persist its pages in the clear. A path is a
+sidecar only when:
+
+1. its base database is already known (databases are discovered in open order at
+   run time, and shortest-path-first at load, so a base is always resolved
+   before anything derived from it), or the base file exists; or
+2. the content positively identifies it: a WAL header magic, or a finalized
+   rollback journal magic.
+
+In all cases, content that starts with `AHTLA` or `SQLite format 3` vetoes the
+sidecar role and the file is treated as a database.
+
+### MVCC
+
+The engine writes the MVCC logical log (`x.db-log`) outside the page codec, so
+on desktop it is plaintext. Reproducing that in the browser would put row data
+in OPFS unencrypted, so `PRAGMA journal_mode=mvcc` on an encrypted browser
+database fails with an explicit `NotSupportedException` instead. Encryption is
+never silently weakened.
 
 Page 1 keeps a visible 100-byte header: the `AHTLA` magic, format version 0,
 the cipher id, zeroed reserved bytes, and the SQLite header bytes 16..100
@@ -91,6 +116,28 @@ state is committed only after the transformed bytes reach OPFS. A cancelled or
 failed flush therefore leaves the unreplayed mutations queued and replayable
 instead of advancing state or reporting false success.
 
+## Recovery runs before authentication
+
+An OPFS write is not atomic, so losing the process can leave a torn page that no
+longer authenticates. Authenticating the main database first would turn that
+into a fatal open even when the information needed to repair it is sitting in a
+journal or WAL. Loading therefore runs in recovery order:
+
+1. Decrypt the WAL, stopping at the first frame that fails its chain, and record
+   the page images belonging to committed frames.
+2. Replay a hot rollback journal's **encrypted** page images back into the
+   encrypted database image and truncate to the journal's declared original page
+   count. This is the pre-transaction content, restored before anything is
+   authenticated.
+3. Decrypt the database. A page that still fails authentication is satisfied
+   from a committed WAL frame when one exists — the same content a checkpoint
+   would have written.
+
+A page with no recovery source still fails closed. Abandoned engine temporaries
+(`.vacuum-<guid>.tmp`, `.page-size-<guid>.tmp`, and `.v4-upgrade`, plus their
+sidecars) are recognized by exact shape, never decrypted, and removed, so a
+preallocated leftover cannot block opening a healthy database.
+
 ## Failing closed
 
 There is no plaintext fallback and no cipher inference. Opening encrypted
@@ -121,7 +168,10 @@ using var options = new AhtolaBrowserOptions(
 await using var dataSource = new AhtolaBrowserDataSource(options);
 ```
 
-The data source snapshots the encryption settings during construction, so
-caller-owned `AhtolaBrowserOptions` and `AhtolaBrowserEncryptionOptions`
-instances can be disposed independently. The data source releases its own copy
-after all connections drain and pending encrypted writes finish.
+A data source that builds its own `AhtolaBrowserOptions` (the convenience
+constructors) owns them, keeps a single copy of the key rather than a second
+snapshot, and disposes them with itself. Options supplied by the caller stay the
+caller's to dispose, so the data source takes an independent snapshot instead —
+otherwise disposing the options would break a data source that opens storage
+lazily. Every disposal and failure path releases key material through one code
+path.

--- a/docs/browser-encrypted-storage.md
+++ b/docs/browser-encrypted-storage.md
@@ -1,0 +1,111 @@
+# Browser encrypted storage
+
+`Devolutions.Ahtola.Data.Sqlite.Browser` stores databases in the Origin Private
+File System (OPFS) and can encrypt them with Ahtola's AHTLA page format. An
+encrypted browser database is a **plain Ahtola encrypted database**: it is not a
+browser-specific container, it has no plaintext sidecar, and it opens on the
+desktop with `AhtolaEncryptionOptions` (and vice versa).
+
+## Why encryption happens at the persistence boundary
+
+The desktop engine encrypts pages through `IPageCodec`
+(`EncryptionPageCodec`), whose `EncodePage`/`DecodePage` are **synchronous**.
+Browser Web Crypto (`SubtleCrypto`) is promise-based and has no synchronous
+API, so it can never satisfy that contract on the .NET WebAssembly runtime.
+Deriving the raw key and using `System.Security.Cryptography.AesGcm` instead is
+not an option either: the package's crypto contract is Web Crypto with
+non-extractable key handles.
+
+The browser therefore splits the two concerns:
+
+```mermaid
+flowchart LR
+    engine["Managed engine<br/>(plaintext pages,<br/>28 reserved bytes)"]
+    mirror["BrowserMirroredFileSystem<br/>(synchronous in-memory mirror)"]
+    transform["BrowserEncryptedPersistence<br/>(async AHTLA transform)"]
+    opfs["OPFS<br/>(exact encrypted bytes)"]
+
+    engine <--> mirror
+    mirror -- "captured whole pages/frames/records" --> transform
+    transform -- "Web Crypto AES-GCM" --> opfs
+    opfs -- "decrypt on load" --> mirror
+```
+
+- The engine keeps operating on plaintext, synchronously, exactly as it does
+  today. Nothing in `Ahtola.Core` becomes `async` for the browser's benefit.
+- `AhtolaBrowserReservedSpaceCodec` is an **identity** `IPageCodec` that
+  declares `RequiredReservedBytes = 28`. Binding it makes the pager create
+  databases with 28 reserved bytes per page from creation onward, and reject an
+  existing database whose reserved space disagrees. Those 28 bytes are where
+  the 16-byte AES-GCM tag and 12-byte nonce live once the page is encrypted.
+- `BrowserEncryptedPersistence` performs the actual AHTLA transform
+  asynchronously while the mirror replays its pending mutations to OPFS.
+
+`IPageCodecSource` (in `Ahtola.Core`) lets the mirror advertise its codec
+without being wrapped in `AhtolaPageCodecFileSystem`. Wrapping would hide the
+mirror's `IAtomicFileSystem`, `ITemporaryFileSystem`, `IStoragePathResolver`,
+and `ISnapshotFileIdentity` implementations, which VACUUM, backup, and the
+sorter depend on.
+
+## What is encrypted, and how
+
+`AhtolaEncryptedPageFormat` is the single definition of the byte layout, shared
+by the synchronous desktop `AhtolaPageEncryption` and the asynchronous browser
+transform. Files are classified by SQLite's naming conventions:
+
+| File | Treatment |
+| --- | --- |
+| database (`x.db`, attached, VACUUM temporaries) | every page encrypted |
+| `x.db-wal` | header plaintext; frame bodies encrypted; rolling checksums recomputed over the **encrypted** bytes |
+| `x.db-journal` | header plaintext; page records encrypted; per-record checksum recomputed over the **encrypted** page |
+| `x.db-shm` | passthrough — the WAL index is derived, rebuildable metadata |
+
+Page 1 keeps a visible 100-byte header: the `AHTLA` magic, format version 0,
+the cipher id, zeroed reserved bytes, and the SQLite header bytes 16..100
+copied verbatim. That whole 100-byte prefix is authenticated as AES-GCM
+associated data. Every other page has no associated data. This is byte-for-byte
+what the desktop engine writes.
+
+Because WAL and journal checksums must cover encrypted bytes, the transform
+recomputes them rather than copying the engine's plaintext checksums. The WAL's
+rolling chain is seeded by the WAL header's own checksum, which is identical in
+both images because the header itself is never encrypted.
+
+## Ordering and durability
+
+The mirror records the engine's exact mutation stream. When encryption is
+enabled, each write is **captured at enqueue time**, expanded to the whole
+pages, WAL frames, or journal records it touches. Capturing eagerly (rather
+than re-reading the final image at flush time) preserves the engine's exact
+durability ordering — in particular that a rollback journal is durable before
+the database pages it protects are overwritten.
+
+A rollback journal record is built from three separate engine writes (page
+number, page image, checksum). The transform persists nothing until the record
+is complete, because the encrypted checksum cannot be derived from a partial
+page. Records are still emitted before the journal's flush, so crash recovery
+is unaffected.
+
+Encryption is applied in `PrepareAsync`, which is side-effect free; WAL chain
+state is committed only after the transformed bytes reach OPFS. A cancelled or
+failed flush therefore leaves the unreplayed mutations queued and replayable
+instead of advancing state or reporting false success.
+
+## Failing closed
+
+There is no plaintext fallback and no cipher inference. Opening encrypted
+storage fails with a mapped exception when the key is wrong, the AHTLA header
+declares a different cipher, a page fails authentication, or the file turns out
+to be a plaintext SQLite database. If the transform ever encounters a write it
+cannot map onto whole pages, frames, or records, it throws rather than
+persisting plaintext.
+
+## Key material
+
+`AhtolaBrowserEncryptionOptions` accepts an `Ahtola.Password.v1` passphrase
+(PBKDF2-HMAC-SHA256, 210,000 iterations, the same domain salt as the desktop
+scheme) or an exact AES-128/AES-256 key as raw bytes or hex. Key material is
+copied defensively, zeroed on disposal, and **never placed in a connection
+string**. The Web Crypto key handle is non-extractable and is released during
+disposal, after connections are drained and pending writes are persisted, and
+before the OPFS store is closed.

--- a/docs/browser-encrypted-storage.md
+++ b/docs/browser-encrypted-storage.md
@@ -109,3 +109,19 @@ copied defensively, zeroed on disposal, and **never placed in a connection
 string**. The Web Crypto key handle is non-extractable and is released during
 disposal, after connections are drained and pending writes are persisted, and
 before the OPFS store is closed.
+
+```csharp
+using var encryption =
+    AhtolaBrowserEncryptionOptions.FromHex(
+        AhtolaEncryptionCipher.Aes256Gcm,
+        hexKey);
+using var options = new AhtolaBrowserOptions(
+    databasePath: "secure/main.db",
+    encryption: encryption);
+await using var dataSource = new AhtolaBrowserDataSource(options);
+```
+
+The data source snapshots the encryption settings during construction, so
+caller-owned `AhtolaBrowserOptions` and `AhtolaBrowserEncryptionOptions`
+instances can be disposed independently. The data source releases its own copy
+after all connections drain and pending encrypted writes finish.

--- a/docs/browser-wasm.md
+++ b/docs/browser-wasm.md
@@ -158,6 +158,46 @@ Use EF Core async APIs (`EnsureCreatedAsync`, `MigrateAsync`,
 does not own a separately supplied connection unless configured to do so;
 dispose objects in context, connection, data-source order.
 
+## Encrypted OPFS databases
+
+Browser storage supports the same AHTLA AES-GCM page format as desktop Ahtola.
+Web Crypto derives/imports a non-extractable key and encrypts database pages,
+WAL frame bodies, and rollback-journal page records at the asynchronous OPFS
+boundary.
+
+```csharp
+using var encryption =
+    AhtolaBrowserEncryptionOptions.FromPassword("correct horse battery staple");
+using var browserOptions = new AhtolaBrowserOptions(
+    databasePath: "secure/main.db",
+    encryption: encryption);
+await using var dataSource = new AhtolaBrowserDataSource(browserOptions);
+
+await using var connection = await dataSource.OpenConnectionAsync();
+await using var command = connection.CreateCommand();
+command.CommandText = "CREATE TABLE IF NOT EXISTS secrets(value TEXT NOT NULL)";
+await command.ExecuteNonQueryAsync();
+```
+
+For exact key material, use `FromKey(AhtolaEncryptionCipher, ReadOnlySpan<byte>)`
+or `FromHex(AhtolaEncryptionCipher, string)`. Password mode is the stable
+`Ahtola.Password.v1` scheme: PBKDF2-HMAC-SHA256 with its fixed domain salt,
+210,000 iterations, and an AES-256-GCM key.
+
+Encryption options are copied by both `AhtolaBrowserOptions` and
+`AhtolaBrowserDataSource`. Dispose caller-owned option objects after constructing
+their owner; key material is never included in `ConnectionString`. A wrong key,
+cipher mismatch, plaintext file, or authentication failure is rejected without
+fallback.
+
+The on-disk bytes are desktop/browser compatible. A browser-written file can be
+opened by the desktop provider with the matching `Password` or
+`Encryption Cipher`/`Encryption Key` settings, and the browser can open a
+desktop-written AHTLA database and retained WAL.
+
+See [Browser encrypted storage](browser-encrypted-storage.md) for byte layout,
+WAL/journal checksum handling, cancellation, retry, and durability details.
+
 ## Ownership and locking
 
 One data source owns one OPFS worker and one Web Lock named for its owned

--- a/docs/browser-wasm.md
+++ b/docs/browser-wasm.md
@@ -109,6 +109,12 @@ All database, `ATTACH`, WAL, journal, backup, and temporary paths are
 normalized relative paths. Traversal (`..`), absolute paths, and paths outside
 the owned directory are rejected.
 
+For a non-persistent database that still enforces the browser async-only
+contract, use `new AhtolaBrowserDataSource(":memory:")`. Connections from that
+data source share one managed in-memory database until the data source is
+disposed and do not initialize OPFS. Read-only and encryption settings are not
+applicable to `:memory:`.
+
 ## Async-only contract
 
 Connections produced by `AhtolaBrowserDataSource` never block on an incomplete

--- a/docs/browser-wasm.md
+++ b/docs/browser-wasm.md
@@ -57,6 +57,7 @@ web assets publish them at:
 
 ```text
 _content/Devolutions.Ahtola.Data.Sqlite.Browser/ahtola-opfs.mjs
+_content/Devolutions.Ahtola.Data.Sqlite.Browser/ahtola-opfs-capability-probe-worker.mjs
 _content/Devolutions.Ahtola.Data.Sqlite.Browser/ahtola-opfs-worker.mjs
 _content/Devolutions.Ahtola.Data.Sqlite.Browser/ahtola-crypto.mjs
 ```

--- a/docs/browser-wasm.md
+++ b/docs/browser-wasm.md
@@ -1,0 +1,233 @@
+# Browser WebAssembly
+
+`Devolutions.Ahtola.Data.Sqlite.Browser` runs Ahtola's managed SQL engine in
+.NET WebAssembly and stores durable SQLite-compatible files in the browser's
+Origin Private File System (OPFS). It is a Razor class library: the NuGet
+package carries the JavaScript module and worker as static web assets and does
+not ship a second database WebAssembly binary.
+
+> Ahtola is experimental. Treat browser databases as application data that can
+> be recreated or exported, and test browser eviction and quota behavior for
+> your deployment.
+
+## Install
+
+```bash
+dotnet add package Devolutions.Ahtola.Data.Sqlite.Browser
+
+# Add this as well when using EF Core:
+dotnet add package Devolutions.Ahtola.EntityFrameworkCore.Sqlite
+```
+
+The packages target `net8.0`, `net9.0`, and `net10.0`.
+
+## Required browser features
+
+Call `AhtolaBrowserRuntime.GetCapabilitiesAsync()` before presenting a
+persistent-storage workflow. `IsSupported` requires all of:
+
+- a secure browser context;
+- cross-origin isolation;
+- `SharedArrayBuffer`;
+- OPFS and `FileSystemSyncAccessHandle`;
+- module workers; and
+- Web Locks.
+
+Current evergreen Chromium, Firefox, and Safari are the intended browser
+targets. Chromium is the mandatory automated package gate. Capability
+detection, rather than user-agent detection, is authoritative.
+
+## Hosting headers
+
+Every document that creates an Ahtola browser data source must be served with:
+
+```text
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Embedder-Policy: require-corp
+```
+
+HTTPS is required outside loopback development hosts. Under
+`require-corp`, cross-origin scripts, fonts, images, and other subresources
+must opt in through CORS or an appropriate
+`Cross-Origin-Resource-Policy` header. A missing or blocked subresource can
+prevent `crossOriginIsolated` from becoming true.
+
+Do not copy the packaged modules into the application manually. Razor static
+web assets publish them at:
+
+```text
+_content/Devolutions.Ahtola.Data.Sqlite.Browser/ahtola-opfs.mjs
+_content/Devolutions.Ahtola.Data.Sqlite.Browser/ahtola-opfs-worker.mjs
+_content/Devolutions.Ahtola.Data.Sqlite.Browser/ahtola-crypto.mjs
+```
+
+## ADO.NET
+
+Keep one data source for the lifetime of the application feature and create
+short-lived connections from it:
+
+```csharp
+using Ahtola.Data.Sqlite.Browser;
+
+await using var dataSource = new AhtolaBrowserDataSource("inventory/main.db");
+
+await using (var connection = await dataSource.OpenConnectionAsync())
+{
+    await using var command = connection.CreateCommand();
+    command.CommandText = """
+        CREATE TABLE IF NOT EXISTS products(
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL
+        );
+        INSERT INTO products(name) VALUES ($name);
+        """;
+    command.Parameters.AddWithValue("$name", "keyboard");
+    await command.ExecuteNonQueryAsync();
+}
+
+await using (var connection = await dataSource.OpenConnectionAsync())
+{
+    await using var command = connection.CreateCommand();
+    command.CommandText = "SELECT id, name FROM products ORDER BY id";
+    await using var reader = await command.ExecuteReaderAsync();
+    while (await reader.ReadAsync())
+        Console.WriteLine($"{reader.GetInt64(0)} {reader.GetString(1)}");
+}
+```
+
+The one-argument constructor derives the owned directory from the database
+path. Use the explicit overload when attached databases need a larger common
+directory:
+
+```csharp
+await using var dataSource = new AhtolaBrowserDataSource(
+    databasePath: "inventory/databases/main.db",
+    ownedDirectory: "inventory");
+```
+
+All database, `ATTACH`, WAL, journal, backup, and temporary paths are
+normalized relative paths. Traversal (`..`), absolute paths, and paths outside
+the owned directory are rejected.
+
+## Async-only contract
+
+Connections produced by `AhtolaBrowserDataSource` never block on an incomplete
+browser operation. Use the asynchronous lifecycle and execution surface:
+
+| Operation | Browser API |
+| --- | --- |
+| Open / close | `OpenAsync`, `CloseAsync`, `DisposeAsync` |
+| Commands | `ExecuteNonQueryAsync`, `ExecuteScalarAsync`, `ExecuteReaderAsync` |
+| Readers | `ReadAsync`, `NextResultAsync`, `DisposeAsync` |
+| Transactions | `BeginTransactionAsync`, `CommitAsync`, `RollbackAsync`, `DisposeAsync` |
+| Incremental blobs | `OpenBlobAsync`, stream async read/write/flush/dispose |
+| Backup | `BackupDatabaseAsync` |
+
+Synchronous counterparts throw `PlatformNotSupportedException` when they
+would cross the browser storage boundary. Use `await using` for the data
+source, connections, readers, transactions, commands, and blobs so pending
+durable mutations are flushed before their owners are released.
+
+Cancellation is cooperative. A cancellation requested before a mutation
+prevents it. Once a non-reversible managed mutation succeeds, Ahtola completes
+the durability boundary with a non-cancelable flush rather than reporting a
+false cancellation for committed work.
+
+## EF Core
+
+Create and asynchronously open a browser connection, then give that existing
+connection to `UseAhtola`:
+
+```csharp
+await using var dataSource = new AhtolaBrowserDataSource("notes/main.db");
+await using var connection = await dataSource.OpenConnectionAsync();
+
+var options = new DbContextOptionsBuilder<NotesContext>()
+    .UseAhtola(connection)
+    .Options;
+
+await using var context = new NotesContext(options);
+await context.Database.EnsureCreatedAsync();
+context.Notes.Add(new Note { Text = "stored in OPFS" });
+await context.SaveChangesAsync();
+var notes = await context.Notes.ToListAsync();
+```
+
+Use EF Core async APIs (`EnsureCreatedAsync`, `MigrateAsync`,
+`SaveChangesAsync`, async LINQ operators, and async transactions). A context
+does not own a separately supplied connection unless configured to do so;
+dispose objects in context, connection, data-source order.
+
+## Ownership and locking
+
+One data source owns one OPFS worker and one Web Lock named for its owned
+directory. Connections from that data source may share the database in the
+same page. A second data source, tab, or worker attempting to own the same
+directory fails immediately with `AhtolaBrowserDatabaseLockedException`
+instead of waiting indefinitely.
+
+Choose an owned directory that is private to one logical database family.
+Different independently opened data sources need different owned
+directories. Dispose every connection before disposing its data source; data
+source disposal waits for active connections to drain.
+
+## Persistence, quota, and clearing data
+
+OPFS is scoped to the page's origin. Its lifetime follows browser storage
+policy, not the application deployment:
+
+- private browsing may use ephemeral storage;
+- users can clear site data at any time;
+- browsers may evict non-persistent origins under storage pressure;
+- quota differs by browser, device, and user settings.
+
+Applications can inspect `navigator.storage.estimate()` and request
+`navigator.storage.persist()` in their own JavaScript when their product
+policy calls for it. Ahtola maps quota failures to an explicit storage error;
+it does not silently switch to IndexedDB or memory.
+
+Changing the site's scheme, host, or port selects a different origin and
+therefore a different OPFS. Plan migrations before changing production
+origins.
+
+## Architecture and security boundary
+
+SQL parsing, compilation, execution, and result materialization remain in the
+primary .NET WebAssembly runtime. A dedicated JavaScript module worker owns
+OPFS synchronous access handles. Requests use a bounded
+`SharedArrayBuffer`; the main browser thread never calls `Atomics.wait`.
+
+The worker obtains a fail-fast Web Lock, normalizes every path, and uses a
+checksummed replacement-intent journal for crash-safe cross-file publication.
+The shared buffer avoids a second JavaScript worker copy, but supported .NET
+JavaScript interop still copies at the managed boundary.
+
+No Rust toolchain, native SQLite library, P/Invoke SDK, runtime native asset,
+or custom database `.wasm` is part of the browser package.
+
+## Troubleshooting
+
+| Symptom | Check |
+| --- | --- |
+| `IsSupported` is false | HTTPS/loopback, COOP, COEP, `SharedArrayBuffer`, OPFS sync handles, Web Locks |
+| Static module import fails | Razor static web assets are enabled and `_content/Devolutions.Ahtola.Data.Sqlite.Browser/` is deployed |
+| `AhtolaBrowserDatabaseLockedException` | Another data source/tab owns the same directory; reuse the existing data source or close the other owner |
+| Quota or I/O exception | Available site storage, private-browsing policy, eviction, and browser console diagnostics |
+| Synchronous API throws | Use the async counterpart and `await using` |
+| Data appears missing after deployment | Confirm the application origin (scheme, host, and port) did not change |
+
+## Package validation
+
+The repository validates the actual nupkgs through a published Blazor
+consumer:
+
+```powershell
+pwsh ./build.ps1 pack -Configuration Release -PackageVersion 0.0.0-local
+pwsh ./scripts/Invoke-BrowserPackageConsumer.ps1 `
+  -PackageDirectory ./artifacts/managed-packages `
+  -PackageVersion 0.0.0-local
+```
+
+CI additionally publishes the consumer with browser AOT compilation and
+checks the packed/published closure for native, Rust, and custom WebAssembly
+payloads.

--- a/docs/dotnet-packages.md
+++ b/docs/dotnet-packages.md
@@ -1,6 +1,6 @@
 # NuGet packages guide
 
-Ahtola ships as three NuGet packages that build directly on top of each
+Ahtola ships as four NuGet packages that build directly on top of each
 other. This guide goes deeper than the [top-level README](../README.md#install):
 which package to install for a given scenario, the full ADO.NET / EF Core API
 surface, connection-string keywords, and end-to-end walkthroughs for a
@@ -27,6 +27,7 @@ replica**.
 | --- | --- | --- |
 | `Devolutions.Ahtola.Core` | [nuget.org](https://www.nuget.org/packages/Devolutions.Ahtola.Core) | Pure-managed engine (pager, b-tree, WAL, VDBE). Rarely referenced directly — it flows in transitively — unless you need engine-level types such as `IPageCodec`. |
 | `Devolutions.Ahtola.Data.Sqlite` | [nuget.org](https://www.nuget.org/packages/Devolutions.Ahtola.Data.Sqlite) | ADO.NET provider: the `Microsoft.Data.Sqlite`-compatible facade (`Ahtola.Data.Sqlite.SqliteConnection`, …) plus the native `Ahtola.AhtolaConnection` types (local files, MVCC, Turso Cloud direct/replica). Embeds `Ahtola.Data`. |
+| `Devolutions.Ahtola.Data.Sqlite.Browser` | [nuget.org](https://www.nuget.org/packages/Devolutions.Ahtola.Data.Sqlite.Browser) | Blazor/.NET WebAssembly data source with durable OPFS storage. See the [browser deployment guide](browser-wasm.md). |
 | `Devolutions.Ahtola.EntityFrameworkCore.Sqlite` | [nuget.org](https://www.nuget.org/packages/Devolutions.Ahtola.EntityFrameworkCore.Sqlite) | EF Core provider (`UseAhtola`) — local databases, direct remote Turso Cloud/Hrana connections, and embedded replicas (see [Entity Framework Core](#entity-framework-core)). |
 
 ```bash
@@ -35,10 +36,13 @@ dotnet add package Devolutions.Ahtola.Data.Sqlite
 
 # + EF Core (9.x on net8.0/net9.0, 10.x on net10.0)
 dotnet add package Devolutions.Ahtola.EntityFrameworkCore.Sqlite
+
+# Blazor/.NET WebAssembly OPFS support
+dotnet add package Devolutions.Ahtola.Data.Sqlite.Browser
 ```
 
 Targets `net8.0`, `net9.0`, `net10.0` — no `net48` / .NET Framework assets, no
-native SQLite binary, and no P/Invoke SDK to restore. All three packages are
+native SQLite binary, and no P/Invoke SDK to restore. The shipped packages are
 `IsAotCompatible`/`IsTrimmable` in `Ahtola.Core`, and the shipped
 provider/EF Core packages publish and trim cleanly on every supported TFM.
 
@@ -60,6 +64,10 @@ Devolutions.Ahtola.Core` yourself. Add it directly only if you're writing an
   `optionsBuilder.UseAhtola(...)` — local files, direct remote Turso Cloud/Hrana
   URLs, and embedded replicas are all supported (see
   [Entity Framework Core](#entity-framework-core)).
+- **Blazor/.NET WebAssembly with durable OPFS storage** → add
+  `Devolutions.Ahtola.Data.Sqlite.Browser`, create an
+  `AhtolaBrowserDataSource`, and use async APIs. See the
+  [browser deployment guide](browser-wasm.md).
 
 ## The SQLite-compatible facade
 

--- a/docs/mvcc-port-contract.md
+++ b/docs/mvcc-port-contract.md
@@ -5,7 +5,9 @@ Companion to [`wal-interoperability-contract.md`](wal-interoperability-contract.
 
 ## Upstream reference
 
-Pinned submodule: `turso-src/` @ **v0.7.2** (`046e9cbf6`).
+Behavioral baseline: Turso **v0.7.2** (`046e9cbf6`). The read-only submodule
+now pins **v0.8.0-pre.7** (`277ddd050`) for browser-WASM work; retrieve the
+original baseline with `git -C turso-src show v0.7.2:<path>`.
 
 | Turso | Ahtola |
 | --- | --- |

--- a/docs/turso-gap-analysis.md
+++ b/docs/turso-gap-analysis.md
@@ -1,10 +1,13 @@
 # Ahtola ↔ Turso gap analysis
 
-**Scope.** Exhaustive comparison of the Ahtola managed engine against the pinned
-Turso Rust core — `turso-src/` submodule at tag **v0.7.2** (commit `046e9cbf6`) —
-across all seven layers: **VDBE** (deep-dive priority), compilation/translate,
-parser/dialect, built-in functions, storage/pager/WAL/b-tree, MVCC/transactions,
-and sync/replication.
+**Scope.** Exhaustive comparison of the Ahtola managed engine against its
+historical Turso **v0.7.2** baseline (commit `046e9cbf6`) across all seven
+layers: **VDBE** (deep-dive priority), compilation/translate, parser/dialect,
+built-in functions, storage/pager/WAL/b-tree, MVCC/transactions, and
+sync/replication. The read-only `turso-src/` submodule now pins
+**v0.8.0-pre.7** (`277ddd050`) for browser-WASM work; use
+`git -C turso-src show v0.7.2:<path>` when reproducing citations from this
+historical analysis.
 
 **Companion artifact.** [`turso-gap-inventory.json`](./turso-gap-inventory.json) —
 the machine-readable inventory, with stable IDs for status tracking

--- a/docs/turso-gap-inventory.json
+++ b/docs/turso-gap-inventory.json
@@ -7,7 +7,7 @@
       "repo": "tursodatabase/turso",
       "tag": "v0.7.2",
       "commit": "046e9cbf6",
-      "submodule": "turso-src/ (read-only)"
+      "submodule": "historical analysis baseline; current read-only submodule is v0.8.0-pre.7 (277ddd050)"
     },
     "ahtola_ref": {
       "branch": "copilot/ahtola-turso-gap-analysis",

--- a/docs/wal-interoperability-contract.md
+++ b/docs/wal-interoperability-contract.md
@@ -266,6 +266,18 @@ and is only refreshed on pooling reset.
   installation.
 - Any of these failures transitions the pager to `SqlitePagerState.Faulted`. The
   pager never silently re-reads a database that changed underneath it.
+- `SqlitePagerLockManager.WalPublicationBoundary` is a second process-local signal,
+  used only by `AsyncSqlitePager`. A commit-bearing frame reaches the WAL file
+  before its durable flush returns, so the committing writer lowers the boundary to
+  the last published frame before appending and raises it again only after the
+  flush, the post-flush scan, and the committed-view publication have all
+  succeeded. Reader scans stop at the boundary, so a concurrent async reader on the
+  same database never adopts a transaction that is still in flight or that failed
+  to become durable. The boundary constrains visibility only; it never changes WAL
+  bytes, and it resets to unbounded on create, open, checkpoint, WAL tail recovery,
+  and whenever a new writer takes the writer lock, so a peer process — or a
+  reopened pager — still derives visibility from the file exactly as
+  §1.8 describes.
 
 ### 1.8 Recovery and handoff today
 

--- a/samples/BrowserWasmConsumer/App.razor
+++ b/samples/BrowserWasmConsumer/App.razor
@@ -42,6 +42,9 @@
             }
             var persistentCore = await RunPersistentCoreAsync();
             var persistentFeatures = await RunPersistentFeaturesAsync();
+            var persistentBlob = await RunPersistentBlobAsync();
+            var persistentBackup = await RunPersistentBackupAsync();
+            var persistentInboundBackup = await RunPersistentInboundBackupAsync();
             status =
                 $"PASS:capabilities={capabilities.IsSupported};"
                 + $"storage={storage.Succeeded};"
@@ -49,7 +52,10 @@
                 + $"ado={ado};ef={ef};"
                 + $"persistent-ado={persistentAdo};persistent-ef={persistentEf};"
                 + $"persistent-core={persistentCore};"
-                + $"persistent-features={persistentFeatures}";
+                + $"persistent-features={persistentFeatures};"
+                + $"persistent-blob={persistentBlob};"
+                + $"persistent-backup={persistentBackup};"
+                + $"persistent-inbound-backup={persistentInboundBackup}";
         }
         catch (Exception exception)
         {
@@ -208,6 +214,93 @@
                 "SELECT value FROM local_probe",
                 "read local");
             return attached + local;
+        }
+    }
+
+    private static async Task<string> RunPersistentBlobAsync()
+    {
+        const string path = "packed-consumer-blob/main.db";
+        await using (var source = new AhtolaBrowserDataSource(path))
+        {
+            await using var connection = await source.OpenConnectionAsync();
+            await ExecuteFeatureAsync(
+                connection,
+                "CREATE TABLE blobs(value BLOB);"
+                + "INSERT INTO blobs(rowid, value) VALUES (1, X'01020304');",
+                "blob setup");
+            await using var blob = await connection.OpenBlobAsync("blobs", "value", 1);
+            var prefix = new byte[2];
+            if (await blob.ReadAsync(prefix) != prefix.Length)
+                throw new InvalidOperationException("Blob prefix was truncated.");
+            await blob.WriteAsync(new byte[] { 9, 8 });
+            await blob.FlushAsync();
+        }
+
+        await using (var source = new AhtolaBrowserDataSource(path))
+        {
+            await using var connection = await source.OpenConnectionAsync();
+            await using var command = connection.CreateCommand();
+            command.CommandText = "SELECT hex(value) FROM blobs WHERE rowid = 1";
+            return Convert.ToString(
+                       await command.ExecuteScalarAsync(),
+                       CultureInfo.InvariantCulture)
+                   ?? string.Empty;
+        }
+    }
+
+    private static async Task<long> RunPersistentBackupAsync()
+    {
+        const string sourcePath = "packed-consumer-backup/source.db";
+        const string destinationPath = "packed-consumer-backup-destination/main.db";
+        await using (var sourceDataSource = new AhtolaBrowserDataSource(sourcePath))
+        await using (var destinationDataSource = new AhtolaBrowserDataSource(destinationPath))
+        {
+            await using var source = await sourceDataSource.OpenConnectionAsync();
+            await using var destination = destinationDataSource.CreateConnection();
+            await ExecuteFeatureAsync(
+                source,
+                "CREATE TABLE probe(value INTEGER NOT NULL);"
+                + "INSERT INTO probe(value) VALUES (336);",
+                "backup setup");
+            await source.BackupDatabaseAsync(destination);
+        }
+
+        await using (var source = new AhtolaBrowserDataSource(destinationPath))
+        {
+            await using var connection = await source.OpenConnectionAsync();
+            await using var command = connection.CreateCommand();
+            command.CommandText = "SELECT value FROM probe";
+            return Convert.ToInt64(
+                await command.ExecuteScalarAsync(),
+                CultureInfo.InvariantCulture);
+        }
+    }
+
+    private static async Task<long> RunPersistentInboundBackupAsync()
+    {
+        const string destinationPath = "packed-consumer-inbound-backup/main.db";
+        await using (var source = new SqliteConnection(
+                         "Data Source=:memory:;Local Provider=Managed;Pooling=False"))
+        await using (var destinationDataSource = new AhtolaBrowserDataSource(destinationPath))
+        {
+            await source.OpenAsync();
+            await using var destination = destinationDataSource.CreateConnection();
+            await ExecuteFeatureAsync(
+                source,
+                "CREATE TABLE probe(value INTEGER NOT NULL);"
+                + "INSERT INTO probe(value) VALUES (378);",
+                "inbound backup setup");
+            await source.BackupDatabaseAsync(destination);
+        }
+
+        await using (var source = new AhtolaBrowserDataSource(destinationPath))
+        {
+            await using var connection = await source.OpenConnectionAsync();
+            await using var command = connection.CreateCommand();
+            command.CommandText = "SELECT value FROM probe";
+            return Convert.ToInt64(
+                await command.ExecuteScalarAsync(),
+                CultureInfo.InvariantCulture);
         }
     }
 

--- a/samples/BrowserWasmConsumer/App.razor
+++ b/samples/BrowserWasmConsumer/App.razor
@@ -1,4 +1,5 @@
 @using System.Globalization
+@using Ahtola
 @using Ahtola.Data.Sqlite
 @using Microsoft.EntityFrameworkCore
 
@@ -45,6 +46,10 @@
             var persistentBlob = await RunPersistentBlobAsync();
             var persistentBackup = await RunPersistentBackupAsync();
             var persistentInboundBackup = await RunPersistentInboundBackupAsync();
+            var persistentEncrypted = await RunPersistentEncryptedAsync();
+            var persistentEncryptedPassword = await RunPersistentEncryptedPasswordAsync();
+            var encryptedWrongKeyRejected = await RunEncryptedWrongKeyAsync();
+            var encryptedCipherMismatchRejected = await RunEncryptedCipherMismatchAsync();
             status =
                 $"PASS:capabilities={capabilities.IsSupported};"
                 + $"storage={storage.Succeeded};"
@@ -55,7 +60,11 @@
                 + $"persistent-features={persistentFeatures};"
                 + $"persistent-blob={persistentBlob};"
                 + $"persistent-backup={persistentBackup};"
-                + $"persistent-inbound-backup={persistentInboundBackup}";
+                + $"persistent-inbound-backup={persistentInboundBackup};"
+                + $"persistent-encrypted={persistentEncrypted};"
+                + $"persistent-encrypted-password={persistentEncryptedPassword};"
+                + $"encrypted-wrong-key-rejected={encryptedWrongKeyRejected};"
+                + $"encrypted-cipher-mismatch-rejected={encryptedCipherMismatchRejected}";
         }
         catch (Exception exception)
         {
@@ -304,6 +313,158 @@
         }
     }
 
+    private static async Task<long> RunPersistentEncryptedAsync()
+    {
+        const string path = "packed-consumer-encrypted/main.db";
+        const string hexKey = "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F";
+
+        using (var encryption = AhtolaBrowserEncryptionOptions.FromHex(
+                   AhtolaEncryptionCipher.Aes256Gcm,
+                   hexKey))
+        using (var options = new AhtolaBrowserOptions(path, encryption: encryption))
+        {
+            if (options.ConnectionString.Contains(hexKey, StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException("The connection string leaked encryption key material.");
+
+            await using var source = new AhtolaBrowserDataSource(options);
+            await using var connection = await source.OpenConnectionAsync();
+            await ExecuteFeatureAsync(
+                connection,
+                "CREATE TABLE probe(value INTEGER NOT NULL);"
+                + "INSERT INTO probe(value) VALUES (420);",
+                "encrypted setup");
+        }
+
+        using (var encryption = AhtolaBrowserEncryptionOptions.FromHex(
+                   AhtolaEncryptionCipher.Aes256Gcm,
+                   hexKey))
+        using (var options = new AhtolaBrowserOptions(path, encryption: encryption))
+        {
+            await using var source = new AhtolaBrowserDataSource(options);
+            await using var connection = await source.OpenConnectionAsync();
+            await using var command = connection.CreateCommand();
+            command.CommandText = "SELECT value FROM probe";
+            return Convert.ToInt64(
+                await command.ExecuteScalarAsync(),
+                CultureInfo.InvariantCulture);
+        }
+    }
+
+    private static async Task<long> RunPersistentEncryptedPasswordAsync()
+    {
+        const string path = "packed-consumer-encrypted-password/main.db";
+        const string password = "packed-consumer-passphrase";
+
+        using (var encryption = AhtolaBrowserEncryptionOptions.FromPassword(password))
+        using (var options = new AhtolaBrowserOptions(path, encryption: encryption))
+        {
+            if (options.ConnectionString.Contains(password, StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException("The connection string leaked the passphrase.");
+
+            await using var source = new AhtolaBrowserDataSource(options);
+            await using var connection = await source.OpenConnectionAsync();
+            await ExecuteFeatureAsync(
+                connection,
+                "CREATE TABLE probe(value INTEGER NOT NULL);"
+                + "INSERT INTO probe(value) VALUES (462);",
+                "encrypted password setup");
+        }
+
+        using (var encryption = AhtolaBrowserEncryptionOptions.FromPassword(password))
+        using (var options = new AhtolaBrowserOptions(path, encryption: encryption))
+        {
+            await using var source = new AhtolaBrowserDataSource(options);
+            await using var connection = await source.OpenConnectionAsync();
+            await using var command = connection.CreateCommand();
+            command.CommandText = "SELECT value FROM probe";
+            return Convert.ToInt64(
+                await command.ExecuteScalarAsync(),
+                CultureInfo.InvariantCulture);
+        }
+    }
+
+    private static async Task<bool> RunEncryptedWrongKeyAsync()
+    {
+        const string path = "packed-consumer-encrypted-wrong-key/main.db";
+        using (var encryption = AhtolaBrowserEncryptionOptions.FromPassword("first-passphrase"))
+        using (var options = new AhtolaBrowserOptions(path, encryption: encryption))
+        {
+            await using var source = new AhtolaBrowserDataSource(options);
+            await using var connection = await source.OpenConnectionAsync();
+            await ExecuteFeatureAsync(
+                connection,
+                "CREATE TABLE probe(value INTEGER NOT NULL);"
+                + "INSERT INTO probe(value) VALUES (504);",
+                "wrong-key setup");
+        }
+
+        using var wrong = AhtolaBrowserEncryptionOptions.FromPassword("second-passphrase");
+        using var wrongOptions = new AhtolaBrowserOptions(path, encryption: wrong);
+        try
+        {
+            await using var source = new AhtolaBrowserDataSource(wrongOptions);
+            await using var connection = await source.OpenConnectionAsync();
+            return false;
+        }
+        catch (Exception exception) when (IsEncryptionRejection(exception))
+        {
+            return true;
+        }
+    }
+
+    private static async Task<bool> RunEncryptedCipherMismatchAsync()
+    {
+        const string path = "packed-consumer-encrypted-cipher/main.db";
+        const string aes256Key = "0F0E0D0C0B0A09080706050403020100F0E0D0C0B0A090807060504030201000";
+        const string aes128Key = "0F0E0D0C0B0A09080706050403020100";
+
+        using (var encryption = AhtolaBrowserEncryptionOptions.FromHex(
+                   AhtolaEncryptionCipher.Aes256Gcm,
+                   aes256Key))
+        using (var options = new AhtolaBrowserOptions(path, encryption: encryption))
+        {
+            await using var source = new AhtolaBrowserDataSource(options);
+            await using var connection = await source.OpenConnectionAsync();
+            await ExecuteFeatureAsync(
+                connection,
+                "CREATE TABLE probe(value INTEGER NOT NULL);"
+                + "INSERT INTO probe(value) VALUES (546);",
+                "cipher mismatch setup");
+        }
+
+        // The AHTLA header records the cipher id, so opening an AES-256 database
+        // with AES-256 key material of the wrong cipher must fail closed instead
+        // of silently falling back.
+        using var mismatched = AhtolaBrowserEncryptionOptions.FromHex(
+            AhtolaEncryptionCipher.Aes128Gcm,
+            aes128Key);
+        using var mismatchedOptions = new AhtolaBrowserOptions(path, encryption: mismatched);
+        try
+        {
+            await using var source = new AhtolaBrowserDataSource(mismatchedOptions);
+            await using var connection = await source.OpenConnectionAsync();
+            return false;
+        }
+        catch (Exception exception) when (IsEncryptionRejection(exception))
+        {
+            return true;
+        }
+    }
+
+    /// Encrypted-open failures surface as InvalidDataException wrapping the
+    /// Web Crypto CryptographicException, so the whole chain must be inspected
+    /// rather than only the innermost JSException.
+    private static bool IsEncryptionRejection(Exception exception)
+    {
+        for (var current = exception; current is not null; current = current.InnerException)
+        {
+            if (current is InvalidDataException or System.Security.Cryptography.CryptographicException)
+                return true;
+        }
+
+        return false;
+    }
+
     private static async Task ExecuteFeatureAsync(
         SqliteConnection connection,
         string sql,
@@ -353,3 +514,4 @@
         public long Value { get; set; }
     }
 }
+

--- a/samples/BrowserWasmConsumer/App.razor
+++ b/samples/BrowserWasmConsumer/App.razor
@@ -43,6 +43,7 @@
             }
             var persistentCore = await RunPersistentCoreAsync();
             var persistentFeatures = await RunPersistentFeaturesAsync();
+            var browserMemory = await RunBrowserMemoryAsync();
             var persistentBlob = await RunPersistentBlobAsync();
             var persistentBackup = await RunPersistentBackupAsync();
             var persistentInboundBackup = await RunPersistentInboundBackupAsync();
@@ -58,6 +59,7 @@
                 + $"persistent-ado={persistentAdo};persistent-ef={persistentEf};"
                 + $"persistent-core={persistentCore};"
                 + $"persistent-features={persistentFeatures};"
+                + $"browser-memory={browserMemory};"
                 + $"persistent-blob={persistentBlob};"
                 + $"persistent-backup={persistentBackup};"
                 + $"persistent-inbound-backup={persistentInboundBackup};"
@@ -205,6 +207,28 @@
             await ExecuteFeatureAsync(connection, "INSERT INTO local_probe(value) VALUES (294)", "insert concurrent");
             await ExecuteFeatureAsync(connection, "COMMIT", "commit concurrent");
             await ExecuteFeatureAsync(connection, "VACUUM", "vacuum");
+        }
+
+        private static async Task<long> RunBrowserMemoryAsync()
+        {
+            await using var source = new AhtolaBrowserDataSource(":memory:");
+            await using (var connection = await source.OpenConnectionAsync())
+            {
+                await ExecuteFeatureAsync(
+                    connection,
+                    "CREATE TABLE probe(value INTEGER NOT NULL);"
+                    + "INSERT INTO probe(value) VALUES (504);",
+                    "browser memory setup");
+            }
+
+            await using (var connection = await source.OpenConnectionAsync())
+            {
+                await using var command = connection.CreateCommand();
+                command.CommandText = "SELECT value FROM probe";
+                return Convert.ToInt64(
+                    await command.ExecuteScalarAsync(),
+                    CultureInfo.InvariantCulture);
+            }
         }
 
         await using (var source = new AhtolaBrowserDataSource(mainPath))
@@ -514,4 +538,3 @@
         public long Value { get; set; }
     }
 }
-

--- a/samples/BrowserWasmConsumer/App.razor
+++ b/samples/BrowserWasmConsumer/App.razor
@@ -22,15 +22,39 @@
             var crypto = await AhtolaBrowserCryptoDiagnostics.RunKnownAnswersAsync();
             var ado = await RunAdoAsync();
             var ef = await RunEfAsync();
+            long persistentAdo;
+            try
+            {
+                persistentAdo = await RunPersistentAdoAsync();
+            }
+            catch (Exception exception)
+            {
+                throw new InvalidOperationException("persistent-ado failed", exception);
+            }
+            long persistentEf;
+            try
+            {
+                persistentEf = await RunPersistentEfAsync();
+            }
+            catch (Exception exception)
+            {
+                throw new InvalidOperationException("persistent-ef failed", exception);
+            }
+            var persistentCore = await RunPersistentCoreAsync();
             status =
                 $"PASS:capabilities={capabilities.IsSupported};"
                 + $"storage={storage.Succeeded};"
                 + $"crypto={crypto.Succeeded};"
-                + $"ado={ado};ef={ef}";
+                + $"ado={ado};ef={ef};"
+                + $"persistent-ado={persistentAdo};persistent-ef={persistentEf};"
+                + $"persistent-core={persistentCore}";
         }
         catch (Exception exception)
         {
-            status = $"FAIL:{exception.GetType().Name}:{exception.Message}";
+            var root = exception.GetBaseException();
+            status =
+                $"FAIL:{exception.GetType().Name}:{exception.Message}:"
+                + $"{root.GetType().Name}:{root.Message}";
         }
 
         StateHasChanged();
@@ -62,6 +86,88 @@
         context.Rows.Add(new ProbeRow { Value = 84 });
         await context.SaveChangesAsync();
         return await context.Rows.Select(static row => row.Value).SingleAsync();
+    }
+
+    private static async Task<long> RunPersistentAdoAsync()
+    {
+        const string path = "packed-consumer/ado.db";
+        await using (var source = new AhtolaBrowserDataSource(path))
+        {
+            await using var connection = await source.OpenConnectionAsync();
+            await using var command = connection.CreateCommand();
+            command.CommandText = """
+                CREATE TABLE probe(value INTEGER NOT NULL);
+                INSERT INTO probe(value) VALUES (126);
+                """;
+            await command.ExecuteNonQueryAsync();
+        }
+
+        await using (var source = new AhtolaBrowserDataSource(path))
+        {
+            await using var connection = await source.OpenConnectionAsync();
+            await using var command = connection.CreateCommand();
+            command.CommandText = "SELECT value FROM probe";
+            return Convert.ToInt64(
+                await command.ExecuteScalarAsync(),
+                CultureInfo.InvariantCulture);
+        }
+    }
+
+    private static async Task<long> RunPersistentEfAsync()
+    {
+        const string path = "packed-consumer-ef/main.db";
+        await using (var source = new AhtolaBrowserDataSource(path))
+        {
+            await using var connection = await source.OpenConnectionAsync();
+            var options = new DbContextOptionsBuilder<ProbeContext>()
+                .UseAhtola(connection)
+                .Options;
+            await using var context = new ProbeContext(options);
+            await context.Database.EnsureCreatedAsync();
+            context.Rows.Add(new ProbeRow { Value = 168 });
+            await context.SaveChangesAsync();
+        }
+
+        await using (var source = new AhtolaBrowserDataSource(path))
+        {
+            await using var connection = await source.OpenConnectionAsync();
+            var options = new DbContextOptionsBuilder<ProbeContext>()
+                .UseAhtola(connection)
+                .Options;
+            await using var context = new ProbeContext(options);
+            return await context.Rows.Select(static row => row.Value).SingleAsync();
+        }
+    }
+
+    private static async Task<long> RunPersistentCoreAsync()
+    {
+        const string path = "packed-consumer-core/main.db";
+        await using (var source = new AhtolaBrowserDataSource(path))
+        {
+            await using var connection = source.CreateAhtolaConnection();
+            await connection.OpenAsync();
+            await using (var create = connection.CreateCommand())
+            {
+                create.CommandText = "CREATE TABLE probe(value INTEGER NOT NULL)";
+                await create.ExecuteNonQueryAsync();
+            }
+            await using (var insert = connection.CreateCommand())
+            {
+                insert.CommandText = "INSERT INTO probe(value) VALUES (210)";
+                await insert.ExecuteNonQueryAsync();
+            }
+        }
+
+        await using (var source = new AhtolaBrowserDataSource(path))
+        {
+            await using var connection = source.CreateAhtolaConnection();
+            await connection.OpenAsync();
+            await using var command = connection.CreateCommand();
+            command.CommandText = "SELECT value FROM probe";
+            return Convert.ToInt64(
+                await command.ExecuteScalarAsync(),
+                CultureInfo.InvariantCulture);
+        }
     }
 
     private sealed class ProbeContext(DbContextOptions<ProbeContext> options) : DbContext(options)

--- a/samples/BrowserWasmConsumer/App.razor
+++ b/samples/BrowserWasmConsumer/App.razor
@@ -1,0 +1,78 @@
+@using System.Globalization
+@using Ahtola.Data.Sqlite
+@using Microsoft.EntityFrameworkCore
+
+<PageTitle>Ahtola browser package consumer</PageTitle>
+
+<h1>Ahtola browser package consumer</h1>
+<p id="browser-test-status">@status</p>
+
+@code {
+    private string status = "pending";
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+            return;
+
+        try
+        {
+            var capabilities = await AhtolaBrowserRuntime.GetCapabilitiesAsync();
+            var storage = await AhtolaBrowserStorageDiagnostics.RunAsync();
+            var crypto = await AhtolaBrowserCryptoDiagnostics.RunKnownAnswersAsync();
+            var ado = await RunAdoAsync();
+            var ef = await RunEfAsync();
+            status =
+                $"PASS:capabilities={capabilities.IsSupported};"
+                + $"storage={storage.Succeeded};"
+                + $"crypto={crypto.Succeeded};"
+                + $"ado={ado};ef={ef}";
+        }
+        catch (Exception exception)
+        {
+            status = $"FAIL:{exception.GetType().Name}:{exception.Message}";
+        }
+
+        StateHasChanged();
+    }
+
+    private static async Task<long> RunAdoAsync()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:;Mode=Memory");
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            CREATE TABLE probe(value INTEGER NOT NULL);
+            INSERT INTO probe(value) VALUES (42);
+            SELECT value FROM probe;
+            """;
+        var result = await command.ExecuteScalarAsync();
+        return Convert.ToInt64(result, CultureInfo.InvariantCulture);
+    }
+
+    private static async Task<long> RunEfAsync()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:;Mode=Memory");
+        await connection.OpenAsync();
+        var options = new DbContextOptionsBuilder<ProbeContext>()
+            .UseAhtola(connection)
+            .Options;
+        await using var context = new ProbeContext(options);
+        await context.Database.EnsureCreatedAsync();
+        context.Rows.Add(new ProbeRow { Value = 84 });
+        await context.SaveChangesAsync();
+        return await context.Rows.Select(static row => row.Value).SingleAsync();
+    }
+
+    private sealed class ProbeContext(DbContextOptions<ProbeContext> options) : DbContext(options)
+    {
+        public DbSet<ProbeRow> Rows => Set<ProbeRow>();
+    }
+
+    private sealed class ProbeRow
+    {
+        public int Id { get; set; }
+
+        public long Value { get; set; }
+    }
+}

--- a/samples/BrowserWasmConsumer/App.razor
+++ b/samples/BrowserWasmConsumer/App.razor
@@ -48,6 +48,7 @@
             var persistentBackup = await RunPersistentBackupAsync();
             var persistentInboundBackup = await RunPersistentInboundBackupAsync();
             var persistentEncrypted = await RunPersistentEncryptedAsync();
+            var encryptedMaintenance = await RunEncryptedMaintenanceAsync();
             var persistentEncryptedPassword = await RunPersistentEncryptedPasswordAsync();
             var encryptedWrongKeyRejected = await RunEncryptedWrongKeyAsync();
             var encryptedCipherMismatchRejected = await RunEncryptedCipherMismatchAsync();
@@ -64,6 +65,7 @@
                 + $"persistent-backup={persistentBackup};"
                 + $"persistent-inbound-backup={persistentInboundBackup};"
                 + $"persistent-encrypted={persistentEncrypted};"
+                + $"encrypted-maintenance={encryptedMaintenance};"
                 + $"persistent-encrypted-password={persistentEncryptedPassword};"
                 + $"encrypted-wrong-key-rejected={encryptedWrongKeyRejected};"
                 + $"encrypted-cipher-mismatch-rejected={encryptedCipherMismatchRejected}";
@@ -372,6 +374,79 @@
                 await command.ExecuteScalarAsync(),
                 CultureInfo.InvariantCulture);
         }
+    }
+
+    private static async Task<long> RunEncryptedMaintenanceAsync()
+    {
+        const string ownedDirectory = "packed-consumer-encrypted-maintenance";
+        const string path = ownedDirectory + "/main.db";
+        const string vacuumPath = ownedDirectory + "/vacuum.db";
+        const string hexKey = "101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F";
+
+        using (var encryption = AhtolaBrowserEncryptionOptions.FromHex(
+                   AhtolaEncryptionCipher.Aes256Gcm,
+                   hexKey))
+        using (var options = new AhtolaBrowserOptions(
+                   path,
+                   ownedDirectory,
+                   encryption: encryption))
+        {
+            await using var source = new AhtolaBrowserDataSource(options);
+            await using var connection = await source.OpenConnectionAsync();
+            await ExecuteFeatureAsync(
+                connection,
+                "CREATE TABLE probe(value INTEGER NOT NULL);"
+                + "INSERT INTO probe(value) VALUES (588);"
+                + "PRAGMA journal_mode=DELETE;"
+                + "PRAGMA page_size=8192;"
+                + "VACUUM;",
+                "encrypted page-size migration");
+            await ExecuteFeatureAsync(
+                connection,
+                $"VACUUM INTO '{vacuumPath}';",
+                "encrypted vacuum into");
+        }
+
+        long mainValue;
+        long pageSize;
+        using (var encryption = AhtolaBrowserEncryptionOptions.FromHex(
+                   AhtolaEncryptionCipher.Aes256Gcm,
+                   hexKey))
+        using (var options = new AhtolaBrowserOptions(
+                   path,
+                   ownedDirectory,
+                   encryption: encryption))
+        {
+            await using var source = new AhtolaBrowserDataSource(options);
+            await using var connection = await source.OpenConnectionAsync();
+            mainValue = await ExecuteScalarFeatureAsync(
+                connection,
+                "SELECT value FROM probe",
+                "read migrated encrypted database");
+            pageSize = await ExecuteScalarFeatureAsync(
+                connection,
+                "PRAGMA page_size",
+                "read migrated encrypted page size");
+        }
+
+        long vacuumValue;
+        using (var encryption = AhtolaBrowserEncryptionOptions.FromHex(
+                   AhtolaEncryptionCipher.Aes256Gcm,
+                   hexKey))
+        using (var options = new AhtolaBrowserOptions(
+                   vacuumPath,
+                   ownedDirectory,
+                   encryption: encryption))
+        {
+            await using var source = new AhtolaBrowserDataSource(options);
+            await using var connection = await source.OpenConnectionAsync();
+            vacuumValue = await ExecuteScalarFeatureAsync(
+                connection,
+                "SELECT value FROM probe",
+                "read encrypted vacuum destination");
+        }
+
+        return mainValue + pageSize + vacuumValue;
     }
 
     private static async Task<long> RunPersistentEncryptedPasswordAsync()

--- a/samples/BrowserWasmConsumer/App.razor
+++ b/samples/BrowserWasmConsumer/App.razor
@@ -44,6 +44,8 @@
             var persistentCore = await RunPersistentCoreAsync();
             var persistentFeatures = await RunPersistentFeaturesAsync();
             var browserMemory = await RunBrowserMemoryAsync();
+            var reservedPathRejected = await RunReservedPathRejectedAsync();
+            var workerIsolation = await RunWorkerIsolationAsync();
             var persistentBlob = await RunPersistentBlobAsync();
             var persistentBackup = await RunPersistentBackupAsync();
             var persistentInboundBackup = await RunPersistentInboundBackupAsync();
@@ -61,6 +63,8 @@
                 + $"persistent-core={persistentCore};"
                 + $"persistent-features={persistentFeatures};"
                 + $"browser-memory={browserMemory};"
+                + $"reserved-path-rejected={reservedPathRejected};"
+                + $"worker-isolation={workerIsolation};"
                 + $"persistent-blob={persistentBlob};"
                 + $"persistent-backup={persistentBackup};"
                 + $"persistent-inbound-backup={persistentInboundBackup};"
@@ -250,6 +254,42 @@
                 await command.ExecuteScalarAsync(),
                 CultureInfo.InvariantCulture);
         }
+    }
+
+    private static async Task<bool> RunReservedPathRejectedAsync()
+    {
+        try
+        {
+            await using var source = new AhtolaBrowserDataSource(
+                "packed-consumer-reserved/.ahtola-replace-user.db",
+                "packed-consumer-reserved");
+            await using var connection = await source.OpenConnectionAsync();
+            return false;
+        }
+        catch (ArgumentException exception) when (
+            exception.Message.Contains(".ahtola-replace-", StringComparison.Ordinal))
+        {
+            return true;
+        }
+    }
+
+    private static async Task<long> RunWorkerIsolationAsync()
+    {
+        // These names collide under the old 32-bit FNV-1a intent-slot hash.
+        await using var firstSource = new AhtolaBrowserDataSource("tenant-97018/main.db");
+        await using var secondSource = new AhtolaBrowserDataSource("tenant-180400/main.db");
+        await using var first = await firstSource.OpenConnectionAsync();
+        await using var second = await secondSource.OpenConnectionAsync();
+        await ExecuteFeatureAsync(
+            first,
+            "CREATE TABLE probe(value INTEGER NOT NULL); INSERT INTO probe VALUES (1);",
+            "first collision-isolation database");
+        await ExecuteFeatureAsync(
+            second,
+            "CREATE TABLE probe(value INTEGER NOT NULL); INSERT INTO probe VALUES (2);",
+            "second collision-isolation database");
+        return await ExecuteScalarFeatureAsync(first, "SELECT value FROM probe", "read first isolated database")
+               + await ExecuteScalarFeatureAsync(second, "SELECT value FROM probe", "read second isolated database");
     }
 
     private static async Task<string> RunPersistentBlobAsync()

--- a/samples/BrowserWasmConsumer/App.razor
+++ b/samples/BrowserWasmConsumer/App.razor
@@ -209,28 +209,6 @@
             await ExecuteFeatureAsync(connection, "VACUUM", "vacuum");
         }
 
-        private static async Task<long> RunBrowserMemoryAsync()
-        {
-            await using var source = new AhtolaBrowserDataSource(":memory:");
-            await using (var connection = await source.OpenConnectionAsync())
-            {
-                await ExecuteFeatureAsync(
-                    connection,
-                    "CREATE TABLE probe(value INTEGER NOT NULL);"
-                    + "INSERT INTO probe(value) VALUES (504);",
-                    "browser memory setup");
-            }
-
-            await using (var connection = await source.OpenConnectionAsync())
-            {
-                await using var command = connection.CreateCommand();
-                command.CommandText = "SELECT value FROM probe";
-                return Convert.ToInt64(
-                    await command.ExecuteScalarAsync(),
-                    CultureInfo.InvariantCulture);
-            }
-        }
-
         await using (var source = new AhtolaBrowserDataSource(mainPath))
         {
             await using var connection = await source.OpenConnectionAsync();
@@ -247,6 +225,28 @@
                 "SELECT value FROM local_probe",
                 "read local");
             return attached + local;
+        }
+    }
+
+    private static async Task<long> RunBrowserMemoryAsync()
+    {
+        await using var source = new AhtolaBrowserDataSource(":memory:");
+        await using (var connection = await source.OpenConnectionAsync())
+        {
+            await ExecuteFeatureAsync(
+                connection,
+                "CREATE TABLE probe(value INTEGER NOT NULL);"
+                + "INSERT INTO probe(value) VALUES (504);",
+                "browser memory setup");
+        }
+
+        await using (var connection = await source.OpenConnectionAsync())
+        {
+            await using var command = connection.CreateCommand();
+            command.CommandText = "SELECT value FROM probe";
+            return Convert.ToInt64(
+                await command.ExecuteScalarAsync(),
+                CultureInfo.InvariantCulture);
         }
     }
 

--- a/samples/BrowserWasmConsumer/App.razor
+++ b/samples/BrowserWasmConsumer/App.razor
@@ -41,13 +41,15 @@
                 throw new InvalidOperationException("persistent-ef failed", exception);
             }
             var persistentCore = await RunPersistentCoreAsync();
+            var persistentFeatures = await RunPersistentFeaturesAsync();
             status =
                 $"PASS:capabilities={capabilities.IsSupported};"
                 + $"storage={storage.Succeeded};"
                 + $"crypto={crypto.Succeeded};"
                 + $"ado={ado};ef={ef};"
                 + $"persistent-ado={persistentAdo};persistent-ef={persistentEf};"
-                + $"persistent-core={persistentCore}";
+                + $"persistent-core={persistentCore};"
+                + $"persistent-features={persistentFeatures}";
         }
         catch (Exception exception)
         {
@@ -151,6 +153,7 @@
                 create.CommandText = "CREATE TABLE probe(value INTEGER NOT NULL)";
                 await create.ExecuteNonQueryAsync();
             }
+
             await using (var insert = connection.CreateCommand())
             {
                 insert.CommandText = "INSERT INTO probe(value) VALUES (210)";
@@ -167,6 +170,81 @@
             return Convert.ToInt64(
                 await command.ExecuteScalarAsync(),
                 CultureInfo.InvariantCulture);
+        }
+    }
+
+    private static async Task<long> RunPersistentFeaturesAsync()
+    {
+        const string mainPath = "packed-consumer-features/main.db";
+        const string attachedPath = "packed-consumer-features/attached.db";
+        await using (var source = new AhtolaBrowserDataSource(mainPath))
+        {
+            await using var connection = await source.OpenConnectionAsync();
+            await ExecuteFeatureAsync(connection, $"ATTACH DATABASE '{attachedPath}' AS aux", "attach");
+            await ExecuteFeatureAsync(connection, "CREATE TABLE aux.probe(value INTEGER NOT NULL)", "create attached");
+            await ExecuteFeatureAsync(connection, "INSERT INTO aux.probe(value) VALUES (252)", "insert attached");
+            await ExecuteFeatureAsync(connection, "CREATE TABLE local_probe(value INTEGER NOT NULL)", "create local");
+            await ExecuteFeatureAsync(connection, "PRAGMA main.journal_mode = mvcc", "main mvcc");
+            await ExecuteFeatureAsync(connection, "PRAGMA aux.journal_mode = mvcc", "attached mvcc");
+            await ExecuteFeatureAsync(connection, "BEGIN CONCURRENT", "begin concurrent");
+            await ExecuteFeatureAsync(connection, "INSERT INTO local_probe(value) VALUES (294)", "insert concurrent");
+            await ExecuteFeatureAsync(connection, "COMMIT", "commit concurrent");
+            await ExecuteFeatureAsync(connection, "VACUUM", "vacuum");
+        }
+
+        await using (var source = new AhtolaBrowserDataSource(mainPath))
+        {
+            await using var connection = await source.OpenConnectionAsync();
+            await ExecuteFeatureAsync(
+                connection,
+                $"ATTACH DATABASE '{attachedPath}' AS aux",
+                "reopen attach");
+            var attached = await ExecuteScalarFeatureAsync(
+                connection,
+                "SELECT value FROM aux.probe",
+                "read attached");
+            var local = await ExecuteScalarFeatureAsync(
+                connection,
+                "SELECT value FROM local_probe",
+                "read local");
+            return attached + local;
+        }
+    }
+
+    private static async Task ExecuteFeatureAsync(
+        SqliteConnection connection,
+        string sql,
+        string phase)
+    {
+        try
+        {
+            await using var command = connection.CreateCommand();
+            command.CommandText = sql;
+            await command.ExecuteNonQueryAsync();
+        }
+
+        catch (Exception exception)
+        {
+            throw new InvalidOperationException($"persistent feature phase '{phase}' failed", exception);
+        }
+    }
+
+    private static async Task<long> ExecuteScalarFeatureAsync(
+        SqliteConnection connection,
+        string sql,
+        string phase)
+    {
+        try
+        {
+            await using var command = connection.CreateCommand();
+            command.CommandText = sql;
+            return Convert.ToInt64(
+                await command.ExecuteScalarAsync(),
+                CultureInfo.InvariantCulture);
+        }
+        catch (Exception exception)
+        {
+            throw new InvalidOperationException($"persistent feature phase '{phase}' failed", exception);
         }
     }
 

--- a/samples/BrowserWasmConsumer/BrowserWasmConsumer.csproj
+++ b/samples/BrowserWasmConsumer/BrowserWasmConsumer.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
+    <AhtolaPackageVersion Condition="'$(AhtolaPackageVersion)' == ''">0.0.0-managed-local</AhtolaPackageVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Devolutions.Ahtola.Data.Sqlite.Browser" Version="$(AhtolaPackageVersion)" />
+    <PackageReference Include="Devolutions.Ahtola.EntityFrameworkCore.Sqlite" Version="$(AhtolaPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
+  </ItemGroup>
+</Project>

--- a/samples/BrowserWasmConsumer/Program.cs
+++ b/samples/BrowserWasmConsumer/Program.cs
@@ -1,0 +1,6 @@
+using BrowserWasmConsumer;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+builder.RootComponents.Add<App>("#app");
+await builder.Build().RunAsync();

--- a/samples/BrowserWasmConsumer/_Imports.razor
+++ b/samples/BrowserWasmConsumer/_Imports.razor
@@ -1,0 +1,3 @@
+@using Ahtola.Data.Sqlite.Browser
+@using BrowserWasmConsumer
+@using Microsoft.AspNetCore.Components.Web

--- a/samples/BrowserWasmConsumer/serve.mjs
+++ b/samples/BrowserWasmConsumer/serve.mjs
@@ -1,0 +1,40 @@
+import fs from "node:fs";
+import http from "node:http";
+import path from "node:path";
+import process from "node:process";
+
+const root = path.resolve(process.argv[2]);
+const port = Number(process.argv[3] ?? 8123);
+const contentTypes = new Map([
+    [".css", "text/css"],
+    [".dll", "application/octet-stream"],
+    [".html", "text/html"],
+    [".js", "text/javascript"],
+    [".json", "application/json"],
+    [".mjs", "text/javascript"],
+    [".wasm", "application/wasm"],
+]);
+
+const server = http.createServer((request, response) => {
+    const requestPath = decodeURIComponent(
+        new URL(request.url, `http://${request.headers.host}`).pathname);
+    let filePath = path.join(root, requestPath === "/" ? "index.html" : requestPath);
+    if (!filePath.startsWith(root)
+        || !fs.existsSync(filePath)
+        || fs.statSync(filePath).isDirectory()) {
+        filePath = path.join(root, "index.html");
+    }
+
+    response.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+    response.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+    response.setHeader("Cross-Origin-Resource-Policy", "same-origin");
+    response.setHeader("Cache-Control", "no-store");
+    response.setHeader(
+        "Content-Type",
+        contentTypes.get(path.extname(filePath)) ?? "application/octet-stream");
+    fs.createReadStream(filePath).pipe(response);
+});
+
+server.listen(port, "127.0.0.1", () => {
+    console.log(`READY:http://127.0.0.1:${port}`);
+});

--- a/samples/BrowserWasmConsumer/wwwroot/index.html
+++ b/samples/BrowserWasmConsumer/wwwroot/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ahtola browser package consumer</title>
+    <base href="/">
+    <link rel="preload" id="webassembly">
+    <script type="importmap"></script>
+</head>
+<body>
+    <div id="app">Loading...</div>
+    <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
+</body>
+</html>

--- a/scripts/Invoke-BrowserPackageConsumer.ps1
+++ b/scripts/Invoke-BrowserPackageConsumer.ps1
@@ -125,7 +125,7 @@ try {
             $env:AHTOLA_BROWSER_EXECUTABLE = $BrowserExecutable
         }
         if ($BrowserEngine -eq 'chromium') {
-            & node $probeScript $uri 'PASS:capabilities=True;storage=True;crypto=True;ado=42;ef=84;persistent-ado=126;persistent-ef=168;persistent-core=210;persistent-features=546;browser-memory=504;persistent-blob=01020908;persistent-backup=336;persistent-inbound-backup=378;persistent-encrypted=420;persistent-encrypted-password=462;encrypted-wrong-key-rejected=True;encrypted-cipher-mismatch-rejected=True'
+            & node $probeScript $uri 'PASS:capabilities=True;storage=True;crypto=True;ado=42;ef=84;persistent-ado=126;persistent-ef=168;persistent-core=210;persistent-features=546;browser-memory=504;persistent-blob=01020908;persistent-backup=336;persistent-inbound-backup=378;persistent-encrypted=420;encrypted-maintenance=9368;persistent-encrypted-password=462;encrypted-wrong-key-rejected=True;encrypted-cipher-mismatch-rejected=True'
         } else {
             & node $playwrightProbeScript $BrowserEngine $uri 'PASS:'
         }

--- a/scripts/Invoke-BrowserPackageConsumer.ps1
+++ b/scripts/Invoke-BrowserPackageConsumer.ps1
@@ -121,7 +121,7 @@ try {
         if (-not [string]::IsNullOrWhiteSpace($BrowserExecutable)) {
             $env:AHTOLA_BROWSER_EXECUTABLE = $BrowserExecutable
         }
-        & node $probeScript $uri 'PASS:capabilities=True;storage=True;crypto=True;ado=42;ef=84;persistent-ado=126;persistent-ef=168;persistent-core=210'
+        & node $probeScript $uri 'PASS:capabilities=True;storage=True;crypto=True;ado=42;ef=84;persistent-ado=126;persistent-ef=168;persistent-core=210;persistent-features=546'
         if ($LASTEXITCODE -ne 0) {
             throw "Browser consumer probe failed with exit code $LASTEXITCODE."
         }

--- a/scripts/Invoke-BrowserPackageConsumer.ps1
+++ b/scripts/Invoke-BrowserPackageConsumer.ps1
@@ -121,7 +121,7 @@ try {
         if (-not [string]::IsNullOrWhiteSpace($BrowserExecutable)) {
             $env:AHTOLA_BROWSER_EXECUTABLE = $BrowserExecutable
         }
-        & node $probeScript $uri 'PASS:capabilities=True;storage=True;crypto=True;ado=42;ef=84;persistent-ado=126;persistent-ef=168;persistent-core=210;persistent-features=546;persistent-blob=01020908;persistent-backup=336;persistent-inbound-backup=378'
+        & node $probeScript $uri 'PASS:capabilities=True;storage=True;crypto=True;ado=42;ef=84;persistent-ado=126;persistent-ef=168;persistent-core=210;persistent-features=546;persistent-blob=01020908;persistent-backup=336;persistent-inbound-backup=378;persistent-encrypted=420;persistent-encrypted-password=462;encrypted-wrong-key-rejected=True;encrypted-cipher-mismatch-rejected=True'
         if ($LASTEXITCODE -ne 0) {
             throw "Browser consumer probe failed with exit code $LASTEXITCODE."
         }

--- a/scripts/Invoke-BrowserPackageConsumer.ps1
+++ b/scripts/Invoke-BrowserPackageConsumer.ps1
@@ -125,7 +125,7 @@ try {
             $env:AHTOLA_BROWSER_EXECUTABLE = $BrowserExecutable
         }
         if ($BrowserEngine -eq 'chromium') {
-            & node $probeScript $uri 'PASS:capabilities=True;storage=True;crypto=True;ado=42;ef=84;persistent-ado=126;persistent-ef=168;persistent-core=210;persistent-features=546;browser-memory=504;persistent-blob=01020908;persistent-backup=336;persistent-inbound-backup=378;persistent-encrypted=420;encrypted-maintenance=9368;persistent-encrypted-password=462;encrypted-wrong-key-rejected=True;encrypted-cipher-mismatch-rejected=True'
+            & node $probeScript $uri 'PASS:capabilities=True;storage=True;crypto=True;ado=42;ef=84;persistent-ado=126;persistent-ef=168;persistent-core=210;persistent-features=546;browser-memory=504;reserved-path-rejected=True;worker-isolation=3;persistent-blob=01020908;persistent-backup=336;persistent-inbound-backup=378;persistent-encrypted=420;encrypted-maintenance=9368;persistent-encrypted-password=462;encrypted-wrong-key-rejected=True;encrypted-cipher-mismatch-rejected=True'
         } else {
             & node $playwrightProbeScript $BrowserEngine $uri 'PASS:'
         }

--- a/scripts/Invoke-BrowserPackageConsumer.ps1
+++ b/scripts/Invoke-BrowserPackageConsumer.ps1
@@ -121,7 +121,7 @@ try {
         if (-not [string]::IsNullOrWhiteSpace($BrowserExecutable)) {
             $env:AHTOLA_BROWSER_EXECUTABLE = $BrowserExecutable
         }
-        & node $probeScript $uri 'PASS:capabilities=True;storage=True;crypto=True;ado=42;ef=84'
+        & node $probeScript $uri 'PASS:capabilities=True;storage=True;crypto=True;ado=42;ef=84;persistent-ado=126;persistent-ef=168;persistent-core=210'
         if ($LASTEXITCODE -ne 0) {
             throw "Browser consumer probe failed with exit code $LASTEXITCODE."
         }

--- a/scripts/Invoke-BrowserPackageConsumer.ps1
+++ b/scripts/Invoke-BrowserPackageConsumer.ps1
@@ -125,7 +125,7 @@ try {
             $env:AHTOLA_BROWSER_EXECUTABLE = $BrowserExecutable
         }
         if ($BrowserEngine -eq 'chromium') {
-            & node $probeScript $uri 'PASS:capabilities=True;storage=True;crypto=True;ado=42;ef=84;persistent-ado=126;persistent-ef=168;persistent-core=210;persistent-features=546;persistent-blob=01020908;persistent-backup=336;persistent-inbound-backup=378;persistent-encrypted=420;persistent-encrypted-password=462;encrypted-wrong-key-rejected=True;encrypted-cipher-mismatch-rejected=True'
+            & node $probeScript $uri 'PASS:capabilities=True;storage=True;crypto=True;ado=42;ef=84;persistent-ado=126;persistent-ef=168;persistent-core=210;persistent-features=546;browser-memory=504;persistent-blob=01020908;persistent-backup=336;persistent-inbound-backup=378;persistent-encrypted=420;persistent-encrypted-password=462;encrypted-wrong-key-rejected=True;encrypted-cipher-mismatch-rejected=True'
         } else {
             & node $playwrightProbeScript $BrowserEngine $uri 'PASS:'
         }

--- a/scripts/Invoke-BrowserPackageConsumer.ps1
+++ b/scripts/Invoke-BrowserPackageConsumer.ps1
@@ -6,6 +6,8 @@ param(
     [string]$Output = './artifacts/browser-wasm-consumer',
     [int]$Port = 8124,
     [string]$BrowserExecutable,
+    [ValidateSet('chromium', 'firefox', 'webkit')]
+    [string]$BrowserEngine = 'chromium',
     [switch]$RunAot
 )
 
@@ -14,6 +16,7 @@ $repoRoot = Split-Path -Parent $PSScriptRoot
 $project = Join-Path $repoRoot 'samples/BrowserWasmConsumer/BrowserWasmConsumer.csproj'
 $serverScript = Join-Path $repoRoot 'samples/BrowserWasmConsumer/serve.mjs'
 $probeScript = Join-Path $repoRoot 'scripts/Run-BrowserProbe.mjs'
+$playwrightProbeScript = Join-Path $repoRoot 'scripts/Run-PlaywrightBrowserProbe.mjs'
 $validator = Join-Path $repoRoot 'scripts/Validate-ManagedPackageClosure.ps1'
 $packageDirectory = if ([System.IO.Path]::IsPathRooted($PackageDirectory)) {
     [System.IO.Path]::GetFullPath($PackageDirectory)
@@ -121,9 +124,13 @@ try {
         if (-not [string]::IsNullOrWhiteSpace($BrowserExecutable)) {
             $env:AHTOLA_BROWSER_EXECUTABLE = $BrowserExecutable
         }
-        & node $probeScript $uri 'PASS:capabilities=True;storage=True;crypto=True;ado=42;ef=84;persistent-ado=126;persistent-ef=168;persistent-core=210;persistent-features=546;persistent-blob=01020908;persistent-backup=336;persistent-inbound-backup=378;persistent-encrypted=420;persistent-encrypted-password=462;encrypted-wrong-key-rejected=True;encrypted-cipher-mismatch-rejected=True'
+        if ($BrowserEngine -eq 'chromium') {
+            & node $probeScript $uri 'PASS:capabilities=True;storage=True;crypto=True;ado=42;ef=84;persistent-ado=126;persistent-ef=168;persistent-core=210;persistent-features=546;persistent-blob=01020908;persistent-backup=336;persistent-inbound-backup=378;persistent-encrypted=420;persistent-encrypted-password=462;encrypted-wrong-key-rejected=True;encrypted-cipher-mismatch-rejected=True'
+        } else {
+            & node $playwrightProbeScript $BrowserEngine $uri 'PASS:'
+        }
         if ($LASTEXITCODE -ne 0) {
-            throw "Browser consumer probe failed with exit code $LASTEXITCODE."
+            throw "$BrowserEngine browser consumer probe failed with exit code $LASTEXITCODE."
         }
     } finally {
         $env:AHTOLA_BROWSER_EXECUTABLE = $previousBrowser
@@ -135,4 +142,4 @@ try {
     }
 }
 
-Write-Host 'Packed browser consumer passed.' -ForegroundColor Green
+Write-Host "Packed browser consumer passed in $BrowserEngine." -ForegroundColor Green

--- a/scripts/Invoke-BrowserPackageConsumer.ps1
+++ b/scripts/Invoke-BrowserPackageConsumer.ps1
@@ -1,0 +1,138 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [string]$PackageDirectory = './artifacts/managed-packages',
+    [string]$PackageVersion = '0.0.0-browser-local',
+    [string]$Output = './artifacts/browser-wasm-consumer',
+    [int]$Port = 8124,
+    [string]$BrowserExecutable,
+    [switch]$RunAot
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$project = Join-Path $repoRoot 'samples/BrowserWasmConsumer/BrowserWasmConsumer.csproj'
+$serverScript = Join-Path $repoRoot 'samples/BrowserWasmConsumer/serve.mjs'
+$probeScript = Join-Path $repoRoot 'scripts/Run-BrowserProbe.mjs'
+$validator = Join-Path $repoRoot 'scripts/Validate-ManagedPackageClosure.ps1'
+$packageDirectory = if ([System.IO.Path]::IsPathRooted($PackageDirectory)) {
+    [System.IO.Path]::GetFullPath($PackageDirectory)
+} else {
+    [System.IO.Path]::GetFullPath((Join-Path $repoRoot $PackageDirectory))
+}
+$output = if ([System.IO.Path]::IsPathRooted($Output)) {
+    [System.IO.Path]::GetFullPath($Output)
+} else {
+    [System.IO.Path]::GetFullPath((Join-Path $repoRoot $Output))
+}
+$obj = Join-Path (Split-Path -Parent $project) 'obj'
+$config = Join-Path $obj 'browser-consumer.nuget.config'
+$globalPackages = Join-Path $packageDirectory '.browser-consumer-packages'
+$serverOutput = Join-Path $repoRoot 'artifacts/test-results/browser-consumer-server.log'
+$serverError = Join-Path $repoRoot 'artifacts/test-results/browser-consumer-server.err.log'
+
+if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+    throw 'Browser package validation requires Node.js.'
+}
+if (-not (Test-Path -LiteralPath $packageDirectory -PathType Container)) {
+    throw "Package directory '$packageDirectory' does not exist."
+}
+
+New-Item -ItemType Directory -Path $obj -Force | Out-Null
+New-Item -ItemType Directory -Path (Split-Path -Parent $serverOutput) -Force | Out-Null
+if (Test-Path -LiteralPath $output) {
+    Remove-Item -LiteralPath $output -Recurse -Force
+}
+
+$configXml = @"
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="managed-package" value="$packageDirectory" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>
+"@
+Set-Content -LiteralPath $config -Value $configXml -Encoding utf8
+
+& dotnet restore $project `
+    --configfile $config `
+    --packages $globalPackages `
+    "-p:AhtolaPackageVersion=$PackageVersion"
+if ($LASTEXITCODE -ne 0) {
+    throw "Browser consumer restore failed with exit code $LASTEXITCODE."
+}
+
+$publishArguments = @(
+    'publish',
+    $project,
+    '--configuration', 'Release',
+    '--no-restore',
+    '--output', $output,
+    "-p:AhtolaPackageVersion=$PackageVersion"
+)
+if ($RunAot) {
+    $publishArguments += '-p:RunAOTCompilation=true'
+}
+& dotnet @publishArguments
+if ($LASTEXITCODE -ne 0) {
+    throw "Browser consumer publish failed with exit code $LASTEXITCODE."
+}
+
+& pwsh -NoLogo -NoProfile -File $validator -PublishOutput $output
+if ($LASTEXITCODE -ne 0) {
+    throw "Browser consumer closure validation failed with exit code $LASTEXITCODE."
+}
+
+$wwwroot = Join-Path $output 'wwwroot'
+$server = Start-Process `
+    -FilePath (Get-Command node).Source `
+    -ArgumentList @($serverScript, $wwwroot, "$Port") `
+    -RedirectStandardOutput $serverOutput `
+    -RedirectStandardError $serverError `
+    -NoNewWindow `
+    -PassThru
+try {
+    $uri = "http://127.0.0.1:$Port/"
+    $ready = $false
+    for ($attempt = 0; $attempt -lt 120; $attempt++) {
+        if ($server.HasExited) {
+            throw "Browser consumer server exited with code $($server.ExitCode): $(Get-Content -LiteralPath $serverError -Raw)"
+        }
+        try {
+            $response = Invoke-WebRequest -Uri $uri -UseBasicParsing
+            if ($response.StatusCode -eq 200 -and
+                $response.Headers['Cross-Origin-Opener-Policy'] -eq 'same-origin' -and
+                $response.Headers['Cross-Origin-Embedder-Policy'] -eq 'require-corp') {
+                $ready = $true
+                break
+            }
+        } catch {
+        }
+        Start-Sleep -Milliseconds 250
+    }
+    if (-not $ready) {
+        throw 'Browser consumer server did not become cross-origin isolated before timeout.'
+    }
+
+    $previousBrowser = $env:AHTOLA_BROWSER_EXECUTABLE
+    try {
+        if (-not [string]::IsNullOrWhiteSpace($BrowserExecutable)) {
+            $env:AHTOLA_BROWSER_EXECUTABLE = $BrowserExecutable
+        }
+        & node $probeScript $uri 'PASS:capabilities=True;storage=True;crypto=True;ado=42;ef=84'
+        if ($LASTEXITCODE -ne 0) {
+            throw "Browser consumer probe failed with exit code $LASTEXITCODE."
+        }
+    } finally {
+        $env:AHTOLA_BROWSER_EXECUTABLE = $previousBrowser
+    }
+} finally {
+    if (-not $server.HasExited) {
+        Stop-Process -Id $server.Id
+        $server.WaitForExit()
+    }
+}
+
+Write-Host 'Packed browser consumer passed.' -ForegroundColor Green

--- a/scripts/Invoke-BrowserPackageConsumer.ps1
+++ b/scripts/Invoke-BrowserPackageConsumer.ps1
@@ -121,7 +121,7 @@ try {
         if (-not [string]::IsNullOrWhiteSpace($BrowserExecutable)) {
             $env:AHTOLA_BROWSER_EXECUTABLE = $BrowserExecutable
         }
-        & node $probeScript $uri 'PASS:capabilities=True;storage=True;crypto=True;ado=42;ef=84;persistent-ado=126;persistent-ef=168;persistent-core=210;persistent-features=546'
+        & node $probeScript $uri 'PASS:capabilities=True;storage=True;crypto=True;ado=42;ef=84;persistent-ado=126;persistent-ef=168;persistent-core=210;persistent-features=546;persistent-blob=01020908;persistent-backup=336;persistent-inbound-backup=378'
         if ($LASTEXITCODE -ne 0) {
             throw "Browser consumer probe failed with exit code $LASTEXITCODE."
         }

--- a/scripts/Invoke-BrowserSmokeCheck.ps1
+++ b/scripts/Invoke-BrowserSmokeCheck.ps1
@@ -1,0 +1,119 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Runs the packed browser consumer smoke probe for one engine, downgrading
+    only a specific, proven capability gap in the test engine to a visible
+    notice instead of a failing check.
+
+.DESCRIPTION
+    Playwright's bundled WebKit build does not implement the Origin Private
+    File System API at all (verified directly against the pinned Playwright
+    version on Linux: navigator.storage.getDirectory is undefined), so
+    Ahtola's capability probe correctly and safely refuses to initialize
+    OPFS-backed storage. That is a limitation of the automated test engine,
+    not of Ahtola, and not of real-world Safari/WebKit, which has supported
+    OPFS synchronous access handles since 16.4. Failing the "Browser smoke
+    (webkit)" check for that reason would hide real signal behind permanent,
+    unfixable noise.
+
+    Every other failure still fails this script: an application FAIL status
+    for any other reason, a timeout, an unexpected exception, or a missing
+    capability WebKit is expected to have (cross-origin isolation,
+    SharedArrayBuffer, Web Locks) all propagate as a real failure. Only a
+    PlatformNotSupportedException whose reported missing capabilities are a
+    non-empty subset of exactly the known OPFS-related gap is downgraded.
+#>
+[CmdletBinding()]
+param(
+    [string]$PackageDirectory = './artifacts/managed-packages',
+
+    [Parameter(Mandatory)]
+    [string]$PackageVersion,
+
+    [Parameter(Mandatory)]
+    [ValidateSet('chromium', 'firefox', 'webkit')]
+    [string]$BrowserEngine,
+
+    # Capabilities Playwright's bundled WebKit is proven to lack. A failure
+    # whose missing-capability set is a non-empty subset of exactly these
+    # names is the known gap; anything else - including one of these normally
+    # present capabilities (cross-origin isolation, SharedArrayBuffer, Web
+    # Locks) also going missing - is treated as a real failure.
+    [string[]]$KnownGapMissingCapabilities = @(
+        'Origin Private File System',
+        'Origin Private File System synchronous access handles'
+    )
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 3.0
+
+function Fail([string]$Message) {
+    throw "Browser smoke check failed: $Message"
+}
+
+$consumerRunner = Join-Path $PSScriptRoot 'Invoke-BrowserPackageConsumer.ps1'
+if (-not (Test-Path -LiteralPath $consumerRunner -PathType Leaf)) {
+    Fail "browser consumer runner not found: $consumerRunner"
+}
+
+$capturedLines = [System.Collections.Generic.List[string]]::new()
+$failureMessage = $null
+try {
+    & $consumerRunner `
+        -PackageDirectory $PackageDirectory `
+        -PackageVersion $PackageVersion `
+        -BrowserEngine $BrowserEngine *>&1 |
+        ForEach-Object {
+            $line = $_.ToString()
+            $capturedLines.Add($line)
+            Write-Host $line
+        }
+}
+catch {
+    $failureMessage = $_.Exception.Message
+    $capturedLines.Add($failureMessage)
+}
+
+if (-not $failureMessage) {
+    Write-Host "$BrowserEngine browser smoke passed; nothing to downgrade." -ForegroundColor Green
+    exit 0
+}
+
+if ($BrowserEngine -ne 'webkit') {
+    Fail $failureMessage
+}
+
+$combinedOutput = $capturedLines -join "`n"
+$match = [regex]::Match(
+    $combinedOutput,
+    'FAIL:PlatformNotSupportedException:.*?Missing in this browser: (?<missing>[^.]+)\.')
+if (-not $match.Success) {
+    Fail "webkit probe failed with an error that is not the known, structured OPFS capability gap. $failureMessage"
+}
+
+$missing = @(
+    $match.Groups['missing'].Value -split ',\s*' |
+        ForEach-Object { $_.Trim() } |
+        Where-Object { $_ }
+)
+if ($missing.Count -eq 0) {
+    Fail "webkit probe reported a capability failure with no missing capabilities parsed; treating as a real failure. $failureMessage"
+}
+
+$unexpectedlyMissing = @($missing | Where-Object { $KnownGapMissingCapabilities -notcontains $_ })
+if ($unexpectedlyMissing.Count -gt 0) {
+    Fail ("webkit is missing capabilities beyond the known OPFS test-engine gap " +
+        "($($unexpectedlyMissing -join ', ')); this looks like a real regression, not the documented WebKit limitation.")
+}
+
+$notice = "Playwright's bundled WebKit does not implement the Origin Private File System API used for " +
+    "Ahtola browser persistence (missing: $($missing -join ', ')). This is a known limitation of the " +
+    "WebKit test engine (verified directly against the pinned Playwright version), not an Ahtola " +
+    "regression and not a real-world Safari/WebKit capability gap. Downgrading this run to informational."
+Write-Host "::notice title=Known WebKit OPFS test-engine gap::$notice"
+if ($env:GITHUB_STEP_SUMMARY) {
+    Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value "- :information_source: $notice"
+}
+
+exit 0

--- a/scripts/Run-BrowserProbe.mjs
+++ b/scripts/Run-BrowserProbe.mjs
@@ -1,0 +1,200 @@
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { spawn, spawnSync } from "node:child_process";
+
+const targetUrl = process.argv[2];
+const expectedPrefix = process.argv[3] ?? "PASS:";
+const timeoutMilliseconds = Number(process.argv[4] ?? 90_000);
+if (!targetUrl)
+    throw new Error("Usage: node Run-BrowserProbe.mjs <url> [expected-prefix] [timeout-ms]");
+
+function commandPath(name) {
+    const command = process.platform === "win32" ? "where.exe" : "which";
+    const result = spawnSync(command, [name], { encoding: "utf8" });
+    return result.status === 0
+        ? result.stdout.split(/\r?\n/u).find(Boolean)
+        : undefined;
+}
+
+function findBrowser() {
+    const explicit = process.env.AHTOLA_BROWSER_EXECUTABLE;
+    const candidates = [
+        explicit,
+        process.platform === "win32"
+            ? path.join(process.env["ProgramFiles"] ?? "", "Google/Chrome/Application/chrome.exe")
+            : undefined,
+        process.platform === "win32"
+            ? path.join(process.env["ProgramFiles(x86)"] ?? "", "Microsoft/Edge/Application/msedge.exe")
+            : undefined,
+        process.platform === "darwin"
+            ? "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+            : undefined,
+        process.platform === "darwin"
+            ? "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge"
+            : undefined,
+        commandPath("google-chrome"),
+        commandPath("chromium"),
+        commandPath("chromium-browser"),
+        commandPath("microsoft-edge"),
+    ].filter(Boolean);
+
+    const browser = candidates.find(candidate => fs.existsSync(candidate));
+    if (!browser)
+        throw new Error("No Chromium browser was found. Set AHTOLA_BROWSER_EXECUTABLE.");
+    return browser;
+}
+
+async function reservePort() {
+    const server = net.createServer();
+    await new Promise((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    await new Promise(resolve => server.close(resolve));
+    return address.port;
+}
+
+function delay(milliseconds) {
+    return new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
+function waitForExit(childProcess, timeoutMilliseconds) {
+    if (childProcess.exitCode !== null)
+        return Promise.resolve();
+    return Promise.race([
+        new Promise(resolve => childProcess.once("exit", resolve)),
+        delay(timeoutMilliseconds),
+    ]);
+}
+
+async function findPage(port, deadline) {
+    while (Date.now() < deadline) {
+        try {
+            const response = await fetch(`http://127.0.0.1:${port}/json/list`);
+            if (response.ok) {
+                const pages = await response.json();
+                const page = pages.find(candidate =>
+                    candidate.type === "page"
+                    && candidate.url.startsWith(targetUrl));
+                if (page)
+                    return page;
+            }
+        } catch {
+        }
+        await delay(100);
+    }
+    throw new Error("Chromium did not expose the browser test page before timeout.");
+}
+
+class DevToolsClient {
+    constructor(url) {
+        this.socket = new WebSocket(url);
+        this.nextId = 0;
+        this.pending = new Map();
+    }
+
+    async open() {
+        await new Promise((resolve, reject) => {
+            this.socket.addEventListener("open", resolve, { once: true });
+            this.socket.addEventListener("error", reject, { once: true });
+        });
+        this.socket.addEventListener("message", event => {
+            const message = JSON.parse(event.data);
+            if (!message.id)
+                return;
+            const pending = this.pending.get(message.id);
+            if (!pending)
+                return;
+            this.pending.delete(message.id);
+            if (message.error)
+                pending.reject(new Error(message.error.message));
+            else
+                pending.resolve(message.result);
+        });
+    }
+
+    send(method, params = {}) {
+        const id = ++this.nextId;
+        return new Promise((resolve, reject) => {
+            this.pending.set(id, { resolve, reject });
+            this.socket.send(JSON.stringify({ id, method, params }));
+        });
+    }
+
+    close() {
+        this.socket.close();
+    }
+}
+
+const browser = findBrowser();
+const debuggingPort = await reservePort();
+const profile = fs.mkdtempSync(path.join(os.tmpdir(), "ahtola-browser-"));
+const output = [];
+const child = spawn(
+    browser,
+    [
+        "--headless=new",
+        "--disable-gpu",
+        "--no-first-run",
+        "--no-default-browser-check",
+        "--no-sandbox",
+        `--remote-debugging-port=${debuggingPort}`,
+        `--user-data-dir=${profile}`,
+        targetUrl,
+    ],
+    { stdio: ["ignore", "ignore", "pipe"] });
+child.stderr.on("data", data => output.push(data.toString()));
+
+let client;
+try {
+    const deadline = Date.now() + timeoutMilliseconds;
+    const page = await findPage(debuggingPort, deadline);
+    client = new DevToolsClient(page.webSocketDebuggerUrl);
+    await client.open();
+    await client.send("Runtime.enable");
+
+    while (Date.now() < deadline) {
+        const evaluation = await client.send("Runtime.evaluate", {
+            expression: "document.querySelector('#browser-test-status')?.textContent ?? ''",
+            returnByValue: true,
+        });
+        const status = evaluation.result?.value ?? "";
+        if (status.startsWith(expectedPrefix)) {
+            console.log(status);
+            break;
+        }
+        if (status.startsWith("FAIL:"))
+            throw new Error(status);
+        await delay(100);
+    }
+
+    if (Date.now() >= deadline)
+        throw new Error("Browser package consumer did not finish before timeout.");
+} catch (error) {
+    if (output.length > 0)
+        console.error(output.join(""));
+    throw error;
+} finally {
+    client?.close();
+    if (child.exitCode === null)
+        child.kill();
+    await waitForExit(child, 5_000);
+
+    let cleanupError;
+    for (let attempt = 0; attempt < 20; attempt++) {
+        try {
+            fs.rmSync(profile, { recursive: true, force: true });
+            cleanupError = undefined;
+            break;
+        } catch (error) {
+            cleanupError = error;
+            await delay(100);
+        }
+    }
+    if (cleanupError)
+        console.warn(`Could not remove Chromium profile '${profile}': ${cleanupError.message}`);
+}

--- a/scripts/Run-PlaywrightBrowserProbe.mjs
+++ b/scripts/Run-PlaywrightBrowserProbe.mjs
@@ -1,0 +1,52 @@
+import process from "node:process";
+import { chromium, firefox, webkit } from "playwright";
+
+const engineName = process.argv[2];
+const targetUrl = process.argv[3];
+const expectedPrefix = process.argv[4] ?? "PASS:";
+const timeoutMilliseconds = Number(process.argv[5] ?? 90_000);
+if (!engineName || !targetUrl) {
+    throw new Error(
+        "Usage: node Run-PlaywrightBrowserProbe.mjs <chromium|firefox|webkit> <url> "
+        + "[expected-prefix] [timeout-ms]");
+}
+
+const engines = { chromium, firefox, webkit };
+const engine = engines[engineName];
+if (!engine)
+    throw new Error(`Unsupported Playwright browser engine '${engineName}'.`);
+
+const launchOptions = { headless: true };
+if (process.env.AHTOLA_BROWSER_EXECUTABLE)
+    launchOptions.executablePath = process.env.AHTOLA_BROWSER_EXECUTABLE;
+
+const browser = await engine.launch(launchOptions);
+try {
+    const page = await browser.newPage();
+    await page.goto(targetUrl, {
+        waitUntil: "domcontentloaded",
+        timeout: timeoutMilliseconds,
+    });
+
+    const deadline = Date.now() + timeoutMilliseconds;
+    let passed = false;
+    while (Date.now() < deadline) {
+        const status = await page
+            .locator("#browser-test-status")
+            .textContent({ timeout: Math.min(5_000, timeoutMilliseconds) })
+            .catch(() => "");
+        if (status?.startsWith(expectedPrefix)) {
+            console.log(status);
+            passed = true;
+            break;
+        }
+        if (status?.startsWith("FAIL:"))
+            throw new Error(status);
+        await page.waitForTimeout(100);
+    }
+
+    if (!passed)
+        throw new Error(`${engineName} browser package consumer did not finish before timeout.`);
+} finally {
+    await browser.close();
+}

--- a/scripts/Validate-ManagedPackageClosure.ps1
+++ b/scripts/Validate-ManagedPackageClosure.ps1
@@ -46,6 +46,61 @@ function Test-EfCorePackageContract([xml]$Nuspec, [string]$PackageName) {
         }
 }
 
+function Test-BrowserPackageContract(
+    [xml]$Nuspec,
+    [string]$PackageName,
+    [string[]]$EntryNames
+) {
+    $metadata = $Nuspec.SelectSingleNode("//*[local-name()='metadata']")
+    $packageId = $metadata.SelectSingleNode("*[local-name()='id']")
+    if ($null -eq $packageId -or $packageId.InnerText -ne 'Devolutions.Ahtola.Data.Sqlite.Browser') {
+        return
+    }
+
+    $version = $metadata.SelectSingleNode("*[local-name()='version']")
+    if ($null -eq $version -or [string]::IsNullOrWhiteSpace($version.InnerText)) {
+        Fail "browser package '$PackageName' does not declare a version."
+    }
+
+    $requiredEntries = @(
+        'lib/net8.0/Devolutions.Ahtola.Data.Sqlite.Browser.dll',
+        'lib/net9.0/Devolutions.Ahtola.Data.Sqlite.Browser.dll',
+        'lib/net10.0/Devolutions.Ahtola.Data.Sqlite.Browser.dll',
+        'staticwebassets/ahtola-opfs.mjs',
+        'staticwebassets/ahtola-opfs-worker.mjs',
+        'staticwebassets/ahtola-crypto.mjs'
+    )
+    foreach ($requiredEntry in $requiredEntries) {
+        if ($EntryNames -notcontains $requiredEntry) {
+            Fail "browser package '$PackageName' is missing required entry '$requiredEntry'."
+        }
+    }
+
+    $forbiddenBinary = @($EntryNames | Where-Object {
+            $_ -match '(?i)\.(wasm|a|lib|o|obj|so|dylib)$'
+        })
+    if ($forbiddenBinary.Count -ne 0) {
+        Fail "browser package '$PackageName' contains custom native/WASM payload '$($forbiddenBinary[0])'."
+    }
+
+    $dependencyGroups = @($metadata.SelectNodes("*[local-name()='dependencies']/*[local-name()='group']"))
+    foreach ($targetFramework in @('net8.0', 'net9.0', 'net10.0')) {
+        $groups = @($dependencyGroups | Where-Object { $_.targetFramework -eq $targetFramework })
+        if ($groups.Count -ne 1) {
+            Fail "browser package '$PackageName' must declare exactly one dependency group for '$targetFramework'."
+        }
+
+        $dependencies = @($groups[0].SelectNodes("*[local-name()='dependency']"))
+        if ($dependencies.Count -ne 1 -or
+            $dependencies[0].id -ne 'Devolutions.Ahtola.Data.Sqlite') {
+            Fail "browser package '$PackageName' must depend only on Devolutions.Ahtola.Data.Sqlite for '$targetFramework'."
+        }
+        if ($dependencies[0].version -ne $version.InnerText) {
+            Fail "browser package '$PackageName' must use its own version '$($version.InnerText)' as the provider dependency floor for '$targetFramework'."
+        }
+    }
+}
+
 function Test-PackageDirectory([string]$Path) {
     if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
         Fail "package directory '$Path' does not exist."
@@ -63,6 +118,7 @@ function Test-PackageDirectory([string]$Path) {
         $archive = [System.IO.Compression.ZipFile]::OpenRead($package.FullName)
         try {
             $nuspecContent = $null
+            $entryNames = @($archive.Entries | ForEach-Object { $_.FullName })
             foreach ($entry in $archive.Entries) {
                 if ($entry.FullName -match $nativeArchiveEntryPattern) {
                     Fail "package '$($package.Name)' contains native entry '$($entry.FullName)'."
@@ -93,6 +149,7 @@ function Test-PackageDirectory([string]$Path) {
             }
 
             Test-EfCorePackageContract ([xml]$nuspecContent) $package.Name
+            Test-BrowserPackageContract ([xml]$nuspecContent) $package.Name $entryNames
         }
         finally {
             $archive.Dispose()

--- a/scripts/Validate-ManagedPackageClosure.ps1
+++ b/scripts/Validate-ManagedPackageClosure.ps1
@@ -67,6 +67,7 @@ function Test-BrowserPackageContract(
         'lib/net9.0/Devolutions.Ahtola.Data.Sqlite.Browser.dll',
         'lib/net10.0/Devolutions.Ahtola.Data.Sqlite.Browser.dll',
         'staticwebassets/ahtola-opfs.mjs',
+        'staticwebassets/ahtola-opfs-capability-probe-worker.mjs',
         'staticwebassets/ahtola-opfs-worker.mjs',
         'staticwebassets/ahtola-crypto.mjs'
     )

--- a/scripts/tests/Test-AssertExactPackageVersion.ps1
+++ b/scripts/tests/Test-AssertExactPackageVersion.ps1
@@ -96,3 +96,4 @@ $passed++
 Write-Host 'PASS: missing -PackageVersion fails' -ForegroundColor Green
 
 Write-Host "Test-AssertExactPackageVersion passed ($passed checks)." -ForegroundColor Green
+exit 0

--- a/scripts/tests/Test-AssertExactPackageVersion.ps1
+++ b/scripts/tests/Test-AssertExactPackageVersion.ps1
@@ -1,0 +1,98 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Self-contained smoke test for build.ps1's assert-package-version task and
+    Invoke-ValidatePackage's "reuse an existing CI-versioned package instead
+    of silently repacking it" behavior.
+
+.DESCRIPTION
+    Exercises Assert-ExactPackageVersion (via the assert-package-version
+    task) against synthetic nupkg files, proving both that a matching
+    version passes and that a mismatched or missing set of packages fails
+    loudly. This is the regression guard for the CI packaging bug where
+    validate-package used to delete and repack artifacts/managed-packages
+    under a different, throwaway version, silently orphaning the intended
+    CI-versioned artifacts.
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 3.0
+
+$repoRoot = Split-Path -Parent $PSScriptRoot | Split-Path -Parent
+$buildScript = Join-Path $repoRoot 'build.ps1'
+if (-not (Test-Path -LiteralPath $buildScript -PathType Leaf)) {
+    throw "build.ps1 not found at $buildScript"
+}
+
+function Fail([string]$Message) {
+    throw "Test-AssertExactPackageVersion failed: $Message"
+}
+
+function New-FakeNupkgDirectory([string]$Version, [string[]]$PackageIds) {
+    $directory = Join-Path ([System.IO.Path]::GetTempPath()) "ahtola-assert-version-$([System.Guid]::NewGuid().ToString('N'))"
+    New-Item -ItemType Directory -Path $directory -Force | Out-Null
+    foreach ($id in $PackageIds) {
+        New-Item -ItemType File -Path (Join-Path $directory "$id.$Version.nupkg") -Force | Out-Null
+    }
+    return $directory
+}
+
+$passed = 0
+
+# 1. Matching version: every nupkg carries the expected version -> succeeds.
+$matchingDirectory = New-FakeNupkgDirectory -Version '0.0.0-ci.74' -PackageIds @(
+    'Devolutions.Ahtola.Core',
+    'Devolutions.Ahtola.Data.Sqlite'
+)
+try {
+    & pwsh -NoLogo -NoProfile -File $buildScript assert-package-version `
+        -PackageOutput $matchingDirectory -PackageVersion '0.0.0-ci.74' | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Fail "assert-package-version was expected to succeed for a matching version but exited $LASTEXITCODE."
+    }
+    $passed++
+    Write-Host 'PASS: matching version succeeds' -ForegroundColor Green
+} finally {
+    Remove-Item -LiteralPath $matchingDirectory -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# 2. Mismatched version: nupkgs exist but carry a different version -> fails.
+$mismatchedDirectory = New-FakeNupkgDirectory -Version '0.0.0-ci.74' -PackageIds @('Devolutions.Ahtola.Core')
+try {
+    & pwsh -NoLogo -NoProfile -File $buildScript assert-package-version `
+        -PackageOutput $mismatchedDirectory -PackageVersion '0.0.0-managed-local' 2>$null | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        Fail 'assert-package-version was expected to fail for a mismatched version but exited 0.'
+    }
+    $passed++
+    Write-Host 'PASS: mismatched version fails' -ForegroundColor Green
+} finally {
+    Remove-Item -LiteralPath $mismatchedDirectory -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# 3. Empty directory: no nupkgs at all -> fails, not a silent no-op pass.
+$emptyDirectory = Join-Path ([System.IO.Path]::GetTempPath()) "ahtola-assert-version-$([System.Guid]::NewGuid().ToString('N'))"
+New-Item -ItemType Directory -Path $emptyDirectory -Force | Out-Null
+try {
+    & pwsh -NoLogo -NoProfile -File $buildScript assert-package-version `
+        -PackageOutput $emptyDirectory -PackageVersion '0.0.0-ci.74' 2>$null | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        Fail 'assert-package-version was expected to fail with no packages present but exited 0.'
+    }
+    $passed++
+    Write-Host 'PASS: empty package directory fails' -ForegroundColor Green
+} finally {
+    Remove-Item -LiteralPath $emptyDirectory -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# 4. Missing -PackageVersion on the task itself -> fails with a clear message.
+& pwsh -NoLogo -NoProfile -File $buildScript assert-package-version 2>$null | Out-Null
+if ($LASTEXITCODE -eq 0) {
+    Fail "assert-package-version was expected to require -PackageVersion but exited 0."
+}
+$passed++
+Write-Host 'PASS: missing -PackageVersion fails' -ForegroundColor Green
+
+Write-Host "Test-AssertExactPackageVersion passed ($passed checks)." -ForegroundColor Green

--- a/scripts/tests/browser-worker/capability-probe.test.mjs
+++ b/scripts/tests/browser-worker/capability-probe.test.mjs
@@ -1,0 +1,96 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const opfsModuleUrl = new URL(
+    "../../../src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs.mjs",
+    import.meta.url
+).href;
+
+// hasSynchronousAccessHandlePrerequisites() (a fast-path guard inside
+// evaluateSynchronousAccessHandleSupport) checks `typeof Worker` and
+// `navigator.storage?.getDirectory`. Importing ahtola-opfs.mjs itself never
+// touches these at module-evaluation time (only when a function that reads
+// them is called), so a single shared navigator/Worker stub is enough for
+// every test in this file - no per-test module reload is required here,
+// unlike the OPFS worker tests.
+Object.defineProperty(globalThis, "navigator", {
+    value: { storage: { getDirectory: async () => ({}) } },
+    configurable: true,
+    writable: true,
+});
+if (typeof globalThis.Worker === "undefined") {
+    Object.defineProperty(globalThis, "Worker", {
+        value: class {},
+        configurable: true,
+        writable: true,
+    });
+}
+
+const { evaluateSynchronousAccessHandleSupport } = await import(opfsModuleUrl);
+
+function prober(...outcomes) {
+    const calls = [];
+    return {
+        calls,
+        run: async () => {
+            calls.push(Date.now());
+            return outcomes[Math.min(calls.length - 1, outcomes.length - 1)];
+        },
+    };
+}
+
+test("returns true immediately when the probe succeeds on the first attempt", async () => {
+    const probe = prober({ ok: true });
+    const result = await evaluateSynchronousAccessHandleSupport(probe.run, 3, 0);
+    assert.equal(result, true);
+    assert.equal(probe.calls.length, 1);
+});
+
+test("returns false without retrying for a non-transient error", async () => {
+    const probe = prober({ ok: false, name: "NotSupportedError" });
+    const result = await evaluateSynchronousAccessHandleSupport(probe.run, 3, 0);
+    assert.equal(result, false);
+    assert.equal(probe.calls.length, 1, "a definitive unsupported result must not be retried");
+});
+
+test("retries a transient error and succeeds once the handle becomes available", async () => {
+    const probe = prober(
+        { ok: false, name: "NoModificationAllowedError" },
+        { ok: false, name: "NoModificationAllowedError" },
+        { ok: true }
+    );
+    const result = await evaluateSynchronousAccessHandleSupport(probe.run, 3, 0);
+    assert.equal(result, true);
+    assert.equal(probe.calls.length, 3);
+});
+
+test("gives up and returns false after exhausting the retry budget on transient errors", async () => {
+    const probe = prober({ ok: false, name: "InvalidStateError" });
+    const result = await evaluateSynchronousAccessHandleSupport(probe.run, 3, 0);
+    assert.equal(result, false);
+    assert.equal(probe.calls.length, 3, "must attempt exactly the configured number of times, no more");
+});
+
+test("skips probing entirely when prerequisites are absent", async () => {
+    const originalWorker = globalThis.Worker;
+    Object.defineProperty(globalThis, "Worker", { value: undefined, configurable: true, writable: true });
+    try {
+        const probe = prober({ ok: true });
+        const result = await evaluateSynchronousAccessHandleSupport(probe.run, 3, 0);
+        assert.equal(result, false);
+        assert.equal(probe.calls.length, 0, "must not spin up a worker when Worker itself is unavailable");
+    } finally {
+        Object.defineProperty(globalThis, "Worker", { value: originalWorker, configurable: true, writable: true });
+    }
+});
+
+test("real probeSynchronousAccessHandleSupport uses the retry-policy default and reports false without Worker/OPFS", async () => {
+    const { probeSynchronousAccessHandleSupport } = await import(opfsModuleUrl);
+    const originalWorker = globalThis.Worker;
+    Object.defineProperty(globalThis, "Worker", { value: undefined, configurable: true, writable: true });
+    try {
+        assert.equal(await probeSynchronousAccessHandleSupport(), false);
+    } finally {
+        Object.defineProperty(globalThis, "Worker", { value: originalWorker, configurable: true, writable: true });
+    }
+});

--- a/scripts/tests/browser-worker/capability-probe.test.mjs
+++ b/scripts/tests/browser-worker/capability-probe.test.mjs
@@ -94,3 +94,81 @@ test("real probeSynchronousAccessHandleSupport uses the retry-policy default and
         Object.defineProperty(globalThis, "Worker", { value: originalWorker, configurable: true, writable: true });
     }
 });
+
+// Regression test: the synchronous-access-handle probe must load its worker
+// from a real, packaged, same-origin script URL - exactly like the real
+// storage worker does - and must never construct a Blob or call
+// URL.createObjectURL. A Content-Security-Policy of `worker-src 'self'`
+// (with no `blob:`) blocks blob: workers while still allowing the real,
+// same-origin ahtola-opfs-worker.mjs; a blob-based probe would therefore
+// report the browser as unsupported even though Ahtola OPFS storage itself
+// works fine under that exact policy.
+test("the real capability probe uses a same-origin packaged worker, never Blob/createObjectURL (CSP worker-src 'self' safety)", async () => {
+    const { probeSynchronousAccessHandleSupport } = await import(opfsModuleUrl);
+
+    const originalWorker = globalThis.Worker;
+    const originalBlob = globalThis.Blob;
+    const hadCreateObjectURL = Object.prototype.hasOwnProperty.call(URL, "createObjectURL");
+    const originalCreateObjectURL = URL.createObjectURL;
+
+    let capturedUrl;
+    let capturedOptions;
+    class FakeWorker {
+        constructor(url, options) {
+            capturedUrl = url;
+            capturedOptions = options;
+        }
+
+        addEventListener(type, listener) {
+            if (type === "message")
+                this._onMessage = listener;
+        }
+
+        postMessage() {
+            // Simulate the real probe worker reporting success.
+            queueMicrotask(() => this._onMessage?.({ data: { ok: true } }));
+        }
+
+        terminate() {}
+    }
+
+    Object.defineProperty(globalThis, "Worker", { value: FakeWorker, configurable: true, writable: true });
+    Object.defineProperty(globalThis, "Blob", {
+        value: class {
+            constructor() {
+                throw new Error(
+                    "Blob must never be constructed for the capability probe: a CSP of "
+                    + "worker-src 'self' blocks blob: workers.");
+            }
+        },
+        configurable: true,
+        writable: true,
+    });
+    URL.createObjectURL = () => {
+        throw new Error(
+            "URL.createObjectURL must never be called for the capability probe: a CSP of "
+            + "worker-src 'self' blocks blob: workers.");
+    };
+
+    try {
+        const supported = await probeSynchronousAccessHandleSupport();
+        assert.equal(supported, true);
+        assert.ok(
+            capturedUrl instanceof URL,
+            "the probe worker must be constructed from a real URL, not an inline script string"
+        );
+        assert.notEqual(capturedUrl.protocol, "blob:");
+        assert.ok(
+            capturedUrl.pathname.endsWith("ahtola-opfs-capability-probe-worker.mjs"),
+            `expected the packaged probe worker file, got '${capturedUrl.href}'`
+        );
+        assert.equal(capturedOptions?.type, "module");
+    } finally {
+        Object.defineProperty(globalThis, "Worker", { value: originalWorker, configurable: true, writable: true });
+        Object.defineProperty(globalThis, "Blob", { value: originalBlob, configurable: true, writable: true });
+        if (hadCreateObjectURL)
+            URL.createObjectURL = originalCreateObjectURL;
+        else
+            delete URL.createObjectURL;
+    }
+});

--- a/scripts/tests/browser-worker/fake-opfs.mjs
+++ b/scripts/tests/browser-worker/fake-opfs.mjs
@@ -1,0 +1,208 @@
+// Minimal in-memory fakes for the OPFS/Web Locks/Worker-adjacent globals
+// that src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs-worker.mjs and
+// ahtola-opfs.mjs rely on, so their logic can run under plain Node without a
+// browser. Only the surface those two files actually touch is implemented.
+
+export class FakeSyncAccessHandle {
+    constructor(record) {
+        this._record = record;
+        this._closed = false;
+    }
+
+    getSize() {
+        this._assertOpen();
+        return this._record.bytes.length;
+    }
+
+    read(buffer, { at }) {
+        this._assertOpen();
+        const source = this._record.bytes;
+        const count = Math.max(0, Math.min(buffer.length, source.length - at));
+        buffer.set(source.subarray(at, at + count));
+        return count;
+    }
+
+    write(buffer, { at }) {
+        this._assertOpen();
+        const end = at + buffer.length;
+        if (end > this._record.bytes.length) {
+            const grown = new Uint8Array(end);
+            grown.set(this._record.bytes);
+            this._record.bytes = grown;
+        }
+        this._record.bytes.set(buffer, at);
+        return buffer.length;
+    }
+
+    truncate(newSize) {
+        this._assertOpen();
+        const next = new Uint8Array(newSize);
+        next.set(this._record.bytes.subarray(0, Math.min(newSize, this._record.bytes.length)));
+        this._record.bytes = next;
+    }
+
+    flush() {
+        this._assertOpen();
+    }
+
+    close() {
+        this._closed = true;
+    }
+
+    _assertOpen() {
+        if (this._closed)
+            throw new DOMException("The sync access handle is closed.", "InvalidStateError");
+    }
+}
+
+export class FakeFileHandle {
+    kind = "file";
+
+    constructor(directory, name) {
+        this._directory = directory;
+        this.name = name;
+    }
+
+    async createSyncAccessHandle() {
+        const record = this._directory._files.get(this.name);
+        if (!record)
+            throw new DOMException(`File '${this.name}' does not exist.`, "NotFoundError");
+        return new FakeSyncAccessHandle(record);
+    }
+}
+
+export class FakeDirectoryHandle {
+    kind = "directory";
+
+    constructor(name = "") {
+        this.name = name;
+        this._directories = new Map();
+        this._files = new Map();
+    }
+
+    async getDirectoryHandle(name, { create = false } = {}) {
+        if (!this._directories.has(name)) {
+            if (!create)
+                throw new DOMException(`Directory '${name}' does not exist.`, "NotFoundError");
+            this._directories.set(name, new FakeDirectoryHandle(name));
+        }
+        return this._directories.get(name);
+    }
+
+    async getFileHandle(name, { create = false } = {}) {
+        if (!this._files.has(name)) {
+            if (!create)
+                throw new DOMException(`File '${name}' does not exist.`, "NotFoundError");
+            this._files.set(name, { bytes: new Uint8Array(0) });
+        }
+        return new FakeFileHandle(this, name);
+    }
+
+    async removeEntry(name) {
+        if (this._files.delete(name))
+            return;
+        if (this._directories.delete(name))
+            return;
+        throw new DOMException(`Entry '${name}' does not exist.`, "NotFoundError");
+    }
+
+    /** Test-only helper: seed a file's raw bytes without going through the worker. */
+    seedFile(name, bytes) {
+        this._files.set(name, { bytes });
+    }
+
+    /** Test-only helper: whether a plain file entry exists directly in this directory. */
+    hasFile(name) {
+        return this._files.has(name);
+    }
+
+    async *entries() {
+        for (const [name, directory] of this._directories)
+            yield [name, directory];
+        for (const [name] of this._files)
+            yield [name, new FakeFileHandle(this, name)];
+    }
+}
+
+/** A permissive stand-in for navigator.locks: exclusive per resource name. */
+export class FakeLockManager {
+    constructor() {
+        this._held = new Map();
+    }
+
+    async request(name, options, callback) {
+        if (this._held.has(name)) {
+            if (options?.ifAvailable)
+                return callback(null);
+            throw new Error("FakeLockManager only supports ifAvailable:true in tests.");
+        }
+
+        const marker = {};
+        this._held.set(name, marker);
+        try {
+            return await callback({ name });
+        } finally {
+            if (this._held.get(name) === marker)
+                this._held.delete(name);
+        }
+    }
+}
+
+export function installFakeNavigator(root, lockManager = new FakeLockManager()) {
+    Object.defineProperty(globalThis, "navigator", {
+        value: {
+            storage: { getDirectory: async () => root },
+            locks: lockManager,
+        },
+        configurable: true,
+        writable: true,
+    });
+}
+
+/**
+ * Loads a fresh instance of the OPFS worker module against the given fake
+ * root, returning a `send(data)` helper that drives its single "message"
+ * listener the same way the real Worker/postMessage bridge would.
+ */
+export async function loadWorkerModule(workerModuleUrl, root, lockManager) {
+    installFakeNavigator(root, lockManager);
+
+    let messageHandler;
+    const posted = [];
+    Object.defineProperty(globalThis, "self", {
+        value: {
+            addEventListener: (type, handler) => {
+                if (type === "message")
+                    messageHandler = handler;
+            },
+            postMessage: message => posted.push(message),
+        },
+        configurable: true,
+        writable: true,
+    });
+
+    // Cache-bust so every test gets an independent module instance (fresh
+    // top-level `let`/`const` state), matching one worker per open database.
+    const instanceUrl = `${workerModuleUrl}?instance=${loadWorkerModule.nextInstanceId++}`;
+    await import(instanceUrl);
+
+    let nextMessageId = 0;
+    return {
+        posted,
+        async send(data) {
+            const id = ++nextMessageId;
+            await messageHandler({ data: { ...data, id } });
+            const response = posted.find(entry => entry.id === id);
+            if (!response)
+                throw new Error(`No response observed for message id ${id}.`);
+            if (response.error) {
+                const error = new Error(`${response.error.name}: ${response.error.message}`);
+                error.name = response.error.name;
+                error.code = response.error.code;
+                throw error;
+            }
+            return response.result;
+        },
+    };
+}
+loadWorkerModule.nextInstanceId = 0;

--- a/scripts/tests/browser-worker/opfs-worker.test.mjs
+++ b/scripts/tests/browser-worker/opfs-worker.test.mjs
@@ -1,0 +1,220 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { FakeDirectoryHandle, FakeLockManager, loadWorkerModule } from "./fake-opfs.mjs";
+
+const workerModuleUrl = new URL(
+    "../../../src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs-worker.mjs",
+    import.meta.url
+).href;
+
+const SHARED_BYTES = new ArrayBuffer(64 * 1024);
+const CONTROL_BUFFER = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);
+
+async function initializeWorker(root, lockName, lockManager) {
+    const worker = await loadWorkerModule(workerModuleUrl, root, lockManager);
+    await worker.send({
+        type: "initialize",
+        lockName,
+        shared: SHARED_BYTES,
+        control: CONTROL_BUFFER,
+    });
+    return worker;
+}
+
+// --- Finding 1: reserved ".ahtola-replace-" namespace boundary -------------
+
+test("rejects opening a top-level path whose segment starts with the reserved prefix", async () => {
+    const worker = await initializeWorker(new FakeDirectoryHandle(), "db-a");
+    await assert.rejects(
+        () => worker.send({ type: "open", path: ".ahtola-replace-not-a-slot", mode: 2, readOnly: false }),
+        error => {
+            assert.equal(error.name, "NotAllowedError");
+            return true;
+        }
+    );
+});
+
+test("rejects a nested path whose final segment starts with the reserved prefix", async () => {
+    const worker = await initializeWorker(new FakeDirectoryHandle(), "db-a");
+    await assert.rejects(
+        () => worker.send({
+            type: "open",
+            path: "app-data/.ahtola-replace-nested",
+            mode: 2,
+            readOnly: false,
+        }),
+        error => {
+            assert.equal(error.name, "NotAllowedError");
+            return true;
+        }
+    );
+});
+
+test("rejects exists/delete/list/replace operations on a reserved-prefixed path", async () => {
+    const worker = await initializeWorker(new FakeDirectoryHandle(), "db-a");
+
+    await assert.rejects(() => worker.send({ type: "exists", path: ".ahtola-replace-x" }));
+    await assert.rejects(() => worker.send({ type: "delete", path: ".ahtola-replace-x" }));
+    await assert.rejects(() => worker.send({ type: "list", directoryPath: ".ahtola-replace-x" }));
+    await assert.rejects(() => worker.send({
+        type: "replace",
+        sourcePath: ".ahtola-replace-x",
+        destinationPath: "app-data/dest.db",
+        replaceEmptyDestination: false,
+        operationId: 0,
+    }));
+
+    // A legitimate replacement source must still work; only the destination
+    // side is reserved-prefixed here, proving both source and destination
+    // are checked independently.
+    await worker.send({ type: "open", path: "app-data/source.db", mode: 2, readOnly: false });
+    await assert.rejects(() => worker.send({
+        type: "replace",
+        sourcePath: "app-data/source.db",
+        destinationPath: ".ahtola-replace-y",
+        replaceEmptyDestination: false,
+        operationId: 0,
+    }));
+});
+
+test("allows a real name that merely contains, but does not start with, the reserved prefix", async () => {
+    const worker = await initializeWorker(new FakeDirectoryHandle(), "db-a");
+    const handleId = await worker.send({
+        type: "open",
+        path: "app-data/not.ahtola-replace-mine.db",
+        mode: 2,
+        readOnly: false,
+    });
+    assert.equal(typeof handleId, "number");
+    assert.equal(await worker.send({ type: "exists", path: "app-data/not.ahtola-replace-mine.db" }), true);
+});
+
+test("list hides only the exact reserved slot filename shape, not any reserved-prefixed name", async () => {
+    const root = new FakeDirectoryHandle();
+    const worker = await initializeWorker(root, "db-a");
+
+    await worker.send({ type: "open", path: "app-data/app.db", mode: 2, readOnly: false });
+
+    // Simulate a pre-existing file that merely starts with the reserved
+    // prefix but does not match the exact <prefix><64-hex>.<0|1> slot shape
+    // (for example left over from a different Ahtola version). Seeded
+    // directly because the public "open" boundary now rejects creating one.
+    const appData = await root.getDirectoryHandle("app-data");
+    appData.seedFile(".ahtola-replace-legacy-name", new Uint8Array([1]));
+
+    // A real slot-shaped name should still be hidden even if it ends up
+    // inside a listed directory instead of at the true OPFS root.
+    appData.seedFile(".ahtola-replace-journal.0", new Uint8Array([2]));
+
+    const listing = await worker.send({ type: "list", directoryPath: "app-data" });
+    const files = listing ? listing.split("\n") : [];
+    assert.ok(files.includes("app-data/app.db"));
+    assert.ok(files.includes("app-data/.ahtola-replace-legacy-name"));
+    assert.ok(!files.includes("app-data/.ahtola-replace-journal.0"));
+});
+
+// --- Finding 2: intent-journal location/identity binding --------------------
+
+function envelopeBytes(record) {
+    const encoder = new TextEncoder();
+    function checksum(value) {
+        const bytes = encoder.encode(value);
+        let hash = 0x811c9dc5;
+        for (const byte of bytes) {
+            hash ^= byte;
+            hash = Math.imul(hash, 0x01000193);
+        }
+        return hash >>> 0;
+    }
+    const body = JSON.stringify(record);
+    return encoder.encode(JSON.stringify({ body, checksum: checksum(body) }));
+}
+
+test("two different lock names never share journal slots, even under the same OPFS root", async () => {
+    const root = new FakeDirectoryHandle();
+
+    // Tenant A leaves an abandoned "prepared" atomic-replace intent (as if
+    // it crashed mid-replace) inside its OWN directory.
+    const tenantA = await root.getDirectoryHandle("tenant-a", { create: true });
+    tenantA.seedFile("source.db", new Uint8Array([1, 2, 3, 4]));
+    tenantA.seedFile(".ahtola-replace-journal.0", envelopeBytes({
+        version: 2,
+        generation: 1,
+        lockName: "tenant-a",
+        payload: {
+            type: "replace",
+            sourcePath: "tenant-a/source.db",
+            destinationPath: "tenant-a/dest.db",
+            destinationExisted: false,
+            phase: "prepared",
+        },
+    }));
+    tenantA.seedFile(".ahtola-replace-journal.1", new Uint8Array(0));
+
+    // Tenant B has its own, entirely separate directory and journal slots;
+    // nothing about its initialization can even see tenant A's slot files.
+    const workerB = await initializeWorker(root, "tenant-b");
+    assert.equal(tenantA.hasFile("source.db"), true, "tenant A's abandoned source must be untouched");
+    assert.equal(tenantA.hasFile("dest.db"), false, "tenant A's intent must not have been recovered by tenant B");
+
+    const sourceHandle = await workerB.send({ type: "open", path: "tenant-b/source.db", mode: 2, readOnly: false });
+    await workerB.send({ type: "close", handleId: sourceHandle });
+    await workerB.send({
+        type: "replace",
+        sourcePath: "tenant-b/source.db",
+        destinationPath: "tenant-b/dest.db",
+        replaceEmptyDestination: false,
+        operationId: 0,
+    });
+    assert.equal(await workerB.send({ type: "exists", path: "tenant-b/dest.db" }), true);
+
+    // Recovery preserved: reopening as tenant A still recovers its own
+    // abandoned intent, unaffected by tenant B ever having existed.
+    const workerA = await initializeWorker(root, "tenant-a");
+    assert.equal(tenantA.hasFile("source.db"), false);
+    assert.equal(await workerA.send({ type: "exists", path: "tenant-a/dest.db" }), true);
+});
+
+test("a well-formed record naming a different lock is isolated as defense in depth, not recovered", async () => {
+    // Even though the directory-scoped slot location already makes this
+    // scenario unreachable in practice, readIntentSlot's identity check must
+    // still hold if a slot ever ends up with another lock's well-formed
+    // record in it (for example a bug elsewhere, or a manually copied file).
+    const root = new FakeDirectoryHandle();
+    const directory = await root.getDirectoryHandle("app-data", { create: true });
+    directory.seedFile("victim.db", new Uint8Array([9, 9]));
+    directory.seedFile(".ahtola-replace-journal.0", envelopeBytes({
+        version: 2,
+        generation: 1,
+        lockName: "some-other-lock",
+        payload: {
+            type: "replace",
+            sourcePath: "app-data/victim.db",
+            destinationPath: "app-data/clobbered.db",
+            destinationExisted: false,
+            phase: "prepared",
+        },
+    }));
+    directory.seedFile(".ahtola-replace-journal.1", new Uint8Array(0));
+
+    await initializeWorker(root, "app-data");
+
+    assert.equal(directory.hasFile("victim.db"), true, "the foreign intent must not have been acted on");
+    assert.equal(directory.hasFile("clobbered.db"), false);
+});
+
+test("both slots genuinely corrupted still fails initialization", async () => {
+    const root = new FakeDirectoryHandle();
+    const directory = await root.getDirectoryHandle("app-data", { create: true });
+    directory.seedFile(".ahtola-replace-journal.0", new TextEncoder().encode("not json at all"));
+    directory.seedFile(".ahtola-replace-journal.1", new TextEncoder().encode("also not json"));
+
+    await assert.rejects(
+        () => initializeWorker(root, "app-data"),
+        error => {
+            assert.equal(error.name, "DataError");
+            return true;
+        }
+    );
+});
+

--- a/src/Ahtola.Core/EmbeddedDatabase.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.cs
@@ -3162,26 +3162,26 @@ public sealed partial class EmbeddedDatabase : IDisposable
     /// <paramref name="owner"/>'s next attempt, or the busy deadline expires.
     /// </summary>
     /// <remarks>
-    /// This is the asynchronous half of the busy handler: it uses the same
-    /// transaction-lock and catalog-writer waits the synchronous engine blocks on,
-    /// but suspends the caller instead of parking a thread in
-    /// <see cref="Monitor.Wait(object)"/> or <see cref="Thread.Sleep(int)"/>. A
-    /// browser connection therefore never occupies its only thread while another
-    /// connection holds the write reservation.
+    /// This is the asynchronous half of the busy handler: it waits on the same
+    /// write reservation the synchronous engine blocks on, but suspends the caller
+    /// instead of parking a thread in <see cref="Monitor.Wait(object)"/> or
+    /// <see cref="Thread.Sleep(int)"/>. A browser connection therefore never
+    /// occupies its only thread while another connection holds the reservation.
+    /// It deliberately does not wait for catalog-writer quiescence: under sustained
+    /// write contention a settled instant may never come, and a stale snapshot is
+    /// resolved by adopting the committed catalog rather than by waiting.
     /// </remarks>
-    internal async ValueTask WaitForBusyRetryAsync(
+    internal ValueTask WaitForBusyRetryAsync(
         object owner,
         long deadline,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(owner);
         cancellationToken.ThrowIfCancellationRequested();
-        if (IsFileBacked && _fileSystem is not null)
-            await WaitForCatalogStabilityAsync(deadline, cancellationToken).ConfigureAwait(false);
-
-        await _transactionLock
-            .ThrowIfWriteBlockedAsync(owner, GetRemainingBusyTimeout(deadline), cancellationToken)
-            .ConfigureAwait(false);
+        return _transactionLock.ThrowIfWriteBlockedAsync(
+            owner,
+            GetRemainingBusyTimeout(deadline),
+            cancellationToken);
     }
 
     private static long GetBusyWaitDeadline(TimeSpan busyTimeout)
@@ -41892,14 +41892,19 @@ public sealed partial class EmbeddedConnection : IDisposable
     }
 
     /// <summary>
-    /// Runs the synchronous engine with a zero busy budget so no execution path
-    /// can park the calling thread waiting for a competing connection.
+    /// Fails this connection's lock acquisitions immediately instead of parking the
+    /// calling thread until its busy timeout expires.
     /// </summary>
     /// <remarks>
     /// The asynchronous statement seam pairs this with
-    /// <see cref="WaitForBusyRetryAsync"/>: fail fast, suspend on the managed
-    /// lock's asynchronous signal, then retry. Saving and restoring makes nesting
-    /// safe when a SQL callback steps another statement on this connection.
+    /// <see cref="AcquireAutocommitWriteReservationAsync"/> and
+    /// <see cref="WaitForBusyRetryAsync"/>: drain contention on the managed lock's
+    /// asynchronous signal, then run the statement so no <see cref="Monitor"/> wait
+    /// or <see cref="Thread.Sleep(int)"/> inside it can block. Only this
+    /// connection's budget changes; the owning <see cref="EmbeddedDatabase"/> keeps
+    /// its own, so a peer connection's retry budget is untouched and the engine's
+    /// stale-catalog statement restart still converges. Saving and restoring makes
+    /// nesting safe when a SQL callback steps another statement here.
     /// </remarks>
     internal FailFastBusyScope EnterFailFastBusyScope() => new(this);
 
@@ -41911,17 +41916,64 @@ public sealed partial class EmbeddedConnection : IDisposable
         internal FailFastBusyScope(EmbeddedConnection connection)
         {
             _connection = connection;
-            _restore = connection.BusyTimeout;
+            _restore = connection._busyTimeout;
             if (_restore != TimeSpan.Zero)
-                connection.BusyTimeout = TimeSpan.Zero;
+                connection._busyTimeout = TimeSpan.Zero;
         }
 
         public void Dispose()
         {
             // A PRAGMA busy_timeout executed inside the scope is the caller's new
             // intent; never clobber it with the value this scope displaced.
-            if (_restore != TimeSpan.Zero && _connection.BusyTimeout == TimeSpan.Zero)
-                _connection.BusyTimeout = _restore;
+            if (_restore != TimeSpan.Zero && _connection._busyTimeout == TimeSpan.Zero)
+                _connection._busyTimeout = _restore;
+        }
+    }
+
+    /// <summary>
+    /// Asynchronously takes the write reservation an autocommit mutation would
+    /// otherwise block on, returning <see langword="null"/> when the statement does
+    /// not need one.
+    /// </summary>
+    /// <remarks>
+    /// Draining the contention here rather than retrying the whole statement keeps
+    /// the barging shape SQLite has between autocommit writers — the reservation is
+    /// held across the statement instead of being re-raced on every attempt — while
+    /// the acquisition itself suspends rather than sleeping a thread. The engine's
+    /// own <c>EnterAutocommit</c> then finds the reservation re-entrant and never
+    /// waits. The lease is taken per attempt so a failed attempt cannot pin a
+    /// database another connection needs to make progress.
+    /// </remarks>
+    internal async ValueTask<IDisposable?> AcquireAutocommitWriteReservationAsync(
+        ParsedStatement statement,
+        TimeSpan busyTimeout,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(statement);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (_transactionDatabases is not null
+            || _database.IsReadOnly
+            || !EmbeddedDatabase.MayMutate(statement))
+        {
+            return null;
+        }
+
+        await _database.TransactionLock
+            .EnterAutocommitAsync(this, busyTimeout, cancellationToken)
+            .ConfigureAwait(false);
+        return new AutocommitWriteReservation(this, _database);
+    }
+
+    private sealed class AutocommitWriteReservation(
+        EmbeddedConnection owner,
+        EmbeddedDatabase database) : IDisposable
+    {
+        private EmbeddedDatabase? _database = database;
+
+        public void Dispose()
+        {
+            var released = Interlocked.Exchange(ref _database, null);
+            released?.TransactionLock.Exit(owner);
         }
     }
 
@@ -41931,8 +41983,6 @@ public sealed partial class EmbeddedConnection : IDisposable
     /// </summary>
     internal async ValueTask<bool> WaitForBusyRetryAsync(
         long deadline,
-        int attempt,
-        bool staleCatalog,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -41955,25 +42005,13 @@ public sealed partial class EmbeddedConnection : IDisposable
             return false;
         }
 
-        // Running the attempt with a zero busy budget also disables the engine's
-        // own stale-catalog retry, so adopt the committed catalog here instead.
-        // An explicit transaction must keep its snapshot, and fails busy exactly
-        // as a zero-timeout synchronous statement would.
-        if (staleCatalog && _transactionDatabases is null)
-        {
-            foreach (var database in EnumerateReachableDatabases())
-            {
-                if (database.IsFileBacked)
-                    database.ReloadFileCatalogAfterStale();
-            }
-        }
-
-        // A stale catalog version, unlike a held reservation, has no signal to wait
-        // on, so back off on SQLite's own delay schedule instead of spinning.
-        var remaining = EmbeddedDatabase.RemainingBusyBudget(deadline);
-        var delay = SqliteBusyBackoff.DelayForAttempt(attempt, TimeSpan.Zero, remaining);
-        if (delay <= TimeSpan.Zero && remaining != Timeout.InfiniteTimeSpan)
-            return false;
+        // The reservation can be retaken between that signal and this retry, so
+        // yield for SQLite's shortest busy delay rather than spinning — the same
+        // one-millisecond poll the synchronous autocommit contender uses.
+        var delay = SqliteBusyBackoff.DelayForAttempt(
+            attempt: 0,
+            TimeSpan.Zero,
+            EmbeddedDatabase.RemainingBusyBudget(deadline));
         if (delay > TimeSpan.Zero)
             await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
 
@@ -48105,15 +48143,17 @@ public sealed class EmbeddedStatement : IDisposable
     /// contention, honoring <paramref name="cancellationToken"/> exactly.
     /// </summary>
     /// <remarks>
-    /// The engine's execution pipeline is synchronous, and its busy waits park a
+    /// The engine's execution pipeline is synchronous, and its lock waits park a
     /// thread in <see cref="Monitor.Wait(object)"/> or <see cref="Thread.Sleep(int)"/>
     /// for the whole busy timeout — fatal on a browser's single thread and
-    /// unresponsive to cancellation. This runs each attempt with a zero busy budget,
-    /// so the synchronous path fails fast instead of waiting, then suspends on the
-    /// managed transaction lock's asynchronous signal before retrying. The observed
-    /// busy semantics are unchanged: the retries are bounded by the connection's
-    /// <c>busy_timeout</c> and the original failure is what surfaces when it runs
-    /// out. The statement is only advanced by a successful attempt, because
+    /// unresponsive to cancellation. This drains the contention first: an autocommit
+    /// mutation takes its write reservation through the transaction lock's
+    /// asynchronous barging acquisition, so the synchronous attempt finds it
+    /// re-entrant, and the attempt itself runs with this connection's budget zeroed
+    /// so no remaining wait can block. Anything still reported busy suspends on the
+    /// same lock's asynchronous signal and retries, bounded by the connection's
+    /// <c>busy_timeout</c>, and surfaces the original busy failure when the budget
+    /// runs out. The statement is only advanced by a successful attempt, because
     /// execution publishes its result as a single assignment.
     /// </remarks>
     public async ValueTask<StatementStepResult> StepAsync(CancellationToken cancellationToken = default)
@@ -48128,27 +48168,32 @@ public sealed class EmbeddedStatement : IDisposable
             return Step(cancellationToken);
 
         var deadline = EmbeddedDatabase.CreateBusyDeadline(busyTimeout);
-        var attempt = 0;
         while (true)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            var reservation = await _connection
+                .AcquireAutocommitWriteReservationAsync(
+                    _statement,
+                    EmbeddedDatabase.RemainingBusyBudget(deadline),
+                    cancellationToken)
+                .ConfigureAwait(false);
             try
             {
                 using (_connection.EnterFailFastBusyScope())
                     return Step(cancellationToken);
             }
-            catch (EmbeddedBusyException busy)
+            catch (EmbeddedBusyException)
             {
                 if (!await _connection
-                        .WaitForBusyRetryAsync(
-                            deadline,
-                            attempt++,
-                            busy is EmbeddedCatalogSnapshotStaleException,
-                            cancellationToken)
+                        .WaitForBusyRetryAsync(deadline, cancellationToken)
                         .ConfigureAwait(false))
                 {
                     throw;
                 }
+            }
+            finally
+            {
+                reservation?.Dispose();
             }
         }
     }

--- a/src/Ahtola.Core/EmbeddedDatabase.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.cs
@@ -3157,6 +3157,33 @@ public sealed partial class EmbeddedDatabase : IDisposable
         }
     }
 
+    /// <summary>
+    /// Asynchronously waits until nothing on this database is blocking
+    /// <paramref name="owner"/>'s next attempt, or the busy deadline expires.
+    /// </summary>
+    /// <remarks>
+    /// This is the asynchronous half of the busy handler: it uses the same
+    /// transaction-lock and catalog-writer waits the synchronous engine blocks on,
+    /// but suspends the caller instead of parking a thread in
+    /// <see cref="Monitor.Wait(object)"/> or <see cref="Thread.Sleep(int)"/>. A
+    /// browser connection therefore never occupies its only thread while another
+    /// connection holds the write reservation.
+    /// </remarks>
+    internal async ValueTask WaitForBusyRetryAsync(
+        object owner,
+        long deadline,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(owner);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (IsFileBacked && _fileSystem is not null)
+            await WaitForCatalogStabilityAsync(deadline, cancellationToken).ConfigureAwait(false);
+
+        await _transactionLock
+            .ThrowIfWriteBlockedAsync(owner, GetRemainingBusyTimeout(deadline), cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     private static long GetBusyWaitDeadline(TimeSpan busyTimeout)
     {
         if (busyTimeout == Timeout.InfiniteTimeSpan)
@@ -3177,6 +3204,15 @@ public sealed partial class EmbeddedDatabase : IDisposable
         var remaining = Math.Max(0, deadline - Environment.TickCount64);
         return TimeSpan.FromMilliseconds(remaining);
     }
+
+    internal static long CreateBusyDeadline(TimeSpan busyTimeout)
+        => GetBusyWaitDeadline(busyTimeout);
+
+    internal static bool HasBusyBudgetRemaining(long deadline)
+        => GetRemainingBusyWait(deadline) > 0;
+
+    internal static TimeSpan RemainingBusyBudget(long deadline)
+        => GetRemainingBusyTimeout(deadline);
 
     /// <summary>
     /// A foreign read-only connection holds no ownership and no catalog write
@@ -41855,6 +41891,102 @@ public sealed partial class EmbeddedConnection : IDisposable
         }
     }
 
+    /// <summary>
+    /// Runs the synchronous engine with a zero busy budget so no execution path
+    /// can park the calling thread waiting for a competing connection.
+    /// </summary>
+    /// <remarks>
+    /// The asynchronous statement seam pairs this with
+    /// <see cref="WaitForBusyRetryAsync"/>: fail fast, suspend on the managed
+    /// lock's asynchronous signal, then retry. Saving and restoring makes nesting
+    /// safe when a SQL callback steps another statement on this connection.
+    /// </remarks>
+    internal FailFastBusyScope EnterFailFastBusyScope() => new(this);
+
+    internal readonly struct FailFastBusyScope : IDisposable
+    {
+        private readonly EmbeddedConnection _connection;
+        private readonly TimeSpan _restore;
+
+        internal FailFastBusyScope(EmbeddedConnection connection)
+        {
+            _connection = connection;
+            _restore = connection.BusyTimeout;
+            if (_restore != TimeSpan.Zero)
+                connection.BusyTimeout = TimeSpan.Zero;
+        }
+
+        public void Dispose()
+        {
+            // A PRAGMA busy_timeout executed inside the scope is the caller's new
+            // intent; never clobber it with the value this scope displaced.
+            if (_restore != TimeSpan.Zero && _connection.BusyTimeout == TimeSpan.Zero)
+                _connection.BusyTimeout = _restore;
+        }
+    }
+
+    /// <summary>
+    /// Asynchronously waits out whatever made this connection's last attempt busy,
+    /// returning <see langword="false"/> once the busy budget is spent.
+    /// </summary>
+    internal async ValueTask<bool> WaitForBusyRetryAsync(
+        long deadline,
+        int attempt,
+        bool staleCatalog,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (!EmbeddedDatabase.HasBusyBudgetRemaining(deadline))
+            return false;
+
+        try
+        {
+            foreach (var database in EnumerateReachableDatabases())
+            {
+                await database
+                    .WaitForBusyRetryAsync(this, deadline, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+        catch (EmbeddedBusyException)
+        {
+            // The wait itself ran out of budget; the caller reports the original
+            // busy failure rather than this one.
+            return false;
+        }
+
+        // Running the attempt with a zero busy budget also disables the engine's
+        // own stale-catalog retry, so adopt the committed catalog here instead.
+        // An explicit transaction must keep its snapshot, and fails busy exactly
+        // as a zero-timeout synchronous statement would.
+        if (staleCatalog && _transactionDatabases is null)
+        {
+            foreach (var database in EnumerateReachableDatabases())
+            {
+                if (database.IsFileBacked)
+                    database.ReloadFileCatalogAfterStale();
+            }
+        }
+
+        // A stale catalog version, unlike a held reservation, has no signal to wait
+        // on, so back off on SQLite's own delay schedule instead of spinning.
+        var remaining = EmbeddedDatabase.RemainingBusyBudget(deadline);
+        var delay = SqliteBusyBackoff.DelayForAttempt(attempt, TimeSpan.Zero, remaining);
+        if (delay <= TimeSpan.Zero && remaining != Timeout.InfiniteTimeSpan)
+            return false;
+        if (delay > TimeSpan.Zero)
+            await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+
+        return EmbeddedDatabase.HasBusyBudgetRemaining(deadline);
+    }
+
+    private IEnumerable<EmbeddedDatabase> EnumerateReachableDatabases()
+    {
+        yield return _database;
+        foreach (var attachment in _attachedDatabases.Values)
+            yield return attachment.Database;
+    }
+
     private VdbeExecutionOptions CreateVdbeExecutionOptions(EmbeddedDatabase database)
     {
         ArgumentNullException.ThrowIfNull(database);
@@ -47966,6 +48098,59 @@ public sealed class EmbeddedStatement : IDisposable
         _currentRow = null;
         ReleaseReaderLease();
         return StatementStepResult.Done;
+    }
+
+    /// <summary>
+    /// Advances the statement without ever blocking the calling thread on lock
+    /// contention, honoring <paramref name="cancellationToken"/> exactly.
+    /// </summary>
+    /// <remarks>
+    /// The engine's execution pipeline is synchronous, and its busy waits park a
+    /// thread in <see cref="Monitor.Wait(object)"/> or <see cref="Thread.Sleep(int)"/>
+    /// for the whole busy timeout — fatal on a browser's single thread and
+    /// unresponsive to cancellation. This runs each attempt with a zero busy budget,
+    /// so the synchronous path fails fast instead of waiting, then suspends on the
+    /// managed transaction lock's asynchronous signal before retrying. The observed
+    /// busy semantics are unchanged: the retries are bounded by the connection's
+    /// <c>busy_timeout</c> and the original failure is what surfaces when it runs
+    /// out. The statement is only advanced by a successful attempt, because
+    /// execution publishes its result as a single assignment.
+    /// </remarks>
+    public async ValueTask<StatementStepResult> StepAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        cancellationToken.ThrowIfCancellationRequested();
+        var busyTimeout = _connection.BusyTimeout;
+
+        // A zero budget already fails fast, and a busy_timeout PRAGMA owns the very
+        // knob the fail-fast scope displaces, so both run the statement directly.
+        if (busyTimeout == TimeSpan.Zero || _statement is PragmaBusyTimeoutStatement)
+            return Step(cancellationToken);
+
+        var deadline = EmbeddedDatabase.CreateBusyDeadline(busyTimeout);
+        var attempt = 0;
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                using (_connection.EnterFailFastBusyScope())
+                    return Step(cancellationToken);
+            }
+            catch (EmbeddedBusyException busy)
+            {
+                if (!await _connection
+                        .WaitForBusyRetryAsync(
+                            deadline,
+                            attempt++,
+                            busy is EmbeddedCatalogSnapshotStaleException,
+                            cancellationToken)
+                        .ConfigureAwait(false))
+                {
+                    throw;
+                }
+            }
+        }
     }
 
     public SqlValue GetValue(int ordinal)

--- a/src/Ahtola.Core/EmbeddedDatabase.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.cs
@@ -267,7 +267,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
     private EmbeddedFileStore? _fileStore;
     private readonly string _databasePath = string.Empty;
     private readonly IFileSystem? _fileSystem;
-    private readonly object? _fileCatalogWriteLock;
+    private readonly AsyncFifoGate? _fileCatalogWriteLock;
     private readonly bool _readOnly;
     private readonly bool _foreignReadOnly;
     private SqlitePagerViewToken _foreignViewToken;
@@ -308,7 +308,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
         string databasePath,
         IFileSystem fileSystem,
         FileCatalogVersion fileCatalogVersion,
-        object fileCatalogWriteLock,
+        AsyncFifoGate fileCatalogWriteLock,
         bool readOnly,
         bool foreignReadOnly = false)
     {
@@ -353,7 +353,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
             throw new ArgumentException("A foreign open is always read-only.", nameof(foreignReadOnly));
         var effectiveFileSystem = fileSystem ?? PhysicalFileSystem.Instance;
         var fileCatalogWriteLock = GetFileCatalogWriteLock(effectiveFileSystem, path);
-        lock (fileCatalogWriteLock)
+        using (fileCatalogWriteLock.Enter(Timeout.InfiniteTimeSpan))
         {
             using var catalogWriteLease = readOnly
                 ? null
@@ -439,7 +439,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
             if (_fileStore is null || _fileSystem is null || _fileCatalogWriteLock is null)
                 throw new InvalidOperationException("The managed file catalog persistence state is not initialized.");
 
-            lock (_fileCatalogWriteLock)
+            using (_fileCatalogWriteLock.Enter(Timeout.InfiniteTimeSpan))
             {
                 // A commit landing mid-reload fails the race check; spin until the
                 // reload observes a settled version. Bounded so a commit storm
@@ -1930,7 +1930,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 if (_fileCatalogWriteLock is null)
                     throw new InvalidOperationException("The managed file catalog persistence state is not initialized.");
 
-                lock (_fileCatalogWriteLock)
+                using (_fileCatalogWriteLock.Enter(Timeout.InfiniteTimeSpan))
                 {
                     if (_foreignReadOnly)
                     {
@@ -2739,7 +2739,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
             && _fileSystem is not null
             && _fileCatalogWriteLock is not null)
         {
-            lock (_fileCatalogWriteLock)
+            using (_fileCatalogWriteLock.Enter(Timeout.InfiniteTimeSpan))
             {
                 using var catalogWriteLease = EnterPhysicalFileCatalogWriteLock(_fileSystem, _databasePath);
                 EnsureFileCatalogVersionCurrent(busyTimeout);
@@ -2793,7 +2793,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 _mvStore = null;
             }
 
-            lock (fileCatalogWriteLock)
+            using (fileCatalogWriteLock.Enter(Timeout.InfiniteTimeSpan))
             {
                 using var catalogWriteLease = EnterPhysicalFileCatalogWriteLock(fileSystem, _databasePath);
                 EnsureFileCatalogVersionCurrent(busyTimeout);
@@ -2823,7 +2823,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
             if (_fileSystem is null || _fileCatalogWriteLock is null)
                 throw new InvalidOperationException("The managed file catalog persistence state is not initialized.");
 
-            lock (_fileCatalogWriteLock)
+            using (_fileCatalogWriteLock.Enter(Timeout.InfiniteTimeSpan))
             {
                 using var catalogWriteLease = EnterPhysicalFileCatalogWriteLock(_fileSystem, _databasePath);
                 EnsureFileCatalogVersionCurrent(busyTimeout);
@@ -2865,11 +2865,11 @@ public sealed partial class EmbeddedDatabase : IDisposable
 
             if (string.CompareOrdinal(sourceLockPath, destinationLockPath) < 0)
             {
-                lock (_fileCatalogWriteLock)
+                using (_fileCatalogWriteLock.Enter(Timeout.InfiniteTimeSpan))
                 {
                     using var sourceWriteLease =
                         EnterPhysicalFileCatalogWriteLock(_fileSystem, _databasePath);
-                    lock (destinationWriteLock)
+                    using (destinationWriteLock.Enter(Timeout.InfiniteTimeSpan))
                     {
                         using var destinationWriteLease =
                             EnterPhysicalFileCatalogWriteLock(_fileSystem, destinationPath);
@@ -2879,11 +2879,11 @@ public sealed partial class EmbeddedDatabase : IDisposable
             }
             else
             {
-                lock (destinationWriteLock)
+                using (destinationWriteLock.Enter(Timeout.InfiniteTimeSpan))
                 {
                     using var destinationWriteLease =
                         EnterPhysicalFileCatalogWriteLock(_fileSystem, destinationPath);
-                    lock (_fileCatalogWriteLock)
+                    using (_fileCatalogWriteLock.Enter(Timeout.InfiniteTimeSpan))
                     {
                         using var sourceWriteLease =
                             EnterPhysicalFileCatalogWriteLock(_fileSystem, _databasePath);
@@ -2936,7 +2936,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
             if (_fileSystem is null || _fileCatalogWriteLock is null)
                 throw new InvalidOperationException("The managed file catalog persistence state is not initialized.");
 
-            lock (_fileCatalogWriteLock)
+            using (_fileCatalogWriteLock.Enter(Timeout.InfiniteTimeSpan))
             {
                 using var catalogWriteLease = EnterPhysicalFileCatalogWriteLock(_fileSystem, _databasePath);
                 EnsureFileCatalogVersionCurrent(busyTimeout);
@@ -2986,7 +2986,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
         if (_fileStore is null || _fileSystem is null || _fileCatalogWriteLock is null)
             throw new InvalidOperationException("The managed file catalog persistence state is not initialized.");
 
-        lock (_fileCatalogWriteLock)
+        using (_fileCatalogWriteLock.Enter(Timeout.InfiniteTimeSpan))
         {
             using var catalogWriteLease = EnterPhysicalFileCatalogWriteLock(_fileSystem, _databasePath);
             EnsureFileCatalogVersionCurrent(busyTimeout);
@@ -3143,6 +3143,20 @@ public sealed partial class EmbeddedDatabase : IDisposable
         }
     }
 
+    private async ValueTask WaitForCatalogStabilityAsync(
+        long deadline,
+        CancellationToken cancellationToken)
+    {
+        var registry = GetFileCatalogWriterRegistry(_fileSystem!);
+        var registryKey = GetFileCatalogLockPath(_fileSystem!, _databasePath);
+        if (!await registry
+                .WaitUntilIdleAsync(registryKey, deadline, cancellationToken)
+                .ConfigureAwait(false))
+        {
+            ThrowCatalogSnapshotBusy();
+        }
+    }
+
     private static long GetBusyWaitDeadline(TimeSpan busyTimeout)
     {
         if (busyTimeout == Timeout.InfiniteTimeSpan)
@@ -3220,7 +3234,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
         {
             if (_fileCatalogWriteLock is null)
                 throw new InvalidOperationException("The managed file catalog persistence state is not initialized.");
-            lock (_fileCatalogWriteLock)
+            using (_fileCatalogWriteLock.Enter(Timeout.InfiniteTimeSpan))
                 RefreshForeignCatalogIfChangedLocked();
         }
     }
@@ -3257,7 +3271,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
             if (_fileCatalogWriteLock is null)
                 throw new InvalidOperationException("The managed file catalog persistence state is not initialized.");
 
-            lock (_fileCatalogWriteLock)
+            using (_fileCatalogWriteLock.Enter(Timeout.InfiniteTimeSpan))
             {
                 var replacement = EmbeddedFileStore.Open(
                     _databasePath,
@@ -3317,7 +3331,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
             if (_fileSystem is null || _fileCatalogWriteLock is null)
                 throw new InvalidOperationException("The managed file catalog persistence state is not initialized.");
 
-            lock (_fileCatalogWriteLock)
+            using (_fileCatalogWriteLock.Enter(Timeout.InfiniteTimeSpan))
             {
                 using var catalogWriteLease = EnterPhysicalFileCatalogWriteLock(_fileSystem, _databasePath);
                 var durableVersion = ReadFileCatalogVersion(_fileSystem, _databasePath);
@@ -3437,7 +3451,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
             header.TextEncoding);
     }
 
-    private static object GetFileCatalogWriteLock(IFileSystem fileSystem, string path)
+    private static AsyncFifoGate GetFileCatalogWriteLock(IFileSystem fileSystem, string path)
     {
         var unwrappedFileSystem = AhtolaEncryptionFileSystem.Unwrap(fileSystem);
         return FileCatalogWriteLocks
@@ -3522,15 +3536,15 @@ public sealed partial class EmbeddedDatabase : IDisposable
 
     private sealed class FileCatalogWriteLockScope
     {
-        private readonly Dictionary<string, object> _locks = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, AsyncFifoGate> _locks = new(StringComparer.OrdinalIgnoreCase);
 
-        public object Get(string path)
+        public AsyncFifoGate Get(string path)
         {
             lock (_locks)
             {
                 if (!_locks.TryGetValue(path, out var fileCatalogWriteLock))
                 {
-                    fileCatalogWriteLock = new object();
+                    fileCatalogWriteLock = new AsyncFifoGate();
                     _locks.Add(path, fileCatalogWriteLock);
                 }
 
@@ -3549,6 +3563,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
     private sealed class FileCatalogWriterRegistry
     {
         private readonly Dictionary<string, int> _writers = new(StringComparer.OrdinalIgnoreCase);
+        private readonly AsyncConditionPulse _stateChanged = new();
 
         internal object WritersGate => _writers;
 
@@ -3571,6 +3586,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
                     _writers[path] = count - 1;
 
                 Monitor.PulseAll(_writers);
+                _stateChanged.PulseAll();
             }
         }
 
@@ -3578,6 +3594,44 @@ public sealed partial class EmbeddedDatabase : IDisposable
         {
             // Caller must hold WritersGate.
             return _writers.ContainsKey(path);
+        }
+
+        public async ValueTask<bool> WaitUntilIdleAsync(
+            string path,
+            long deadline,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            while (true)
+            {
+                Task stateChanged;
+                lock (_writers)
+                {
+                    if (!_writers.ContainsKey(path))
+                        return true;
+                    stateChanged = _stateChanged.Capture();
+                }
+
+                if (deadline == long.MaxValue)
+                {
+                    await stateChanged.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                var remaining = deadline - Environment.TickCount64;
+                if (remaining <= 0)
+                    return false;
+                try
+                {
+                    await stateChanged
+                        .WaitAsync(TimeSpan.FromMilliseconds(remaining), cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                catch (TimeoutException)
+                {
+                    return false;
+                }
+            }
         }
     }
 

--- a/src/Ahtola.Core/EmbeddedDatabase.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.cs
@@ -42747,9 +42747,30 @@ public sealed partial class EmbeddedConnection : IDisposable
 
         var storageKind = GetSnapshotStorageKind(database.FileSystem);
         var otherStorageKind = GetSnapshotStorageKind(otherDatabase.FileSystem);
-        return storageKind == SnapshotStorageKind.Unknown
-               || otherStorageKind == SnapshotStorageKind.Unknown;
+        if (storageKind != SnapshotStorageKind.Unknown
+            && otherStorageKind != SnapshotStorageKind.Unknown)
+        {
+            return false;
+        }
+
+        var fileSystem = AhtolaEncryptionFileSystem.Unwrap(database.FileSystem);
+        var otherFileSystem = AhtolaEncryptionFileSystem.Unwrap(otherDatabase.FileSystem);
+        return !CanProveDistinctSnapshotFiles(
+            fileSystem,
+            database.DatabasePath,
+            otherFileSystem,
+            otherDatabase.DatabasePath);
     }
+
+    private static bool CanProveDistinctSnapshotFiles(
+        IFileSystem fileSystem,
+        string path,
+        IFileSystem otherFileSystem,
+        string otherPath)
+        => fileSystem is ISnapshotFileIdentity identity
+               && identity.CanProveDistinctFile(path, otherFileSystem, otherPath)
+           || otherFileSystem is ISnapshotFileIdentity otherIdentity
+               && otherIdentity.CanProveDistinctFile(otherPath, fileSystem, path);
 
     private static SnapshotStorageKind GetSnapshotStorageKind(IFileSystem fileSystem)
         => AhtolaEncryptionFileSystem.Unwrap(fileSystem) switch

--- a/src/Ahtola.Core/EmbeddedTransactionLock.cs
+++ b/src/Ahtola.Core/EmbeddedTransactionLock.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Ahtola.Core.Storage;
 
@@ -42,6 +43,7 @@ internal sealed class EmbeddedTransactionLock
 {
     private readonly object _gate = new();
     private readonly Queue<Waiter> _waiters = new();
+    private readonly AsyncConditionPulse _stateChanged = new();
     private object? _owner;
     private int _holds;
     private bool _excludesReaders;
@@ -53,9 +55,13 @@ internal sealed class EmbeddedTransactionLock
     /// ENGINE #17). Each waiter sleeps on its own monitor; the releaser hands off
     /// by pulsing only the head of the queue.
     /// </summary>
-    private sealed class Waiter(object owner)
+    private sealed class Waiter(object owner, bool excludeReaders, bool async = false)
     {
         internal readonly object Owner = owner;
+        internal readonly bool ExcludeReaders = excludeReaders;
+        internal readonly TaskCompletionSource? SignalSource = async
+            ? new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
+            : null;
         internal bool Signaled;
         internal bool Removed;
     }
@@ -108,7 +114,7 @@ internal sealed class EmbeddedTransactionLock
             // releaser hands off to this waiter specifically (FIFO). The handoff
             // transfers ownership at signal time (in SignalHeadLocked), so this
             // waiter becomes the owner the moment it is dequeued.
-            var waiter = new Waiter(owner);
+            var waiter = new Waiter(owner, excludeReaders);
             _waiters.Enqueue(waiter);
             var handedOff = false;
             try
@@ -117,37 +123,71 @@ internal sealed class EmbeddedTransactionLock
                     WaitForSignalOrThrow(waiter, deadline);
 
                 handedOff = true;
-                _holds = 1;
-                _excludesReaders = excludeReaders;
             }
             finally
             {
                 if (!handedOff)
+                    AbandonWaiterLocked(waiter);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Asynchronously takes the same FIFO write reservation as <see cref="Enter"/>
+    /// without blocking a thread while another owner holds it.
+    /// </summary>
+    internal async ValueTask EnterAsync(
+        object owner,
+        bool excludeReaders,
+        TimeSpan busyTimeout,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(owner);
+        cancellationToken.ThrowIfCancellationRequested();
+        var deadline = GetBusyDeadline(busyTimeout);
+        Waiter waiter;
+        lock (_gate)
+        {
+            if (ReferenceEquals(_owner, owner))
+            {
+                _holds = checked(_holds + 1);
+                _excludesReaders |= excludeReaders;
+                return;
+            }
+
+            if (_owner is null && _waiters.Count == 0)
+            {
+                _owner = owner;
+                _holds = 1;
+                _excludesReaders = excludeReaders;
+                return;
+            }
+
+            waiter = new Waiter(owner, excludeReaders, async: true);
+            _waiters.Enqueue(waiter);
+        }
+
+        var handedOff = false;
+        try
+        {
+            await WaitForSignalOrThrowAsync(waiter, deadline, cancellationToken).ConfigureAwait(false);
+            lock (_gate)
+            {
+                if (!waiter.Signaled || !ReferenceEquals(_owner, owner))
                 {
-                    if (waiter.Removed)
-                    {
-                        // Dequeued as the handoff target: ownership already moved to
-                        // this owner at signal time with _holds==0. Release it so the
-                        // lock is not stranded in a dead owner. Use a raw release
-                        // (not Exit) because _holds is 0 here.
-                        if (ReferenceEquals(_owner, owner))
-                        {
-                            _owner = null;
-                            _excludesReaders = false;
-                            SignalHeadLocked();
-                        }
-                    }
-                    else
-                    {
-                        // Never handed off: drop from wherever it sits in the queue.
-                        waiter.Removed = true;
-                        if (_waiters.Count > 0 && ReferenceEquals(_waiters.Peek(), waiter))
-                        {
-                            _waiters.Dequeue();
-                            SignalHeadLocked();
-                        }
-                    }
+                    throw new InvalidOperationException(
+                        "The asynchronous managed transaction write reservation handoff was lost.");
                 }
+
+                handedOff = true;
+            }
+        }
+        finally
+        {
+            if (!handedOff)
+            {
+                lock (_gate)
+                    AbandonWaiterLocked(waiter);
             }
         }
     }
@@ -204,6 +244,50 @@ internal sealed class EmbeddedTransactionLock
         }
     }
 
+    /// <summary>
+    /// Asynchronously takes the barging autocommit reservation without sleeping a
+    /// worker thread between attempts.
+    /// </summary>
+    internal async ValueTask EnterAutocommitAsync(
+        object owner,
+        TimeSpan busyTimeout,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(owner);
+        var stopwatch = busyTimeout == Timeout.InfiniteTimeSpan ? null : Stopwatch.StartNew();
+        var attempt = 0;
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            lock (_gate)
+            {
+                if (ReferenceEquals(_owner, owner))
+                {
+                    _holds = checked(_holds + 1);
+                    return;
+                }
+
+                if (_owner is null)
+                {
+                    _owner = owner;
+                    _holds = 1;
+                    _excludesReaders = false;
+                    return;
+                }
+            }
+
+            if (!await SqliteBusyBackoff.WaitAsync(
+                    attempt++,
+                    busyTimeout,
+                    stopwatch,
+                    cancellationToken)
+                .ConfigureAwait(false))
+            {
+                throw new EmbeddedBusyException();
+            }
+        }
+    }
+
     /// <summary>Releases one reservation taken by <paramref name="owner"/>.</summary>
     internal void Exit(object owner)
     {
@@ -231,6 +315,7 @@ internal sealed class EmbeddedTransactionLock
         while (_waiters.Count > 0 && _waiters.Peek().Removed)
             _waiters.Dequeue();
 
+        _stateChanged.PulseAll();
         if (_waiters.Count == 0)
             return;
 
@@ -241,8 +326,10 @@ internal sealed class EmbeddedTransactionLock
         // before claiming can still release on its own behalf (handedOff==false
         // path in Enter) instead of stranding the lock.
         _owner = head.Owner;
-        _holds = 0; // the woken waiter sets this to 1 when it claims
+        _excludesReaders = head.ExcludeReaders;
+        _holds = 1;
         Monitor.PulseAll(_gate);
+        head.SignalSource?.TrySetResult();
     }
 
     private void WaitForSignalOrThrow(Waiter waiter, long deadline)
@@ -258,6 +345,34 @@ internal sealed class EmbeddedTransactionLock
             throw new EmbeddedBusyException();
 
         Monitor.Wait(_gate, (int)Math.Min(remaining, int.MaxValue));
+    }
+
+    private static async ValueTask WaitForSignalOrThrowAsync(
+        Waiter waiter,
+        long deadline,
+        CancellationToken cancellationToken)
+    {
+        var signal = waiter.SignalSource?.Task
+            ?? throw new InvalidOperationException("An asynchronous transaction waiter has no signal source.");
+        try
+        {
+            if (deadline == long.MaxValue)
+            {
+                await signal.WaitAsync(cancellationToken).ConfigureAwait(false);
+                return;
+            }
+
+            var remaining = deadline - Environment.TickCount64;
+            if (remaining <= 0)
+                throw new EmbeddedBusyException();
+            await signal
+                .WaitAsync(TimeSpan.FromMilliseconds(remaining), cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (TimeoutException)
+        {
+            throw new EmbeddedBusyException();
+        }
     }
 
     /// <summary>
@@ -281,6 +396,18 @@ internal sealed class EmbeddedTransactionLock
         }
     }
 
+    /// <summary>Asynchronously waits until writes are not blocked for <paramref name="owner"/>.</summary>
+    internal ValueTask ThrowIfWriteBlockedAsync(
+        object owner,
+        TimeSpan busyTimeout,
+        CancellationToken cancellationToken = default)
+        => WaitUntilUnblockedAsync(
+            owner,
+            busyTimeout,
+            static transactionLock =>
+                transactionLock._owner is null && transactionLock._waiters.Count == 0,
+            cancellationToken);
+
     /// <summary>
     /// Throws busy when another owner holds a reader-excluding reservation,
     /// waiting up to <paramref name="busyTimeout"/> for it to be released first.
@@ -295,6 +422,19 @@ internal sealed class EmbeddedTransactionLock
                 WaitForReleaseOrThrow(deadline);
         }
     }
+
+    /// <summary>Asynchronously waits until reads are not blocked for <paramref name="owner"/>.</summary>
+    internal ValueTask ThrowIfReadBlockedAsync(
+        object owner,
+        TimeSpan busyTimeout,
+        CancellationToken cancellationToken = default)
+        => WaitUntilUnblockedAsync(
+            owner,
+            busyTimeout,
+            transactionLock => !transactionLock._excludesReaders
+                               || transactionLock._owner is null
+                               || ReferenceEquals(transactionLock._owner, owner),
+            cancellationToken);
 
     private static long GetBusyDeadline(TimeSpan busyTimeout)
     {
@@ -318,6 +458,79 @@ internal sealed class EmbeddedTransactionLock
             throw new EmbeddedBusyException();
 
         Monitor.Wait(_gate, (int)Math.Min(remaining, int.MaxValue));
+    }
+
+    private async ValueTask WaitUntilUnblockedAsync(
+        object owner,
+        TimeSpan busyTimeout,
+        Func<EmbeddedTransactionLock, bool> canProceed,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(owner);
+        cancellationToken.ThrowIfCancellationRequested();
+        var deadline = GetBusyDeadline(busyTimeout);
+        while (true)
+        {
+            Task stateChanged;
+            lock (_gate)
+            {
+                if (canProceed(this)
+                    || (_owner is not null && ReferenceEquals(_owner, owner) && _waiters.Count == 0))
+                {
+                    return;
+                }
+
+                stateChanged = _stateChanged.Capture();
+            }
+
+            try
+            {
+                if (deadline == long.MaxValue)
+                {
+                    await stateChanged.WaitAsync(cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    var remaining = deadline - Environment.TickCount64;
+                    if (remaining <= 0)
+                        throw new EmbeddedBusyException();
+                    await stateChanged
+                        .WaitAsync(TimeSpan.FromMilliseconds(remaining), cancellationToken)
+                        .ConfigureAwait(false);
+                }
+            }
+            catch (TimeoutException)
+            {
+                throw new EmbeddedBusyException();
+            }
+        }
+    }
+
+    private void AbandonWaiterLocked(Waiter waiter)
+    {
+        if (waiter.Removed)
+        {
+            if (ReferenceEquals(_owner, waiter.Owner))
+            {
+                _owner = null;
+                _excludesReaders = false;
+                SignalHeadLocked();
+            }
+            return;
+        }
+
+        waiter.Removed = true;
+        if (_waiters.Count > 0 && ReferenceEquals(_waiters.Peek(), waiter))
+        {
+            _waiters.Dequeue();
+            while (_waiters.Count > 0 && _waiters.Peek().Removed)
+                _waiters.Dequeue();
+
+            _stateChanged.PulseAll();
+            Monitor.PulseAll(_gate);
+            if (_owner is null)
+                SignalHeadLocked();
+        }
     }
 }
 

--- a/src/Ahtola.Core/ManagedIncrementalBlobAdapter.cs
+++ b/src/Ahtola.Core/ManagedIncrementalBlobAdapter.cs
@@ -2,13 +2,39 @@ using Ahtola.Core.Parsing;
 
 namespace Ahtola.Core;
 
-public interface IManagedIncrementalBlobAdapter : IDisposable
+public interface IManagedIncrementalBlobAdapter : IDisposable, IAsyncDisposable
 {
     long Length { get; }
 
     int Read(long offset, Span<byte> destination);
 
+    ValueTask<int> ReadAsync(
+        long offset,
+        Memory<byte> destination,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var result = Read(offset, destination.Span);
+        return ValueTask.FromResult(result);
+    }
+
     void Write(long offset, ReadOnlySpan<byte> source);
+
+    ValueTask WriteAsync(
+        long offset,
+        ReadOnlyMemory<byte> source,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Write(offset, source.Span);
+        return ValueTask.CompletedTask;
+    }
+
+    ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        Dispose();
+        return ValueTask.CompletedTask;
+    }
 }
 
 public sealed class ManagedBlobException : Exception
@@ -195,6 +221,12 @@ internal sealed class ManagedIncrementalBlobAdapter : IManagedIncrementalBlobAda
             _value = [];
             _mutationLease.Dispose();
         }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        return ValueTask.CompletedTask;
     }
 
     private void EnsureCurrent()

--- a/src/Ahtola.Core/ManagedLocalAdapters.cs
+++ b/src/Ahtola.Core/ManagedLocalAdapters.cs
@@ -110,6 +110,16 @@ public sealed class ManagedSnapshotException : Exception
     public string? ObjectName { get; }
 }
 
+internal interface IManagedDatabaseFactory
+{
+    string DataSource { get; }
+
+    bool IsReadOnly { get; }
+
+    ValueTask<IManagedDatabaseAdapter> OpenDatabaseAsync(
+        CancellationToken cancellationToken = default);
+}
+
 public interface IManagedDatabaseAdapter : IDisposable, IAsyncDisposable
 {
     IManagedConnectionAdapter Connect();

--- a/src/Ahtola.Core/ManagedLocalAdapters.cs
+++ b/src/Ahtola.Core/ManagedLocalAdapters.cs
@@ -812,8 +812,22 @@ public sealed class ManagedStatementAdapter : IManagedStatementAdapter
         }
     }
 
-    public ValueTask<StatementStepResult> StepAsync(CancellationToken cancellationToken = default)
-        => ValueTask.FromResult(Step(cancellationToken));
+    public async ValueTask<StatementStepResult> StepAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var result = await GetStatement().StepAsync(cancellationToken).ConfigureAwait(false);
+            lock (_gate)
+                _hasCurrentRow = result == StatementStepResult.Row;
+            return result;
+        }
+        catch
+        {
+            lock (_gate)
+                _hasCurrentRow = false;
+            throw;
+        }
+    }
 
     public bool HasRows()
     {

--- a/src/Ahtola.Core/ManagedLocalAdapters.cs
+++ b/src/Ahtola.Core/ManagedLocalAdapters.cs
@@ -116,6 +116,8 @@ internal interface IManagedDatabaseFactory
 
     bool IsReadOnly { get; }
 
+    bool IsSharedMemory => false;
+
     ValueTask<IManagedDatabaseAdapter> OpenDatabaseAsync(
         CancellationToken cancellationToken = default);
 }

--- a/src/Ahtola.Core/ManagedLocalAdapters.cs
+++ b/src/Ahtola.Core/ManagedLocalAdapters.cs
@@ -201,14 +201,45 @@ public interface IManagedConnectionAdapter : IDisposable, IAsyncDisposable
     void CopySnapshotTo(IManagedConnectionAdapter destination)
         => throw new NotSupportedException("Managed snapshot copying is not supported by this connection adapter.");
 
+    ValueTask CopySnapshotToAsync(
+        IManagedConnectionAdapter destination,
+        CancellationToken cancellationToken = default)
+        => ManagedConnectionDurability.CopySnapshotToAsync(
+            this,
+            destination,
+            cancellationToken);
+
     void CopySnapshotTo(
         IManagedConnectionAdapter destination,
         string destinationName,
         string sourceName)
         => throw new NotSupportedException("Named managed snapshot copying is not supported by this connection adapter.");
 
+    ValueTask CopySnapshotToAsync(
+        IManagedConnectionAdapter destination,
+        string destinationName,
+        string sourceName,
+        CancellationToken cancellationToken = default)
+        => ManagedConnectionDurability.CopySnapshotToAsync(
+            this,
+            destination,
+            destinationName,
+            sourceName,
+            cancellationToken);
+
     void ApplySnapshotPragmaHeader(int schemaVersion, int userVersion, int applicationId)
         => throw new NotSupportedException("Managed snapshot PRAGMA metadata is not supported by this connection adapter.");
+
+    ValueTask ApplySnapshotPragmaHeaderAsync(
+        int schemaVersion,
+        int userVersion,
+        int applicationId,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ApplySnapshotPragmaHeader(schemaVersion, userVersion, applicationId);
+        return ValueTask.CompletedTask;
+    }
 
     /// <summary>
     /// The update, commit, rollback, authorizer, trace and progress callbacks registered on this
@@ -221,6 +252,72 @@ public interface IManagedConnectionAdapter : IDisposable, IAsyncDisposable
     {
         Dispose();
         return ValueTask.CompletedTask;
+    }
+}
+
+internal interface IManagedConnectionAdapterDecorator
+{
+    IManagedConnectionAdapter InnerConnectionAdapter { get; }
+}
+
+internal interface IManagedConnectionDurabilityBoundary
+{
+    ValueTask SynchronizeAsync();
+}
+
+internal static class ManagedConnectionDurability
+{
+    internal static ValueTask CopySnapshotToAsync(
+        IManagedConnectionAdapter source,
+        IManagedConnectionAdapter destination,
+        CancellationToken cancellationToken)
+        => CopySnapshotToAsync(
+            source,
+            destination,
+            destinationName: null,
+            sourceName: null,
+            cancellationToken);
+
+    internal static async ValueTask CopySnapshotToAsync(
+        IManagedConnectionAdapter source,
+        IManagedConnectionAdapter destination,
+        string? destinationName,
+        string? sourceName,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Exception? failure = null;
+        try
+        {
+            if (destinationName is null)
+                source.CopySnapshotTo(destination);
+            else
+                source.CopySnapshotTo(destination, destinationName, sourceName!);
+        }
+        catch (Exception exception)
+        {
+            failure = exception;
+        }
+
+        if (destination is IManagedConnectionDurabilityBoundary durability)
+        {
+            try
+            {
+                await durability.SynchronizeAsync().ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                failure = failure is null
+                    ? exception
+                    : new AggregateException(
+                        "Managed snapshot copying and destination synchronization both failed.",
+                        failure,
+                        exception);
+            }
+        }
+
+        if (failure is not null)
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(failure).Throw();
     }
 }
 
@@ -526,6 +623,7 @@ public sealed class ManagedConnectionAdapter : IManagedConnectionAdapter
         ArgumentNullException.ThrowIfNull(destination);
         ArgumentNullException.ThrowIfNull(destinationName);
         ArgumentNullException.ThrowIfNull(sourceName);
+        destination = UnwrapConnectionAdapter(destination);
         if (destination is not ManagedConnectionAdapter managedDestination)
             throw new ArgumentException("Managed snapshots require a managed destination adapter.", nameof(destination));
 
@@ -627,6 +725,22 @@ public sealed class ManagedConnectionAdapter : IManagedConnectionAdapter
         {
             return _connection ?? throw new ObjectDisposedException(nameof(ManagedConnectionAdapter));
         }
+    }
+
+    private static IManagedConnectionAdapter UnwrapConnectionAdapter(
+        IManagedConnectionAdapter adapter)
+    {
+        HashSet<IManagedConnectionAdapter>? visited = null;
+        while (adapter is IManagedConnectionAdapterDecorator decorator)
+        {
+            visited ??= new HashSet<IManagedConnectionAdapter>(
+                ReferenceEqualityComparer.Instance);
+            if (!visited.Add(adapter))
+                throw new InvalidOperationException("Managed connection adapter decorators cannot form a cycle.");
+            adapter = decorator.InnerConnectionAdapter;
+        }
+
+        return adapter;
     }
 }
 

--- a/src/Ahtola.Core/ManagedLocalAdapters.cs
+++ b/src/Ahtola.Core/ManagedLocalAdapters.cs
@@ -110,16 +110,42 @@ public sealed class ManagedSnapshotException : Exception
     public string? ObjectName { get; }
 }
 
-public interface IManagedDatabaseAdapter : IDisposable
+public interface IManagedDatabaseAdapter : IDisposable, IAsyncDisposable
 {
     IManagedConnectionAdapter Connect();
 
+    ValueTask<IManagedConnectionAdapter> ConnectAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return ValueTask.FromResult(Connect());
+    }
+
     IManagedConnectionAdapter Connection { get; }
+
+    ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        Dispose();
+        return ValueTask.CompletedTask;
+    }
 }
 
-public interface IManagedConnectionAdapter : IDisposable
+public interface IManagedConnectionAdapter : IDisposable, IAsyncDisposable
 {
     IManagedStatementAdapter Prepare(string sql);
+
+    ValueTask<IManagedStatementAdapter> PrepareAsync(
+        string sql,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var statement = Prepare(sql);
+        if (!cancellationToken.IsCancellationRequested)
+            return ValueTask.FromResult(statement);
+
+        statement.Dispose();
+        cancellationToken.ThrowIfCancellationRequested();
+        return default;
+    }
 
     bool HasAttachedDatabases => true;
 
@@ -180,9 +206,15 @@ public interface IManagedConnectionAdapter : IDisposable
     /// </summary>
     ManagedConnectionHooks Hooks
         => throw new NotSupportedException("Managed SQL hooks are not supported by this connection adapter.");
+
+    ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        Dispose();
+        return ValueTask.CompletedTask;
+    }
 }
 
-public interface IManagedStatementAdapter : IDisposable
+public interface IManagedStatementAdapter : IDisposable, IAsyncDisposable
 {
     int ParameterCount { get; }
 
@@ -204,9 +236,20 @@ public interface IManagedStatementAdapter : IDisposable
         return result;
     }
 
+    ValueTask<StatementStepResult> StepAsync(CancellationToken cancellationToken = default)
+        => ValueTask.FromResult(Step(cancellationToken));
+
     bool HasRows();
 
     void Reset();
+
+    ValueTask ResetAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Reset();
+        cancellationToken.ThrowIfCancellationRequested();
+        return ValueTask.CompletedTask;
+    }
 
     void ClearBindings();
 
@@ -227,6 +270,12 @@ public interface IManagedStatementAdapter : IDisposable
     ManagedResultMetadata ResultMetadata => new(this);
 
     string? GetParameterName(int index);
+
+    ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        Dispose();
+        return ValueTask.CompletedTask;
+    }
 }
 
 public sealed class ManagedDatabaseAdapter : IManagedDatabaseAdapter
@@ -303,6 +352,12 @@ public sealed class ManagedDatabaseAdapter : IManagedDatabaseAdapter
         }
     }
 
+    public ValueTask<IManagedConnectionAdapter> ConnectAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return ValueTask.FromResult(Connect());
+    }
+
     public IManagedConnectionAdapter Connection
     {
         get
@@ -342,6 +397,12 @@ public sealed class ManagedDatabaseAdapter : IManagedDatabaseAdapter
         }
     }
 
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        return ValueTask.CompletedTask;
+    }
+
     private void ThrowIfDisposed()
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -378,6 +439,20 @@ public sealed class ManagedConnectionAdapter : IManagedConnectionAdapter
     {
         ArgumentNullException.ThrowIfNull(sql);
         return ManagedStatementAdapter.FromPreparedStatement(this, sql, GetConnection().Prepare(sql));
+    }
+
+    public ValueTask<IManagedStatementAdapter> PrepareAsync(
+        string sql,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var statement = Prepare(sql);
+        if (!cancellationToken.IsCancellationRequested)
+            return ValueTask.FromResult(statement);
+
+        statement.Dispose();
+        cancellationToken.ThrowIfCancellationRequested();
+        return default;
     }
 
     public void ResetForPooling()
@@ -510,6 +585,12 @@ public sealed class ManagedConnectionAdapter : IManagedConnectionAdapter
         connection?.Dispose();
     }
 
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        return ValueTask.CompletedTask;
+    }
+
     internal EmbeddedStatement PrepareEmbeddedStatement(string sql)
     {
         return GetConnection().Prepare(sql);
@@ -605,6 +686,9 @@ public sealed class ManagedStatementAdapter : IManagedStatementAdapter
         }
     }
 
+    public ValueTask<StatementStepResult> StepAsync(CancellationToken cancellationToken = default)
+        => ValueTask.FromResult(Step(cancellationToken));
+
     public bool HasRows()
     {
         return GetStatement().HasRows();
@@ -625,6 +709,14 @@ public sealed class ManagedStatementAdapter : IManagedStatementAdapter
         GetStatement().Reset();
         lock (_gate)
             _hasCurrentRow = false;
+    }
+
+    public ValueTask ResetAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Reset();
+        cancellationToken.ThrowIfCancellationRequested();
+        return ValueTask.CompletedTask;
     }
 
     public void ClearBindings()
@@ -691,6 +783,12 @@ public sealed class ManagedStatementAdapter : IManagedStatementAdapter
         }
 
         statement?.Dispose();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        return ValueTask.CompletedTask;
     }
 
     private void ReplaceStatementWithoutBindings()

--- a/src/Ahtola.Core/Properties/AssemblyInfo.cs
+++ b/src/Ahtola.Core/Properties/AssemblyInfo.cs
@@ -2,3 +2,4 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Ahtola.Tests")]
 [assembly: InternalsVisibleTo("Devolutions.Ahtola.Data")]
+[assembly: InternalsVisibleTo("Devolutions.Ahtola.Data.Sqlite.Browser")]

--- a/src/Ahtola.Core/Properties/AssemblyInfo.cs
+++ b/src/Ahtola.Core/Properties/AssemblyInfo.cs
@@ -2,4 +2,5 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Ahtola.Tests")]
 [assembly: InternalsVisibleTo("Devolutions.Ahtola.Data")]
+[assembly: InternalsVisibleTo("Devolutions.Ahtola.Data.Sqlite")]
 [assembly: InternalsVisibleTo("Devolutions.Ahtola.Data.Sqlite.Browser")]

--- a/src/Ahtola.Core/Storage/AhtolaEncryptedPageFormat.cs
+++ b/src/Ahtola.Core/Storage/AhtolaEncryptedPageFormat.cs
@@ -1,0 +1,190 @@
+namespace Ahtola.Core.Storage;
+
+/// <summary>
+/// The regions of one AHTLA version 0 encrypted page, expressed as offsets into
+/// a full page image.
+/// </summary>
+/// <remarks>
+/// <see cref="AssociatedDataLength"/> is zero for every page except page 1,
+/// whose 100-byte visible header authenticates the encrypted payload.
+/// </remarks>
+internal readonly record struct AhtolaEncryptedPageRegions(
+    int PayloadOffset,
+    int PayloadLength,
+    int TagOffset,
+    int NonceOffset,
+    int AssociatedDataOffset,
+    int AssociatedDataLength);
+
+/// <summary>
+/// The byte layout of Ahtola's AES-GCM encrypted page format, factored out of
+/// <see cref="AhtolaPageEncryption"/> so callers that cannot use the synchronous
+/// <see cref="System.Security.Cryptography.AesGcm"/> primitive (notably the
+/// browser package, whose Web Crypto bindings are asynchronous) still produce
+/// byte-identical pages.
+/// </summary>
+/// <remarks>
+/// Every offset here is part of the on-disk contract shared with Turso's Rust
+/// engine. Changing any constant changes the file format.
+/// </remarks>
+internal static class AhtolaEncryptedPageFormat
+{
+    /// <summary>Reserved bytes consumed per page: a 16-byte tag plus a 12-byte nonce.</summary>
+    internal const int MetadataSize = TagSize + NonceSize;
+
+    /// <summary>AES-GCM authentication tag length.</summary>
+    internal const int TagSize = 16;
+
+    /// <summary>AES-GCM nonce length.</summary>
+    internal const int NonceSize = 12;
+
+    /// <summary>The only encrypted-page format version managed storage accepts.</summary>
+    internal const byte FormatVersion = 0;
+
+    /// <summary>The SQLite database header length, which stays visible on page 1.</summary>
+    internal const int SqliteHeaderSize = 100;
+
+    /// <summary>The AHTLA header length that replaces the SQLite magic on page 1.</summary>
+    internal const int AhtolaHeaderSize = 16;
+
+    /// <summary>The plaintext SQLite file magic.</summary>
+    internal static ReadOnlySpan<byte> SqliteHeaderMagic => "SQLite format 3\0"u8;
+
+    /// <summary>
+    /// Fixed 5-byte magic so version/cipher remain at offsets 5/6 inside the
+    /// 16-byte AHTLA header.
+    /// </summary>
+    internal static ReadOnlySpan<byte> AhtolaHeaderMagic => "AHTLA"u8;
+
+    /// <summary>Whether <paramref name="header"/> starts with the AHTLA magic.</summary>
+    internal static bool IsAhtolaEncrypted(ReadOnlySpan<byte> header)
+        => header.Length >= AhtolaHeaderMagic.Length
+           && header[..AhtolaHeaderMagic.Length].SequenceEqual(AhtolaHeaderMagic);
+
+    /// <summary>Rejects page sizes that cannot hold the header plus encryption metadata.</summary>
+    internal static void ValidatePageSize(int pageSize)
+    {
+        if (pageSize <= SqliteHeaderSize + MetadataSize)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(pageSize),
+                "The page is too small for Ahtola encryption metadata.");
+        }
+    }
+
+    /// <summary>Reports the encrypted regions of <paramref name="pageNumber"/>.</summary>
+    internal static AhtolaEncryptedPageRegions Describe(int pageSize, uint pageNumber)
+    {
+        ValidatePageSize(pageSize);
+        if (pageNumber == 0)
+            throw new ArgumentOutOfRangeException(nameof(pageNumber), "SQLite page numbers are 1-based.");
+
+        var payloadOffset = pageNumber == 1 ? SqliteHeaderSize : 0;
+        return new AhtolaEncryptedPageRegions(
+            payloadOffset,
+            pageSize - payloadOffset - MetadataSize,
+            pageSize - MetadataSize,
+            pageSize - NonceSize,
+            AssociatedDataOffset: 0,
+            AssociatedDataLength: pageNumber == 1 ? SqliteHeaderSize : 0);
+    }
+
+    /// <summary>
+    /// Writes the visible prefix of an encrypted page 1: the AHTLA magic, format
+    /// version, cipher id, and the SQLite header bytes that stay in the clear.
+    /// </summary>
+    internal static void WriteEncryptedHeaderPrefix(
+        Span<byte> encryptedPage,
+        ReadOnlySpan<byte> plaintextPage,
+        AhtolaEncryptionCipher cipher)
+    {
+        if (!plaintextPage[..SqliteHeaderMagic.Length].SequenceEqual(SqliteHeaderMagic))
+            throw new InvalidDataException("The first plaintext page must contain an SQLite format 3 header.");
+
+        AhtolaHeaderMagic.CopyTo(encryptedPage);
+        encryptedPage[5] = FormatVersion;
+        encryptedPage[6] = (byte)cipher;
+        encryptedPage[7..AhtolaHeaderSize].Clear();
+        plaintextPage[AhtolaHeaderSize..SqliteHeaderSize].CopyTo(encryptedPage[AhtolaHeaderSize..]);
+    }
+
+    /// <summary>Restores the plaintext SQLite header prefix of a decrypted page 1.</summary>
+    internal static void RestorePlaintextHeaderPrefix(
+        Span<byte> plaintextPage,
+        ReadOnlySpan<byte> encryptedPage)
+    {
+        SqliteHeaderMagic.CopyTo(plaintextPage);
+        encryptedPage[AhtolaHeaderSize..SqliteHeaderSize].CopyTo(plaintextPage[AhtolaHeaderSize..]);
+    }
+
+    /// <summary>
+    /// Validates an encrypted page 1 header against <paramref name="expectedCipher"/>,
+    /// refusing any format or cipher fallback.
+    /// </summary>
+    internal static void ValidateEncryptedHeader(
+        ReadOnlySpan<byte> header,
+        AhtolaEncryptionCipher expectedCipher)
+    {
+        if (header.Length < AhtolaHeaderSize)
+            throw new InvalidDataException("Encrypted Ahtola database header is truncated.");
+        if (!IsAhtolaEncrypted(header))
+            throw new InvalidDataException("Database does not contain a Ahtola encrypted header.");
+        if (header[5] != FormatVersion)
+        {
+            throw new InvalidDataException(
+                $"Unsupported Ahtola encrypted database format version {header[5]}; "
+                + "managed storage supports only format version 0 and will not infer or fall back to another format.");
+        }
+        if (header[6] is not (byte)AhtolaEncryptionCipher.Aes128Gcm and not (byte)AhtolaEncryptionCipher.Aes256Gcm)
+        {
+            throw new InvalidDataException(
+                $"Encrypted database uses Ahtola cipher ID {header[6]} ({GetCipherName(header[6])}); "
+                + "managed storage supports only cipher ID 1 (AES-128-GCM) and cipher ID 2 (AES-256-GCM) "
+                + "for format version 0 and will not infer or fall back to another cipher.");
+        }
+        if (header[6] != (byte)expectedCipher)
+        {
+            throw new InvalidDataException(
+                $"Encrypted database uses Ahtola cipher ID {header[6]} ({GetCipherName(header[6])}), "
+                + $"but the supplied options specify cipher ID {(byte)expectedCipher} ({GetCipherName((byte)expectedCipher)}); "
+                + "cipher fallback is not permitted.");
+        }
+        if (header[7..AhtolaHeaderSize].IndexOfAnyExcept((byte)0) >= 0)
+            throw new InvalidDataException("Ahtola encrypted database header has non-zero reserved bytes.");
+    }
+
+    /// <summary>
+    /// Rejects plaintext pages that already use the reserved bytes the encrypted
+    /// layout needs for its tag and nonce.
+    /// </summary>
+    internal static void ValidatePlaintextReservedBytes(ReadOnlySpan<byte> page, uint pageNumber)
+    {
+        if (page[^MetadataSize..].IndexOfAnyExcept((byte)0) >= 0)
+        {
+            throw new InvalidDataException(
+                $"Plaintext page {pageNumber} uses the {MetadataSize} SQLite reserved bytes required for Ahtola encryption metadata.");
+        }
+    }
+
+    /// <summary>The failure raised when a page does not authenticate.</summary>
+    internal static InvalidDataException CreateAuthenticationFailure(uint pageNumber, Exception? inner)
+        => new(
+            $"Encrypted Ahtola page {pageNumber} failed authentication. The encryption key is incorrect or the file was tampered with.",
+            inner);
+
+    /// <summary>Maps an Ahtola cipher id to its documented name.</summary>
+    internal static string GetCipherName(byte cipherId)
+        => cipherId switch
+        {
+            0 => "none",
+            1 => "AES-128-GCM",
+            2 => "AES-256-GCM",
+            3 => "AEGIS-256",
+            4 => "AEGIS-256X2",
+            5 => "AEGIS-256X4",
+            6 => "AEGIS-128L",
+            7 => "AEGIS-128X2",
+            8 => "AEGIS-128X4",
+            _ => "unknown",
+        };
+}

--- a/src/Ahtola.Core/Storage/AhtolaPageEncryption.cs
+++ b/src/Ahtola.Core/Storage/AhtolaPageEncryption.cs
@@ -123,16 +123,11 @@ public sealed class AhtolaEncryptionOptions : IDisposable
 
 internal sealed class AhtolaPageEncryption : IDisposable
 {
-    internal const int MetadataSize = TagSize + NonceSize;
-    internal const int TagSize = 16;
-    internal const int NonceSize = 12;
-    internal const byte FormatVersion = 0;
-    private const int SqliteHeaderSize = 100;
-    private const int AhtolaHeaderSize = 16;
-
-    private static ReadOnlySpan<byte> SqliteHeader => "SQLite format 3\0"u8;
-    // Fixed 5-byte magic so version/cipher remain at offsets 5/6 inside the 16-byte header.
-    private static ReadOnlySpan<byte> AhtolaHeaderPrefix => "AHTLA"u8;
+    internal const int MetadataSize = AhtolaEncryptedPageFormat.MetadataSize;
+    internal const int TagSize = AhtolaEncryptedPageFormat.TagSize;
+    internal const int NonceSize = AhtolaEncryptedPageFormat.NonceSize;
+    internal const byte FormatVersion = AhtolaEncryptedPageFormat.FormatVersion;
+    private const int SqliteHeaderSize = AhtolaEncryptedPageFormat.SqliteHeaderSize;
 
     private readonly byte[] _key;
     private bool _disposed;
@@ -141,8 +136,7 @@ internal sealed class AhtolaPageEncryption : IDisposable
     {
         Cipher = cipher;
         PageSize = pageSize;
-        if (pageSize <= SqliteHeaderSize + MetadataSize)
-            throw new ArgumentOutOfRangeException(nameof(pageSize), "The page is too small for Ahtola encryption metadata.");
+        AhtolaEncryptedPageFormat.ValidatePageSize(pageSize);
         if (key.Length != AhtolaEncryptionOptions.GetRequiredKeyLength(cipher))
             throw new ArgumentException("The encryption key length does not match the configured cipher.", nameof(key));
 
@@ -167,53 +161,24 @@ internal sealed class AhtolaPageEncryption : IDisposable
     public void ValidateEncryptedHeader(ReadOnlySpan<byte> header)
     {
         ThrowIfDisposed();
-        if (header.Length < AhtolaHeaderSize)
-            throw new InvalidDataException("Encrypted Ahtola database header is truncated.");
-        if (!header[..AhtolaHeaderPrefix.Length].SequenceEqual(AhtolaHeaderPrefix))
-            throw new InvalidDataException("Database does not contain a Ahtola encrypted header.");
-        if (header[5] != FormatVersion)
-        {
-            throw new InvalidDataException(
-                $"Unsupported Ahtola encrypted database format version {header[5]}; "
-                + "managed storage supports only format version 0 and will not infer or fall back to another format.");
-        }
-        if (header[6] is not (byte)AhtolaEncryptionCipher.Aes128Gcm and not (byte)AhtolaEncryptionCipher.Aes256Gcm)
-        {
-            throw new InvalidDataException(
-                $"Encrypted database uses Ahtola cipher ID {header[6]} ({GetCipherName(header[6])}); "
-                + "managed storage supports only cipher ID 1 (AES-128-GCM) and cipher ID 2 (AES-256-GCM) "
-                + "for format version 0 and will not infer or fall back to another cipher.");
-        }
-        if (header[6] != (byte)Cipher)
-        {
-            throw new InvalidDataException(
-                $"Encrypted database uses Ahtola cipher ID {header[6]} ({GetCipherName(header[6])}), "
-                + $"but the supplied options specify cipher ID {(byte)Cipher} ({GetCipherName((byte)Cipher)}); "
-                + "cipher fallback is not permitted.");
-        }
-        if (header[7..AhtolaHeaderSize].IndexOfAnyExcept((byte)0) >= 0)
-            throw new InvalidDataException("Ahtola encrypted database header has non-zero reserved bytes.");
+        AhtolaEncryptedPageFormat.ValidateEncryptedHeader(header, Cipher);
     }
 
     public byte[] EncryptPage(ReadOnlySpan<byte> page, uint pageNumber)
     {
         ThrowIfDisposed();
         ValidatePage(page, pageNumber);
-        if (page[^MetadataSize..].IndexOfAnyExcept((byte)0) >= 0)
-        {
-            throw new InvalidDataException(
-                $"Plaintext page {pageNumber} uses the {MetadataSize} SQLite reserved bytes required for Ahtola encryption metadata.");
-        }
+        AhtolaEncryptedPageFormat.ValidatePlaintextReservedBytes(page, pageNumber);
         if (pageNumber == 1)
             return EncryptFirstPage(page);
 
         var encrypted = new byte[PageSize];
-        var payloadLength = PageSize - MetadataSize;
+        var regions = AhtolaEncryptedPageFormat.Describe(PageSize, pageNumber);
         Encrypt(
-            page[..payloadLength],
-            encrypted.AsSpan(..payloadLength),
-            encrypted.AsSpan(payloadLength, TagSize),
-            encrypted.AsSpan(PageSize - NonceSize, NonceSize),
+            page.Slice(regions.PayloadOffset, regions.PayloadLength),
+            encrypted.AsSpan(regions.PayloadOffset, regions.PayloadLength),
+            encrypted.AsSpan(regions.TagOffset, TagSize),
+            encrypted.AsSpan(regions.NonceOffset, NonceSize),
             []);
         return encrypted;
     }
@@ -226,12 +191,12 @@ internal sealed class AhtolaPageEncryption : IDisposable
             return DecryptFirstPage(encryptedPage);
 
         var plaintext = new byte[PageSize];
-        var payloadLength = PageSize - MetadataSize;
+        var regions = AhtolaEncryptedPageFormat.Describe(PageSize, pageNumber);
         Decrypt(
-            encryptedPage[..payloadLength],
-            encryptedPage.Slice(payloadLength, TagSize),
-            encryptedPage[^NonceSize..],
-            plaintext.AsSpan(0, payloadLength),
+            encryptedPage.Slice(regions.PayloadOffset, regions.PayloadLength),
+            encryptedPage.Slice(regions.TagOffset, TagSize),
+            encryptedPage.Slice(regions.NonceOffset, NonceSize),
+            plaintext.AsSpan(regions.PayloadOffset, regions.PayloadLength),
             [],
             pageNumber);
         return plaintext;
@@ -248,22 +213,16 @@ internal sealed class AhtolaPageEncryption : IDisposable
 
     private byte[] EncryptFirstPage(ReadOnlySpan<byte> page)
     {
-        if (!page[..SqliteHeader.Length].SequenceEqual(SqliteHeader))
-            throw new InvalidDataException("The first plaintext page must contain an SQLite format 3 header.");
-
         var encrypted = new byte[PageSize];
-        AhtolaHeaderPrefix.CopyTo(encrypted);
-        encrypted[5] = FormatVersion;
-        encrypted[6] = (byte)Cipher;
-        page[AhtolaHeaderSize..SqliteHeaderSize].CopyTo(encrypted.AsSpan(AhtolaHeaderSize));
+        AhtolaEncryptedPageFormat.WriteEncryptedHeaderPrefix(encrypted, page, Cipher);
 
-        var payloadLength = PageSize - SqliteHeaderSize - MetadataSize;
+        var regions = AhtolaEncryptedPageFormat.Describe(PageSize, pageNumber: 1);
         Encrypt(
-            page.Slice(SqliteHeaderSize, payloadLength),
-            encrypted.AsSpan(SqliteHeaderSize, payloadLength),
-            encrypted.AsSpan(PageSize - MetadataSize, TagSize),
-            encrypted.AsSpan(PageSize - NonceSize, NonceSize),
-            encrypted.AsSpan(0, SqliteHeaderSize));
+            page.Slice(regions.PayloadOffset, regions.PayloadLength),
+            encrypted.AsSpan(regions.PayloadOffset, regions.PayloadLength),
+            encrypted.AsSpan(regions.TagOffset, TagSize),
+            encrypted.AsSpan(regions.NonceOffset, NonceSize),
+            encrypted.AsSpan(regions.AssociatedDataOffset, regions.AssociatedDataLength));
         return encrypted;
     }
 
@@ -272,15 +231,14 @@ internal sealed class AhtolaPageEncryption : IDisposable
         ValidateEncryptedHeader(encryptedPage);
 
         var plaintext = new byte[PageSize];
-        SqliteHeader.CopyTo(plaintext);
-        encryptedPage[AhtolaHeaderSize..SqliteHeaderSize].CopyTo(plaintext.AsSpan(AhtolaHeaderSize));
-        var payloadLength = PageSize - SqliteHeaderSize - MetadataSize;
+        AhtolaEncryptedPageFormat.RestorePlaintextHeaderPrefix(plaintext, encryptedPage);
+        var regions = AhtolaEncryptedPageFormat.Describe(PageSize, pageNumber: 1);
         Decrypt(
-            encryptedPage.Slice(SqliteHeaderSize, payloadLength),
-            encryptedPage.Slice(PageSize - MetadataSize, TagSize),
-            encryptedPage[^NonceSize..],
-            plaintext.AsSpan(SqliteHeaderSize, payloadLength),
-            encryptedPage[..SqliteHeaderSize],
+            encryptedPage.Slice(regions.PayloadOffset, regions.PayloadLength),
+            encryptedPage.Slice(regions.TagOffset, TagSize),
+            encryptedPage.Slice(regions.NonceOffset, NonceSize),
+            plaintext.AsSpan(regions.PayloadOffset, regions.PayloadLength),
+            encryptedPage.Slice(regions.AssociatedDataOffset, regions.AssociatedDataLength),
             pageNumber: 1);
         return plaintext;
     }
@@ -312,9 +270,7 @@ internal sealed class AhtolaPageEncryption : IDisposable
         }
         catch (CryptographicException exception)
         {
-            throw new InvalidDataException(
-                $"Encrypted Ahtola page {pageNumber} failed authentication. The encryption key is incorrect or the file was tampered with.",
-                exception);
+            throw AhtolaEncryptedPageFormat.CreateAuthenticationFailure(pageNumber, exception);
         }
     }
 
@@ -325,21 +281,6 @@ internal sealed class AhtolaPageEncryption : IDisposable
         if (page.Length != PageSize)
             throw new ArgumentException($"Encrypted page data must be exactly {PageSize} bytes.", nameof(page));
     }
-
-    private static string GetCipherName(byte cipherId)
-        => cipherId switch
-        {
-            0 => "none",
-            1 => "AES-128-GCM",
-            2 => "AES-256-GCM",
-            3 => "AEGIS-256",
-            4 => "AEGIS-256X2",
-            5 => "AEGIS-256X4",
-            6 => "AEGIS-128L",
-            7 => "AEGIS-128X2",
-            8 => "AEGIS-128X4",
-            _ => "unknown",
-        };
 
     private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposed, this);
 }

--- a/src/Ahtola.Core/Storage/AsyncConditionPulse.cs
+++ b/src/Ahtola.Core/Storage/AsyncConditionPulse.cs
@@ -1,0 +1,23 @@
+namespace Ahtola.Core.Storage;
+
+/// <summary>
+/// A monitor-adjacent asynchronous condition signal. Callers capture and pulse
+/// while holding their own state lock, then await the captured task after
+/// leaving that lock.
+/// </summary>
+internal sealed class AsyncConditionPulse
+{
+    private TaskCompletionSource _source = CreateSource();
+
+    internal Task Capture() => _source.Task;
+
+    internal void PulseAll()
+    {
+        var source = _source;
+        _source = CreateSource();
+        source.TrySetResult();
+    }
+
+    private static TaskCompletionSource CreateSource()
+        => new(TaskCreationOptions.RunContinuationsAsynchronously);
+}

--- a/src/Ahtola.Core/Storage/AsyncFifoGate.cs
+++ b/src/Ahtola.Core/Storage/AsyncFifoGate.cs
@@ -1,0 +1,232 @@
+using System.Diagnostics;
+
+namespace Ahtola.Core.Storage;
+
+/// <summary>
+/// A fair exclusive gate with independent synchronous and asynchronous wait
+/// paths. The returned lease, not a thread, owns the gate.
+/// </summary>
+internal sealed class AsyncFifoGate : IDisposable
+{
+    private readonly object _gate = new();
+    private readonly Queue<Waiter> _waiters = new();
+    private bool _held;
+    private bool _disposed;
+
+    internal Lease Enter(TimeSpan timeout = default)
+    {
+        ValidateTimeout(timeout);
+        var stopwatch = timeout == Timeout.InfiniteTimeSpan ? null : Stopwatch.StartNew();
+        lock (_gate)
+        {
+            ThrowIfDisposed();
+            if (!_held && _waiters.Count == 0)
+            {
+                _held = true;
+                return new Lease(this);
+            }
+
+            var waiter = new Waiter();
+            _waiters.Enqueue(waiter);
+            try
+            {
+                while (!waiter.Signaled)
+                {
+                    ThrowIfDisposed();
+                    var remaining = RemainingTimeout(timeout, stopwatch);
+                    if (remaining == TimeSpan.Zero)
+                        throw new TimeoutException("The asynchronous FIFO gate acquisition timed out.");
+                    Monitor.Wait(_gate, remaining);
+                }
+
+                return new Lease(this);
+            }
+            catch
+            {
+                AbandonLocked(waiter);
+                throw;
+            }
+        }
+    }
+
+    internal async ValueTask<Lease> EnterAsync(
+        TimeSpan timeout = default,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateTimeout(timeout);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        Waiter waiter;
+        lock (_gate)
+        {
+            ThrowIfDisposed();
+            if (!_held && _waiters.Count == 0)
+            {
+                _held = true;
+                return new Lease(this);
+            }
+
+            waiter = new Waiter(async: true);
+            _waiters.Enqueue(waiter);
+        }
+
+        try
+        {
+            if (timeout == Timeout.InfiniteTimeSpan)
+            {
+                await waiter.SignalTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                await waiter.SignalTask.WaitAsync(timeout, cancellationToken).ConfigureAwait(false);
+            }
+
+            return new Lease(this);
+        }
+        catch
+        {
+            lock (_gate)
+                AbandonLocked(waiter);
+            throw;
+        }
+    }
+
+    public void Dispose()
+    {
+        TaskCompletionSource[] asyncWaiters;
+        lock (_gate)
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            asyncWaiters = _waiters
+                .Where(static waiter => waiter.SignalSource is not null)
+                .Select(static waiter => waiter.SignalSource!)
+                .ToArray();
+            foreach (var waiter in _waiters)
+                waiter.Removed = true;
+            _waiters.Clear();
+            Monitor.PulseAll(_gate);
+        }
+
+        foreach (var waiter in asyncWaiters)
+            waiter.TrySetException(new ObjectDisposedException(nameof(AsyncFifoGate)));
+    }
+
+    private void Release()
+    {
+        TaskCompletionSource? asyncWaiter = null;
+        lock (_gate)
+        {
+            if (!_held)
+                throw new InvalidOperationException("The asynchronous FIFO gate lease was already released.");
+
+            while (_waiters.Count > 0 && _waiters.Peek().Removed)
+                _waiters.Dequeue();
+
+            if (_disposed || _waiters.Count == 0)
+            {
+                _held = false;
+                return;
+            }
+
+            var waiter = _waiters.Dequeue();
+            waiter.Removed = true;
+            waiter.Signaled = true;
+            asyncWaiter = waiter.SignalSource;
+            Monitor.PulseAll(_gate);
+        }
+
+        asyncWaiter?.TrySetResult();
+    }
+
+    private void AbandonLocked(Waiter waiter)
+    {
+        if (waiter.Signaled)
+        {
+            ReleaseHandedOffLocked();
+            return;
+        }
+
+        waiter.Removed = true;
+        while (_waiters.Count > 0 && _waiters.Peek().Removed)
+            _waiters.Dequeue();
+    }
+
+    private void ReleaseHandedOffLocked()
+    {
+        while (_waiters.Count > 0 && _waiters.Peek().Removed)
+            _waiters.Dequeue();
+
+        if (_disposed || _waiters.Count == 0)
+        {
+            _held = false;
+            return;
+        }
+
+        var next = _waiters.Dequeue();
+        next.Removed = true;
+        next.Signaled = true;
+        Monitor.PulseAll(_gate);
+        next.SignalSource?.TrySetResult();
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(AsyncFifoGate));
+    }
+
+    private static void ValidateTimeout(TimeSpan timeout)
+    {
+        if (timeout < TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan)
+            throw new ArgumentOutOfRangeException(nameof(timeout), "Timeout must be non-negative or infinite.");
+    }
+
+    private static TimeSpan RemainingTimeout(TimeSpan timeout, Stopwatch? stopwatch)
+    {
+        if (timeout == Timeout.InfiniteTimeSpan)
+            return Timeout.InfiniteTimeSpan;
+
+        var remaining = timeout - stopwatch!.Elapsed;
+        if (remaining <= TimeSpan.Zero)
+            return TimeSpan.Zero;
+        return remaining > TimeSpan.FromMilliseconds(int.MaxValue)
+            ? TimeSpan.FromMilliseconds(int.MaxValue)
+            : remaining;
+    }
+
+    private sealed class Waiter
+    {
+        internal Waiter(bool async = false)
+        {
+            if (async)
+                SignalSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        internal TaskCompletionSource? SignalSource { get; }
+
+        internal Task SignalTask => SignalSource?.Task
+            ?? throw new InvalidOperationException("A synchronous gate waiter has no asynchronous signal.");
+
+        internal bool Signaled { get; set; }
+
+        internal bool Removed { get; set; }
+    }
+
+    internal sealed class Lease : IDisposable
+    {
+        private AsyncFifoGate? _owner;
+
+        internal Lease(AsyncFifoGate owner) => _owner = owner;
+
+        internal bool IsActive => Volatile.Read(ref _owner) is not null;
+
+        public void Dispose()
+        {
+            var owner = Interlocked.Exchange(ref _owner, null);
+            owner?.Release();
+        }
+    }
+}

--- a/src/Ahtola.Core/Storage/AsyncFileSystemAdapter.cs
+++ b/src/Ahtola.Core/Storage/AsyncFileSystemAdapter.cs
@@ -30,9 +30,11 @@ public static class AsyncFileSystemAdapter
         };
     }
 
-    private class FileSystemAdapter(IFileSystem inner) : IAsyncFileSystem
+    private class FileSystemAdapter(IFileSystem inner) : IAsyncFileSystem, IAsyncFileSystemBacking
     {
         protected IFileSystem Inner { get; } = inner;
+
+        public IFileSystem BackingFileSystem => Inner;
 
         public StringComparer PathComparer
             => ((IStoragePathResolver)Inner).PathComparer;

--- a/src/Ahtola.Core/Storage/AsyncFileSystemAdapter.cs
+++ b/src/Ahtola.Core/Storage/AsyncFileSystemAdapter.cs
@@ -1,0 +1,252 @@
+namespace Ahtola.Core.Storage;
+
+/// <summary>
+/// Adapts existing synchronous storage to the orthogonal asynchronous
+/// contracts. Operations execute immediately and return completed
+/// <see cref="ValueTask"/> instances.
+/// </summary>
+public static class AsyncFileSystemAdapter
+{
+    /// <summary>
+    /// Wraps <paramref name="fileSystem"/>, preserving its optional atomic and
+    /// temporary-file capabilities.
+    /// </summary>
+    public static IAsyncFileSystem Create(IFileSystem fileSystem)
+    {
+        ArgumentNullException.ThrowIfNull(fileSystem);
+        return (
+            fileSystem is IAtomicFileSystem,
+            fileSystem is ITemporaryFileSystem,
+            fileSystem is IStoragePathResolver) switch
+        {
+            (true, true, true) => new PathAtomicTemporaryAdapter(fileSystem),
+            (true, true, false) => new AtomicTemporaryAdapter(fileSystem),
+            (true, false, true) => new PathAtomicAdapter(fileSystem),
+            (true, false, false) => new AtomicAdapter(fileSystem),
+            (false, true, true) => new PathTemporaryAdapter(fileSystem),
+            (false, true, false) => new TemporaryAdapter(fileSystem),
+            (false, false, true) => new PathAdapter(fileSystem),
+            _ => new FileSystemAdapter(fileSystem),
+        };
+    }
+
+    private class FileSystemAdapter(IFileSystem inner) : IAsyncFileSystem
+    {
+        protected IFileSystem Inner { get; } = inner;
+
+        public StringComparer PathComparer
+            => ((IStoragePathResolver)Inner).PathComparer;
+
+        public string GetCanonicalPath(string path)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(path);
+            return ((IStoragePathResolver)Inner).GetCanonicalPath(path);
+        }
+
+        public ValueTask<bool> FileExistsAsync(
+            string path,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult(Inner.FileExists(path));
+        }
+
+        public ValueTask<IAsyncFile> OpenFileAsync(
+            string path,
+            FileOpenMode mode,
+            bool readOnly = false,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult(AsyncFileAdapter.Create(Inner.OpenFile(path, mode, readOnly)));
+        }
+
+        public ValueTask DeleteFileAsync(
+            string path,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Inner.DeleteFile(path);
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask<FileWriteStamp?> GetWriteStampAsync(
+            string path,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult(Inner.GetWriteStamp(path));
+        }
+    }
+
+    private class AtomicAdapter(IFileSystem inner) :
+        FileSystemAdapter(inner),
+        IAsyncAtomicFileSystem
+    {
+        public ValueTask ReplaceFileAtomicallyAsync(
+            string sourcePath,
+            string destinationPath,
+            bool replaceEmptyDestination,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ((IAtomicFileSystem)Inner).ReplaceFileAtomically(
+                sourcePath,
+                destinationPath,
+                replaceEmptyDestination);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private class TemporaryAdapter(IFileSystem inner) :
+        FileSystemAdapter(inner),
+        IAsyncTemporaryFileSystem
+    {
+        public ValueTask<IAsyncFile> OpenTemporaryFileAsync(
+            string path,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var file = ((ITemporaryFileSystem)Inner).OpenTemporaryFile(path);
+            return ValueTask.FromResult(AsyncFileAdapter.Create(file));
+        }
+    }
+
+    private class AtomicTemporaryAdapter(IFileSystem inner) :
+        FileSystemAdapter(inner),
+        IAsyncAtomicFileSystem,
+        IAsyncTemporaryFileSystem
+    {
+        public ValueTask ReplaceFileAtomicallyAsync(
+            string sourcePath,
+            string destinationPath,
+            bool replaceEmptyDestination,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ((IAtomicFileSystem)Inner).ReplaceFileAtomically(
+                sourcePath,
+                destinationPath,
+                replaceEmptyDestination);
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask<IAsyncFile> OpenTemporaryFileAsync(
+            string path,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var file = ((ITemporaryFileSystem)Inner).OpenTemporaryFile(path);
+            return ValueTask.FromResult(AsyncFileAdapter.Create(file));
+        }
+    }
+
+    private sealed class PathAdapter(IFileSystem inner) :
+        FileSystemAdapter(inner),
+        IStoragePathResolver
+    {
+    }
+
+    private sealed class PathAtomicAdapter(IFileSystem inner) :
+        AtomicAdapter(inner),
+        IStoragePathResolver
+    {
+    }
+
+    private sealed class PathTemporaryAdapter(IFileSystem inner) :
+        TemporaryAdapter(inner),
+        IStoragePathResolver
+    {
+    }
+
+    private sealed class PathAtomicTemporaryAdapter(IFileSystem inner) :
+        AtomicTemporaryAdapter(inner),
+        IStoragePathResolver
+    {
+    }
+}
+
+/// <summary>Adapts an existing synchronous positional file.</summary>
+public static class AsyncFileAdapter
+{
+    /// <summary>
+    /// Wraps <paramref name="file"/>, preserving its optional page
+    /// materialization capability.
+    /// </summary>
+    public static IAsyncFile Create(IFile file)
+    {
+        ArgumentNullException.ThrowIfNull(file);
+        return file is IPageMaterializingFile
+            ? new MaterializingFileAdapter(file)
+            : new FileAdapter(file);
+    }
+
+    private class FileAdapter(IFile inner) : IAsyncFile
+    {
+        protected IFile Inner { get; } = inner;
+
+        public bool IsReadOnly => Inner.IsReadOnly;
+
+        public ValueTask<long> GetLengthAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult(Inner.Length);
+        }
+
+        public ValueTask<int> ReadAsync(
+            long position,
+            Memory<byte> destination,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult(Inner.Read(position, destination.Span));
+        }
+
+        public ValueTask WriteAsync(
+            long position,
+            ReadOnlyMemory<byte> source,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Inner.Write(position, source.Span);
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask SetLengthAsync(
+            long length,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Inner.SetLength(length);
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask FlushToDiskAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Inner.FlushToDisk();
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Inner.Dispose();
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class MaterializingFileAdapter(IFile inner) :
+        FileAdapter(inner),
+        IAsyncPageMaterializingFile
+    {
+        public ValueTask EnsureMaterializedAsync(
+            long position,
+            int length,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ((IPageMaterializingFile)Inner).EnsureMaterialized(position, length);
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/Ahtola.Core/Storage/AsyncSqlitePageStore.cs
+++ b/src/Ahtola.Core/Storage/AsyncSqlitePageStore.cs
@@ -1,0 +1,928 @@
+using System.Buffers;
+using System.Buffers.Binary;
+
+namespace Ahtola.Core.Storage;
+
+/// <summary>
+/// An asynchronous page store over a SQLite-format database file.
+/// </summary>
+/// <remarks>
+/// The store preserves the same page alignment, header, and append invariants
+/// as <see cref="SqlitePageStore"/>, but depends only on <see cref="IAsyncFile"/>.
+/// Page codecs remain synchronous because encoding and decoding are CPU work;
+/// codec calls are made only between asynchronous file operations.
+/// </remarks>
+public sealed class AsyncSqlitePageStore : IAsyncDisposable
+{
+    private const int MaximumSequentialWriteBytes = 1 << 20;
+
+    private readonly IAsyncFile _file;
+    private readonly IPageCodec? _pageCodec;
+    private readonly bool _ownsPageCodec;
+    private SqliteDatabaseHeader _header;
+    private bool _disposed;
+
+    private AsyncSqlitePageStore(
+        IAsyncFile file,
+        SqliteDatabaseHeader header,
+        IPageCodec? pageCodec,
+        bool ownsPageCodec,
+        string path)
+    {
+        _file = file;
+        _header = header;
+        _pageCodec = pageCodec;
+        _ownsPageCodec = ownsPageCodec;
+        PageSize = header.PageSize;
+        Path = path;
+    }
+
+    /// <summary>Page size in bytes; fixed for the life of the store.</summary>
+    public int PageSize { get; }
+
+    /// <summary>The storage path used to open the database.</summary>
+    public string Path { get; }
+
+    /// <summary>Whether the underlying file was opened read-only.</summary>
+    public bool IsReadOnly => _file.IsReadOnly;
+
+    /// <summary>The database header currently stored on page 1.</summary>
+    public SqliteDatabaseHeader Header
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return _header;
+        }
+    }
+
+    /// <summary>
+    /// Opens an existing SQLite-format file and validates its header and length.
+    /// </summary>
+    public static ValueTask<AsyncSqlitePageStore> OpenAsync(
+        IAsyncFileSystem fileSystem,
+        string path,
+        bool readOnly = false,
+        AhtolaEncryptionOptions? encryption = null,
+        IPageCodec? pageCodec = null,
+        CancellationToken cancellationToken = default)
+        => OpenCoreAsync(
+            fileSystem,
+            path,
+            readOnly,
+            encryption,
+            pageCodec,
+            allowTrailingPages: false,
+            cancellationToken);
+
+    /// <summary>
+    /// Opens a store while allowing pager-verified trailing physical pages.
+    /// </summary>
+    internal static ValueTask<AsyncSqlitePageStore> OpenForPagerAsync(
+        IAsyncFileSystem fileSystem,
+        string path,
+        bool readOnly = false,
+        AhtolaEncryptionOptions? encryption = null,
+        IPageCodec? pageCodec = null,
+        CancellationToken cancellationToken = default)
+        => OpenCoreAsync(
+            fileSystem,
+            path,
+            readOnly,
+            encryption,
+            pageCodec,
+            allowTrailingPages: true,
+            cancellationToken);
+
+    private static async ValueTask<AsyncSqlitePageStore> OpenCoreAsync(
+        IAsyncFileSystem fileSystem,
+        string path,
+        bool readOnly,
+        AhtolaEncryptionOptions? encryption,
+        IPageCodec? pageCodec,
+        bool allowTrailingPages,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(fileSystem);
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        PageCodecSupport.RejectCombinedTransforms(encryption, pageCodec);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        IPageCodec? boundCodec = null;
+        var ownsCodec = false;
+        var file = await fileSystem.OpenFileAsync(
+            path,
+            FileOpenMode.OpenExisting,
+            readOnly,
+            cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var length = await file.GetLengthAsync(cancellationToken).ConfigureAwait(false);
+            if (length < SqliteDatabaseHeader.Size)
+                throw new InvalidDataException("File is too small to contain a SQLite database header.");
+
+            var rawHeader = new byte[SqliteDatabaseHeader.Size];
+            if (await file.ReadAsync(0, rawHeader, cancellationToken).ConfigureAwait(false)
+                != SqliteDatabaseHeader.Size)
+            {
+                throw new InvalidDataException("Failed to read the complete SQLite database header.");
+            }
+
+            SqliteDatabaseHeader header;
+            if (pageCodec is not null)
+            {
+                PageCodecSupport.ValidateExternalCodec(pageCodec);
+                boundCodec = pageCodec;
+                header = await OpenWithCodecAsync(
+                    file,
+                    length,
+                    boundCodec,
+                    rawHeader,
+                    requireAhtolaMagic: false,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            else if (IsAhtolaEncrypted(rawHeader))
+            {
+                if (encryption is null)
+                {
+                    throw new InvalidDataException(
+                        "Database is encrypted with Ahtola page encryption. Supply AhtolaEncryptionOptions; plaintext fallback is not permitted.");
+                }
+
+                var pageSize = SqlitePageSize.Decode(
+                    BinaryPrimitives.ReadUInt16BigEndian(rawHeader.AsSpan(16)));
+                boundCodec = EncryptionPageCodec.Create(encryption, pageSize);
+                ownsCodec = true;
+                header = await OpenWithCodecAsync(
+                    file,
+                    length,
+                    boundCodec,
+                    rawHeader,
+                    requireAhtolaMagic: true,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                if (encryption is not null)
+                {
+                    throw new InvalidDataException(
+                        "Encryption was requested, but the database contains a plaintext SQLite header. Plaintext fallback is not permitted.");
+                }
+
+                header = SqliteDatabaseHeader.Parse(rawHeader);
+            }
+
+            ValidateFileLayout(length, header, allowTrailingPages);
+            return new AsyncSqlitePageStore(file, header, boundCodec, ownsCodec, path);
+        }
+        catch
+        {
+            try
+            {
+                await file.DisposeAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                PageCodecSupport.DisposeOwned(boundCodec, ownsCodec);
+            }
+
+            throw;
+        }
+    }
+
+    private static async ValueTask<SqliteDatabaseHeader> OpenWithCodecAsync(
+        IAsyncFile file,
+        long length,
+        IPageCodec codec,
+        ReadOnlyMemory<byte> rawHeader,
+        bool requireAhtolaMagic,
+        CancellationToken cancellationToken)
+    {
+        var bootstrapLength = (int)Math.Min(
+            length,
+            Math.Max(SqliteDatabaseHeader.Size, PageCodecHeaderInfo.SqliteBootstrapHeaderLength));
+        var bootstrap = new byte[bootstrapLength];
+        if (await file.ReadAsync(0, bootstrap, cancellationToken).ConfigureAwait(false)
+            != bootstrapLength)
+        {
+            throw new InvalidDataException("Failed to read the page-codec bootstrap prefix.");
+        }
+
+        var layout = codec.BootstrapPageInfo(bootstrap);
+        var pageSize = layout.PageSize;
+        if (length < pageSize)
+            throw new InvalidDataException("Database is smaller than its declared page size.");
+        if (length % pageSize != 0)
+            throw new InvalidDataException("Database file is not a whole number of pages.");
+
+        if (codec is EncryptionPageCodec encryptionCodec)
+        {
+            if (requireAhtolaMagic && !IsAhtolaEncrypted(rawHeader.Span))
+                throw new InvalidDataException("Encrypted Ahtola database is missing the AHTLA header magic.");
+            encryptionCodec.ValidateEncryptedHeader(rawHeader.Span);
+        }
+
+        var encodedFirstPage = new byte[pageSize];
+        if (await file.ReadAsync(0, encodedFirstPage, cancellationToken).ConfigureAwait(false)
+            != pageSize)
+        {
+            throw new InvalidDataException("Failed to read the complete first page.");
+        }
+
+        var plaintextFirstPage = new byte[pageSize];
+        PageCodecSupport.Decode(
+            codec,
+            PageLocation.Database,
+            1,
+            encodedFirstPage,
+            plaintextFirstPage);
+        var header = SqliteDatabaseHeader.Parse(plaintextFirstPage);
+        if (header.PageSize != pageSize)
+        {
+            throw new InvalidDataException(
+                $"Page codec bootstrap page size {pageSize} disagrees with decoded header page size {header.PageSize}.");
+        }
+
+        var requiredReserved = codec.RequiredReservedBytes;
+        if (requiredReserved != 0 && header.ReservedSpace != requiredReserved)
+        {
+            throw new InvalidDataException(
+                $"Database reserves {header.ReservedSpace} bytes per page, but the page codec requires {requiredReserved}.");
+        }
+
+        return header;
+    }
+
+    /// <summary>
+    /// Creates a fresh single-page SQLite database containing an empty table root.
+    /// </summary>
+    public static async ValueTask<AsyncSqlitePageStore> CreateAsync(
+        IAsyncFileSystem fileSystem,
+        string path,
+        SqliteDatabaseHeader? header = null,
+        bool overwrite = false,
+        AhtolaEncryptionOptions? encryption = null,
+        IPageCodec? pageCodec = null,
+        bool flushOnCreate = true,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(fileSystem);
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var effectiveHeader = (header ?? SqliteDatabaseHeader.CreateDefault()) with
+        {
+            ChangeCounter = 1,
+            DatabaseSizeInPages = 1,
+            VersionValidFor = 1,
+        };
+        var boundCodec = PageCodecSupport.Bind(
+            encryption,
+            pageCodec,
+            effectiveHeader.PageSize,
+            out var ownsCodec);
+
+        var mode = overwrite ? FileOpenMode.OpenOrCreate : FileOpenMode.CreateNew;
+        IAsyncFile? file = null;
+        var createdArtifact = false;
+        try
+        {
+            if (boundCodec is not null)
+                effectiveHeader = PageCodecSupport.ApplyReservedBytes(boundCodec, effectiveHeader);
+
+            var pageSize = effectiveHeader.PageSize;
+            var firstPage = new byte[pageSize];
+            effectiveHeader.WriteTo(firstPage);
+            SqliteBtreePageHeader
+                .CreateEmpty(
+                    SqliteBtreePageType.TableLeaf,
+                    pageSize,
+                    isFirstPage: true,
+                    usableSpace: effectiveHeader.UsableSpace)
+                .WriteTo(firstPage);
+
+            file = await fileSystem.OpenFileAsync(
+                path,
+                mode,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+            createdArtifact = mode == FileOpenMode.CreateNew;
+            await file.SetLengthAsync(0, cancellationToken).ConfigureAwait(false);
+            if (boundCodec is null)
+            {
+                await file.WriteAsync(0, firstPage, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                var encoded = new byte[pageSize];
+                PageCodecSupport.Encode(
+                    boundCodec,
+                    PageLocation.Database,
+                    1,
+                    firstPage,
+                    encoded);
+                await file.WriteAsync(0, encoded, cancellationToken).ConfigureAwait(false);
+            }
+
+            await file.SetLengthAsync(pageSize, cancellationToken).ConfigureAwait(false);
+            if (flushOnCreate)
+                await file.FlushToDiskAsync(cancellationToken).ConfigureAwait(false);
+            return new AsyncSqlitePageStore(
+                file,
+                effectiveHeader,
+                boundCodec,
+                ownsCodec,
+                path);
+        }
+        catch
+        {
+            try
+            {
+                if (file is not null)
+                    await file.DisposeAsync().ConfigureAwait(false);
+            }
+            catch
+            {
+            }
+
+            try
+            {
+                PageCodecSupport.DisposeOwned(boundCodec, ownsCodec);
+            }
+            catch
+            {
+            }
+
+            if (createdArtifact)
+            {
+                try
+                {
+                    await fileSystem.DeleteFileAsync(path, CancellationToken.None).ConfigureAwait(false);
+                }
+                catch
+                {
+                }
+            }
+
+            throw;
+        }
+    }
+
+    /// <summary>Returns the number of whole pages currently in the file.</summary>
+    public async ValueTask<uint> GetPageCountAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        var length = await _file.GetLengthAsync(cancellationToken).ConfigureAwait(false);
+        return checked((uint)(length / PageSize));
+    }
+
+    /// <summary>Reads a page into exactly one page of caller-provided memory.</summary>
+    public async ValueTask ReadPageAsync(
+        uint pageNumber,
+        Memory<byte> destination,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        if (destination.Length != PageSize)
+            throw new ArgumentException($"Destination must be exactly {PageSize} bytes.", nameof(destination));
+
+        var count = await GetPageCountAsync(cancellationToken).ConfigureAwait(false);
+        ValidateReadablePageNumber(pageNumber, count);
+        await EnsurePageMaterializedAsync(pageNumber, cancellationToken).ConfigureAwait(false);
+
+        var offset = PageOffset(pageNumber);
+        if (_pageCodec is not null)
+        {
+            var encodedPage = new byte[PageSize];
+            var encodedRead = await _file.ReadAsync(
+                offset,
+                encodedPage,
+                cancellationToken).ConfigureAwait(false);
+            if (encodedRead != PageSize)
+            {
+                throw new InvalidDataException(
+                    $"Short read on encoded page {pageNumber}: expected {PageSize} bytes, got {encodedRead}. The file may be truncated.");
+            }
+
+            PageCodecSupport.Decode(
+                _pageCodec,
+                PageLocation.Database,
+                pageNumber,
+                encodedPage,
+                destination.Span);
+            return;
+        }
+
+        var read = await _file.ReadAsync(
+            offset,
+            destination,
+            cancellationToken).ConfigureAwait(false);
+        if (read != PageSize)
+        {
+            throw new InvalidDataException(
+                $"Short read on page {pageNumber}: expected {PageSize} bytes, got {read}. The file may be truncated.");
+        }
+    }
+
+    /// <summary>Reads a page into a newly allocated array.</summary>
+    public async ValueTask<byte[]> ReadPageAsync(
+        uint pageNumber,
+        CancellationToken cancellationToken = default)
+    {
+        var page = new byte[PageSize];
+        await ReadPageAsync(pageNumber, page, cancellationToken).ConfigureAwait(false);
+        return page;
+    }
+
+    internal async ValueTask<byte[]> ReadRawPageAsync(
+        uint pageNumber,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        var count = await GetPageCountAsync(cancellationToken).ConfigureAwait(false);
+        ValidateReadablePageNumber(pageNumber, count);
+        await EnsurePageMaterializedAsync(pageNumber, cancellationToken).ConfigureAwait(false);
+
+        var page = new byte[PageSize];
+        var read = await _file.ReadAsync(
+            PageOffset(pageNumber),
+            page,
+            cancellationToken).ConfigureAwait(false);
+        if (read != PageSize)
+        {
+            throw new InvalidDataException(
+                $"Short raw read on page {pageNumber}: expected {PageSize} bytes, got {read}.");
+        }
+
+        return page;
+    }
+
+    internal async ValueTask EnsurePageMaterializedAsync(
+        uint pageNumber,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        if (_file is not IAsyncPageMaterializingFile materializingFile || pageNumber < 1)
+            return;
+
+        var count = await GetPageCountAsync(cancellationToken).ConfigureAwait(false);
+        if (pageNumber <= count)
+        {
+            await materializingFile.EnsureMaterializedAsync(
+                PageOffset(pageNumber),
+                PageSize,
+                cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    internal bool SupportsPageMaterialization => _file is IAsyncPageMaterializingFile;
+
+    internal async ValueTask RefreshHeaderAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        var firstPage = await ReadPageAsync(1, cancellationToken).ConfigureAwait(false);
+        var header = SqliteDatabaseHeader.Parse(firstPage);
+        if (header.PageSize != PageSize)
+            throw new InvalidDataException("SQLite database page size changed; dispose and reopen this pager.");
+
+        var length = await _file.GetLengthAsync(cancellationToken).ConfigureAwait(false);
+        ValidateFileLayout(length, header, allowTrailingPages: false);
+        _header = header;
+    }
+
+    internal async ValueTask ReplaceRawContentAsync(
+        IAsyncFile source,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ThrowIfDisposed();
+        ThrowIfReadOnly();
+
+        var sourceLength = await source.GetLengthAsync(cancellationToken).ConfigureAwait(false);
+        var buffer = new byte[64 * 1024];
+        await _file.SetLengthAsync(0, cancellationToken).ConfigureAwait(false);
+        var offset = 0L;
+        while (offset < sourceLength)
+        {
+            var count = checked((int)Math.Min(buffer.Length, sourceLength - offset));
+            var read = await source.ReadAsync(
+                offset,
+                buffer.AsMemory(0, count),
+                cancellationToken).ConfigureAwait(false);
+            if (read != count)
+            {
+                throw new InvalidDataException(
+                    "Replacement SQLite database file was truncated while being copied.");
+            }
+
+            await _file.WriteAsync(
+                offset,
+                buffer.AsMemory(0, count),
+                cancellationToken).ConfigureAwait(false);
+            offset += count;
+        }
+
+        await _file.SetLengthAsync(sourceLength, cancellationToken).ConfigureAwait(false);
+        await _file.FlushToDiskAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    internal ValueTask WriteUnpublishedImageAsync(
+        uint pageCount,
+        Func<uint, ReadOnlyMemory<byte>> getPageImage,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(getPageImage);
+        return WriteUnpublishedImageAsync(
+            pageCount,
+            (pageNumber, _) => ValueTask.FromResult(getPageImage(pageNumber)),
+            cancellationToken);
+    }
+
+    internal async ValueTask WriteUnpublishedImageAsync(
+        uint pageCount,
+        Func<uint, CancellationToken, ValueTask<ReadOnlyMemory<byte>>> getPageImage,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(getPageImage);
+        ThrowIfDisposed();
+        ThrowIfReadOnly();
+        if (pageCount == 0)
+            throw new ArgumentOutOfRangeException(nameof(pageCount), pageCount, "A SQLite database has at least one page.");
+
+        var targetLength = checked((long)pageCount * PageSize);
+        await _file.SetLengthAsync(targetLength, cancellationToken).ConfigureAwait(false);
+        if (await _file.GetLengthAsync(cancellationToken).ConfigureAwait(false) != targetLength)
+        {
+            throw new InvalidDataException(
+                "Preallocating the vacuum destination did not reach its page boundary.");
+        }
+
+        var pagesPerBatch = Math.Max(1, MaximumSequentialWriteBytes / PageSize);
+        var batchPages = (int)Math.Min(pageCount, (uint)pagesPerBatch);
+        var buffer = ArrayPool<byte>.Shared.Rent(checked(batchPages * PageSize));
+        SqliteDatabaseHeader? firstPageHeader = null;
+        try
+        {
+            var buffered = 0;
+            var batchOffset = 0L;
+            for (var pageNumber = 1U; pageNumber <= pageCount; pageNumber++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var page = await getPageImage(pageNumber, cancellationToken).ConfigureAwait(false);
+                if (page.Length != PageSize)
+                {
+                    throw new InvalidDataException(
+                        $"Vacuum destination page {pageNumber} is {page.Length} bytes; expected {PageSize}.");
+                }
+
+                if (pageNumber == 1)
+                {
+                    firstPageHeader = SqliteDatabaseHeader.Parse(page.Span);
+                    if (firstPageHeader.PageSize != PageSize)
+                    {
+                        throw new InvalidDataException(
+                            "Vacuum destination page 1 does not declare the store's page size.");
+                    }
+
+                    if (firstPageHeader.DatabaseSizeInPages != pageCount
+                        || firstPageHeader.VersionValidFor != firstPageHeader.ChangeCounter)
+                    {
+                        throw new InvalidDataException(
+                            "Vacuum destination page 1 must authoritatively declare its own page count.");
+                    }
+                }
+
+                StagePage(pageNumber, page, buffer, buffered * PageSize);
+
+                buffered++;
+                if (buffered != batchPages && pageNumber != pageCount)
+                    continue;
+
+                await _file.WriteAsync(
+                    batchOffset,
+                    buffer.AsMemory(0, buffered * PageSize),
+                    cancellationToken).ConfigureAwait(false);
+                batchOffset += buffered * PageSize;
+                buffered = 0;
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+
+        await AssertPageAlignedAsync(cancellationToken).ConfigureAwait(false);
+        if (await _file.GetLengthAsync(cancellationToken).ConfigureAwait(false) != targetLength)
+        {
+            throw new InvalidDataException(
+                "Writing the vacuum destination changed its expected file length.");
+        }
+
+        await _file.FlushToDiskAsync(cancellationToken).ConfigureAwait(false);
+        _header = firstPageHeader
+            ?? throw new InvalidDataException("Vacuum destination did not receive a first page.");
+    }
+
+    /// <summary>Writes or appends exactly one complete page image.</summary>
+    public ValueTask WritePageAsync(
+        uint pageNumber,
+        ReadOnlyMemory<byte> source,
+        CancellationToken cancellationToken = default)
+        => WritePageCoreAsync(
+            pageNumber,
+            source,
+            allowShrinkPageOneHeader: false,
+            cancellationToken);
+
+    internal ValueTask WriteShrinkCheckpointPageOneAsync(
+        ReadOnlyMemory<byte> source,
+        CancellationToken cancellationToken = default)
+        => WritePageCoreAsync(
+            pageNumber: 1,
+            source,
+            allowShrinkPageOneHeader: true,
+            cancellationToken);
+
+    private async ValueTask WritePageCoreAsync(
+        uint pageNumber,
+        ReadOnlyMemory<byte> source,
+        bool allowShrinkPageOneHeader,
+        CancellationToken cancellationToken)
+    {
+        ThrowIfDisposed();
+        ThrowIfReadOnly();
+        if (source.Length != PageSize)
+            throw new ArgumentException($"Page data must be exactly {PageSize} bytes.", nameof(source));
+        if (pageNumber < 1)
+            throw new ArgumentOutOfRangeException(nameof(pageNumber), pageNumber, "Page numbers are 1-based.");
+
+        var count = await GetPageCountAsync(cancellationToken).ConfigureAwait(false);
+        if (pageNumber > count + 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(pageNumber),
+                pageNumber,
+                $"Cannot write page {pageNumber}: it would skip past the current end of {count} page(s).");
+        }
+
+        SqliteDatabaseHeader? updatedHeader = null;
+        if (pageNumber == 1)
+        {
+            updatedHeader = SqliteDatabaseHeader.Parse(source.Span);
+            if (updatedHeader.PageSize != PageSize)
+                throw new InvalidOperationException("Page 1 header cannot change the store's page size.");
+            if (updatedHeader.VersionValidFor == updatedHeader.ChangeCounter
+                && updatedHeader.DatabaseSizeInPages != count
+                && (!allowShrinkPageOneHeader
+                    || updatedHeader.DatabaseSizeInPages == 0
+                    || updatedHeader.DatabaseSizeInPages >= count))
+            {
+                throw new InvalidOperationException(
+                    "Page 1 header page count must match the current file size when it is authoritative.");
+            }
+        }
+        else if (allowShrinkPageOneHeader)
+        {
+            throw new InvalidOperationException(
+                "Only page 1 may be installed through the shrink checkpoint path.");
+        }
+
+        if (pageNumber == count + 1)
+        {
+            await WriteAppendedPageAsync(
+                pageNumber,
+                source,
+                count,
+                cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        await WriteRawPageAsync(pageNumber, source, cancellationToken).ConfigureAwait(false);
+        await AssertPageAlignedAsync(cancellationToken).ConfigureAwait(false);
+        if (updatedHeader is not null)
+            _header = updatedHeader;
+    }
+
+    private async ValueTask WriteAppendedPageAsync(
+        uint pageNumber,
+        ReadOnlyMemory<byte> source,
+        uint previousPageCount,
+        CancellationToken cancellationToken)
+    {
+        var originalLength = checked((long)previousPageCount * PageSize);
+        try
+        {
+            await WriteRawPageAsync(pageNumber, source, cancellationToken).ConfigureAwait(false);
+            await AssertPageAlignedAsync(cancellationToken).ConfigureAwait(false);
+            await UpdateHeaderPageCountAsync(pageNumber, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception writeException)
+        {
+            try
+            {
+                if (await _file.GetLengthAsync(CancellationToken.None).ConfigureAwait(false)
+                    != originalLength)
+                {
+                    await _file.SetLengthAsync(
+                        originalLength,
+                        CancellationToken.None).ConfigureAwait(false);
+                }
+            }
+            catch (Exception rollbackException)
+            {
+                throw new InvalidDataException(
+                    "Appending a page failed and the prior file length could not be restored.",
+                    new AggregateException(writeException, rollbackException));
+            }
+
+            throw;
+        }
+    }
+
+    private async ValueTask UpdateHeaderPageCountAsync(
+        uint pageCount,
+        CancellationToken cancellationToken)
+    {
+        var updatedHeader = _header with
+        {
+            DatabaseSizeInPages = pageCount,
+            VersionValidFor = _header.ChangeCounter,
+        };
+        if (_pageCodec is null)
+        {
+            var headerBytes = new byte[SqliteDatabaseHeader.Size];
+            updatedHeader.WriteTo(headerBytes);
+            await _file.WriteAsync(0, headerBytes, cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            var firstPage = await ReadPageAsync(1, cancellationToken).ConfigureAwait(false);
+            updatedHeader.WriteTo(firstPage);
+            await WriteRawPageAsync(1, firstPage, cancellationToken).ConfigureAwait(false);
+        }
+
+        _header = updatedHeader;
+    }
+
+    /// <summary>Flushes all written pages to durable storage.</summary>
+    public async ValueTask FlushAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        cancellationToken.ThrowIfCancellationRequested();
+        if (!IsReadOnly)
+            await _file.FlushToDiskAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    internal async ValueTask TruncateToPageCountAsync(
+        uint pageCount,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ThrowIfReadOnly();
+        var currentPageCount = await GetPageCountAsync(cancellationToken).ConfigureAwait(false);
+        if (pageCount == 0 || pageCount > currentPageCount)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(pageCount),
+                pageCount,
+                $"Truncation page count must be between 1 and the current {currentPageCount} page(s).");
+        }
+
+        if (pageCount == currentPageCount)
+            return;
+
+        var firstPage = await ReadPageAsync(1, cancellationToken).ConfigureAwait(false);
+        var header = SqliteDatabaseHeader.Parse(firstPage);
+        if (header.VersionValidFor != header.ChangeCounter
+            || header.DatabaseSizeInPages != pageCount)
+        {
+            throw new InvalidOperationException(
+                "Cannot truncate a SQLite database before page 1 durably declares the requested authoritative page count.");
+        }
+
+        var targetLength = checked((long)pageCount * PageSize);
+        await _file.SetLengthAsync(targetLength, cancellationToken).ConfigureAwait(false);
+        if (await _file.GetLengthAsync(cancellationToken).ConfigureAwait(false) != targetLength)
+        {
+            throw new InvalidDataException(
+                "SQLite database truncation did not reach its requested page boundary.");
+        }
+
+        await AssertPageAlignedAsync(cancellationToken).ConfigureAwait(false);
+        _header = header;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        try
+        {
+            await _file.DisposeAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            PageCodecSupport.DisposeOwned(_pageCodec, _ownsPageCodec);
+        }
+    }
+
+    private long PageOffset(uint pageNumber) => (long)(pageNumber - 1) * PageSize;
+
+    private async ValueTask WriteRawPageAsync(
+        uint pageNumber,
+        ReadOnlyMemory<byte> page,
+        CancellationToken cancellationToken)
+    {
+        if (_pageCodec is null)
+        {
+            await _file.WriteAsync(
+                PageOffset(pageNumber),
+                page,
+                cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        var onDiskPage = new byte[PageSize];
+        PageCodecSupport.Encode(
+            _pageCodec,
+            PageLocation.Database,
+            pageNumber,
+            page.Span,
+            onDiskPage);
+        await _file.WriteAsync(
+            PageOffset(pageNumber),
+            onDiskPage,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private void StagePage(
+        uint pageNumber,
+        ReadOnlyMemory<byte> page,
+        byte[] destination,
+        int destinationOffset)
+    {
+        var slot = destination.AsSpan(destinationOffset, PageSize);
+        if (_pageCodec is null)
+            page.Span.CopyTo(slot);
+        else
+            PageCodecSupport.Encode(
+                _pageCodec,
+                PageLocation.Database,
+                pageNumber,
+                page.Span,
+                slot);
+    }
+
+    private async ValueTask AssertPageAlignedAsync(CancellationToken cancellationToken)
+    {
+        var length = await _file.GetLengthAsync(cancellationToken).ConfigureAwait(false);
+        if (length % PageSize != 0)
+            throw new InvalidDataException("Write left the database file at a non page-aligned length.");
+    }
+
+    private static bool IsAhtolaEncrypted(ReadOnlySpan<byte> header)
+        => header.Length >= 5 && header[..5].SequenceEqual("AHTLA"u8);
+
+    private static void ValidateFileLayout(
+        long length,
+        SqliteDatabaseHeader header,
+        bool allowTrailingPages)
+    {
+        var pageSize = header.PageSize;
+        if (length < pageSize)
+            throw new InvalidDataException("File is smaller than a single page.");
+        if (length % pageSize != 0)
+            throw new InvalidDataException("SQLite database file is not a whole number of pages.");
+
+        var pageCount = length / pageSize;
+        if (header.DatabaseSizeInPages != 0
+            && header.VersionValidFor == header.ChangeCounter
+            && (header.DatabaseSizeInPages > pageCount
+                || (!allowTrailingPages && header.DatabaseSizeInPages != pageCount)))
+        {
+            throw new InvalidDataException(
+                $"Header page count {header.DatabaseSizeInPages} disagrees with file size ({pageCount} page(s)).");
+        }
+    }
+
+    private static void ValidateReadablePageNumber(uint pageNumber, uint count)
+    {
+        if (pageNumber < 1 || pageNumber > count)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(pageNumber),
+                pageNumber,
+                $"Page number is out of range for a database of {count} page(s).");
+        }
+    }
+
+    private void ThrowIfReadOnly()
+    {
+        if (IsReadOnly)
+            throw new InvalidOperationException("The page store was opened read-only.");
+    }
+
+    private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposed, this);
+}

--- a/src/Ahtola.Core/Storage/AsyncSqlitePager.cs
+++ b/src/Ahtola.Core/Storage/AsyncSqlitePager.cs
@@ -14,7 +14,9 @@ namespace Ahtola.Core.Storage;
 /// </remarks>
 public sealed class AsyncSqlitePager : IAsyncDisposable
 {
-    private static readonly ConditionalWeakTable<IAsyncFileSystem, AsyncLockScope> LockScopes = new();
+    private static readonly ConditionalWeakTable<IAsyncFileSystem, AsyncLockScope> AsyncLockScopes = new();
+    private static readonly ConditionalWeakTable<IFileSystem, AsyncLockScope> BackingLockScopes = new();
+    private static readonly AsyncLockScope PhysicalLockScope = new(PhysicalFileSystem.Instance);
 
     private readonly object _stateGate = new();
     private readonly SemaphoreSlim _ioGate = new(1, 1);
@@ -194,6 +196,7 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
             manager,
             timeout,
             cancellationToken).ConfigureAwait(false);
+        manager.PublishAllWalFrames();
 
         AsyncSqlitePageStore? pageStore = null;
         SqliteWalFile? wal = null;
@@ -279,6 +282,7 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
             manager,
             timeout,
             cancellationToken).ConfigureAwait(false);
+        manager.PublishAllWalFrames();
 
         AsyncSqlitePageStore? pageStore = null;
         var databaseCreated = false;
@@ -404,6 +408,12 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
                 manager,
                 encryption,
                 pageCodec);
+
+            // Opening re-derives visibility from the file itself, which is what a
+            // fresh process would see, so drop any publication boundary a faulted
+            // in-process writer left pinned.
+            if (!readOnly)
+                manager.PublishAllWalFrames();
             if (UsesWalStorage(journalMode) && wal is not null)
             {
                 var recovery = await wal.ScanRecoveryAsync(cancellationToken).ConfigureAwait(false);
@@ -543,6 +553,12 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
             {
                 ThrowIfDisposed();
                 ThrowIfReadOnly();
+
+                // This writer now owns the WAL, so the file is authoritative again:
+                // republish every physical frame, including a previous writer's
+                // durable-but-unconfirmed tail, before deriving the committed view.
+                if (UsesWalStorage(JournalMode))
+                    _lockManager.PublishAllWalFrames();
                 await SynchronizeCommittedViewAsync(cancellationToken).ConfigureAwait(false);
                 if (UsesWalStorage(JournalMode) && HasUncommittedOrInvalidTail(_recoveryInfo))
                     await RecoverWalTailUnderWriterLockAsync(cancellationToken).ConfigureAwait(false);
@@ -557,7 +573,8 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
                     writerLock,
                     targetDatabaseSizeInPages,
                     _committedPageCount,
-                    CloneOverlay(_walPageOverlay));
+                    CloneOverlay(_walPageOverlay),
+                    timeout);
                 lock (_stateGate)
                 {
                     _activeTransaction = transaction;
@@ -655,6 +672,7 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
                 throw new InvalidOperationException($"Cannot recover a SQLite WAL while the pager is {_state}.");
             try
             {
+                _lockManager.PublishAllWalFrames();
                 await SynchronizeCommittedViewAsync(cancellationToken).ConfigureAwait(false);
                 if (HasUncommittedOrInvalidTail(_recoveryInfo))
                     await RecoverWalTailUnderWriterLockAsync(cancellationToken).ConfigureAwait(false);
@@ -759,6 +777,14 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
         AsyncSqlitePagerTransaction transaction,
         CancellationToken cancellationToken)
     {
+        // A DELETE-mode commit rewrites the main database file in place, which
+        // every read snapshot on this database reads through directly. Take the
+        // same EXCLUSIVE upgrade the synchronous pager takes so no reader can
+        // observe a half-applied rollback-journal commit. This happens before the
+        // I/O gate so a draining reader can still finish its own page reads.
+        if (JournalMode == SqliteJournalMode.Delete)
+            await transaction.UpgradeToExclusiveCommitAsync(cancellationToken).ConfigureAwait(false);
+
         await _ioGate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
@@ -830,6 +856,10 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
         {
             ThrowIfDisposed();
             ThrowIfReadOnly();
+
+            // The checkpoint lease excludes every reader and writer, so the WAL
+            // file is authoritative again for whatever it is about to install.
+            _lockManager.PublishAllWalFrames();
             await SynchronizeCommittedViewAsync(cancellationToken).ConfigureAwait(false);
             if (JournalMode == SqliteJournalMode.Delete)
             {
@@ -904,6 +934,13 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
     {
         await ValidateWalHasNotChangedAsync(cancellationToken).ConfigureAwait(false);
         var wal = RequireWal();
+
+        // Hide everything this commit is about to append until its durable flush
+        // and post-flush validation both succeed. Readers on other pagers over the
+        // same WAL rescan the physical file, so without this boundary they could
+        // adopt a commit-bearing frame that has not been made durable yet — or one
+        // that never commits at all because the flush fails.
+        transaction.BeginWalPublication(_committedFrameCount);
         await wal.AppendFramesAsync(
             new AsyncSqlitePagerTransaction.WalFrameSource(transaction),
             transaction.TargetDatabaseSizeInPages,
@@ -942,6 +979,8 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
             _recoveryInfo = recovery;
             _visibleRecoveryInfo = recovery;
         }
+
+        transaction.PublishWalFrames();
     }
 
     private async ValueTask CommitRollbackTransactionAsync(
@@ -1140,7 +1179,9 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
             return;
         }
 
-        var recovery = await _wal.ScanRecoveryAsync(cancellationToken).ConfigureAwait(false);
+        var recovery = await _wal
+            .ScanRecoveryAsync(_lockManager.WalPublicationBoundary, cancellationToken)
+            .ConfigureAwait(false);
         if (recovery.LastCommittedFrameNumber == 0
             && recovery.StopReason == SqliteWalRecoveryStopReason.EndOfFile)
         {
@@ -1638,17 +1679,55 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
         string databasePath,
         string walPath)
     {
-        var scope = LockScopes.GetValue(fileSystem, static _ => new AsyncLockScope());
-        var key = CreateLockKey(fileSystem, databasePath, walPath);
-        return scope.GetOrAdd(key);
+        var (scope, resolver) = GetLockScope(fileSystem);
+        return scope.GetOrAdd(CreateLockKey(resolver, databasePath, walPath));
+    }
+
+    /// <summary>
+    /// Resolves the lock scope that owns every pager over one physical storage.
+    /// </summary>
+    /// <remarks>
+    /// Two <see cref="AsyncFileSystemAdapter"/> wrappers over the same backend are
+    /// distinct objects, so keying the scope on the asynchronous facade would hand
+    /// each of them an independent writer lock over one database file. Unwrap to
+    /// the backing <see cref="IFileSystem"/> (through encryption, page-codec, and
+    /// decorator layers) first, and give every <see cref="PhysicalFileSystem"/> a
+    /// single process-wide scope because those instances are interchangeable.
+    /// </remarks>
+    private static (AsyncLockScope Scope, IStoragePathResolver? Resolver) GetLockScope(
+        IAsyncFileSystem fileSystem)
+    {
+        var resolver = ResolvePathResolver(fileSystem);
+        if (fileSystem is IAsyncFileSystemBacking backing)
+        {
+            var inner = AhtolaEncryptionFileSystem.Unwrap(backing.BackingFileSystem);
+            resolver ??= inner as IStoragePathResolver;
+            return inner is PhysicalFileSystem
+                ? (PhysicalLockScope, resolver)
+                : (BackingLockScopes.GetValue(inner, _ => new AsyncLockScope(resolver)), resolver);
+        }
+
+        var capturedResolver = resolver;
+        return (
+            AsyncLockScopes.GetValue(fileSystem, _ => new AsyncLockScope(capturedResolver)),
+            resolver);
+    }
+
+    private static IStoragePathResolver? ResolvePathResolver(IAsyncFileSystem fileSystem)
+    {
+        if (fileSystem is IStoragePathResolver asyncResolver)
+            return asyncResolver;
+        return fileSystem is IAsyncFileSystemBacking backing
+            ? AhtolaEncryptionFileSystem.Unwrap(backing.BackingFileSystem) as IStoragePathResolver
+            : null;
     }
 
     private static string CreateLockKey(
-        IAsyncFileSystem fileSystem,
+        IStoragePathResolver? resolver,
         string databasePath,
         string walPath)
     {
-        if (fileSystem is IStoragePathResolver resolver)
+        if (resolver is not null)
         {
             databasePath = resolver.GetCanonicalPath(databasePath);
             walPath = resolver.GetCanonicalPath(walPath);
@@ -1680,10 +1759,14 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
         }
     }
 
-    private sealed class AsyncLockScope
+    private sealed class AsyncLockScope(IStoragePathResolver? resolver)
     {
         private readonly object _gate = new();
-        private readonly Dictionary<string, SqlitePagerLockManager> _locks = new(StringComparer.Ordinal);
+
+        // Canonical paths are only unique under the resolver's own comparison, so
+        // two spellings of one Windows path must land on a single lock manager.
+        private readonly Dictionary<string, SqlitePagerLockManager> _locks =
+            new(resolver?.PathComparer ?? StringComparer.Ordinal);
 
         internal SqlitePagerLockManager GetOrAdd(string key)
         {
@@ -1805,6 +1888,7 @@ public sealed class AsyncSqlitePagerTransaction : IAsyncDisposable
     private readonly IReadOnlyDictionary<uint, byte[]> _sourceOverlay;
     private readonly Dictionary<uint, byte[]> _pageImages = [];
     private readonly List<uint> _writeOrder = [];
+    private readonly TimeSpan _busyTimeout;
     private SqlitePagerLockLease? _writerLock;
     private SqlitePagerTransactionState _state = SqlitePagerTransactionState.Active;
 
@@ -1813,13 +1897,15 @@ public sealed class AsyncSqlitePagerTransaction : IAsyncDisposable
         SqlitePagerLockLease writerLock,
         uint targetDatabaseSizeInPages,
         uint sourcePageCount,
-        IReadOnlyDictionary<uint, byte[]> sourceOverlay)
+        IReadOnlyDictionary<uint, byte[]> sourceOverlay,
+        TimeSpan busyTimeout)
     {
         _pager = pager;
         _writerLock = writerLock;
         TargetDatabaseSizeInPages = targetDatabaseSizeInPages;
         _sourcePageCount = sourcePageCount;
         _sourceOverlay = sourceOverlay;
+        _busyTimeout = busyTimeout;
     }
 
     /// <summary>The database size written into this transaction's commit boundary.</summary>
@@ -1958,6 +2044,24 @@ public sealed class AsyncSqlitePagerTransaction : IAsyncDisposable
         => (_writerLock
             ?? throw new InvalidOperationException("SQLite pager transaction no longer owns its writer lock."))
             .PublishStorageChange();
+
+    /// <summary>
+    /// Excludes readers before a rollback-journal commit rewrites the main file.
+    /// </summary>
+    internal ValueTask UpgradeToExclusiveCommitAsync(CancellationToken cancellationToken)
+        => RequireWriterLock().UpgradeToExclusiveAsync(_busyTimeout, cancellationToken);
+
+    /// <summary>Hides WAL frames past <paramref name="lastPublishedFrameNumber"/> from readers.</summary>
+    internal void BeginWalPublication(long lastPublishedFrameNumber)
+        => RequireWriterLock().BeginWalPublication(lastPublishedFrameNumber);
+
+    /// <summary>Republishes the physical WAL once this commit is durable.</summary>
+    internal void PublishWalFrames()
+        => RequireWriterLock().PublishWalFrames();
+
+    private SqlitePagerLockLease RequireWriterLock()
+        => _writerLock
+           ?? throw new InvalidOperationException("SQLite pager transaction no longer owns its writer lock.");
 
     internal void ReleaseWriterLock()
     {

--- a/src/Ahtola.Core/Storage/AsyncSqlitePager.cs
+++ b/src/Ahtola.Core/Storage/AsyncSqlitePager.cs
@@ -233,10 +233,13 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
             await pager.InitializeCommittedViewAsync(
                 await wal.ScanRecoveryAsync(cancellationToken).ConfigureAwait(false),
                 cancellationToken).ConfigureAwait(false);
+
+            // Fresh storage replaced whatever the boundary was hiding, so publish it
+            // only now: a create that fails must leave an abandoned tail hidden.
+            manager.PublishAllWalFrames();
             pager._lockGeneration = openingLock.Lease.PublishStorageChange();
             pager._busyTimeout = timeout;
             pager._state = SqlitePagerState.Ready;
-            manager.PublishAllWalFrames();
             return pager;
         }
         catch
@@ -309,10 +312,13 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
                 encryption,
                 pageCodec);
             await pager.InitializeRollbackViewAsync(cancellationToken).ConfigureAwait(false);
+
+            // Fresh storage replaced whatever the boundary was hiding, so publish it
+            // only now: a create that fails must leave an abandoned tail hidden.
+            manager.PublishAllWalFrames();
             pager._lockGeneration = openingLock.Lease.PublishStorageChange();
             pager._busyTimeout = timeout;
             pager._state = SqlitePagerState.Ready;
-            manager.PublishAllWalFrames();
             return pager;
         }
         catch
@@ -957,9 +963,12 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
                 cancellationToken).ConfigureAwait(false);
             await wal.FlushAsync(cancellationToken).ConfigureAwait(false);
 
-            // Past this point the commit frame is durable, so SQLite considers the
-            // transaction committed even if our own bookkeeping then fails. The
-            // frames must become visible again either way.
+            // Past this point the commit frame is durable, so the transaction is
+            // committed whatever happens next. Finish recording it on
+            // CancellationToken.None: a caller that cancels now cannot un-commit
+            // it, and abandoning the bookkeeping would leave the boundary pinned
+            // over a durable commit that the next writer's tail repair would then
+            // truncate away.
             durable = true;
             transaction.PublishWalFrames();
             var recovery = await wal.ScanRecoveryAsync(CancellationToken.None).ConfigureAwait(false);
@@ -1006,7 +1015,28 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
             await TruncateAbandonedWalTailAsync(wal, publishedFrameCount).ConfigureAwait(false);
             throw;
         }
+        catch
+        {
+            // Durable, so this transaction is committed even though recording it
+            // failed. Publish the frames before reporting the failure: leaving the
+            // boundary pinned would hide a committed transaction from every local
+            // reader and invite the next tail repair to truncate it away.
+            PublishDurableCommitIgnoringFailure(transaction);
+            throw;
+        }
 
+    }
+
+    private static void PublishDurableCommitIgnoringFailure(AsyncSqlitePagerTransaction transaction)
+    {
+        try
+        {
+            transaction.PublishWalFrames();
+        }
+        catch
+        {
+            // Never mask the bookkeeping failure that is already propagating.
+        }
     }
 
     private async ValueTask TruncateAbandonedWalTailAsync(
@@ -1254,8 +1284,15 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
         CancellationToken cancellationToken)
     {
         var boundary = lockManager.WalPublicationBoundary;
-        if (boundary != long.MaxValue && !wal.IsReadOnly)
+        if (boundary != long.MaxValue)
+        {
+            // A handle that cannot write cannot repair, and publishing anyway would
+            // expose exactly the tail the boundary exists to hide.
+            if (wal.IsReadOnly)
+                return;
+
             await wal.TruncateToFrameAsync(boundary, cancellationToken).ConfigureAwait(false);
+        }
 
         lockManager.PublishAllWalFrames();
     }

--- a/src/Ahtola.Core/Storage/AsyncSqlitePager.cs
+++ b/src/Ahtola.Core/Storage/AsyncSqlitePager.cs
@@ -1,0 +1,1993 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Ahtola.Core.Storage;
+
+/// <summary>
+/// A true-asynchronous SQLite pager over <see cref="IAsyncFileSystem"/>.
+/// </summary>
+/// <remarks>
+/// The pager uses process-local reader, writer, and checkpoint coordination and
+/// authenticates committed visibility by scanning the WAL. Physical SQLite
+/// <c>-shm</c> interoperability remains the responsibility of
+/// <see cref="SqlitePager"/>.
+/// </remarks>
+public sealed class AsyncSqlitePager : IAsyncDisposable
+{
+    private static readonly ConditionalWeakTable<IAsyncFileSystem, AsyncLockScope> LockScopes = new();
+
+    private readonly object _stateGate = new();
+    private readonly SemaphoreSlim _ioGate = new(1, 1);
+    private readonly IAsyncFileSystem _fileSystem;
+    private readonly string _databasePath;
+    private readonly string _walPath;
+    private readonly string _journalPath;
+    private readonly AsyncSqlitePageStore _pageStore;
+    private readonly SqlitePagerLockManager _lockManager;
+    private readonly AhtolaEncryptionOptions? _encryption;
+    private readonly IPageCodec? _pageCodec;
+    private readonly Dictionary<uint, byte[]> _walPageOverlay = [];
+    private readonly HashSet<AsyncSqlitePagerReadTransaction> _activeReadTransactions = [];
+    private SqliteWalFile? _wal;
+    private AsyncSqlitePagerTransaction? _activeTransaction;
+    private SqliteWalRecoveryInfo _recoveryInfo = CreateEmptyRecoveryInfo();
+    private SqliteWalRecoveryInfo _visibleRecoveryInfo = CreateEmptyRecoveryInfo();
+    private uint _committedPageCount;
+    private long _committedFrameCount;
+    private long _lockGeneration;
+    private SqlitePagerState _state;
+    private TimeSpan _busyTimeout;
+
+    private AsyncSqlitePager(
+        IAsyncFileSystem fileSystem,
+        string databasePath,
+        string walPath,
+        AsyncSqlitePageStore pageStore,
+        SqliteWalFile? wal,
+        SqliteJournalMode journalMode,
+        SqlitePagerLockManager lockManager,
+        AhtolaEncryptionOptions? encryption,
+        IPageCodec? pageCodec)
+    {
+        _fileSystem = fileSystem;
+        _databasePath = databasePath;
+        _walPath = walPath;
+        _journalPath = databasePath + "-journal";
+        _pageStore = pageStore;
+        _wal = wal;
+        JournalMode = journalMode;
+        _lockManager = lockManager;
+        _encryption = encryption;
+        _pageCodec = pageCodec;
+    }
+
+    /// <summary>The fixed SQLite page size shared by the main store and WAL.</summary>
+    public int PageSize
+    {
+        get
+        {
+            lock (_stateGate)
+            {
+                ThrowIfDisposed();
+                return _pageStore.PageSize;
+            }
+        }
+    }
+
+    /// <summary>The durable transaction format used by this pager.</summary>
+    public SqliteJournalMode JournalMode { get; }
+
+    /// <summary>The database size represented by the committed view.</summary>
+    public uint CommittedPageCount
+    {
+        get
+        {
+            lock (_stateGate)
+            {
+                ThrowIfDisposed();
+                return _committedPageCount;
+            }
+        }
+    }
+
+    /// <summary>The final WAL frame in the committed view, or zero in DELETE mode.</summary>
+    public long CommittedFrameCount
+    {
+        get
+        {
+            lock (_stateGate)
+            {
+                ThrowIfDisposed();
+                return _committedFrameCount;
+            }
+        }
+    }
+
+    /// <summary>The recovery state that established the currently visible view.</summary>
+    public SqliteWalRecoveryInfo RecoveryInfo
+    {
+        get
+        {
+            lock (_stateGate)
+            {
+                ThrowIfDisposed();
+                return _visibleRecoveryInfo;
+            }
+        }
+    }
+
+    /// <summary>Whether the database or WAL handle is read-only.</summary>
+    public bool IsReadOnly
+    {
+        get
+        {
+            lock (_stateGate)
+            {
+                ThrowIfDisposed();
+                return _pageStore.IsReadOnly || (_wal?.IsReadOnly ?? false);
+            }
+        }
+    }
+
+    /// <summary>The pager lifecycle state.</summary>
+    public SqlitePagerState State
+    {
+        get
+        {
+            lock (_stateGate)
+                return _state;
+        }
+    }
+
+    /// <summary>The process-local lock manager used by this pager.</summary>
+    public SqlitePagerLockManager LockManager => _lockManager;
+
+    /// <summary>The default wait for reader, writer, and checkpoint ownership.</summary>
+    public TimeSpan BusyTimeout
+    {
+        get
+        {
+            lock (_stateGate)
+                return _busyTimeout;
+        }
+        set
+        {
+            ValidateBusyTimeout(value, nameof(value));
+            lock (_stateGate)
+                _busyTimeout = value;
+        }
+    }
+
+    /// <summary>Creates a fresh WAL-mode database and matching empty WAL.</summary>
+    public static async ValueTask<AsyncSqlitePager> CreateAsync(
+        IAsyncFileSystem fileSystem,
+        string databasePath,
+        string walPath,
+        SqliteWalHeader walHeader,
+        SqliteDatabaseHeader? databaseHeader = null,
+        SqlitePagerLockManager? lockManager = null,
+        TimeSpan? busyTimeout = null,
+        AhtolaEncryptionOptions? encryption = null,
+        IPageCodec? pageCodec = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(fileSystem);
+        ArgumentException.ThrowIfNullOrEmpty(databasePath);
+        ArgumentException.ThrowIfNullOrEmpty(walPath);
+        ArgumentNullException.ThrowIfNull(walHeader);
+        ValidateBusyTimeout(busyTimeout, nameof(busyTimeout));
+        PageCodecSupport.RejectCombinedTransforms(encryption, pageCodec);
+
+        var header = databaseHeader ?? SqliteDatabaseHeader.CreateDefault();
+        if (header.PageSize != walHeader.PageSize)
+            throw new InvalidOperationException("SQLite database and WAL page sizes must match.");
+        if (!IsWalCompatibleFormat(header.WriteVersion)
+            || !IsWalCompatibleFormat(header.ReadVersion))
+        {
+            throw new InvalidOperationException(
+                "A SQLite WAL overlay requires WAL/MVCC read and write format versions.");
+        }
+
+        var timeout = busyTimeout ?? TimeSpan.Zero;
+        var manager = lockManager ?? GetLockManager(fileSystem, databasePath, walPath);
+        await using var openingLock = await AsyncLockLease.AcquireCheckpointAsync(
+            manager,
+            timeout,
+            cancellationToken).ConfigureAwait(false);
+
+        AsyncSqlitePageStore? pageStore = null;
+        SqliteWalFile? wal = null;
+        var databaseCreated = false;
+        var walCreated = false;
+        try
+        {
+            pageStore = await AsyncSqlitePageStore.CreateAsync(
+                fileSystem,
+                databasePath,
+                header,
+                encryption: encryption,
+                pageCodec: pageCodec,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+            databaseCreated = true;
+            wal = await SqliteWalFile.CreateAsync(
+                fileSystem,
+                walPath,
+                walHeader,
+                encryption,
+                pageCodec,
+                cancellationToken).ConfigureAwait(false);
+            walCreated = true;
+
+            var pager = new AsyncSqlitePager(
+                fileSystem,
+                databasePath,
+                walPath,
+                pageStore,
+                wal,
+                GetJournalMode(pageStore.Header),
+                manager,
+                encryption,
+                pageCodec);
+            await pager.InitializeCommittedViewAsync(
+                await wal.ScanRecoveryAsync(cancellationToken).ConfigureAwait(false),
+                cancellationToken).ConfigureAwait(false);
+            pager._lockGeneration = openingLock.Lease.PublishStorageChange();
+            pager._busyTimeout = timeout;
+            pager._state = SqlitePagerState.Ready;
+            return pager;
+        }
+        catch
+        {
+            if (wal is not null)
+                await DisposeIgnoringFailureAsync(wal).ConfigureAwait(false);
+            if (pageStore is not null)
+                await DisposeIgnoringFailureAsync(pageStore).ConfigureAwait(false);
+            if (walCreated)
+                await DeleteIgnoringFailureAsync(fileSystem, walPath).ConfigureAwait(false);
+            if (databaseCreated)
+                await DeleteIgnoringFailureAsync(fileSystem, databasePath).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    /// <summary>Creates a fresh DELETE-mode database without a WAL.</summary>
+    public static async ValueTask<AsyncSqlitePager> CreateRollbackJournalAsync(
+        IAsyncFileSystem fileSystem,
+        string databasePath,
+        string walPath,
+        SqliteDatabaseHeader? databaseHeader = null,
+        SqlitePagerLockManager? lockManager = null,
+        TimeSpan? busyTimeout = null,
+        AhtolaEncryptionOptions? encryption = null,
+        IPageCodec? pageCodec = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(fileSystem);
+        ArgumentException.ThrowIfNullOrEmpty(databasePath);
+        ArgumentException.ThrowIfNullOrEmpty(walPath);
+        ValidateBusyTimeout(busyTimeout, nameof(busyTimeout));
+        PageCodecSupport.RejectCombinedTransforms(encryption, pageCodec);
+
+        var header = (databaseHeader ?? SqliteDatabaseHeader.CreateDefault()) with
+        {
+            ReadVersion = SqliteFileFormatVersion.Legacy,
+            WriteVersion = SqliteFileFormatVersion.Legacy,
+        };
+        var timeout = busyTimeout ?? TimeSpan.Zero;
+        var manager = lockManager ?? GetLockManager(fileSystem, databasePath, walPath);
+        await using var openingLock = await AsyncLockLease.AcquireCheckpointAsync(
+            manager,
+            timeout,
+            cancellationToken).ConfigureAwait(false);
+
+        AsyncSqlitePageStore? pageStore = null;
+        var databaseCreated = false;
+        try
+        {
+            pageStore = await AsyncSqlitePageStore.CreateAsync(
+                fileSystem,
+                databasePath,
+                header,
+                encryption: encryption,
+                pageCodec: pageCodec,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+            databaseCreated = true;
+            if (await fileSystem.FileExistsAsync(walPath, cancellationToken).ConfigureAwait(false))
+                await fileSystem.DeleteFileAsync(walPath, cancellationToken).ConfigureAwait(false);
+
+            var pager = new AsyncSqlitePager(
+                fileSystem,
+                databasePath,
+                walPath,
+                pageStore,
+                wal: null,
+                SqliteJournalMode.Delete,
+                manager,
+                encryption,
+                pageCodec);
+            await pager.InitializeRollbackViewAsync(cancellationToken).ConfigureAwait(false);
+            pager._lockGeneration = openingLock.Lease.PublishStorageChange();
+            pager._busyTimeout = timeout;
+            pager._state = SqlitePagerState.Ready;
+            return pager;
+        }
+        catch
+        {
+            if (pageStore is not null)
+                await DisposeIgnoringFailureAsync(pageStore).ConfigureAwait(false);
+            if (databaseCreated)
+                await DeleteIgnoringFailureAsync(fileSystem, databasePath).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    /// <summary>Opens an existing SQLite database and establishes its committed view.</summary>
+    public static async ValueTask<AsyncSqlitePager> OpenAsync(
+        IAsyncFileSystem fileSystem,
+        string databasePath,
+        string walPath,
+        bool readOnly = false,
+        SqlitePagerLockManager? lockManager = null,
+        TimeSpan? busyTimeout = null,
+        AhtolaEncryptionOptions? encryption = null,
+        IPageCodec? pageCodec = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(fileSystem);
+        ArgumentException.ThrowIfNullOrEmpty(databasePath);
+        ArgumentException.ThrowIfNullOrEmpty(walPath);
+        ValidateBusyTimeout(busyTimeout, nameof(busyTimeout));
+        PageCodecSupport.RejectCombinedTransforms(encryption, pageCodec);
+
+        var timeout = busyTimeout ?? TimeSpan.Zero;
+        var manager = lockManager ?? GetLockManager(fileSystem, databasePath, walPath);
+        await using var openingLock = readOnly
+            ? await AsyncLockLease.AcquireReaderAsync(manager, timeout, cancellationToken).ConfigureAwait(false)
+            : await AsyncLockLease.AcquireCheckpointAsync(manager, timeout, cancellationToken).ConfigureAwait(false);
+
+        AsyncSqlitePageStore? pageStore = null;
+        SqliteWalFile? wal = null;
+        try
+        {
+            await SqliteRollbackJournal.RecoverIfPresentAsync(
+                fileSystem,
+                databasePath,
+                databasePath + "-journal",
+                readOnly,
+                cancellationToken).ConfigureAwait(false);
+            pageStore = await AsyncSqlitePageStore.OpenForPagerAsync(
+                fileSystem,
+                databasePath,
+                readOnly,
+                encryption,
+                pageCodec,
+                cancellationToken).ConfigureAwait(false);
+            var journalMode = GetJournalMode(pageStore.Header);
+
+            if (UsesWalStorage(journalMode))
+            {
+                if (await fileSystem.FileExistsAsync(walPath, cancellationToken).ConfigureAwait(false))
+                {
+                    wal = await SqliteWalFile.OpenAsync(
+                        fileSystem,
+                        walPath,
+                        readOnly,
+                        encryption,
+                        CreateTruncatedWalHeader(pageStore.PageSize),
+                        pageCodec,
+                        cancellationToken).ConfigureAwait(false);
+                }
+                else if (!readOnly)
+                {
+                    wal = await SqliteWalFile.CreateAsync(
+                        fileSystem,
+                        walPath,
+                        CreateTruncatedWalHeader(pageStore.PageSize),
+                        encryption,
+                        pageCodec,
+                        cancellationToken).ConfigureAwait(false);
+                }
+            }
+            else if (!readOnly
+                     && await fileSystem.FileExistsAsync(walPath, cancellationToken).ConfigureAwait(false))
+            {
+                await fileSystem.DeleteFileAsync(walPath, cancellationToken).ConfigureAwait(false);
+            }
+
+            var pager = new AsyncSqlitePager(
+                fileSystem,
+                databasePath,
+                walPath,
+                pageStore,
+                wal,
+                journalMode,
+                manager,
+                encryption,
+                pageCodec);
+            if (UsesWalStorage(journalMode) && wal is not null)
+            {
+                var recovery = await wal.ScanRecoveryAsync(cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    await pager.InitializeCommittedViewAsync(recovery, cancellationToken).ConfigureAwait(false);
+                }
+                catch (InvalidDataException exception) when (readOnly)
+                {
+                    throw new InvalidDataException(
+                        "Cannot safely open the SQLite database read-only because its WAL cannot establish a non-mutating committed snapshot. "
+                        + "Open it writable to recover the WAL.",
+                        exception);
+                }
+
+                if (!readOnly && HasUncommittedOrInvalidTail(recovery))
+                {
+                    var repairedFrom = await wal
+                        .RecoverToLastCommittedFrameAsync(cancellationToken)
+                        .ConfigureAwait(false);
+                    if (repairedFrom != recovery)
+                        throw new InvalidDataException("SQLite WAL changed between recovery scanning and tail repair.");
+
+                    var repaired = await wal.ScanRecoveryAsync(cancellationToken).ConfigureAwait(false);
+                    await pager.InitializeCommittedViewAsync(repaired, cancellationToken).ConfigureAwait(false);
+                    lock (pager._stateGate)
+                        pager._visibleRecoveryInfo = recovery;
+                }
+            }
+            else if (journalMode == SqliteJournalMode.Delete)
+            {
+                await pager.InitializeRollbackViewAsync(cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                await pager.InitializeCleanWalViewAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            pager._lockGeneration = readOnly
+                ? manager.Generation
+                : openingLock.Lease.PublishStorageChange();
+            pager._busyTimeout = timeout;
+            pager._state = SqlitePagerState.Ready;
+            return pager;
+        }
+        catch
+        {
+            if (wal is not null)
+                await DisposeIgnoringFailureAsync(wal).ConfigureAwait(false);
+            if (pageStore is not null)
+                await DisposeIgnoringFailureAsync(pageStore).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    /// <summary>Reads a committed page using a short-lived stable snapshot.</summary>
+    public async ValueTask<byte[]> ReadPageAsync(
+        uint pageNumber,
+        CancellationToken cancellationToken = default)
+    {
+        await using var read = await BeginReadAsync(cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        return await read.ReadPageAsync(pageNumber, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Reads a committed page into an exact page-sized destination.</summary>
+    public async ValueTask ReadPageAsync(
+        uint pageNumber,
+        Memory<byte> destination,
+        CancellationToken cancellationToken = default)
+    {
+        if (destination.Length != PageSize)
+            throw new ArgumentException($"Destination must be exactly {PageSize} bytes.", nameof(destination));
+        var page = await ReadPageAsync(pageNumber, cancellationToken).ConfigureAwait(false);
+        page.CopyTo(destination);
+    }
+
+    /// <summary>Begins a stable committed read snapshot.</summary>
+    public async ValueTask<AsyncSqlitePagerReadTransaction> BeginReadAsync(
+        TimeSpan? busyTimeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        var timeout = ResolveBusyTimeout(busyTimeout);
+        var readerLock = await _lockManager.EnterReaderAsync(timeout, cancellationToken)
+            .ConfigureAwait(false);
+        var handedOff = false;
+        try
+        {
+            await _ioGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                ThrowIfNotReadable();
+                await SynchronizeCommittedViewAsync(cancellationToken).ConfigureAwait(false);
+                var transaction = new AsyncSqlitePagerReadTransaction(
+                    this,
+                    readerLock,
+                    _committedPageCount,
+                    CloneOverlay(_walPageOverlay));
+                lock (_stateGate)
+                    _activeReadTransactions.Add(transaction);
+                handedOff = true;
+                return transaction;
+            }
+            finally
+            {
+                _ioGate.Release();
+            }
+        }
+        finally
+        {
+            if (!handedOff)
+                readerLock.Dispose();
+        }
+    }
+
+    /// <summary>Alias matching the synchronous pager transaction name.</summary>
+    public ValueTask<AsyncSqlitePagerReadTransaction> BeginReadTransactionAsync(
+        TimeSpan? busyTimeout = null,
+        CancellationToken cancellationToken = default)
+        => BeginReadAsync(busyTimeout, cancellationToken);
+
+    /// <summary>Begins one single-writer page transaction.</summary>
+    public async ValueTask<AsyncSqlitePagerTransaction> BeginTransactionAsync(
+        uint targetDatabaseSizeInPages,
+        TimeSpan? busyTimeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfZero(targetDatabaseSizeInPages);
+        var timeout = ResolveBusyTimeout(busyTimeout);
+        var writerLock = await _lockManager.EnterWriterAsync(timeout, cancellationToken)
+            .ConfigureAwait(false);
+        var handedOff = false;
+        try
+        {
+            await _ioGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                ThrowIfDisposed();
+                ThrowIfReadOnly();
+                await SynchronizeCommittedViewAsync(cancellationToken).ConfigureAwait(false);
+                if (UsesWalStorage(JournalMode) && HasUncommittedOrInvalidTail(_recoveryInfo))
+                    await RecoverWalTailUnderWriterLockAsync(cancellationToken).ConfigureAwait(false);
+                if (_state != SqlitePagerState.Ready)
+                {
+                    throw new InvalidOperationException(
+                        $"Cannot begin a SQLite pager transaction while the pager is {_state}.");
+                }
+
+                var transaction = new AsyncSqlitePagerTransaction(
+                    this,
+                    writerLock,
+                    targetDatabaseSizeInPages,
+                    _committedPageCount,
+                    CloneOverlay(_walPageOverlay));
+                lock (_stateGate)
+                {
+                    _activeTransaction = transaction;
+                    _state = SqlitePagerState.TransactionActive;
+                }
+                handedOff = true;
+                return transaction;
+            }
+            finally
+            {
+                _ioGate.Release();
+            }
+        }
+        finally
+        {
+            if (!handedOff)
+                writerLock.Dispose();
+        }
+    }
+
+    /// <summary>Stages a page in the active transaction.</summary>
+    public ValueTask WritePageAsync(
+        uint pageNumber,
+        ReadOnlyMemory<byte> page,
+        CancellationToken cancellationToken = default)
+    {
+        AsyncSqlitePagerTransaction transaction;
+        lock (_stateGate)
+        {
+            ThrowIfDisposed();
+            transaction = _activeTransaction
+                ?? throw new InvalidOperationException("The SQLite pager has no active write transaction.");
+        }
+
+        return transaction.WritePageAsync(pageNumber, page, cancellationToken);
+    }
+
+    /// <summary>Commits the active transaction.</summary>
+    public ValueTask CommitAsync(CancellationToken cancellationToken = default)
+    {
+        AsyncSqlitePagerTransaction transaction;
+        lock (_stateGate)
+        {
+            ThrowIfDisposed();
+            transaction = _activeTransaction
+                ?? throw new InvalidOperationException("The SQLite pager has no active write transaction.");
+        }
+
+        return transaction.CommitAsync(cancellationToken);
+    }
+
+    /// <summary>Rolls back the active transaction without writing storage.</summary>
+    public ValueTask RollbackAsync(CancellationToken cancellationToken = default)
+    {
+        AsyncSqlitePagerTransaction transaction;
+        lock (_stateGate)
+        {
+            ThrowIfDisposed();
+            transaction = _activeTransaction
+                ?? throw new InvalidOperationException("The SQLite pager has no active write transaction.");
+        }
+
+        return transaction.RollbackAsync(cancellationToken);
+    }
+
+    /// <summary>Installs committed WAL pages into the main database and retains the WAL.</summary>
+    public ValueTask<SqliteCheckpointResult> CheckpointToMainStoreAsync(
+        TimeSpan? busyTimeout = null,
+        CancellationToken cancellationToken = default)
+        => CheckpointAsync(resetCommittedWal: false, busyTimeout, cancellationToken);
+
+    /// <summary>Installs committed WAL pages, then durably resets the WAL.</summary>
+    public ValueTask<SqliteCheckpointResult> CheckpointToMainStoreAndResetWalAsync(
+        TimeSpan? busyTimeout = null,
+        CancellationToken cancellationToken = default)
+        => CheckpointAsync(resetCommittedWal: true, busyTimeout, cancellationToken);
+
+    /// <summary>Repairs an uncommitted, partial, or invalid WAL tail.</summary>
+    public async ValueTask RecoverUncommittedWalTailAsync(
+        TimeSpan? busyTimeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (!UsesWalStorage(JournalMode))
+            throw new InvalidOperationException("Rollback-journal mode does not have a WAL tail to recover.");
+
+        var timeout = ResolveBusyTimeout(busyTimeout);
+        using var writerLock = await _lockManager.EnterWriterAsync(timeout, cancellationToken)
+            .ConfigureAwait(false);
+        await _ioGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ThrowIfDisposed();
+            ThrowIfReadOnly();
+            if (_state != SqlitePagerState.Ready)
+                throw new InvalidOperationException($"Cannot recover a SQLite WAL while the pager is {_state}.");
+            try
+            {
+                await SynchronizeCommittedViewAsync(cancellationToken).ConfigureAwait(false);
+                if (HasUncommittedOrInvalidTail(_recoveryInfo))
+                    await RecoverWalTailUnderWriterLockAsync(cancellationToken).ConfigureAwait(false);
+                _lockGeneration = writerLock.PublishStorageChange();
+            }
+            catch
+            {
+                TransitionToFaulted();
+                throw;
+            }
+        }
+        finally
+        {
+            _ioGate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        await _ioGate.WaitAsync().ConfigureAwait(false);
+        AsyncSqlitePagerTransaction? transaction;
+        AsyncSqlitePagerReadTransaction[] readers;
+        try
+        {
+            lock (_stateGate)
+            {
+                if (_state == SqlitePagerState.Disposed)
+                    return;
+                transaction = _activeTransaction;
+                readers = [.. _activeReadTransactions];
+                _activeTransaction = null;
+                _activeReadTransactions.Clear();
+                _state = SqlitePagerState.Disposed;
+            }
+
+            transaction?.AbortFromPagerDispose();
+            foreach (var reader in readers)
+                reader.InvalidateFromPagerDispose();
+
+            try
+            {
+                if (_wal is not null)
+                    await _wal.DisposeAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                await _pageStore.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            _ioGate.Release();
+        }
+    }
+
+    internal async ValueTask<byte[]> ReadSnapshotPageAsync(
+        IReadOnlyDictionary<uint, byte[]> overlay,
+        uint pageCount,
+        uint pageNumber,
+        CancellationToken cancellationToken)
+    {
+        if (pageNumber == 0 || pageNumber > pageCount)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(pageNumber),
+                pageNumber,
+                $"Page number is out of range for snapshot database size {pageCount}.");
+        }
+        if (overlay.TryGetValue(pageNumber, out var walPage))
+            return [.. walPage];
+
+        await _ioGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ThrowIfNotReadable();
+            var physicalPageCount = await _pageStore.GetPageCountAsync(cancellationToken).ConfigureAwait(false);
+            if (pageNumber > physicalPageCount)
+            {
+                throw new InvalidDataException(
+                    $"Snapshot page {pageNumber} is absent from both the WAL overlay and main database file.");
+            }
+
+            return await _pageStore.ReadPageAsync(pageNumber, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _ioGate.Release();
+        }
+    }
+
+    internal void EndReadTransaction(
+        AsyncSqlitePagerReadTransaction transaction,
+        SqlitePagerLockLease readerLock)
+    {
+        lock (_stateGate)
+            _activeReadTransactions.Remove(transaction);
+        readerLock.Dispose();
+    }
+
+    internal async ValueTask CommitTransactionAsync(
+        AsyncSqlitePagerTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        await _ioGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            lock (_stateGate)
+            {
+                ThrowIfDisposed();
+                if (_state != SqlitePagerState.TransactionActive || _activeTransaction != transaction)
+                    throw new InvalidOperationException("This SQLite pager transaction is not active.");
+            }
+
+            ValidateTransaction(transaction);
+            try
+            {
+                if (JournalMode == SqliteJournalMode.Delete)
+                    await CommitRollbackTransactionAsync(transaction, cancellationToken).ConfigureAwait(false);
+                else
+                    await CommitWalTransactionAsync(transaction, cancellationToken).ConfigureAwait(false);
+
+                lock (_stateGate)
+                {
+                    _activeTransaction = null;
+                    _state = SqlitePagerState.Ready;
+                }
+                _lockGeneration = transaction.PublishStorageChange();
+                transaction.ReleaseWriterLock();
+            }
+            catch
+            {
+                lock (_stateGate)
+                    _activeTransaction = null;
+                TransitionToFaulted();
+                transaction.ReleaseWriterLock();
+                throw;
+            }
+        }
+        finally
+        {
+            _ioGate.Release();
+        }
+    }
+
+    internal void RollbackTransaction(AsyncSqlitePagerTransaction transaction)
+    {
+        lock (_stateGate)
+        {
+            if (_state == SqlitePagerState.TransactionActive && _activeTransaction == transaction)
+            {
+                _activeTransaction = null;
+                _state = SqlitePagerState.Ready;
+                transaction.ReleaseWriterLock();
+            }
+            else if (_state == SqlitePagerState.Faulted)
+            {
+                transaction.ReleaseWriterLock();
+            }
+        }
+    }
+
+    private async ValueTask<SqliteCheckpointResult> CheckpointAsync(
+        bool resetCommittedWal,
+        TimeSpan? busyTimeout,
+        CancellationToken cancellationToken)
+    {
+        var timeout = ResolveBusyTimeout(busyTimeout);
+        using var checkpointLock = await _lockManager.EnterCheckpointAsync(timeout, cancellationToken)
+            .ConfigureAwait(false);
+        await _ioGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ThrowIfDisposed();
+            ThrowIfReadOnly();
+            await SynchronizeCommittedViewAsync(cancellationToken).ConfigureAwait(false);
+            if (JournalMode == SqliteJournalMode.Delete)
+            {
+                if (_state != SqlitePagerState.Ready)
+                    throw new InvalidOperationException($"Cannot checkpoint while the SQLite pager is {_state}.");
+                return new SqliteCheckpointResult(_committedPageCount, 0, 0);
+            }
+            if (HasUncommittedOrInvalidTail(_recoveryInfo))
+            {
+                throw new InvalidOperationException(
+                    "Cannot checkpoint a SQLite WAL with an uncommitted or invalid tail; recover it first.");
+            }
+            if (_state != SqlitePagerState.Ready)
+                throw new InvalidOperationException($"Cannot checkpoint while the SQLite pager is {_state}.");
+
+            lock (_stateGate)
+                _state = SqlitePagerState.Checkpointing;
+            try
+            {
+                await ValidateWalHasNotChangedAsync(cancellationToken).ConfigureAwait(false);
+                await RequireWal().FlushAsync(cancellationToken).ConfigureAwait(false);
+                var installed = await InstallCommittedOverlayIntoMainStoreAsync(cancellationToken)
+                    .ConfigureAwait(false);
+                var retainedFrames = _committedFrameCount;
+                if (resetCommittedWal)
+                {
+                    if (await _pageStore.GetPageCountAsync(cancellationToken).ConfigureAwait(false)
+                        != _committedPageCount)
+                    {
+                        throw new InvalidDataException(
+                            "Cannot reset a SQLite WAL before the main database file reaches the committed page count.");
+                    }
+
+                    await ValidateWalHasNotChangedAsync(cancellationToken).ConfigureAwait(false);
+                    await RequireWal().ResetAfterDurableCheckpointAsync(
+                        CanPublishCheckpointedRecoveryMarker(),
+                        cancellationToken).ConfigureAwait(false);
+                    var emptyRecovery = CreateEmptyRecoveryInfo();
+                    var visibleRecovery = await CreateRecoveryVisibleInfoAsync(
+                        emptyRecovery,
+                        cancellationToken).ConfigureAwait(false);
+                    lock (_stateGate)
+                    {
+                        _walPageOverlay.Clear();
+                        _committedFrameCount = 0;
+                        _recoveryInfo = emptyRecovery;
+                        _visibleRecoveryInfo = visibleRecovery;
+                    }
+                    retainedFrames = 0;
+                }
+
+                _lockGeneration = checkpointLock.PublishStorageChange();
+                lock (_stateGate)
+                    _state = SqlitePagerState.Ready;
+                return new SqliteCheckpointResult(_committedPageCount, installed, retainedFrames);
+            }
+            catch
+            {
+                TransitionToFaulted();
+                throw;
+            }
+        }
+        finally
+        {
+            _ioGate.Release();
+        }
+    }
+
+    private async ValueTask CommitWalTransactionAsync(
+        AsyncSqlitePagerTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        await ValidateWalHasNotChangedAsync(cancellationToken).ConfigureAwait(false);
+        var wal = RequireWal();
+        await wal.AppendFramesAsync(
+            new AsyncSqlitePagerTransaction.WalFrameSource(transaction),
+            transaction.TargetDatabaseSizeInPages,
+            cancellationToken).ConfigureAwait(false);
+        await wal.FlushAsync(cancellationToken).ConfigureAwait(false);
+        var recovery = await wal.ScanRecoveryAsync(cancellationToken).ConfigureAwait(false);
+        if (recovery.StopReason != SqliteWalRecoveryStopReason.EndOfFile
+            || recovery.LastCommittedFrameNumber != recovery.LastValidFrameNumber
+            || recovery.LastCommittedDatabaseSizeInPages != transaction.TargetDatabaseSizeInPages)
+        {
+            throw new InvalidDataException("SQLite WAL did not preserve the transaction commit boundary.");
+        }
+
+        var committedOverlay = CloneOverlay(_walPageOverlay);
+        foreach (var pageNumber in transaction.WriteOrder)
+            committedOverlay[pageNumber] = transaction.GetPageImage(pageNumber).ToArray();
+        foreach (var pageNumber in committedOverlay.Keys
+                     .Where(pageNumber => pageNumber > transaction.TargetDatabaseSizeInPages)
+                     .ToArray())
+        {
+            committedOverlay.Remove(pageNumber);
+        }
+
+        await ValidateVisiblePageSourcesAsync(
+            transaction.TargetDatabaseSizeInPages,
+            await _pageStore.GetPageCountAsync(cancellationToken).ConfigureAwait(false),
+            committedOverlay,
+            cancellationToken).ConfigureAwait(false);
+        lock (_stateGate)
+        {
+            _walPageOverlay.Clear();
+            foreach (var pair in committedOverlay)
+                _walPageOverlay[pair.Key] = pair.Value;
+            _committedPageCount = transaction.TargetDatabaseSizeInPages;
+            _committedFrameCount = recovery.LastCommittedFrameNumber;
+            _recoveryInfo = recovery;
+            _visibleRecoveryInfo = recovery;
+        }
+    }
+
+    private async ValueTask CommitRollbackTransactionAsync(
+        AsyncSqlitePagerTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        var originalPageCount = _committedPageCount;
+        var pagesToJournal = new HashSet<uint>(
+            transaction.WriteOrder.Where(pageNumber => pageNumber <= originalPageCount));
+        if (transaction.TargetDatabaseSizeInPages > originalPageCount)
+            pagesToJournal.Add(1);
+        if (transaction.TargetDatabaseSizeInPages < originalPageCount)
+        {
+            for (var pageNumber = transaction.TargetDatabaseSizeInPages + 1;
+                 pageNumber <= originalPageCount;
+                 pageNumber++)
+            {
+                pagesToJournal.Add(pageNumber);
+                if (pageNumber == uint.MaxValue)
+                    break;
+            }
+        }
+
+        await SqliteRollbackJournal.RecoverIfPresentAsync(
+            _fileSystem,
+            _databasePath,
+            _journalPath,
+            readOnly: false,
+            cancellationToken).ConfigureAwait(false);
+        var orderedPages = pagesToJournal
+            .Where(pageNumber => pageNumber >= 1 && pageNumber <= originalPageCount)
+            .OrderBy(static pageNumber => pageNumber)
+            .ToArray();
+        var writer = await SqliteRollbackJournal.BeginAsync(
+            _fileSystem,
+            _journalPath,
+            orderedPages.Length,
+            unchecked((uint)Random.Shared.NextInt64()),
+            originalPageCount,
+            PageSize,
+            cancellationToken).ConfigureAwait(false);
+        try
+        {
+            foreach (var pageNumber in orderedPages)
+            {
+                await writer.WritePageRecordAsync(
+                    pageNumber,
+                    await _pageStore.ReadRawPageAsync(pageNumber, cancellationToken).ConfigureAwait(false),
+                    cancellationToken).ConfigureAwait(false);
+            }
+            await writer.FinalizeAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            await writer.DisposeAsync().ConfigureAwait(false);
+        }
+
+        foreach (var pageNumber in transaction.WriteOrder
+                     .Where(pageNumber => pageNumber != 1 && pageNumber <= originalPageCount)
+                     .OrderBy(static pageNumber => pageNumber))
+        {
+            await _pageStore.WritePageAsync(
+                pageNumber,
+                transaction.GetPageImage(pageNumber),
+                cancellationToken).ConfigureAwait(false);
+        }
+        foreach (var pageNumber in transaction.WriteOrder
+                     .Where(pageNumber => pageNumber > originalPageCount)
+                     .OrderBy(static pageNumber => pageNumber))
+        {
+            await _pageStore.WritePageAsync(
+                pageNumber,
+                transaction.GetPageImage(pageNumber),
+                cancellationToken).ConfigureAwait(false);
+        }
+        if (transaction.PageImages.TryGetValue(1, out var pageOne))
+        {
+            if (transaction.TargetDatabaseSizeInPages < originalPageCount)
+            {
+                await _pageStore.WriteShrinkCheckpointPageOneAsync(pageOne, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                await _pageStore.WritePageAsync(1, pageOne, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        await _pageStore.FlushAsync(cancellationToken).ConfigureAwait(false);
+        if (transaction.TargetDatabaseSizeInPages < originalPageCount)
+        {
+            await _pageStore.TruncateToPageCountAsync(
+                transaction.TargetDatabaseSizeInPages,
+                cancellationToken).ConfigureAwait(false);
+            await _pageStore.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+        await SqliteRollbackJournal.DeleteAsync(_fileSystem, _journalPath, cancellationToken)
+            .ConfigureAwait(false);
+
+        var emptyRecovery = CreateEmptyRecoveryInfo();
+        lock (_stateGate)
+        {
+            _committedPageCount = transaction.TargetDatabaseSizeInPages;
+            _committedFrameCount = 0;
+            _recoveryInfo = emptyRecovery;
+            _visibleRecoveryInfo = emptyRecovery;
+            _walPageOverlay.Clear();
+        }
+    }
+
+    private async ValueTask<int> InstallCommittedOverlayIntoMainStoreAsync(
+        CancellationToken cancellationToken)
+    {
+        var originalPageCount = await _pageStore.GetPageCountAsync(cancellationToken).ConfigureAwait(false);
+        var installed = 0;
+        for (var pageNumber = checked(originalPageCount + 1);
+             pageNumber <= _committedPageCount;
+             pageNumber++)
+        {
+            if (!_walPageOverlay.TryGetValue(pageNumber, out var page))
+            {
+                throw new InvalidDataException(
+                    $"Committed WAL view is missing required appended page {pageNumber}.");
+            }
+            await _pageStore.WritePageAsync(pageNumber, page, cancellationToken).ConfigureAwait(false);
+            installed++;
+            if (pageNumber == uint.MaxValue)
+                break;
+        }
+
+        foreach (var pageNumber in _walPageOverlay.Keys
+                     .Where(pageNumber => pageNumber <= Math.Min(originalPageCount, _committedPageCount)
+                                          && pageNumber != 1)
+                     .OrderBy(static pageNumber => pageNumber))
+        {
+            await _pageStore.WritePageAsync(
+                pageNumber,
+                _walPageOverlay[pageNumber],
+                cancellationToken).ConfigureAwait(false);
+            installed++;
+        }
+
+        if (_committedPageCount < originalPageCount)
+            ValidateShrinkCheckpointPageOne();
+        if (_walPageOverlay.TryGetValue(1, out var firstPage))
+        {
+            if (_committedPageCount < originalPageCount)
+            {
+                await _pageStore.WriteShrinkCheckpointPageOneAsync(firstPage, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                await _pageStore.WritePageAsync(1, firstPage, cancellationToken).ConfigureAwait(false);
+            }
+            installed++;
+        }
+
+        await _pageStore.FlushAsync(cancellationToken).ConfigureAwait(false);
+        if (_committedPageCount < originalPageCount)
+        {
+            await _pageStore.TruncateToPageCountAsync(_committedPageCount, cancellationToken)
+                .ConfigureAwait(false);
+            await _pageStore.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+        return installed;
+    }
+
+    private async ValueTask SynchronizeCommittedViewAsync(CancellationToken cancellationToken)
+    {
+        if (JournalMode == SqliteJournalMode.Delete)
+        {
+            await _pageStore.RefreshHeaderAsync(cancellationToken).ConfigureAwait(false);
+            await InitializeRollbackViewAsync(cancellationToken).ConfigureAwait(false);
+            _lockGeneration = _lockManager.Generation;
+            return;
+        }
+
+        if (_wal is null
+            && await _fileSystem.FileExistsAsync(_walPath, cancellationToken).ConfigureAwait(false))
+        {
+            _wal = await SqliteWalFile.OpenAsync(
+                _fileSystem,
+                _walPath,
+                _pageStore.IsReadOnly,
+                _encryption,
+                CreateTruncatedWalHeader(PageSize),
+                _pageCodec,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        if (_wal is null)
+        {
+            await _pageStore.RefreshHeaderAsync(cancellationToken).ConfigureAwait(false);
+            await InitializeCleanWalViewAsync(cancellationToken).ConfigureAwait(false);
+            _lockGeneration = _lockManager.Generation;
+            return;
+        }
+
+        var recovery = await _wal.ScanRecoveryAsync(cancellationToken).ConfigureAwait(false);
+        if (recovery.LastCommittedFrameNumber == 0
+            && recovery.StopReason == SqliteWalRecoveryStopReason.EndOfFile)
+        {
+            await _pageStore.RefreshHeaderAsync(cancellationToken).ConfigureAwait(false);
+        }
+        await InitializeCommittedViewAsync(recovery, cancellationToken).ConfigureAwait(false);
+        _lockGeneration = _lockManager.Generation;
+    }
+
+    private async ValueTask RecoverWalTailUnderWriterLockAsync(CancellationToken cancellationToken)
+    {
+        var wal = RequireWal();
+        var recovery = await wal.ScanRecoveryAsync(cancellationToken).ConfigureAwait(false);
+        await InitializeCommittedViewAsync(recovery, cancellationToken).ConfigureAwait(false);
+        if (!HasUncommittedOrInvalidTail(recovery))
+            return;
+
+        var repairedFrom = await wal.RecoverToLastCommittedFrameAsync(cancellationToken)
+            .ConfigureAwait(false);
+        if (repairedFrom != recovery)
+            throw new InvalidDataException("SQLite WAL changed between recovery scanning and tail repair.");
+        var repaired = await wal.ScanRecoveryAsync(cancellationToken).ConfigureAwait(false);
+        await InitializeCommittedViewAsync(repaired, cancellationToken).ConfigureAwait(false);
+        lock (_stateGate)
+            _visibleRecoveryInfo = recovery;
+    }
+
+    private async ValueTask InitializeCommittedViewAsync(
+        SqliteWalRecoveryInfo recovery,
+        CancellationToken cancellationToken)
+    {
+        var wal = RequireWal();
+        if (_pageStore.PageSize != wal.PageSize)
+            throw new InvalidDataException("SQLite database and WAL page sizes do not match.");
+        if (!IsWalCompatibleFormat(_pageStore.Header.WriteVersion)
+            || !IsWalCompatibleFormat(_pageStore.Header.ReadVersion))
+        {
+            throw new InvalidDataException(
+                "A SQLite WAL overlay requires WAL/MVCC read and write format versions.");
+        }
+
+        var mainPageCount = await _pageStore.GetPageCountAsync(cancellationToken).ConfigureAwait(false);
+        var committedPageCount = mainPageCount;
+        var overlay = new Dictionary<uint, byte[]>();
+        var transactionPages = new Dictionary<uint, byte[]>();
+        var finalTransactionHasPageOne = false;
+        if (recovery.LastCommittedFrameNumber > 0)
+        {
+            var frameNumber = 0L;
+            foreach (var frame in await wal.ReadFrameRangeAsync(
+                         1,
+                         recovery.LastCommittedFrameNumber,
+                         cancellationToken).ConfigureAwait(false))
+            {
+                frameNumber++;
+                transactionPages[frame.Header.PageNumber] = frame.PageData;
+                if (!frame.Header.IsCommit)
+                    continue;
+
+                ValidateRecoveredTransaction(transactionPages, frame.Header.DatabaseSizeInPages);
+                foreach (var pageNumber in overlay.Keys
+                             .Where(pageNumber => pageNumber > frame.Header.DatabaseSizeInPages)
+                             .ToArray())
+                {
+                    overlay.Remove(pageNumber);
+                }
+                foreach (var pair in transactionPages)
+                    overlay[pair.Key] = pair.Value;
+                committedPageCount = frame.Header.DatabaseSizeInPages;
+                if (frameNumber == recovery.LastCommittedFrameNumber)
+                    finalTransactionHasPageOne = transactionPages.ContainsKey(1);
+                transactionPages.Clear();
+            }
+        }
+        if (transactionPages.Count != 0)
+            throw new InvalidDataException("SQLite WAL recovery stopped before a committed transaction boundary.");
+
+        ValidateTrailingMainDatabasePages(
+            recovery,
+            mainPageCount,
+            committedPageCount,
+            finalTransactionHasPageOne,
+            overlay);
+        await ValidateVisiblePageSourcesAsync(
+            committedPageCount,
+            mainPageCount,
+            overlay,
+            cancellationToken).ConfigureAwait(false);
+
+        var visibleRecovery = await CreateRecoveryVisibleInfoAsync(recovery, cancellationToken)
+            .ConfigureAwait(false);
+        lock (_stateGate)
+        {
+            _walPageOverlay.Clear();
+            foreach (var pair in overlay)
+                _walPageOverlay[pair.Key] = pair.Value;
+            _committedPageCount = committedPageCount;
+            _committedFrameCount = recovery.LastCommittedFrameNumber;
+            _recoveryInfo = recovery;
+            _visibleRecoveryInfo = visibleRecovery;
+        }
+    }
+
+    private async ValueTask InitializeRollbackViewAsync(CancellationToken cancellationToken)
+    {
+        var header = _pageStore.Header;
+        if (header.WriteVersion != SqliteFileFormatVersion.Legacy
+            || header.ReadVersion != SqliteFileFormatVersion.Legacy)
+        {
+            throw new InvalidDataException(
+                "A SQLite rollback-journal pager requires legacy read and write format versions.");
+        }
+        var pageCount = await _pageStore.GetPageCountAsync(cancellationToken).ConfigureAwait(false);
+        if (header.VersionValidFor == header.ChangeCounter
+            && header.DatabaseSizeInPages != 0
+            && header.DatabaseSizeInPages != pageCount)
+        {
+            throw new InvalidDataException(
+                "SQLite rollback-journal database header page count does not match the main file.");
+        }
+
+        var recovery = CreateEmptyRecoveryInfo();
+        lock (_stateGate)
+        {
+            _committedPageCount = pageCount;
+            _committedFrameCount = 0;
+            _walPageOverlay.Clear();
+            _recoveryInfo = recovery;
+            _visibleRecoveryInfo = recovery;
+        }
+    }
+
+    private async ValueTask InitializeCleanWalViewAsync(CancellationToken cancellationToken)
+    {
+        var header = _pageStore.Header;
+        if (!IsWalCompatibleFormat(header.WriteVersion)
+            || !IsWalCompatibleFormat(header.ReadVersion))
+        {
+            throw new InvalidDataException("A clean SQLite WAL view requires WAL/MVCC read and write format versions.");
+        }
+        var pageCount = await _pageStore.GetPageCountAsync(cancellationToken).ConfigureAwait(false);
+        if (header.VersionValidFor != header.ChangeCounter
+            || header.DatabaseSizeInPages != pageCount)
+        {
+            throw new InvalidDataException(
+                "A SQLite WAL database without a WAL file must have an authoritative main-database header.");
+        }
+
+        var recovery = CreateEmptyRecoveryInfo();
+        lock (_stateGate)
+        {
+            _committedPageCount = pageCount;
+            _committedFrameCount = 0;
+            _walPageOverlay.Clear();
+            _recoveryInfo = recovery;
+            _visibleRecoveryInfo = recovery;
+        }
+    }
+
+    private async ValueTask<SqliteWalRecoveryInfo> CreateRecoveryVisibleInfoAsync(
+        SqliteWalRecoveryInfo recovery,
+        CancellationToken cancellationToken)
+    {
+        if (recovery.LastValidFrameNumber != 0
+            || recovery.LastCommittedFrameNumber != 0
+            || recovery.StopReason != SqliteWalRecoveryStopReason.EndOfFile
+            || !RequireWal().HasCheckpointedRecoveryMarker)
+        {
+            return recovery;
+        }
+
+        var pageCount = await _pageStore.GetPageCountAsync(cancellationToken).ConfigureAwait(false);
+        var header = _pageStore.Header;
+        if (pageCount == 0
+            || header.VersionValidFor != header.ChangeCounter
+            || header.DatabaseSizeInPages != pageCount)
+        {
+            throw new InvalidDataException(
+                "SQLite WAL checkpoint recovery marker does not have an authoritative durable main-database state.");
+        }
+        return new SqliteWalRecoveryInfo(
+            LastValidFrameNumber: 0,
+            LastCommittedFrameNumber: 1,
+            LastCommittedDatabaseSizeInPages: pageCount,
+            LastCommittedByteLength: SqliteWalHeader.Size,
+            StopReason: SqliteWalRecoveryStopReason.EndOfFile);
+    }
+
+    private void ValidateTransaction(AsyncSqlitePagerTransaction transaction)
+    {
+        if (transaction.WriteOrder.Count == 0)
+            throw new InvalidOperationException("A SQLite pager transaction must contain at least one complete page image.");
+        foreach (var pageNumber in transaction.WriteOrder)
+        {
+            if (pageNumber == 0 || pageNumber > transaction.TargetDatabaseSizeInPages)
+            {
+                throw new InvalidOperationException(
+                    $"SQLite pager transaction page {pageNumber} is outside its committed database size.");
+            }
+        }
+
+        ValidatePageOneImage(transaction.PageImages, transaction.TargetDatabaseSizeInPages);
+        if (transaction.TargetDatabaseSizeInPages < _committedPageCount)
+            ValidateShrinkTransactionPageOne(transaction.PageImages, transaction.TargetDatabaseSizeInPages);
+        if (transaction.TargetDatabaseSizeInPages <= _committedPageCount)
+            return;
+
+        var required = (ulong)transaction.TargetDatabaseSizeInPages - _committedPageCount;
+        var provided = transaction.WriteOrder.Count(
+            pageNumber => pageNumber > _committedPageCount
+                          && pageNumber <= transaction.TargetDatabaseSizeInPages);
+        if ((ulong)provided != required)
+        {
+            throw new InvalidOperationException(
+                "Every newly committed SQLite page must have an explicit page image in the transaction.");
+        }
+    }
+
+    private void ValidateRecoveredTransaction(
+        IReadOnlyDictionary<uint, byte[]> transactionPages,
+        uint targetPageCount)
+    {
+        if (targetPageCount == 0)
+            throw new InvalidDataException("SQLite WAL commit frame has a zero database size.");
+        foreach (var pageNumber in transactionPages.Keys)
+        {
+            if (pageNumber > targetPageCount)
+            {
+                throw new InvalidDataException(
+                    $"SQLite WAL transaction writes page {pageNumber} beyond committed database size {targetPageCount}.");
+            }
+        }
+        ValidatePageOneImage(transactionPages, targetPageCount);
+    }
+
+    private void ValidatePageOneImage(
+        IReadOnlyDictionary<uint, byte[]> transactionPages,
+        uint targetPageCount)
+    {
+        if (!transactionPages.TryGetValue(1, out var pageOne))
+            return;
+        var header = SqliteDatabaseHeader.Parse(pageOne);
+        if (header.PageSize != _pageStore.PageSize)
+            throw new InvalidDataException("SQLite transaction page 1 changes the database page size.");
+        var expectedVersion = FormatVersionFor(JournalMode);
+        if (header.WriteVersion != expectedVersion || header.ReadVersion != expectedVersion)
+        {
+            throw new InvalidDataException(
+                $"SQLite transaction page 1 does not match the active {JournalMode} journal mode.");
+        }
+        if (header.VersionValidFor == header.ChangeCounter
+            && header.DatabaseSizeInPages != 0
+            && header.DatabaseSizeInPages != targetPageCount)
+        {
+            throw new InvalidDataException(
+                "SQLite transaction page 1 has an authoritative page count different from its commit size.");
+        }
+    }
+
+    private static void ValidateShrinkTransactionPageOne(
+        IReadOnlyDictionary<uint, byte[]> transactionPages,
+        uint targetPageCount)
+    {
+        if (!transactionPages.TryGetValue(1, out var pageOne))
+        {
+            throw new InvalidOperationException(
+                "A database-shrinking SQLite transaction must rewrite page 1 with the new authoritative page count.");
+        }
+        var header = SqliteDatabaseHeader.Parse(pageOne);
+        if (header.VersionValidFor != header.ChangeCounter
+            || header.DatabaseSizeInPages != targetPageCount)
+        {
+            throw new InvalidDataException(
+                "A database-shrinking SQLite transaction must make page 1's page count authoritative and equal to its commit size.");
+        }
+    }
+
+    private void ValidateShrinkCheckpointPageOne()
+    {
+        if (!_walPageOverlay.TryGetValue(1, out var pageOne))
+        {
+            throw new InvalidDataException(
+                "Cannot checkpoint a database-shrinking WAL view without its committed page 1 image.");
+        }
+        var header = SqliteDatabaseHeader.Parse(pageOne);
+        if (header.VersionValidFor != header.ChangeCounter
+            || header.DatabaseSizeInPages != _committedPageCount)
+        {
+            throw new InvalidDataException(
+                "Cannot checkpoint a database-shrinking WAL view whose page 1 does not authoritatively declare the committed size.");
+        }
+    }
+
+    private void ValidateTrailingMainDatabasePages(
+        SqliteWalRecoveryInfo recovery,
+        uint mainPageCount,
+        uint committedPageCount,
+        bool finalTransactionHasPageOne,
+        IReadOnlyDictionary<uint, byte[]> overlay)
+    {
+        if (mainPageCount <= committedPageCount)
+        {
+            var header = _pageStore.Header;
+            if (header.VersionValidFor == header.ChangeCounter
+                && header.DatabaseSizeInPages != 0
+                && header.DatabaseSizeInPages < mainPageCount)
+            {
+                throw new InvalidDataException(
+                    "SQLite database header declares a smaller authoritative size without a recoverable shrinking WAL commit.");
+            }
+            return;
+        }
+        if (recovery.LastCommittedFrameNumber == 0
+            || !finalTransactionHasPageOne
+            || !overlay.TryGetValue(1, out var pageOne))
+        {
+            throw new InvalidDataException(
+                "SQLite database has pages beyond its authoritative size without a recoverable shrinking WAL commit.");
+        }
+
+        var mainHeader = _pageStore.Header;
+        var walHeader = SqliteDatabaseHeader.Parse(pageOne);
+        if (walHeader.VersionValidFor != walHeader.ChangeCounter
+            || walHeader.DatabaseSizeInPages != committedPageCount)
+        {
+            throw new InvalidDataException(
+                "SQLite database has pages beyond its authoritative size, but its retained WAL does not contain the shrinking transaction's authoritative page 1.");
+        }
+        if (mainHeader.VersionValidFor == mainHeader.ChangeCounter
+            && mainHeader.DatabaseSizeInPages == mainPageCount)
+        {
+            return;
+        }
+        if (mainHeader.DatabaseSizeInPages != committedPageCount || walHeader != mainHeader)
+        {
+            throw new InvalidDataException(
+                "SQLite database has pages beyond its authoritative size, but its retained WAL does not prove a matching interrupted shrink checkpoint.");
+        }
+    }
+
+    private async ValueTask ValidateVisiblePageSourcesAsync(CancellationToken cancellationToken)
+        => await ValidateVisiblePageSourcesAsync(
+            _committedPageCount,
+            await _pageStore.GetPageCountAsync(cancellationToken).ConfigureAwait(false),
+            _walPageOverlay,
+            cancellationToken).ConfigureAwait(false);
+
+    private static ValueTask ValidateVisiblePageSourcesAsync(
+        uint committedPageCount,
+        uint mainPageCount,
+        IReadOnlyDictionary<uint, byte[]> overlay,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (committedPageCount <= mainPageCount)
+            return ValueTask.CompletedTask;
+        var required = (ulong)committedPageCount - mainPageCount;
+        var available = overlay.Keys.LongCount(
+            pageNumber => pageNumber > mainPageCount && pageNumber <= committedPageCount);
+        if ((ulong)available != required)
+        {
+            throw new InvalidDataException(
+                "SQLite WAL commit declares appended pages that are absent from both the WAL and main database file.");
+        }
+        return ValueTask.CompletedTask;
+    }
+
+    private async ValueTask ValidateWalHasNotChangedAsync(CancellationToken cancellationToken)
+    {
+        var recovery = await RequireWal().ScanRecoveryAsync(cancellationToken).ConfigureAwait(false);
+        if (recovery.StopReason != SqliteWalRecoveryStopReason.EndOfFile
+            || recovery.LastValidFrameNumber != _committedFrameCount
+            || recovery.LastCommittedFrameNumber != _committedFrameCount
+            || (recovery.LastCommittedFrameNumber != 0
+                && recovery.LastCommittedDatabaseSizeInPages != _committedPageCount))
+        {
+            throw new InvalidDataException(
+                "SQLite WAL changed outside this pager; begin a new transaction before writing.");
+        }
+    }
+
+    private bool CanPublishCheckpointedRecoveryMarker()
+    {
+        var header = _pageStore.Header;
+        return _walPageOverlay.ContainsKey(1)
+               && header.VersionValidFor == header.ChangeCounter
+               && header.DatabaseSizeInPages == _committedPageCount;
+    }
+
+    private TimeSpan ResolveBusyTimeout(TimeSpan? busyTimeout)
+    {
+        ValidateBusyTimeout(busyTimeout, nameof(busyTimeout));
+        lock (_stateGate)
+        {
+            ThrowIfDisposed();
+            return busyTimeout ?? _busyTimeout;
+        }
+    }
+
+    private void ThrowIfNotReadable()
+    {
+        ThrowIfDisposed();
+        if (_state is not SqlitePagerState.Ready and not SqlitePagerState.TransactionActive)
+            throw new InvalidOperationException($"Cannot read from a SQLite pager while it is {_state}.");
+    }
+
+    private void ThrowIfReadOnly()
+    {
+        if (_pageStore.IsReadOnly || (_wal?.IsReadOnly ?? false))
+            throw new InvalidOperationException("Cannot write through a read-only SQLite pager.");
+    }
+
+    private void ThrowIfDisposed()
+        => ObjectDisposedException.ThrowIf(_state == SqlitePagerState.Disposed, this);
+
+    private void TransitionToFaulted()
+    {
+        lock (_stateGate)
+        {
+            if (_state != SqlitePagerState.Disposed)
+                _state = SqlitePagerState.Faulted;
+        }
+    }
+
+    private SqliteWalFile RequireWal()
+        => _wal ?? throw new InvalidOperationException("This SQLite pager has no WAL file.");
+
+    private static SqliteWalHeader CreateTruncatedWalHeader(int pageSize)
+        => SqliteWalHeader.Create(
+            pageSize,
+            unchecked((uint)Random.Shared.NextInt64()),
+            unchecked((uint)Random.Shared.NextInt64()));
+
+    private static SqliteWalRecoveryInfo CreateEmptyRecoveryInfo()
+        => new(
+            LastValidFrameNumber: 0,
+            LastCommittedFrameNumber: 0,
+            LastCommittedDatabaseSizeInPages: 0,
+            LastCommittedByteLength: SqliteWalHeader.Size,
+            StopReason: SqliteWalRecoveryStopReason.EndOfFile);
+
+    private static bool HasUncommittedOrInvalidTail(SqliteWalRecoveryInfo recovery)
+        => recovery.StopReason != SqliteWalRecoveryStopReason.EndOfFile
+           || recovery.LastValidFrameNumber != recovery.LastCommittedFrameNumber;
+
+    private static bool UsesWalStorage(SqliteJournalMode journalMode)
+        => journalMode is SqliteJournalMode.Wal or SqliteJournalMode.Mvcc;
+
+    private static bool IsWalCompatibleFormat(SqliteFileFormatVersion version)
+        => version is SqliteFileFormatVersion.Wal or SqliteFileFormatVersion.Mvcc;
+
+    private static SqliteFileFormatVersion FormatVersionFor(SqliteJournalMode journalMode)
+        => journalMode switch
+        {
+            SqliteJournalMode.Wal => SqliteFileFormatVersion.Wal,
+            SqliteJournalMode.Mvcc => SqliteFileFormatVersion.Mvcc,
+            _ => SqliteFileFormatVersion.Legacy,
+        };
+
+    private static SqliteJournalMode GetJournalMode(SqliteDatabaseHeader header)
+    {
+        if (header.WriteVersion != header.ReadVersion)
+        {
+            throw new InvalidDataException(
+                "SQLite database read and write format versions must match for managed storage.");
+        }
+        return header.WriteVersion switch
+        {
+            SqliteFileFormatVersion.Legacy => SqliteJournalMode.Delete,
+            SqliteFileFormatVersion.Wal => SqliteJournalMode.Wal,
+            SqliteFileFormatVersion.Mvcc => SqliteJournalMode.Mvcc,
+            _ => throw new InvalidDataException(
+                $"Managed storage does not support SQLite file format version {header.WriteVersion}."),
+        };
+    }
+
+    private static Dictionary<uint, byte[]> CloneOverlay(
+        IReadOnlyDictionary<uint, byte[]> overlay)
+        => overlay.ToDictionary(static pair => pair.Key, static pair => pair.Value.ToArray());
+
+    private static void ValidateBusyTimeout(TimeSpan? timeout, string parameterName)
+    {
+        if (timeout is not null)
+            ValidateBusyTimeout(timeout.Value, parameterName);
+    }
+
+    private static void ValidateBusyTimeout(TimeSpan timeout, string parameterName)
+    {
+        if (timeout < TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan)
+            throw new ArgumentOutOfRangeException(parameterName, timeout, "Busy timeout cannot be negative.");
+    }
+
+    private static SqlitePagerLockManager GetLockManager(
+        IAsyncFileSystem fileSystem,
+        string databasePath,
+        string walPath)
+    {
+        var scope = LockScopes.GetValue(fileSystem, static _ => new AsyncLockScope());
+        var key = CreateLockKey(fileSystem, databasePath, walPath);
+        return scope.GetOrAdd(key);
+    }
+
+    private static string CreateLockKey(
+        IAsyncFileSystem fileSystem,
+        string databasePath,
+        string walPath)
+    {
+        if (fileSystem is IStoragePathResolver resolver)
+        {
+            databasePath = resolver.GetCanonicalPath(databasePath);
+            walPath = resolver.GetCanonicalPath(walPath);
+        }
+        return string.Concat(databasePath, "\0", walPath);
+    }
+
+    private static async ValueTask DisposeIgnoringFailureAsync(IAsyncDisposable disposable)
+    {
+        try
+        {
+            await disposable.DisposeAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+        }
+    }
+
+    private static async ValueTask DeleteIgnoringFailureAsync(
+        IAsyncFileSystem fileSystem,
+        string path)
+    {
+        try
+        {
+            await fileSystem.DeleteFileAsync(path, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch
+        {
+        }
+    }
+
+    private sealed class AsyncLockScope
+    {
+        private readonly object _gate = new();
+        private readonly Dictionary<string, SqlitePagerLockManager> _locks = new(StringComparer.Ordinal);
+
+        internal SqlitePagerLockManager GetOrAdd(string key)
+        {
+            lock (_gate)
+            {
+                if (!_locks.TryGetValue(key, out var manager))
+                {
+                    manager = new SqlitePagerLockManager();
+                    _locks.Add(key, manager);
+                }
+                return manager;
+            }
+        }
+    }
+
+    private sealed class AsyncLockLease(SqlitePagerLockLease lease) : IAsyncDisposable
+    {
+        internal SqlitePagerLockLease Lease { get; } = lease;
+
+        internal static async ValueTask<AsyncLockLease> AcquireReaderAsync(
+            SqlitePagerLockManager manager,
+            TimeSpan timeout,
+            CancellationToken cancellationToken)
+            => new(await manager.EnterReaderAsync(timeout, cancellationToken).ConfigureAwait(false));
+
+        internal static async ValueTask<AsyncLockLease> AcquireCheckpointAsync(
+            SqlitePagerLockManager manager,
+            TimeSpan timeout,
+            CancellationToken cancellationToken)
+            => new(await manager.EnterCheckpointAsync(timeout, cancellationToken).ConfigureAwait(false));
+
+        public ValueTask DisposeAsync()
+        {
+            Lease.Dispose();
+            return ValueTask.CompletedTask;
+        }
+    }
+}
+
+/// <summary>A stable committed snapshot owned by an <see cref="AsyncSqlitePager"/>.</summary>
+public sealed class AsyncSqlitePagerReadTransaction : IAsyncDisposable
+{
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly AsyncSqlitePager _pager;
+    private readonly IReadOnlyDictionary<uint, byte[]> _walPageOverlay;
+    private SqlitePagerLockLease? _readerLock;
+
+    internal AsyncSqlitePagerReadTransaction(
+        AsyncSqlitePager pager,
+        SqlitePagerLockLease readerLock,
+        uint pageCount,
+        IReadOnlyDictionary<uint, byte[]> walPageOverlay)
+    {
+        _pager = pager;
+        _readerLock = readerLock;
+        PageCount = pageCount;
+        _walPageOverlay = walPageOverlay;
+    }
+
+    /// <summary>The database size captured at snapshot start.</summary>
+    public uint PageCount { get; }
+
+    /// <summary>Whether the snapshot still owns its reader lease.</summary>
+    public bool IsActive => Volatile.Read(ref _readerLock) is not null;
+
+    /// <summary>Reads one page from the stable snapshot.</summary>
+    public async ValueTask<byte[]> ReadPageAsync(
+        uint pageNumber,
+        CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ObjectDisposedException.ThrowIf(_readerLock is null, this);
+            return await _pager.ReadSnapshotPageAsync(
+                _walPageOverlay,
+                PageCount,
+                pageNumber,
+                cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            var readerLock = _readerLock;
+            _readerLock = null;
+            if (readerLock is not null)
+                _pager.EndReadTransaction(this, readerLock);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    internal void InvalidateFromPagerDispose()
+    {
+        var readerLock = Interlocked.Exchange(ref _readerLock, null);
+        readerLock?.Dispose();
+    }
+}
+
+/// <summary>
+/// In-memory page images that become visible only after their durable commit.
+/// </summary>
+public sealed class AsyncSqlitePagerTransaction : IAsyncDisposable
+{
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly AsyncSqlitePager _pager;
+    private readonly uint _sourcePageCount;
+    private readonly IReadOnlyDictionary<uint, byte[]> _sourceOverlay;
+    private readonly Dictionary<uint, byte[]> _pageImages = [];
+    private readonly List<uint> _writeOrder = [];
+    private SqlitePagerLockLease? _writerLock;
+    private SqlitePagerTransactionState _state = SqlitePagerTransactionState.Active;
+
+    internal AsyncSqlitePagerTransaction(
+        AsyncSqlitePager pager,
+        SqlitePagerLockLease writerLock,
+        uint targetDatabaseSizeInPages,
+        uint sourcePageCount,
+        IReadOnlyDictionary<uint, byte[]> sourceOverlay)
+    {
+        _pager = pager;
+        _writerLock = writerLock;
+        TargetDatabaseSizeInPages = targetDatabaseSizeInPages;
+        _sourcePageCount = sourcePageCount;
+        _sourceOverlay = sourceOverlay;
+    }
+
+    /// <summary>The database size written into this transaction's commit boundary.</summary>
+    public uint TargetDatabaseSizeInPages { get; }
+
+    /// <summary>The transaction lifecycle state.</summary>
+    public SqlitePagerTransactionState State => _state;
+
+    internal IReadOnlyDictionary<uint, byte[]> PageImages => _pageImages;
+    internal IReadOnlyList<uint> WriteOrder => _writeOrder;
+
+    /// <summary>Stages one complete page image.</summary>
+    public async ValueTask WritePageAsync(
+        uint pageNumber,
+        ReadOnlyMemory<byte> page,
+        CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ThrowIfNotActive();
+            if (pageNumber == 0 || pageNumber > TargetDatabaseSizeInPages)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(pageNumber),
+                    pageNumber,
+                    $"Page number must be between 1 and {TargetDatabaseSizeInPages}.");
+            }
+            if (page.Length != _pager.PageSize)
+                throw new ArgumentException($"Page data must be exactly {_pager.PageSize} bytes.", nameof(page));
+            if (!_pageImages.ContainsKey(pageNumber))
+                _writeOrder.Add(pageNumber);
+            _pageImages[pageNumber] = page.ToArray();
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>Reads the latest staged image or the committed source snapshot.</summary>
+    public async ValueTask<byte[]> ReadPageAsync(
+        uint pageNumber,
+        CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ThrowIfNotActive();
+            if (_pageImages.TryGetValue(pageNumber, out var page))
+                return [.. page];
+            return await _pager.ReadSnapshotPageAsync(
+                _sourceOverlay,
+                _sourcePageCount,
+                pageNumber,
+                cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>Durably commits all staged pages.</summary>
+    public async ValueTask CommitAsync(CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ThrowIfNotActive();
+            try
+            {
+                await _pager.CommitTransactionAsync(this, cancellationToken).ConfigureAwait(false);
+                _state = SqlitePagerTransactionState.Committed;
+            }
+            catch
+            {
+                if (_pager.State == SqlitePagerState.Faulted)
+                {
+                    _state = SqlitePagerTransactionState.Faulted;
+                    ReleaseWriterLock();
+                }
+                throw;
+            }
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>Discards all staged pages without writing storage.</summary>
+    public async ValueTask RollbackAsync(CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ThrowIfNotActive();
+            _pageImages.Clear();
+            _writeOrder.Clear();
+            _pager.RollbackTransaction(this);
+            _state = SqlitePagerTransactionState.RolledBack;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (_state == SqlitePagerTransactionState.Active)
+            {
+                _pageImages.Clear();
+                _writeOrder.Clear();
+                _pager.RollbackTransaction(this);
+                _state = SqlitePagerTransactionState.RolledBack;
+            }
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    internal byte[] GetPageImage(uint pageNumber)
+        => _pageImages.TryGetValue(pageNumber, out var page)
+            ? page
+            : throw new InvalidOperationException($"SQLite pager transaction has no image for page {pageNumber}.");
+
+    internal long PublishStorageChange()
+        => (_writerLock
+            ?? throw new InvalidOperationException("SQLite pager transaction no longer owns its writer lock."))
+            .PublishStorageChange();
+
+    internal void ReleaseWriterLock()
+    {
+        var writerLock = Interlocked.Exchange(ref _writerLock, null);
+        writerLock?.Dispose();
+    }
+
+    internal void AbortFromPagerDispose()
+    {
+        if (_state == SqlitePagerTransactionState.Active)
+        {
+            _pageImages.Clear();
+            _writeOrder.Clear();
+            _state = SqlitePagerTransactionState.RolledBack;
+        }
+        ReleaseWriterLock();
+    }
+
+    private void ThrowIfNotActive()
+    {
+        if (_state != SqlitePagerTransactionState.Active)
+            throw new InvalidOperationException($"SQLite pager transaction is {_state}.");
+    }
+
+    internal sealed class WalFrameSource(AsyncSqlitePagerTransaction transaction)
+        : ISqliteWalFrameSource
+    {
+        public int Count => transaction.WriteOrder.Count;
+        public uint GetPageNumber(int index) => transaction.WriteOrder[index];
+        public ReadOnlySpan<byte> GetPageImage(int index)
+            => transaction.GetPageImage(transaction.WriteOrder[index]);
+    }
+}

--- a/src/Ahtola.Core/Storage/AsyncSqlitePager.cs
+++ b/src/Ahtola.Core/Storage/AsyncSqlitePager.cs
@@ -410,13 +410,18 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
                 pageCodec);
 
             // Opening re-derives visibility from the file itself, which is what a
-            // fresh process would see, so drop any publication boundary a faulted
-            // in-process writer left pinned.
-            if (!readOnly)
-                manager.PublishAllWalFrames();
+            // fresh process would see. A writable open first durably removes any
+            // tail an abandoned commit left hidden, so republishing cannot
+            // resurrect it; a read-only open cannot repair anything and therefore
+            // keeps honoring the boundary instead.
             if (UsesWalStorage(journalMode) && wal is not null)
             {
-                var recovery = await wal.ScanRecoveryAsync(cancellationToken).ConfigureAwait(false);
+                if (!readOnly)
+                    await RepairHiddenWalTailAsync(wal, manager, cancellationToken).ConfigureAwait(false);
+
+                var recovery = await wal
+                    .ScanRecoveryAsync(manager.WalPublicationBoundary, cancellationToken)
+                    .ConfigureAwait(false);
                 try
                 {
                     await pager.InitializeCommittedViewAsync(recovery, cancellationToken).ConfigureAwait(false);
@@ -554,12 +559,12 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
                 ThrowIfDisposed();
                 ThrowIfReadOnly();
 
-                // This writer now owns the WAL, so the file is authoritative again:
-                // republish every physical frame, including a previous writer's
-                // durable-but-unconfirmed tail, before deriving the committed view.
-                if (UsesWalStorage(JournalMode))
-                    _lockManager.PublishAllWalFrames();
-                await SynchronizeCommittedViewAsync(cancellationToken).ConfigureAwait(false);
+                // This writer now owns the WAL, so the file becomes authoritative
+                // again — but only after any tail an abandoned commit left hidden is
+                // durably removed, so republishing cannot resurrect it.
+                await SynchronizeCommittedViewAsync(
+                    cancellationToken,
+                    repairHiddenWalTail: UsesWalStorage(JournalMode)).ConfigureAwait(false);
                 if (UsesWalStorage(JournalMode) && HasUncommittedOrInvalidTail(_recoveryInfo))
                     await RecoverWalTailUnderWriterLockAsync(cancellationToken).ConfigureAwait(false);
                 if (_state != SqlitePagerState.Ready)
@@ -672,8 +677,8 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
                 throw new InvalidOperationException($"Cannot recover a SQLite WAL while the pager is {_state}.");
             try
             {
-                _lockManager.PublishAllWalFrames();
-                await SynchronizeCommittedViewAsync(cancellationToken).ConfigureAwait(false);
+                await SynchronizeCommittedViewAsync(cancellationToken, repairHiddenWalTail: true)
+                    .ConfigureAwait(false);
                 if (HasUncommittedOrInvalidTail(_recoveryInfo))
                     await RecoverWalTailUnderWriterLockAsync(cancellationToken).ConfigureAwait(false);
                 _lockGeneration = writerLock.PublishStorageChange();
@@ -857,10 +862,11 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
             ThrowIfDisposed();
             ThrowIfReadOnly();
 
-            // The checkpoint lease excludes every reader and writer, so the WAL
-            // file is authoritative again for whatever it is about to install.
-            _lockManager.PublishAllWalFrames();
-            await SynchronizeCommittedViewAsync(cancellationToken).ConfigureAwait(false);
+            // The checkpoint lease excludes every reader and writer, so this is the
+            // safest point to durably drop a tail an abandoned commit left hidden.
+            await SynchronizeCommittedViewAsync(
+                cancellationToken,
+                repairHiddenWalTail: UsesWalStorage(JournalMode)).ConfigureAwait(false);
             if (JournalMode == SqliteJournalMode.Delete)
             {
                 if (_state != SqlitePagerState.Ready)
@@ -941,46 +947,83 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
         // adopt a commit-bearing frame that has not been made durable yet — or one
         // that never commits at all because the flush fails.
         transaction.BeginWalPublication(_committedFrameCount);
-        await wal.AppendFramesAsync(
-            new AsyncSqlitePagerTransaction.WalFrameSource(transaction),
-            transaction.TargetDatabaseSizeInPages,
-            cancellationToken).ConfigureAwait(false);
-        await wal.FlushAsync(cancellationToken).ConfigureAwait(false);
-        var recovery = await wal.ScanRecoveryAsync(cancellationToken).ConfigureAwait(false);
-        if (recovery.StopReason != SqliteWalRecoveryStopReason.EndOfFile
-            || recovery.LastCommittedFrameNumber != recovery.LastValidFrameNumber
-            || recovery.LastCommittedDatabaseSizeInPages != transaction.TargetDatabaseSizeInPages)
+        var publishedFrameCount = _committedFrameCount;
+        var durable = false;
+        try
         {
-            throw new InvalidDataException("SQLite WAL did not preserve the transaction commit boundary.");
-        }
+            await wal.AppendFramesAsync(
+                new AsyncSqlitePagerTransaction.WalFrameSource(transaction),
+                transaction.TargetDatabaseSizeInPages,
+                cancellationToken).ConfigureAwait(false);
+            await wal.FlushAsync(cancellationToken).ConfigureAwait(false);
 
-        var committedOverlay = CloneOverlay(_walPageOverlay);
-        foreach (var pageNumber in transaction.WriteOrder)
-            committedOverlay[pageNumber] = transaction.GetPageImage(pageNumber).ToArray();
-        foreach (var pageNumber in committedOverlay.Keys
-                     .Where(pageNumber => pageNumber > transaction.TargetDatabaseSizeInPages)
-                     .ToArray())
-        {
-            committedOverlay.Remove(pageNumber);
-        }
+            // Past this point the commit frame is durable, so SQLite considers the
+            // transaction committed even if our own bookkeeping then fails. The
+            // frames must become visible again either way.
+            durable = true;
+            var recovery = await wal.ScanRecoveryAsync(cancellationToken).ConfigureAwait(false);
+            if (recovery.StopReason != SqliteWalRecoveryStopReason.EndOfFile
+                || recovery.LastCommittedFrameNumber != recovery.LastValidFrameNumber
+                || recovery.LastCommittedDatabaseSizeInPages != transaction.TargetDatabaseSizeInPages)
+            {
+                throw new InvalidDataException("SQLite WAL did not preserve the transaction commit boundary.");
+            }
 
-        await ValidateVisiblePageSourcesAsync(
-            transaction.TargetDatabaseSizeInPages,
-            await _pageStore.GetPageCountAsync(cancellationToken).ConfigureAwait(false),
-            committedOverlay,
-            cancellationToken).ConfigureAwait(false);
-        lock (_stateGate)
+            var committedOverlay = CloneOverlay(_walPageOverlay);
+            foreach (var pageNumber in transaction.WriteOrder)
+                committedOverlay[pageNumber] = transaction.GetPageImage(pageNumber).ToArray();
+            foreach (var pageNumber in committedOverlay.Keys
+                         .Where(pageNumber => pageNumber > transaction.TargetDatabaseSizeInPages)
+                         .ToArray())
+            {
+                committedOverlay.Remove(pageNumber);
+            }
+
+            await ValidateVisiblePageSourcesAsync(
+                transaction.TargetDatabaseSizeInPages,
+                await _pageStore.GetPageCountAsync(cancellationToken).ConfigureAwait(false),
+                committedOverlay,
+                cancellationToken).ConfigureAwait(false);
+            lock (_stateGate)
+            {
+                _walPageOverlay.Clear();
+                foreach (var pair in committedOverlay)
+                    _walPageOverlay[pair.Key] = pair.Value;
+                _committedPageCount = transaction.TargetDatabaseSizeInPages;
+                _committedFrameCount = recovery.LastCommittedFrameNumber;
+                _recoveryInfo = recovery;
+                _visibleRecoveryInfo = recovery;
+            }
+        }
+        catch when (!durable)
         {
-            _walPageOverlay.Clear();
-            foreach (var pair in committedOverlay)
-                _walPageOverlay[pair.Key] = pair.Value;
-            _committedPageCount = transaction.TargetDatabaseSizeInPages;
-            _committedFrameCount = recovery.LastCommittedFrameNumber;
-            _recoveryInfo = recovery;
-            _visibleRecoveryInfo = recovery;
+            // The commit never became durable. Roll the WAL back to the published
+            // boundary so a peer process, or a later open, cannot resurrect a
+            // transaction this process already rejected; the boundary stays pinned
+            // when even that fails, which keeps local readers consistent until a
+            // writer or checkpoint can repair the file.
+            await TruncateAbandonedWalTailAsync(wal, publishedFrameCount).ConfigureAwait(false);
+            throw;
         }
 
         transaction.PublishWalFrames();
+    }
+
+    private async ValueTask TruncateAbandonedWalTailAsync(
+        SqliteWalFile wal,
+        long publishedFrameCount)
+    {
+        try
+        {
+            await wal.TruncateToFrameAsync(publishedFrameCount, CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+        catch
+        {
+            return;
+        }
+
+        _lockManager.PublishAllWalFrames();
     }
 
     private async ValueTask CommitRollbackTransactionAsync(
@@ -1149,7 +1192,9 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
         return installed;
     }
 
-    private async ValueTask SynchronizeCommittedViewAsync(CancellationToken cancellationToken)
+    private async ValueTask SynchronizeCommittedViewAsync(
+        CancellationToken cancellationToken,
+        bool repairHiddenWalTail = false)
     {
         if (JournalMode == SqliteJournalMode.Delete)
         {
@@ -1173,10 +1218,17 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
         }
         if (_wal is null)
         {
+            if (repairHiddenWalTail)
+                _lockManager.PublishAllWalFrames();
             await _pageStore.RefreshHeaderAsync(cancellationToken).ConfigureAwait(false);
             await InitializeCleanWalViewAsync(cancellationToken).ConfigureAwait(false);
             _lockGeneration = _lockManager.Generation;
             return;
+        }
+
+        if (repairHiddenWalTail)
+        {
+            await RepairHiddenWalTailAsync(_wal, _lockManager, cancellationToken).ConfigureAwait(false);
         }
 
         var recovery = await _wal
@@ -1189,6 +1241,23 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
         }
         await InitializeCommittedViewAsync(recovery, cancellationToken).ConfigureAwait(false);
         _lockGeneration = _lockManager.Generation;
+    }
+
+    /// <summary>
+    /// Durably discards a WAL tail an abandoned commit left hidden, then makes the
+    /// file authoritative again. The caller must hold the writer or checkpoint
+    /// lease, which is what makes trimming the file safe.
+    /// </summary>
+    private static async ValueTask RepairHiddenWalTailAsync(
+        SqliteWalFile wal,
+        SqlitePagerLockManager lockManager,
+        CancellationToken cancellationToken)
+    {
+        var boundary = lockManager.WalPublicationBoundary;
+        if (boundary != long.MaxValue && !wal.IsReadOnly)
+            await wal.TruncateToFrameAsync(boundary, cancellationToken).ConfigureAwait(false);
+
+        lockManager.PublishAllWalFrames();
     }
 
     private async ValueTask RecoverWalTailUnderWriterLockAsync(CancellationToken cancellationToken)

--- a/src/Ahtola.Core/Storage/AsyncSqlitePager.cs
+++ b/src/Ahtola.Core/Storage/AsyncSqlitePager.cs
@@ -196,7 +196,6 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
             manager,
             timeout,
             cancellationToken).ConfigureAwait(false);
-        manager.PublishAllWalFrames();
 
         AsyncSqlitePageStore? pageStore = null;
         SqliteWalFile? wal = null;
@@ -237,6 +236,7 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
             pager._lockGeneration = openingLock.Lease.PublishStorageChange();
             pager._busyTimeout = timeout;
             pager._state = SqlitePagerState.Ready;
+            manager.PublishAllWalFrames();
             return pager;
         }
         catch
@@ -282,7 +282,6 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
             manager,
             timeout,
             cancellationToken).ConfigureAwait(false);
-        manager.PublishAllWalFrames();
 
         AsyncSqlitePageStore? pageStore = null;
         var databaseCreated = false;
@@ -313,6 +312,7 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
             pager._lockGeneration = openingLock.Lease.PublishStorageChange();
             pager._busyTimeout = timeout;
             pager._state = SqlitePagerState.Ready;
+            manager.PublishAllWalFrames();
             return pager;
         }
         catch
@@ -961,7 +961,8 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
             // transaction committed even if our own bookkeeping then fails. The
             // frames must become visible again either way.
             durable = true;
-            var recovery = await wal.ScanRecoveryAsync(cancellationToken).ConfigureAwait(false);
+            transaction.PublishWalFrames();
+            var recovery = await wal.ScanRecoveryAsync(CancellationToken.None).ConfigureAwait(false);
             if (recovery.StopReason != SqliteWalRecoveryStopReason.EndOfFile
                 || recovery.LastCommittedFrameNumber != recovery.LastValidFrameNumber
                 || recovery.LastCommittedDatabaseSizeInPages != transaction.TargetDatabaseSizeInPages)
@@ -981,9 +982,9 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
 
             await ValidateVisiblePageSourcesAsync(
                 transaction.TargetDatabaseSizeInPages,
-                await _pageStore.GetPageCountAsync(cancellationToken).ConfigureAwait(false),
+                await _pageStore.GetPageCountAsync(CancellationToken.None).ConfigureAwait(false),
                 committedOverlay,
-                cancellationToken).ConfigureAwait(false);
+                CancellationToken.None).ConfigureAwait(false);
             lock (_stateGate)
             {
                 _walPageOverlay.Clear();
@@ -1006,7 +1007,6 @@ public sealed class AsyncSqlitePager : IAsyncDisposable
             throw;
         }
 
-        transaction.PublishWalFrames();
     }
 
     private async ValueTask TruncateAbandonedWalTailAsync(

--- a/src/Ahtola.Core/Storage/IAsyncFileSystem.cs
+++ b/src/Ahtola.Core/Storage/IAsyncFileSystem.cs
@@ -1,0 +1,107 @@
+namespace Ahtola.Core.Storage;
+
+/// <summary>
+/// Asynchronous positional storage that does not require a browser backend to
+/// provide synchronous file APIs.
+/// </summary>
+public interface IAsyncFileSystem
+{
+    /// <summary>Returns whether a file exists at <paramref name="path"/>.</summary>
+    ValueTask<bool> FileExistsAsync(
+        string path,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Opens a file for positional asynchronous access.</summary>
+    ValueTask<IAsyncFile> OpenFileAsync(
+        string path,
+        FileOpenMode mode,
+        bool readOnly = false,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Deletes the file at <paramref name="path"/> if it exists.</summary>
+    ValueTask DeleteFileAsync(
+        string path,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the current write stamp, or <see langword="null"/> when the file
+    /// does not exist or the backend cannot observe write activity.
+    /// </summary>
+    ValueTask<FileWriteStamp?> GetWriteStampAsync(
+        string path,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return ValueTask.FromResult<FileWriteStamp?>(null);
+    }
+}
+
+/// <summary>
+/// Optional capability for asynchronously publishing a fully written sibling
+/// file without exposing a partial destination image.
+/// </summary>
+public interface IAsyncAtomicFileSystem
+{
+    ValueTask ReplaceFileAtomicallyAsync(
+        string sourcePath,
+        string destinationPath,
+        bool replaceEmptyDestination,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Optional capability for opening a host-managed temporary file.
+/// </summary>
+public interface IAsyncTemporaryFileSystem
+{
+    ValueTask<IAsyncFile> OpenTemporaryFileAsync(
+        string path,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// A positionally addressed asynchronous file handle.
+/// </summary>
+public interface IAsyncFile : IAsyncDisposable
+{
+    /// <summary>Whether this handle was opened read-only.</summary>
+    bool IsReadOnly { get; }
+
+    /// <summary>Returns the current file length.</summary>
+    ValueTask<long> GetLengthAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reads into <paramref name="destination"/> at <paramref name="position"/>.
+    /// A short result indicates end-of-file.
+    /// </summary>
+    ValueTask<int> ReadAsync(
+        long position,
+        Memory<byte> destination,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Writes all bytes from <paramref name="source"/>.</summary>
+    ValueTask WriteAsync(
+        long position,
+        ReadOnlyMemory<byte> source,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Truncates or zero-extends the file to <paramref name="length"/>.</summary>
+    ValueTask SetLengthAsync(
+        long length,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Flushes buffered data and metadata to durable storage.</summary>
+    ValueTask FlushToDiskAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Optional capability for a sparse asynchronous file whose missing ranges
+/// must be materialized before reading.
+/// </summary>
+public interface IAsyncPageMaterializingFile
+{
+    ValueTask EnsureMaterializedAsync(
+        long position,
+        int length,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Ahtola.Core/Storage/IAsyncFileSystem.cs
+++ b/src/Ahtola.Core/Storage/IAsyncFileSystem.cs
@@ -37,6 +37,17 @@ public interface IAsyncFileSystem
 }
 
 /// <summary>
+/// Identifies an asynchronous file system that merely adapts a synchronous
+/// backend. Pager locking keys on the adapted backend rather than on wrapper
+/// identity so two adapters over one storage still share a single writer lock.
+/// </summary>
+internal interface IAsyncFileSystemBacking
+{
+    /// <summary>The synchronous storage this asynchronous facade forwards to.</summary>
+    IFileSystem BackingFileSystem { get; }
+}
+
+/// <summary>
 /// Optional capability for asynchronously publishing a fully written sibling
 /// file without exposing a partial destination image.
 /// </summary>

--- a/src/Ahtola.Core/Storage/IFileSystem.cs
+++ b/src/Ahtola.Core/Storage/IFileSystem.cs
@@ -168,6 +168,22 @@ internal interface IFileSystemDecorator
 }
 
 /// <summary>
+/// Lets a file system advertise the page codec every database opened through it
+/// must use, without being wrapped in <see cref="AhtolaPageCodecFileSystem"/>.
+/// </summary>
+/// <remarks>
+/// Wrapping hides optional capabilities such as <see cref="IAtomicFileSystem"/>
+/// and <see cref="ITemporaryFileSystem"/>, which storage adapters that implement
+/// those interfaces themselves cannot afford to lose. Implementations must return
+/// a stable instance so every pager, WAL, and journal opened from the same file
+/// system agrees on the on-disk layout.
+/// </remarks>
+internal interface IPageCodecSource
+{
+    IPageCodec? PageCodec { get; }
+}
+
+/// <summary>
 /// Optional capability for proving that two file-backed databases cannot
 /// alias the same underlying file during a managed snapshot copy.
 /// </summary>

--- a/src/Ahtola.Core/Storage/IFileSystem.cs
+++ b/src/Ahtola.Core/Storage/IFileSystem.cs
@@ -28,6 +28,12 @@ public enum FileSystemOperation
     AtomicReplace = 4,
     Open = 5,
     Delete = 6,
+    FileExists = 7,
+    GetWriteStamp = 8,
+    GetLength = 9,
+    OpenTemporary = 10,
+    EnsureMaterialized = 11,
+    Dispose = 12,
 }
 
 /// <summary>
@@ -37,6 +43,20 @@ public enum FileSystemOperation
 /// (a checkpoint that rewrites pages in place without touching the header).
 /// </summary>
 public readonly record struct FileWriteStamp(long Length, DateTimeOffset LastWriteTimeUtc);
+
+/// <summary>
+/// Optional capability that gives a storage backend authority over canonical
+/// path identity. Host file systems can return absolute paths while browser or
+/// in-memory stores can retain logical keys.
+/// </summary>
+public interface IStoragePathResolver
+{
+    /// <summary>Returns the stable identity used for <paramref name="path"/>.</summary>
+    string GetCanonicalPath(string path);
+
+    /// <summary>Compares canonical paths produced by this resolver.</summary>
+    StringComparer PathComparer { get; }
+}
 
 /// <summary>
 /// Minimal, correctness-first storage abstraction. Backends provide durable,

--- a/src/Ahtola.Core/Storage/IFileSystem.cs
+++ b/src/Ahtola.Core/Storage/IFileSystem.cs
@@ -166,3 +166,15 @@ internal interface IFileSystemDecorator
 {
     IFileSystem InnerFileSystem { get; }
 }
+
+/// <summary>
+/// Optional capability for proving that two file-backed databases cannot
+/// alias the same underlying file during a managed snapshot copy.
+/// </summary>
+internal interface ISnapshotFileIdentity
+{
+    bool CanProveDistinctFile(
+        string path,
+        IFileSystem otherFileSystem,
+        string otherPath);
+}

--- a/src/Ahtola.Core/Storage/InMemoryFileSystem.cs
+++ b/src/Ahtola.Core/Storage/InMemoryFileSystem.cs
@@ -109,7 +109,7 @@ public sealed class DeterministicFaultInjector
 /// the semantics of the engine's in-memory I/O backend. An optional
 /// <see cref="DeterministicFaultInjector"/> makes it usable for error-path tests.
 /// </summary>
-public sealed class InMemoryFileSystem : IFileSystem, IAtomicFileSystem
+public sealed class InMemoryFileSystem : IFileSystem, IAtomicFileSystem, IStoragePathResolver
 {
     private const int BlockSize = 4096;
 
@@ -118,6 +118,14 @@ public sealed class InMemoryFileSystem : IFileSystem, IAtomicFileSystem
     private readonly DeterministicFaultInjector? _faults;
 
     public InMemoryFileSystem(DeterministicFaultInjector? faults = null) => _faults = faults;
+
+    public StringComparer PathComparer => StringComparer.Ordinal;
+
+    public string GetCanonicalPath(string path)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        return path;
+    }
 
     /// <summary>Snapshots every path this file system currently holds.</summary>
     /// <remarks>

--- a/src/Ahtola.Core/Storage/PhysicalFileSystem.cs
+++ b/src/Ahtola.Core/Storage/PhysicalFileSystem.cs
@@ -13,12 +13,24 @@ public sealed partial class PhysicalFileSystem :
     IFileSystem,
     IAtomicFileSystem,
     ITemporaryFileSystem,
+    IStoragePathResolver,
     ISqliteWalSharedMemoryFileSystem
 {
     private const uint ReplaceFileWriteThrough = 0x00000001;
 
     /// <summary>A shared, stateless instance.</summary>
     public static PhysicalFileSystem Instance { get; } = new();
+
+    public StringComparer PathComparer { get; } =
+        OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+
+    public string GetCanonicalPath(string path)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        return Path.GetFullPath(path);
+    }
 
     public bool FileExists(string path)
     {
@@ -190,8 +202,15 @@ public sealed partial class PhysicalFileSystem :
 /// Gives <see cref="SqlitePager"/> its required shared data handles without
 /// weakening the default sharing policy for direct page-store users.
 /// </summary>
-internal sealed class SqlitePagerPhysicalFileSystem(PhysicalFileSystem fileSystem) : IFileSystem, IAtomicFileSystem
+internal sealed class SqlitePagerPhysicalFileSystem(PhysicalFileSystem fileSystem) :
+    IFileSystem,
+    IAtomicFileSystem,
+    IStoragePathResolver
 {
+    public StringComparer PathComparer => fileSystem.PathComparer;
+
+    public string GetCanonicalPath(string path) => fileSystem.GetCanonicalPath(path);
+
     public bool FileExists(string path) => fileSystem.FileExists(path);
 
     public FileWriteStamp? GetWriteStamp(string path) => fileSystem.GetWriteStamp(path);

--- a/src/Ahtola.Core/Storage/SqliteBusyBackoff.cs
+++ b/src/Ahtola.Core/Storage/SqliteBusyBackoff.cs
@@ -84,6 +84,30 @@ public static class SqliteBusyBackoff
     }
 
     /// <summary>
+    /// Asynchronously waits for the next SQLite busy delay or cancellation;
+    /// returns <see langword="false"/> when the timeout has expired.
+    /// </summary>
+    public static async ValueTask<bool> WaitAsync(
+        int attempt,
+        TimeSpan timeout,
+        Stopwatch? stopwatch,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var elapsed = stopwatch?.Elapsed ?? TimeSpan.Zero;
+        var delay = DelayForAttempt(attempt, elapsed, timeout);
+        if (delay <= TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan)
+            return false;
+
+        if (delay > TimeSpan.Zero)
+            await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+
+        return timeout == Timeout.InfiniteTimeSpan
+            || stopwatch is null
+            || stopwatch.Elapsed < timeout;
+    }
+
+    /// <summary>
     /// Convenience overload that estimates the attempt from elapsed time for
     /// simple poll loops. Prefer attempt-indexed overloads at call sites that
     /// already count retries.
@@ -100,6 +124,20 @@ public static class SqliteBusyBackoff
         Stopwatch? stopwatch,
         CancellationToken cancellationToken)
         => Wait(
+            attempt: EstimateAttempt(stopwatch?.Elapsed ?? TimeSpan.Zero),
+            timeout,
+            stopwatch,
+            cancellationToken);
+
+    /// <summary>
+    /// Asynchronous convenience overload pairing with
+    /// <see cref="WaitAsync(int, TimeSpan, Stopwatch?, CancellationToken)"/>.
+    /// </summary>
+    public static ValueTask<bool> WaitAsync(
+        TimeSpan timeout,
+        Stopwatch? stopwatch,
+        CancellationToken cancellationToken = default)
+        => WaitAsync(
             attempt: EstimateAttempt(stopwatch?.Elapsed ?? TimeSpan.Zero),
             timeout,
             stopwatch,

--- a/src/Ahtola.Core/Storage/SqlitePageStore.cs
+++ b/src/Ahtola.Core/Storage/SqlitePageStore.cs
@@ -730,7 +730,7 @@ public sealed class SqlitePageStore : IDisposable
     }
 
     private static bool IsAhtolaEncrypted(ReadOnlySpan<byte> header)
-        => header.Length >= 5 && header[..5].SequenceEqual("AHTLA"u8);
+        => AhtolaEncryptedPageFormat.IsAhtolaEncrypted(header);
 
     private static void ValidateFileLayout(
         long length,

--- a/src/Ahtola.Core/Storage/SqlitePager.cs
+++ b/src/Ahtola.Core/Storage/SqlitePager.cs
@@ -3511,6 +3511,7 @@ public sealed class SqlitePager : IDisposable
         => fileSystem switch
         {
             AhtolaPageCodecFileSystem codec => codec.PageCodec,
+            IPageCodecSource source when source.PageCodec is { } sourceCodec => sourceCodec,
             IFileSystemDecorator decorator => GetFileSystemPageCodec(decorator.InnerFileSystem),
             _ => null,
         };

--- a/src/Ahtola.Core/Storage/SqlitePagerLockManager.cs
+++ b/src/Ahtola.Core/Storage/SqlitePagerLockManager.cs
@@ -160,6 +160,7 @@ public sealed class SqlitePagerLockManager
     private bool _checkpointActive;
     private long _generation;
     private long _journalModeGeneration;
+    private long _walPublicationBoundary = long.MaxValue;
     private IDisposable? _sharedReaderLock;
 
     /// <summary>Creates a process-local SQLite pager lock manager.</summary>
@@ -640,6 +641,128 @@ public sealed class SqlitePagerLockManager
         }
     }
 
+    /// <summary>
+    /// Asynchronously upgrades the active writer lease to EXCLUSIVE without
+    /// blocking a thread while existing readers drain.
+    /// </summary>
+    /// <remarks>
+    /// New readers are excluded the moment the upgrade is requested, so a steady
+    /// stream of arrivals cannot starve the writer. A failed upgrade drops the
+    /// pending flag again: the caller falls back to RESERVED, which SQLite does
+    /// not let block readers.
+    /// </remarks>
+    internal async ValueTask UpgradeWriterToExclusiveAsync(
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var stopwatch = timeout == Timeout.InfiniteTimeSpan ? null : Stopwatch.StartNew();
+        var upgraded = false;
+        var pendingRegistered = false;
+        try
+        {
+            while (true)
+            {
+                Task stateChanged;
+                TimeSpan remaining;
+                lock (_gate)
+                {
+                    if (!_writerActive)
+                        throw new InvalidOperationException("The SQLite writer lease is no longer active.");
+
+                    if (!pendingRegistered)
+                    {
+                        _writerExclusivePending = true;
+                        pendingRegistered = true;
+                    }
+
+                    if (_readerCount == 0)
+                    {
+                        upgraded = true;
+                        return;
+                    }
+
+                    remaining = RemainingTimeout(timeout, stopwatch);
+                    if (remaining == TimeSpan.Zero)
+                        throw new SqlitePagerBusyException(SqlitePagerLockOperation.Writer, timeout);
+                    stateChanged = _stateChanged.Capture();
+                }
+
+                try
+                {
+                    if (remaining == Timeout.InfiniteTimeSpan)
+                        await stateChanged.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    else
+                        await stateChanged.WaitAsync(remaining, cancellationToken).ConfigureAwait(false);
+                }
+                catch (TimeoutException)
+                {
+                    throw new SqlitePagerBusyException(SqlitePagerLockOperation.Writer, timeout);
+                }
+            }
+        }
+        finally
+        {
+            if (!upgraded && pendingRegistered)
+            {
+                lock (_gate)
+                {
+                    if (_writerActive)
+                        _writerExclusivePending = false;
+                    Monitor.PulseAll(_gate);
+                    _stateChanged.PulseAll();
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// The highest WAL frame this process has published to readers, or
+    /// <see cref="long.MaxValue"/> when the physical WAL is authoritative.
+    /// </summary>
+    /// <remarks>
+    /// A commit-bearing frame reaches the WAL file before its durable flush
+    /// succeeds. Without a boundary, a concurrent reader that rescans the physical
+    /// WAL would adopt a transaction that is still in flight and may yet fail. The
+    /// committing writer lowers this boundary to the last published frame before
+    /// appending and raises it again only once the flush and post-flush validation
+    /// have both succeeded. The boundary is deliberately process-local and resets
+    /// to unbounded on open, checkpoint, and WAL tail recovery, so crash recovery
+    /// across a process or open boundary still derives visibility from the file.
+    /// </remarks>
+    internal long WalPublicationBoundary
+    {
+        get
+        {
+            lock (_gate)
+                return _walPublicationBoundary;
+        }
+    }
+
+    /// <summary>Hides WAL frames past <paramref name="lastPublishedFrameNumber"/> from readers.</summary>
+    internal void BeginWalPublication(long lastPublishedFrameNumber)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(lastPublishedFrameNumber);
+        lock (_gate)
+        {
+            if (!_writerActive)
+                throw new InvalidOperationException("Only an active SQLite writer lease can publish WAL frames.");
+
+            _walPublicationBoundary = lastPublishedFrameNumber;
+        }
+    }
+
+    /// <summary>Republishes the physical WAL after a durable commit or recovery.</summary>
+    internal void PublishAllWalFrames()
+    {
+        lock (_gate)
+        {
+            _walPublicationBoundary = long.MaxValue;
+            Monitor.PulseAll(_gate);
+            _stateChanged.PulseAll();
+        }
+    }
+
     internal long PublishJournalModeChange(SqlitePagerLockOperation operation)
     {
         lock (_gate)
@@ -914,6 +1037,29 @@ public sealed class SqlitePagerLockLease : IDisposable
         if (Operation != SqlitePagerLockOperation.Writer)
             throw new InvalidOperationException("Only a SQLite writer lease can upgrade to EXCLUSIVE.");
         manager.UpgradeWriterToExclusive(timeout);
+    }
+
+    internal ValueTask UpgradeToExclusiveAsync(TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        var manager = Volatile.Read(ref _manager)
+            ?? throw new ObjectDisposedException(nameof(SqlitePagerLockLease));
+        if (Operation != SqlitePagerLockOperation.Writer)
+            throw new InvalidOperationException("Only a SQLite writer lease can upgrade to EXCLUSIVE.");
+        return manager.UpgradeWriterToExclusiveAsync(timeout, cancellationToken);
+    }
+
+    internal void BeginWalPublication(long lastPublishedFrameNumber)
+    {
+        var manager = Volatile.Read(ref _manager)
+            ?? throw new ObjectDisposedException(nameof(SqlitePagerLockLease));
+        manager.BeginWalPublication(lastPublishedFrameNumber);
+    }
+
+    internal void PublishWalFrames()
+    {
+        var manager = Volatile.Read(ref _manager)
+            ?? throw new ObjectDisposedException(nameof(SqlitePagerLockLease));
+        manager.PublishAllWalFrames();
     }
 
     /// <inheritdoc />

--- a/src/Ahtola.Core/Storage/SqlitePagerLockManager.cs
+++ b/src/Ahtola.Core/Storage/SqlitePagerLockManager.cs
@@ -119,6 +119,22 @@ public interface ISqlitePagerLockCoordinator
 }
 
 /// <summary>
+/// Optional nonblocking counterpart for pager coordinators that can retry
+/// external ownership without sleeping a worker thread.
+/// </summary>
+public interface IAsyncSqlitePagerLockCoordinator
+{
+    ValueTask<IDisposable> AcquireAsync(
+        SqlitePagerLockOperation operation,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default);
+
+    ValueTask<IDisposable> AcquireRecoveryAsync(
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
 /// Coordinates readers, the single WAL writer, and checkpointing for SQLite
 /// pagers. Readers may coexist with a writer; a checkpoint waits for all
 /// readers and the writer, then excludes every role.
@@ -135,6 +151,7 @@ public sealed class SqlitePagerLockManager
 {
     private static readonly TimeSpan MaximumMonitorTimeout = TimeSpan.FromMilliseconds(int.MaxValue);
     private readonly object _gate = new();
+    private readonly AsyncConditionPulse _stateChanged = new();
     private readonly ISqlitePagerLockCoordinator? _coordinator;
     private int _readerCount;
     private int _checkpointWaiterCount;
@@ -228,6 +245,17 @@ public sealed class SqlitePagerLockManager
     public SqlitePagerLockLease EnterReader(TimeSpan? busyTimeout = null)
         => Enter(SqlitePagerLockOperation.Reader, NormalizeTimeout(busyTimeout), pagerReadOnly: true);
 
+    /// <summary>Asynchronously acquires a read-snapshot lock.</summary>
+    public ValueTask<SqlitePagerLockLease> EnterReaderAsync(
+        TimeSpan? busyTimeout = null,
+        CancellationToken cancellationToken = default)
+        => EnterAsync(
+            SqlitePagerLockOperation.Reader,
+            NormalizeTimeout(busyTimeout),
+            pagerReadOnly: true,
+            useExternalCoordinator: true,
+            cancellationToken);
+
     /// <summary>
     /// Acquires a read-snapshot lock for a pager whose read-only state is known.
     /// A read-write pager may recreate a missing shared-memory lock carrier on
@@ -254,6 +282,17 @@ public sealed class SqlitePagerLockManager
     public SqlitePagerLockLease EnterWriter(TimeSpan? busyTimeout = null)
         => Enter(SqlitePagerLockOperation.Writer, NormalizeTimeout(busyTimeout));
 
+    /// <summary>Asynchronously acquires the single WAL writer lock.</summary>
+    public ValueTask<SqlitePagerLockLease> EnterWriterAsync(
+        TimeSpan? busyTimeout = null,
+        CancellationToken cancellationToken = default)
+        => EnterAsync(
+            SqlitePagerLockOperation.Writer,
+            NormalizeTimeout(busyTimeout),
+            pagerReadOnly: false,
+            useExternalCoordinator: true,
+            cancellationToken);
+
     internal SqlitePagerLockLease EnterWriter(
         TimeSpan? busyTimeout,
         bool useExternalCoordinator)
@@ -266,6 +305,17 @@ public sealed class SqlitePagerLockManager
     /// <summary>Acquires an exclusive checkpoint lock.</summary>
     public SqlitePagerLockLease EnterCheckpoint(TimeSpan? busyTimeout = null)
         => Enter(SqlitePagerLockOperation.Checkpoint, NormalizeTimeout(busyTimeout));
+
+    /// <summary>Asynchronously acquires an exclusive checkpoint lock.</summary>
+    public ValueTask<SqlitePagerLockLease> EnterCheckpointAsync(
+        TimeSpan? busyTimeout = null,
+        CancellationToken cancellationToken = default)
+        => EnterAsync(
+            SqlitePagerLockOperation.Checkpoint,
+            NormalizeTimeout(busyTimeout),
+            pagerReadOnly: false,
+            useExternalCoordinator: true,
+            cancellationToken);
 
     internal SqlitePagerLockLease EnterCheckpoint(
         TimeSpan? busyTimeout,
@@ -298,6 +348,45 @@ public sealed class SqlitePagerLockManager
         try
         {
             return _coordinator.AcquireRecovery(timeout)
+                   ?? throw new InvalidOperationException("SQLite pager lock coordinator returned no recovery lease.");
+        }
+        catch (SqlitePagerBusyException exception)
+        {
+            throw new SqlitePagerBusyException(
+                SqlitePagerLockOperation.Writer,
+                SqlitePagerBusyReason.Recovery,
+                configuredTimeout,
+                exception);
+        }
+    }
+
+    internal async ValueTask<IDisposable?> EnterRecoveryLockAsync(
+        TimeSpan timeout,
+        TimeSpan configuredTimeout,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (_coordinator is null)
+            return null;
+        if (timeout == TimeSpan.Zero && configuredTimeout != TimeSpan.Zero)
+        {
+            throw new SqlitePagerBusyException(
+                SqlitePagerLockOperation.Writer,
+                SqlitePagerBusyReason.Recovery,
+                configuredTimeout);
+        }
+        if (_coordinator is not IAsyncSqlitePagerLockCoordinator asyncCoordinator)
+        {
+            throw new NotSupportedException(
+                "The SQLite pager lock coordinator does not support asynchronous acquisition.");
+        }
+
+        ReleaseIdleSharedReaderLock();
+        try
+        {
+            return await asyncCoordinator
+                       .AcquireRecoveryAsync(timeout, cancellationToken)
+                       .ConfigureAwait(false)
                    ?? throw new InvalidOperationException("SQLite pager lock coordinator returned no recovery lease.");
         }
         catch (SqlitePagerBusyException exception)
@@ -345,8 +434,10 @@ public sealed class SqlitePagerLockManager
                 {
                     _checkpointWaiterCount--;
                     Monitor.PulseAll(_gate);
+                    _stateChanged.PulseAll();
                 }
             }
+
         }
 
         IDisposable? externalLock = null;
@@ -386,6 +477,127 @@ public sealed class SqlitePagerLockManager
         finally
         {
             if (!leaseHandedOff)
+            {
+                externalLock?.Dispose();
+                ExitLocal(operation);
+            }
+        }
+    }
+
+    private async ValueTask<SqlitePagerLockLease> EnterAsync(
+        SqlitePagerLockOperation operation,
+        TimeSpan timeout,
+        bool pagerReadOnly,
+        bool useExternalCoordinator,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var stopwatch = timeout == Timeout.InfiniteTimeSpan ? null : Stopwatch.StartNew();
+        var checkpointWaiterRegistered = false;
+        var localAcquired = false;
+        try
+        {
+            while (true)
+            {
+                Task stateChanged;
+                TimeSpan remaining;
+                lock (_gate)
+                {
+                    if (!checkpointWaiterRegistered
+                        && operation == SqlitePagerLockOperation.Checkpoint)
+                    {
+                        _checkpointWaiterCount++;
+                        checkpointWaiterRegistered = true;
+                        _stateChanged.PulseAll();
+                    }
+
+                    if (CanEnter(operation))
+                    {
+                        Acquire(operation);
+                        localAcquired = true;
+                        break;
+                    }
+
+                    remaining = RemainingTimeout(timeout, stopwatch);
+                    if (remaining == TimeSpan.Zero)
+                        throw new SqlitePagerBusyException(operation, timeout);
+                    stateChanged = _stateChanged.Capture();
+                }
+
+                try
+                {
+                    if (remaining == Timeout.InfiniteTimeSpan)
+                        await stateChanged.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    else
+                        await stateChanged.WaitAsync(remaining, cancellationToken).ConfigureAwait(false);
+                }
+                catch (TimeoutException)
+                {
+                    throw new SqlitePagerBusyException(operation, timeout);
+                }
+            }
+        }
+        finally
+        {
+            if (checkpointWaiterRegistered)
+            {
+                lock (_gate)
+                {
+                    _checkpointWaiterCount--;
+                    Monitor.PulseAll(_gate);
+                    _stateChanged.PulseAll();
+                }
+            }
+        }
+
+        IDisposable? externalLock = null;
+        var leaseHandedOff = false;
+        try
+        {
+            if (_coordinator is not null && useExternalCoordinator)
+            {
+                var coordinatorTimeout = RemainingFileLockTimeout(timeout, stopwatch);
+                if (coordinatorTimeout == TimeSpan.Zero && timeout != TimeSpan.Zero)
+                    throw new SqlitePagerBusyException(operation, timeout);
+                if (_coordinator is not IAsyncSqlitePagerLockCoordinator asyncCoordinator)
+                {
+                    throw new NotSupportedException(
+                        "The SQLite pager lock coordinator does not support asynchronous acquisition.");
+                }
+
+                if (operation == SqlitePagerLockOperation.Reader)
+                {
+                    await AcquireSharedReaderLockAsync(
+                            asyncCoordinator,
+                            coordinatorTimeout,
+                            pagerReadOnly,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                else
+                {
+                    if (operation != SqlitePagerLockOperation.Writer)
+                        ReleaseIdleSharedReaderLock();
+
+                    externalLock = await asyncCoordinator
+                                           .AcquireAsync(operation, coordinatorTimeout, cancellationToken)
+                                           .ConfigureAwait(false)
+                                       ?? throw new InvalidOperationException(
+                                           "SQLite pager lock coordinator returned no lease.");
+                }
+            }
+
+            var lease = new SqlitePagerLockLease(this, operation, externalLock);
+            leaseHandedOff = true;
+            return lease;
+        }
+        catch (SqlitePagerBusyException exception)
+        {
+            throw new SqlitePagerBusyException(operation, timeout, exception);
+        }
+        finally
+        {
+            if (!leaseHandedOff && localAcquired)
             {
                 externalLock?.Dispose();
                 ExitLocal(operation);
@@ -477,6 +689,7 @@ public sealed class SqlitePagerLockManager
             }
 
             Monitor.PulseAll(_gate);
+            _stateChanged.PulseAll();
         }
     }
 
@@ -497,6 +710,45 @@ public sealed class SqlitePagerLockManager
                 ? sharedMemoryLocks.Acquire(SqlitePagerLockOperation.Reader, timeout, pagerReadOnly)
                 : _coordinator!.Acquire(SqlitePagerLockOperation.Reader, timeout))
             ?? throw new InvalidOperationException("SQLite pager lock coordinator returned no lease.");
+
+        var redundant = false;
+        lock (_gate)
+        {
+            if (_sharedReaderLock is null)
+                _sharedReaderLock = acquired;
+            else
+                redundant = true;
+        }
+
+        if (redundant)
+            acquired.Dispose();
+    }
+
+    private async ValueTask AcquireSharedReaderLockAsync(
+        IAsyncSqlitePagerLockCoordinator asyncCoordinator,
+        TimeSpan timeout,
+        bool pagerReadOnly,
+        CancellationToken cancellationToken)
+    {
+        lock (_gate)
+        {
+            if (_sharedReaderLock is not null)
+                return;
+        }
+
+        var acquired = _coordinator is SqliteWalSharedMemoryLocks sharedMemoryLocks
+            ? await sharedMemoryLocks
+                .AcquireAsync(
+                    SqlitePagerLockOperation.Reader,
+                    timeout,
+                    pagerReadOnly,
+                    cancellationToken)
+                .ConfigureAwait(false)
+            : await asyncCoordinator
+                .AcquireAsync(SqlitePagerLockOperation.Reader, timeout, cancellationToken)
+                .ConfigureAwait(false);
+        if (acquired is null)
+            throw new InvalidOperationException("SQLite pager lock coordinator returned no lease.");
 
         var redundant = false;
         lock (_gate)

--- a/src/Ahtola.Core/Storage/SqliteRollbackJournal.cs
+++ b/src/Ahtola.Core/Storage/SqliteRollbackJournal.cs
@@ -41,6 +41,45 @@ internal static class SqliteRollbackJournal
         return magic.SequenceEqual(Magic);
     }
 
+    internal static async ValueTask<bool> IsHotAsync(
+        IAsyncFileSystem fileSystem,
+        string journalPath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(fileSystem);
+        ArgumentException.ThrowIfNullOrEmpty(journalPath);
+
+        if (!await fileSystem.FileExistsAsync(journalPath, cancellationToken).ConfigureAwait(false))
+            return false;
+
+        var journal = await fileSystem
+            .OpenFileAsync(
+                journalPath,
+                FileOpenMode.OpenExisting,
+                readOnly: true,
+                cancellationToken)
+            .ConfigureAwait(false);
+        try
+        {
+            if (await journal.GetLengthAsync(cancellationToken).ConfigureAwait(false) <= Magic.Length)
+                return false;
+
+            var magic = new byte[Magic.Length];
+            await ReadExactAsync(
+                    journal,
+                    0,
+                    magic,
+                    "SQLite rollback journal magic",
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return magic.AsSpan().SequenceEqual(Magic);
+        }
+        finally
+        {
+            await journal.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
     internal static void RecoverIfPresent(
         IFileSystem fileSystem,
         string databasePath,
@@ -145,6 +184,164 @@ internal static class SqliteRollbackJournal
         Invalidate(journalPath, fileSystem);
     }
 
+    internal static async ValueTask RecoverIfPresentAsync(
+        IAsyncFileSystem fileSystem,
+        string databasePath,
+        string journalPath,
+        bool readOnly,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(fileSystem);
+        ArgumentException.ThrowIfNullOrEmpty(databasePath);
+        ArgumentException.ThrowIfNullOrEmpty(journalPath);
+
+        if (!await fileSystem.FileExistsAsync(journalPath, cancellationToken).ConfigureAwait(false))
+            return;
+
+        if (!await IsHotAsync(fileSystem, journalPath, cancellationToken).ConfigureAwait(false))
+        {
+            if (!readOnly)
+                await fileSystem.DeleteFileAsync(journalPath, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        if (readOnly)
+        {
+            throw new InvalidDataException(
+                "Cannot safely open the SQLite database read-only because it has a hot rollback journal. "
+                + "Open it writable to recover the journal.");
+        }
+
+        IAsyncFile? journal = await fileSystem
+            .OpenFileAsync(
+                journalPath,
+                FileOpenMode.OpenExisting,
+                readOnly: true,
+                cancellationToken)
+            .ConfigureAwait(false);
+        IAsyncFile? database = null;
+        try
+        {
+            var header = await ReadHeaderAsync(journal, cancellationToken).ConfigureAwait(false);
+            var recordSize = checked((long)header.PageSize + 8);
+            var page = new byte[header.PageSize];
+            var pageNumberBytes = new byte[4];
+            var checksumBytes = new byte[4];
+            var restoredPages = new HashSet<uint>();
+            var pageNumbers = new List<JournalRecord>();
+            var recordOffset = (long)header.SectorSize;
+            var journalLength = await journal.GetLengthAsync(cancellationToken).ConfigureAwait(false);
+
+            if (header.RecordCount == uint.MaxValue)
+            {
+                while (recordOffset + recordSize <= journalLength)
+                {
+                    await ReadExactAsync(
+                            journal,
+                            recordOffset,
+                            pageNumberBytes,
+                            "SQLite rollback journal page number",
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                    var pageNumber = BinaryPrimitives.ReadUInt32BigEndian(pageNumberBytes);
+                    if (pageNumber == 0)
+                        break;
+                    if (!await TryCollectRecordAsync(
+                            journal,
+                            header,
+                            page,
+                            checksumBytes,
+                            recordOffset,
+                            pageNumber,
+                            restoredPages,
+                            pageNumbers,
+                            cancellationToken)
+                        .ConfigureAwait(false))
+                    {
+                        break;
+                    }
+
+                    recordOffset += recordSize;
+                }
+            }
+            else
+            {
+                var requiredLength = checked(
+                    (long)header.SectorSize + ((long)header.RecordCount * recordSize));
+                if (journalLength < requiredLength)
+                {
+                    throw new InvalidDataException(
+                        "SQLite rollback journal is truncated before its declared page records.");
+                }
+
+                for (var index = 0; index < header.RecordCount; index++)
+                {
+                    await ReadExactAsync(
+                            journal,
+                            recordOffset,
+                            pageNumberBytes,
+                            "SQLite rollback journal page number",
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                    var pageNumber = BinaryPrimitives.ReadUInt32BigEndian(pageNumberBytes);
+                    await ValidateAndCollectRecordAsync(
+                            journal,
+                            header,
+                            page,
+                            checksumBytes,
+                            recordOffset,
+                            pageNumber,
+                            restoredPages,
+                            pageNumbers,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                    recordOffset += recordSize;
+                }
+            }
+
+            database = await fileSystem
+                .OpenFileAsync(
+                    databasePath,
+                    FileOpenMode.OpenExisting,
+                    cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+            foreach (var record in pageNumbers)
+            {
+                await ReadExactAsync(
+                        journal,
+                        record.RecordOffset + 4,
+                        page,
+                        $"SQLite rollback journal page {record.PageNumber}",
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                await database
+                    .WriteAsync(
+                        checked((long)(record.PageNumber - 1) * header.PageSize),
+                        page,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            await database
+                .SetLengthAsync(
+                    checked((long)header.InitialDatabasePageCount * header.PageSize),
+                    cancellationToken)
+                .ConfigureAwait(false);
+            await database.FlushToDiskAsync(cancellationToken).ConfigureAwait(false);
+
+            await journal.DisposeAsync().ConfigureAwait(false);
+            journal = null;
+            await DeleteAsync(fileSystem, journalPath, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            if (journal is not null)
+                await journal.DisposeAsync().ConfigureAwait(false);
+            if (database is not null)
+                await database.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
     private readonly record struct JournalRecord(uint PageNumber, long RecordOffset);
 
     /// <summary>
@@ -184,6 +381,47 @@ internal static class SqliteRollbackJournal
         return true;
     }
 
+    private static async ValueTask<bool> TryCollectRecordAsync(
+        IAsyncFile journal,
+        JournalHeader header,
+        byte[] page,
+        byte[] checksumBytes,
+        long recordOffset,
+        uint pageNumber,
+        HashSet<uint> restoredPages,
+        List<JournalRecord> pageNumbers,
+        CancellationToken cancellationToken)
+    {
+        if (pageNumber == 0 || pageNumber > header.InitialDatabasePageCount)
+            return false;
+        if (!restoredPages.Add(pageNumber))
+            return false;
+
+        await ReadExactAsync(
+                journal,
+                recordOffset + 4,
+                page,
+                $"SQLite rollback journal page {pageNumber}",
+                cancellationToken)
+            .ConfigureAwait(false);
+        await ReadExactAsync(
+                journal,
+                recordOffset + 4 + header.PageSize,
+                checksumBytes,
+                $"SQLite rollback journal checksum for page {pageNumber}",
+                cancellationToken)
+            .ConfigureAwait(false);
+        var expectedChecksum = BinaryPrimitives.ReadUInt32BigEndian(checksumBytes);
+        if (ComputeChecksum(page, header.ChecksumNonce) != expectedChecksum)
+        {
+            restoredPages.Remove(pageNumber);
+            return false;
+        }
+
+        pageNumbers.Add(new JournalRecord(pageNumber, recordOffset));
+        return true;
+    }
+
     private static void ValidateAndCollectRecord(
         IFile journal,
         JournalHeader header,
@@ -205,6 +443,47 @@ internal static class SqliteRollbackJournal
             recordOffset + 4 + header.PageSize,
             checksumBytes,
             $"SQLite rollback journal checksum for page {pageNumber}");
+        var expectedChecksum = BinaryPrimitives.ReadUInt32BigEndian(checksumBytes);
+        var actualChecksum = ComputeChecksum(page, header.ChecksumNonce);
+        if (actualChecksum != expectedChecksum)
+        {
+            throw new InvalidDataException(
+                $"SQLite rollback journal checksum for page {pageNumber} is invalid.");
+        }
+
+        pageNumbers.Add(new JournalRecord(pageNumber, recordOffset));
+    }
+
+    private static async ValueTask ValidateAndCollectRecordAsync(
+        IAsyncFile journal,
+        JournalHeader header,
+        byte[] page,
+        byte[] checksumBytes,
+        long recordOffset,
+        uint pageNumber,
+        HashSet<uint> restoredPages,
+        List<JournalRecord> pageNumbers,
+        CancellationToken cancellationToken)
+    {
+        if (pageNumber == 0 || pageNumber > header.InitialDatabasePageCount)
+            throw new InvalidDataException($"SQLite rollback journal contains invalid page number {pageNumber}.");
+        if (!restoredPages.Add(pageNumber))
+            throw new InvalidDataException($"SQLite rollback journal contains duplicate page {pageNumber}.");
+
+        await ReadExactAsync(
+                journal,
+                recordOffset + 4,
+                page,
+                $"SQLite rollback journal page {pageNumber}",
+                cancellationToken)
+            .ConfigureAwait(false);
+        await ReadExactAsync(
+                journal,
+                recordOffset + 4 + header.PageSize,
+                checksumBytes,
+                $"SQLite rollback journal checksum for page {pageNumber}",
+                cancellationToken)
+            .ConfigureAwait(false);
         var expectedChecksum = BinaryPrimitives.ReadUInt32BigEndian(checksumBytes);
         var actualChecksum = ComputeChecksum(page, header.ChecksumNonce);
         if (actualChecksum != expectedChecksum)
@@ -298,10 +577,241 @@ internal static class SqliteRollbackJournal
         }
     }
 
+    internal static async ValueTask<AsyncWriter> BeginAsync(
+        IAsyncFileSystem fileSystem,
+        string journalPath,
+        int recordCount,
+        uint checksumNonce,
+        uint initialDatabasePageCount,
+        int pageSize,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(fileSystem);
+        ArgumentException.ThrowIfNullOrEmpty(journalPath);
+        if (recordCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(recordCount));
+        ValidateHeaderFields(initialDatabasePageCount, pageSize);
+
+        var journal = await fileSystem
+            .OpenFileAsync(
+                journalPath,
+                FileOpenMode.CreateNew,
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        try
+        {
+            var zeroHeader = new byte[SectorSize];
+            WriteHeader(
+                zeroHeader,
+                recordCount,
+                checksumNonce,
+                initialDatabasePageCount,
+                pageSize,
+                includeMagic: false);
+            await journal.WriteAsync(0, zeroHeader, cancellationToken).ConfigureAwait(false);
+            return new AsyncWriter(
+                journal,
+                recordCount,
+                checksumNonce,
+                initialDatabasePageCount,
+                pageSize);
+        }
+        catch
+        {
+            try
+            {
+                await journal.DisposeAsync().ConfigureAwait(false);
+            }
+            catch
+            {
+            }
+
+            throw;
+        }
+    }
+
+    internal static async ValueTask DeleteAsync(
+        IAsyncFileSystem fileSystem,
+        string journalPath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(fileSystem);
+        ArgumentException.ThrowIfNullOrEmpty(journalPath);
+
+        var journal = await fileSystem
+            .OpenFileAsync(
+                journalPath,
+                FileOpenMode.OpenExisting,
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        try
+        {
+            await journal
+                .WriteAsync(0, new byte[Magic.Length], cancellationToken)
+                .ConfigureAwait(false);
+            await journal.FlushToDiskAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            await journal.DisposeAsync().ConfigureAwait(false);
+        }
+
+        await TryDeleteAsync(fileSystem, journalPath, cancellationToken).ConfigureAwait(false);
+    }
+
+    internal sealed class AsyncWriter : IAsyncDisposable
+    {
+        private readonly IAsyncFile _journal;
+        private readonly int _recordCount;
+        private readonly uint _checksumNonce;
+        private readonly uint _initialDatabasePageCount;
+        private readonly int _pageSize;
+        private readonly SemaphoreSlim _gate = new(1, 1);
+        private readonly HashSet<uint> _writtenPages = [];
+        private int _writtenRecordCount;
+        private long _recordOffset = SectorSize;
+        private bool _finalized;
+        private bool _disposed;
+
+        internal AsyncWriter(
+            IAsyncFile journal,
+            int recordCount,
+            uint checksumNonce,
+            uint initialDatabasePageCount,
+            int pageSize)
+        {
+            _journal = journal;
+            _recordCount = recordCount;
+            _checksumNonce = checksumNonce;
+            _initialDatabasePageCount = initialDatabasePageCount;
+            _pageSize = pageSize;
+        }
+
+        internal async ValueTask WritePageRecordAsync(
+            uint pageNumber,
+            ReadOnlyMemory<byte> rawPage,
+            CancellationToken cancellationToken = default)
+        {
+            if (pageNumber == 0 || pageNumber > _initialDatabasePageCount)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(pageNumber),
+                    pageNumber,
+                    $"Page number must be between 1 and {_initialDatabasePageCount}.");
+            }
+            if (rawPage.Length != _pageSize)
+            {
+                throw new ArgumentException(
+                    $"SQLite rollback journal page data must be exactly {_pageSize} bytes.",
+                    nameof(rawPage));
+            }
+
+            await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                ThrowIfDisposed();
+                if (_finalized)
+                    throw new InvalidOperationException("The SQLite rollback journal is already finalized.");
+                if (_writtenRecordCount >= _recordCount)
+                    throw new InvalidOperationException("The SQLite rollback journal already contains its declared page records.");
+                if (_writtenPages.Contains(pageNumber))
+                {
+                    throw new InvalidOperationException(
+                        $"The SQLite rollback journal already contains page {pageNumber}.");
+                }
+
+                var pageNumberBytes = new byte[4];
+                BinaryPrimitives.WriteUInt32BigEndian(pageNumberBytes, pageNumber);
+                await _journal
+                    .WriteAsync(_recordOffset, pageNumberBytes, cancellationToken)
+                    .ConfigureAwait(false);
+                await _journal
+                    .WriteAsync(_recordOffset + 4, rawPage, cancellationToken)
+                    .ConfigureAwait(false);
+
+                var checksumBytes = new byte[4];
+                BinaryPrimitives.WriteUInt32BigEndian(
+                    checksumBytes,
+                    ComputeChecksum(rawPage.Span, _checksumNonce));
+                await _journal
+                    .WriteAsync(_recordOffset + 4 + _pageSize, checksumBytes, cancellationToken)
+                    .ConfigureAwait(false);
+
+                _recordOffset += _pageSize + 8L;
+                _writtenRecordCount++;
+                _writtenPages.Add(pageNumber);
+            }
+            finally
+            {
+                _gate.Release();
+            }
+        }
+
+        internal async ValueTask FinalizeAsync(CancellationToken cancellationToken = default)
+        {
+            await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                ThrowIfDisposed();
+                if (_finalized)
+                    return;
+                if (_writtenRecordCount != _recordCount)
+                {
+                    throw new InvalidOperationException(
+                        $"The SQLite rollback journal contains {_writtenRecordCount} of {_recordCount} declared page records.");
+                }
+
+                await _journal.SetLengthAsync(_recordOffset, cancellationToken).ConfigureAwait(false);
+                await _journal.FlushToDiskAsync(cancellationToken).ConfigureAwait(false);
+
+                var durableHeader = new byte[HeaderSize];
+                WriteHeader(
+                    durableHeader,
+                    _recordCount,
+                    _checksumNonce,
+                    _initialDatabasePageCount,
+                    _pageSize,
+                    includeMagic: true);
+                await _journal.WriteAsync(0, durableHeader, cancellationToken).ConfigureAwait(false);
+                await _journal.FlushToDiskAsync(cancellationToken).ConfigureAwait(false);
+                _finalized = true;
+            }
+            finally
+            {
+                _gate.Release();
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _gate.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                if (_disposed)
+                    return;
+
+                _disposed = true;
+                await _journal.DisposeAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                _gate.Release();
+            }
+        }
+
+        private void ThrowIfDisposed()
+            => ObjectDisposedException.ThrowIf(_disposed, this);
+    }
+
     private static JournalHeader ReadHeader(IFile journal)
     {
         Span<byte> header = stackalloc byte[HeaderSize];
         ReadExact(journal, 0, header, "SQLite rollback journal header");
+        return ParseHeader(header);
+    }
+
+    private static JournalHeader ParseHeader(ReadOnlySpan<byte> header)
+    {
         if (!header[..Magic.Length].SequenceEqual(Magic))
             throw new InvalidDataException("SQLite rollback journal magic is invalid.");
 
@@ -334,6 +844,21 @@ internal static class SqliteRollbackJournal
         return new JournalHeader(recordCount, checksumNonce, initialDatabasePageCount, pageSize, sectorSize);
     }
 
+    private static async ValueTask<JournalHeader> ReadHeaderAsync(
+        IAsyncFile journal,
+        CancellationToken cancellationToken)
+    {
+        var header = new byte[HeaderSize];
+        await ReadExactAsync(
+                journal,
+                0,
+                header,
+                "SQLite rollback journal header",
+                cancellationToken)
+            .ConfigureAwait(false);
+        return ParseHeader(header);
+    }
+
     private static void WriteHeader(
         Span<byte> destination,
         int recordCount,
@@ -353,6 +878,21 @@ internal static class SqliteRollbackJournal
         BinaryPrimitives.WriteUInt32BigEndian(destination[16..], initialDatabasePageCount);
         BinaryPrimitives.WriteUInt32BigEndian(destination[20..], SectorSize);
         BinaryPrimitives.WriteUInt32BigEndian(destination[24..], checked((uint)pageSize));
+    }
+
+    private static void ValidateHeaderFields(uint initialDatabasePageCount, int pageSize)
+    {
+        if (initialDatabasePageCount == 0)
+            throw new ArgumentOutOfRangeException(nameof(initialDatabasePageCount));
+        if (pageSize < SqlitePageSize.Minimum
+            || pageSize > SqlitePageSize.Maximum
+            || (pageSize & (pageSize - 1)) != 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(pageSize),
+                pageSize,
+                "SQLite rollback journal page size must be a supported power of two.");
+        }
     }
 
     private static uint ComputeChecksum(ReadOnlySpan<byte> page, uint nonce)
@@ -386,9 +926,42 @@ internal static class SqliteRollbackJournal
         }
     }
 
+    private static async ValueTask TryDeleteAsync(
+        IAsyncFileSystem fileSystem,
+        string path,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await fileSystem.DeleteFileAsync(path, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            // A zeroed journal is not hot. A later writable open retries cleanup.
+        }
+    }
+
     private static void ReadExact(IFile file, long offset, Span<byte> destination, string description)
     {
         var read = file.Read(offset, destination);
+        if (read != destination.Length)
+            throw new InvalidDataException($"{description} is truncated.");
+    }
+
+    private static async ValueTask ReadExactAsync(
+        IAsyncFile file,
+        long offset,
+        Memory<byte> destination,
+        string description,
+        CancellationToken cancellationToken)
+    {
+        var read = await file
+            .ReadAsync(offset, destination, cancellationToken)
+            .ConfigureAwait(false);
         if (read != destination.Length)
             throw new InvalidDataException($"{description} is truncated.");
     }

--- a/src/Ahtola.Core/Storage/SqliteRollbackJournal.cs
+++ b/src/Ahtola.Core/Storage/SqliteRollbackJournal.cs
@@ -23,9 +23,9 @@ public enum SqliteJournalMode
 /// </summary>
 internal static class SqliteRollbackJournal
 {
-    private const int HeaderSize = 28;
-    private const int SectorSize = 512;
-    private static ReadOnlySpan<byte> Magic => [0xd9, 0xd5, 0x05, 0xf9, 0x20, 0xa1, 0x63, 0xd7];
+    private const int HeaderSize = SqliteRollbackJournalFormat.HeaderSize;
+    private const int SectorSize = SqliteRollbackJournalFormat.SectorSize;
+    private static ReadOnlySpan<byte> Magic => SqliteRollbackJournalFormat.Magic;
 
     internal static bool IsHot(IFileSystem fileSystem, string journalPath)
     {
@@ -896,12 +896,7 @@ internal static class SqliteRollbackJournal
     }
 
     private static uint ComputeChecksum(ReadOnlySpan<byte> page, uint nonce)
-    {
-        var checksum = nonce;
-        for (var index = page.Length - 200; index >= 0; index -= 200)
-            checksum = unchecked(checksum + page[index]);
-        return checksum;
-    }
+        => SqliteRollbackJournalFormat.ComputeChecksum(page, nonce);
 
     private static void Invalidate(string journalPath, IFileSystem fileSystem)
     {

--- a/src/Ahtola.Core/Storage/SqliteRollbackJournalFormat.cs
+++ b/src/Ahtola.Core/Storage/SqliteRollbackJournalFormat.cs
@@ -1,0 +1,89 @@
+using System.Buffers.Binary;
+
+namespace Ahtola.Core.Storage;
+
+/// <summary>
+/// The on-disk layout of a SQLite DELETE-mode rollback journal, factored out of
+/// <see cref="SqliteRollbackJournal"/> so other storage adapters can rewrite
+/// journal page payloads without duplicating offsets or the checksum algorithm.
+/// </summary>
+/// <remarks>
+/// Journal page records hold the exact on-disk page image, so an encrypted
+/// database stores encrypted pages here and the per-record checksum is computed
+/// over those encrypted bytes.
+/// </remarks>
+internal static class SqliteRollbackJournalFormat
+{
+    /// <summary>Bytes of meaningful header content at offset zero.</summary>
+    internal const int HeaderSize = 28;
+
+    /// <summary>The sector size Ahtola writes, and therefore the first record offset it emits.</summary>
+    internal const int SectorSize = 512;
+
+    /// <summary>Bytes preceding the page image inside one record (the page number).</summary>
+    internal const int RecordPageNumberSize = 4;
+
+    /// <summary>Bytes following the page image inside one record (the checksum).</summary>
+    internal const int RecordChecksumSize = 4;
+
+    /// <summary>The finalized-journal magic written once the records are durable.</summary>
+    internal static ReadOnlySpan<byte> Magic => [0xd9, 0xd5, 0x05, 0xf9, 0x20, 0xa1, 0x63, 0xd7];
+
+    /// <summary>Total bytes occupied by one page record.</summary>
+    internal static long GetRecordSize(int pageSize)
+        => checked((long)pageSize + RecordPageNumberSize + RecordChecksumSize);
+
+    /// <summary>Whether <paramref name="header"/> begins with the finalized-journal magic.</summary>
+    internal static bool HasMagic(ReadOnlySpan<byte> header)
+        => header.Length >= Magic.Length && header[..Magic.Length].SequenceEqual(Magic);
+
+    /// <summary>
+    /// Reads the record count, checksum nonce, and page size from a journal header
+    /// without validating recoverability. Returns false when the header is too
+    /// short or declares a page size that cannot be a SQLite page.
+    /// </summary>
+    internal static bool TryReadLayout(
+        ReadOnlySpan<byte> header,
+        out uint recordCount,
+        out uint checksumNonce,
+        out int pageSize,
+        out int sectorSize)
+    {
+        recordCount = 0;
+        checksumNonce = 0;
+        pageSize = 0;
+        sectorSize = 0;
+        if (header.Length < HeaderSize)
+            return false;
+
+        var encodedSectorSize = BinaryPrimitives.ReadUInt32BigEndian(header[20..]);
+        var encodedPageSize = BinaryPrimitives.ReadUInt32BigEndian(header[24..]);
+        if (encodedPageSize < SqlitePageSize.Minimum
+            || encodedPageSize > SqlitePageSize.Maximum
+            || (encodedPageSize & (encodedPageSize - 1)) != 0)
+        {
+            return false;
+        }
+        if (encodedSectorSize < 512
+            || encodedSectorSize > 65536
+            || (encodedSectorSize & (encodedSectorSize - 1)) != 0)
+        {
+            return false;
+        }
+
+        recordCount = BinaryPrimitives.ReadUInt32BigEndian(header[8..]);
+        checksumNonce = BinaryPrimitives.ReadUInt32BigEndian(header[12..]);
+        pageSize = (int)encodedPageSize;
+        sectorSize = (int)encodedSectorSize;
+        return true;
+    }
+
+    /// <summary>The SQLite journal page checksum: nonce plus every 200th byte from the end.</summary>
+    internal static uint ComputeChecksum(ReadOnlySpan<byte> page, uint nonce)
+    {
+        var checksum = nonce;
+        for (var index = page.Length - 200; index >= 0; index -= 200)
+            checksum = unchecked(checksum + page[index]);
+        return checksum;
+    }
+}

--- a/src/Ahtola.Core/Storage/SqliteWal.cs
+++ b/src/Ahtola.Core/Storage/SqliteWal.cs
@@ -741,8 +741,8 @@ public sealed class SqliteWalFile : IDisposable, IAsyncDisposable
 
     /// <summary>
     /// Asynchronously opens an existing WAL after validating its header. A
-    /// partial or corrupt frame tail is left for <see cref="ScanRecoveryAsync"/>
-    /// to diagnose.
+    /// partial or corrupt frame tail is left for
+    /// <see cref="ScanRecoveryAsync(CancellationToken)"/> to diagnose.
     /// </summary>
     public static async ValueTask<SqliteWalFile> OpenAsync(
         IAsyncFileSystem fileSystem,
@@ -860,7 +860,7 @@ public sealed class SqliteWalFile : IDisposable, IAsyncDisposable
 
         var file = GetAsyncFile();
         await MaterializeHeaderAfterCheckpointTruncateAsync(cancellationToken).ConfigureAwait(false);
-        var scan = await ScanCoreAsync(cancellationToken).ConfigureAwait(false);
+        var scan = await ScanCoreAsync(long.MaxValue, cancellationToken).ConfigureAwait(false);
         if (scan.Info.StopReason != SqliteWalRecoveryStopReason.EndOfFile)
         {
             throw new InvalidDataException(
@@ -1012,7 +1012,7 @@ public sealed class SqliteWalFile : IDisposable, IAsyncDisposable
 
         var file = GetAsyncFile();
         await MaterializeHeaderAfterCheckpointTruncateAsync(cancellationToken).ConfigureAwait(false);
-        var scan = await ScanCoreAsync(cancellationToken).ConfigureAwait(false);
+        var scan = await ScanCoreAsync(long.MaxValue, cancellationToken).ConfigureAwait(false);
         if (scan.Info.StopReason != SqliteWalRecoveryStopReason.EndOfFile)
         {
             throw new InvalidDataException(
@@ -1422,7 +1422,27 @@ public sealed class SqliteWalFile : IDisposable, IAsyncDisposable
         CancellationToken cancellationToken = default)
     {
         ThrowIfDisposed();
-        return (await ScanCoreAsync(cancellationToken).ConfigureAwait(false)).Info;
+        return (await ScanCoreAsync(long.MaxValue, cancellationToken).ConfigureAwait(false)).Info;
+    }
+
+    /// <summary>
+    /// Asynchronously scans frames up to and including
+    /// <paramref name="maxVisibleFrameNumber"/>, ignoring anything past it.
+    /// </summary>
+    /// <remarks>
+    /// Frames beyond the boundary belong to a commit that is still being made
+    /// durable by another pager on this database, so a reader must not adopt them.
+    /// Because the boundary always lands on a published commit, the truncated scan
+    /// reports <see cref="SqliteWalRecoveryStopReason.EndOfFile"/> and never asks
+    /// its caller to repair a tail it simply cannot see yet.
+    /// </remarks>
+    public async ValueTask<SqliteWalRecoveryInfo> ScanRecoveryAsync(
+        long maxVisibleFrameNumber,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ArgumentOutOfRangeException.ThrowIfNegative(maxVisibleFrameNumber);
+        return (await ScanCoreAsync(maxVisibleFrameNumber, cancellationToken).ConfigureAwait(false)).Info;
     }
 
     /// <summary>
@@ -1463,7 +1483,7 @@ public sealed class SqliteWalFile : IDisposable, IAsyncDisposable
         ThrowIfReadOnly();
 
         var file = GetAsyncFile();
-        var scan = await ScanCoreAsync(cancellationToken).ConfigureAwait(false);
+        var scan = await ScanCoreAsync(long.MaxValue, cancellationToken).ConfigureAwait(false);
         var length = await file.GetLengthAsync(cancellationToken).ConfigureAwait(false);
         if (_truncatedAfterCheckpoint && length == 0)
             return scan.Info;
@@ -1556,7 +1576,7 @@ public sealed class SqliteWalFile : IDisposable, IAsyncDisposable
         ThrowIfReadOnly();
 
         var file = GetAsyncFile();
-        var scan = await ScanCoreAsync(cancellationToken).ConfigureAwait(false);
+        var scan = await ScanCoreAsync(long.MaxValue, cancellationToken).ConfigureAwait(false);
         if (scan.Info.StopReason != SqliteWalRecoveryStopReason.EndOfFile
             || scan.Info.LastValidFrameNumber != scan.Info.LastCommittedFrameNumber)
         {
@@ -1629,7 +1649,7 @@ public sealed class SqliteWalFile : IDisposable, IAsyncDisposable
         ThrowIfReadOnly();
 
         var file = GetAsyncFile();
-        var scan = await ScanCoreAsync(cancellationToken).ConfigureAwait(false);
+        var scan = await ScanCoreAsync(long.MaxValue, cancellationToken).ConfigureAwait(false);
         if (scan.Info.StopReason != SqliteWalRecoveryStopReason.EndOfFile
             || scan.Info.LastValidFrameNumber != scan.Info.LastCommittedFrameNumber)
         {
@@ -1776,7 +1796,9 @@ public sealed class SqliteWalFile : IDisposable, IAsyncDisposable
             previousChecksum);
     }
 
-    private async ValueTask<ScanState> ScanCoreAsync(CancellationToken cancellationToken)
+    private async ValueTask<ScanState> ScanCoreAsync(
+        long maxVisibleFrameNumber,
+        CancellationToken cancellationToken)
     {
         var file = GetAsyncFile();
         var length = await file.GetLengthAsync(cancellationToken).ConfigureAwait(false);
@@ -1801,8 +1823,10 @@ public sealed class SqliteWalFile : IDisposable, IAsyncDisposable
             }
         }
 
-        var fullFrameCount = CompleteFrameCount(length);
-        var hasPartialFrame = (length - SqliteWalHeader.Size) % FrameSize != 0;
+        var physicalFrameCount = CompleteFrameCount(length);
+        var fullFrameCount = Math.Min(physicalFrameCount, maxVisibleFrameNumber);
+        var truncatedByBoundary = fullFrameCount < physicalFrameCount;
+        var hasPartialFrame = !truncatedByBoundary && (length - SqliteWalHeader.Size) % FrameSize != 0;
         var previousChecksum = (Header.Checksum1, Header.Checksum2);
         var lastValidFrameNumber = 0L;
         var lastCommittedFrameNumber = 0L;

--- a/src/Ahtola.Core/Storage/SqliteWal.cs
+++ b/src/Ahtola.Core/Storage/SqliteWal.cs
@@ -418,38 +418,54 @@ public interface ISqliteWalFrameSource
 }
 
 /// <summary>
-/// A minimal, single-writer SQLite WAL file codec over <see cref="IFileSystem"/>.
+/// A minimal, single-writer SQLite WAL file codec over <see cref="IFileSystem"/>
+/// or <see cref="IAsyncFileSystem"/>.
 /// It validates checksums and salts but intentionally does not provide SQLite
 /// locking, shared-memory coordination, checkpointing, or transaction orchestration.
 /// </summary>
-public sealed class SqliteWalFile : IDisposable
+public sealed class SqliteWalFile : IDisposable, IAsyncDisposable
 {
     // Ahtola's pager uses this durable sequence marker to distinguish an empty WAL
     // produced by a completed checkpoint from a newly-created empty WAL. Ordinary
     // restarts still use SQLite/Turso's incrementing checkpoint sequence.
     private const uint PagerCheckpointedRecoverySequence = 0xA5C3_5A3C;
 
-    private readonly IFile _file;
-        private readonly IPageCodec? _pageCodec;
-        private readonly bool _ownsPageCodec;
-        private SqliteWalHeader _header;
-        private bool _hasCheckpointedRecoveryMarker;
-        private bool _truncatedAfterCheckpoint;
-        private bool _disposed;
+    private readonly IFile? _file;
+    private readonly IAsyncFile? _asyncFile;
+    private readonly IPageCodec? _pageCodec;
+    private readonly bool _ownsPageCodec;
+    private SqliteWalHeader _header;
+    private bool _hasCheckpointedRecoveryMarker;
+    private bool _truncatedAfterCheckpoint;
+    private bool _disposed;
 
-        private SqliteWalFile(
-            IFile file,
-            SqliteWalHeader header,
-            IPageCodec? pageCodec,
-            bool ownsPageCodec,
-            bool hasCheckpointedRecoveryMarker = false)
-        {
-            _file = file;
-            _header = header;
-            _pageCodec = pageCodec;
-            _ownsPageCodec = ownsPageCodec;
-            _hasCheckpointedRecoveryMarker = hasCheckpointedRecoveryMarker;
-        }
+    private SqliteWalFile(
+        IFile file,
+        SqliteWalHeader header,
+        IPageCodec? pageCodec,
+        bool ownsPageCodec,
+        bool hasCheckpointedRecoveryMarker = false)
+    {
+        _file = file;
+        _header = header;
+        _pageCodec = pageCodec;
+        _ownsPageCodec = ownsPageCodec;
+        _hasCheckpointedRecoveryMarker = hasCheckpointedRecoveryMarker;
+    }
+
+    private SqliteWalFile(
+        IAsyncFile file,
+        SqliteWalHeader header,
+        IPageCodec? pageCodec,
+        bool ownsPageCodec,
+        bool hasCheckpointedRecoveryMarker = false)
+    {
+        _asyncFile = file;
+        _header = header;
+        _pageCodec = pageCodec;
+        _ownsPageCodec = ownsPageCodec;
+        _hasCheckpointedRecoveryMarker = hasCheckpointedRecoveryMarker;
+    }
 
     /// <summary>The validated WAL header.</summary>
     public SqliteWalHeader Header
@@ -468,17 +484,46 @@ public sealed class SqliteWalFile : IDisposable
     public SqliteWalHeader ReadDurableHeader()
     {
         ThrowIfDisposed();
-        if (_truncatedAfterCheckpoint && _file.Length == 0)
+        var file = GetSyncFile();
+        if (_truncatedAfterCheckpoint && file.Length == 0)
             return _header;
-        if (_file.Length < SqliteWalHeader.Size)
+        if (file.Length < SqliteWalHeader.Size)
         {
             throw new InvalidDataException(
                 "File is too small to contain a SQLite WAL header.");
         }
 
         Span<byte> headerBytes = stackalloc byte[SqliteWalHeader.Size];
-        if (_file.Read(0, headerBytes) != headerBytes.Length)
+        if (file.Read(0, headerBytes) != headerBytes.Length)
             throw new InvalidDataException("Failed to read the complete SQLite WAL header.");
+        return SqliteWalHeader.Parse(headerBytes);
+    }
+
+    /// <summary>
+    /// Asynchronously reads the on-disk WAL header without mutating this
+    /// instance's cached header.
+    /// </summary>
+    public async ValueTask<SqliteWalHeader> ReadDurableHeaderAsync(
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        var file = GetAsyncFile();
+        var length = await file.GetLengthAsync(cancellationToken).ConfigureAwait(false);
+        if (_truncatedAfterCheckpoint && length == 0)
+            return _header;
+        if (length < SqliteWalHeader.Size)
+        {
+            throw new InvalidDataException(
+                "File is too small to contain a SQLite WAL header.");
+        }
+
+        var headerBytes = new byte[SqliteWalHeader.Size];
+        if (await file.ReadAsync(0, headerBytes, cancellationToken).ConfigureAwait(false)
+            != headerBytes.Length)
+        {
+            throw new InvalidDataException("Failed to read the complete SQLite WAL header.");
+        }
+
         return SqliteWalHeader.Parse(headerBytes);
     }
 
@@ -508,12 +553,19 @@ public sealed class SqliteWalFile : IDisposable
         get
         {
             ThrowIfDisposed();
-            return _file.Length;
+            return GetSyncFile().Length;
         }
     }
 
+    /// <summary>The current physical file length, including any incomplete tail.</summary>
+    public ValueTask<long> GetLengthAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        return GetAsyncFile().GetLengthAsync(cancellationToken);
+    }
+
     /// <summary>Whether this WAL was opened read-only.</summary>
-    public bool IsReadOnly => _file.IsReadOnly;
+    public bool IsReadOnly => _file?.IsReadOnly ?? _asyncFile!.IsReadOnly;
 
     internal bool HasCheckpointedRecoveryMarker
     {
@@ -530,53 +582,110 @@ public sealed class SqliteWalFile : IDisposable
         IFileSystem fileSystem,
         string path,
         SqliteWalHeader header,
-            AhtolaEncryptionOptions? encryption = null,
-            IPageCodec? pageCodec = null)
-        {
-            ArgumentNullException.ThrowIfNull(fileSystem);
-            ArgumentException.ThrowIfNullOrEmpty(path);
-            ArgumentNullException.ThrowIfNull(header);
+        AhtolaEncryptionOptions? encryption = null,
+        IPageCodec? pageCodec = null)
+    {
+        ArgumentNullException.ThrowIfNull(fileSystem);
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        ArgumentNullException.ThrowIfNull(header);
 
-            var boundCodec = PageCodecSupport.Bind(encryption, pageCodec, header.PageSize, out var ownsCodec);
-            var file = fileSystem.OpenFile(path, FileOpenMode.CreateNew);
+        var boundCodec = PageCodecSupport.Bind(encryption, pageCodec, header.PageSize, out var ownsCodec);
+        var file = fileSystem.OpenFile(path, FileOpenMode.CreateNew);
+        try
+        {
+            file.Write(0, header.ToArray());
+            if (file.Length != SqliteWalHeader.Size)
+                throw new InvalidDataException("Writing the SQLite WAL header produced an invalid file length.");
+
+            file.FlushToDisk();
+            return new SqliteWalFile(file, header, boundCodec, ownsCodec);
+        }
+        catch
+        {
             try
             {
-                file.Write(0, header.ToArray());
-                if (file.Length != SqliteWalHeader.Size)
-                    throw new InvalidDataException("Writing the SQLite WAL header produced an invalid file length.");
-
-                file.FlushToDisk();
-                return new SqliteWalFile(file, header, boundCodec, ownsCodec);
+                file.Dispose();
             }
             catch
             {
-                try
-                {
-                    file.Dispose();
-                }
-                catch
-                {
-                }
-
-                try
-                {
-                    PageCodecSupport.DisposeOwned(boundCodec, ownsCodec);
-                }
-                catch
-                {
-                }
-
-                try
-                {
-                    fileSystem.DeleteFile(path);
-                }
-                catch
-                {
-                }
-
-                throw;
             }
+
+            try
+            {
+                PageCodecSupport.DisposeOwned(boundCodec, ownsCodec);
+            }
+            catch
+            {
+            }
+
+            try
+            {
+                fileSystem.DeleteFile(path);
+            }
+            catch
+            {
+            }
+
+            throw;
         }
+    }
+
+    /// <summary>Asynchronously creates a new WAL file containing only <paramref name="header"/>.</summary>
+    public static async ValueTask<SqliteWalFile> CreateAsync(
+        IAsyncFileSystem fileSystem,
+        string path,
+        SqliteWalHeader header,
+        AhtolaEncryptionOptions? encryption = null,
+        IPageCodec? pageCodec = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(fileSystem);
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        ArgumentNullException.ThrowIfNull(header);
+
+        var boundCodec = PageCodecSupport.Bind(encryption, pageCodec, header.PageSize, out var ownsCodec);
+        var file = await fileSystem.OpenFileAsync(
+            path,
+            FileOpenMode.CreateNew,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await file.WriteAsync(0, header.ToArray(), cancellationToken).ConfigureAwait(false);
+            if (await file.GetLengthAsync(cancellationToken).ConfigureAwait(false) != SqliteWalHeader.Size)
+                throw new InvalidDataException("Writing the SQLite WAL header produced an invalid file length.");
+
+            await file.FlushToDiskAsync(cancellationToken).ConfigureAwait(false);
+            return new SqliteWalFile(file, header, boundCodec, ownsCodec);
+        }
+        catch
+        {
+            try
+            {
+                await file.DisposeAsync().ConfigureAwait(false);
+            }
+            catch
+            {
+            }
+
+            try
+            {
+                PageCodecSupport.DisposeOwned(boundCodec, ownsCodec);
+            }
+            catch
+            {
+            }
+
+            try
+            {
+                await fileSystem.DeleteFileAsync(path, CancellationToken.None).ConfigureAwait(false);
+            }
+            catch
+            {
+            }
+
+            throw;
+        }
+    }
 
     /// <summary>
     /// Opens an existing WAL after validating its header. A partial or corrupt
@@ -587,48 +696,110 @@ public sealed class SqliteWalFile : IDisposable
         string path,
         bool readOnly = false,
         AhtolaEncryptionOptions? encryption = null,
-            SqliteWalHeader? truncatedHeader = null,
-            IPageCodec? pageCodec = null)
+        SqliteWalHeader? truncatedHeader = null,
+        IPageCodec? pageCodec = null)
+    {
+        ArgumentNullException.ThrowIfNull(fileSystem);
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        PageCodecSupport.RejectCombinedTransforms(encryption, pageCodec);
+
+        var file = fileSystem.OpenFile(path, FileOpenMode.OpenExisting, readOnly);
+        IPageCodec? boundCodec = null;
+        var ownsCodec = false;
+        try
         {
-            ArgumentNullException.ThrowIfNull(fileSystem);
-            ArgumentException.ThrowIfNullOrEmpty(path);
-            PageCodecSupport.RejectCombinedTransforms(encryption, pageCodec);
-
-            var file = fileSystem.OpenFile(path, FileOpenMode.OpenExisting, readOnly);
-            IPageCodec? boundCodec = null;
-            var ownsCodec = false;
-            try
+            if (file.Length == 0 && truncatedHeader is not null)
             {
-                if (file.Length == 0 && truncatedHeader is not null)
+                boundCodec = PageCodecSupport.Bind(
+                    encryption,
+                    pageCodec,
+                    truncatedHeader.PageSize,
+                    out ownsCodec);
+                return new SqliteWalFile(file, truncatedHeader, boundCodec, ownsCodec)
                 {
-                    boundCodec = PageCodecSupport.Bind(
-                        encryption,
-                        pageCodec,
-                        truncatedHeader.PageSize,
-                        out ownsCodec);
-                    return new SqliteWalFile(file, truncatedHeader, boundCodec, ownsCodec)
-                    {
-                        _truncatedAfterCheckpoint = true,
-                    };
-                }
-                if (file.Length < SqliteWalHeader.Size)
-                    throw new InvalidDataException("File is too small to contain a SQLite WAL header.");
-
-                Span<byte> headerBytes = stackalloc byte[SqliteWalHeader.Size];
-                if (file.Read(0, headerBytes) != headerBytes.Length)
-                    throw new InvalidDataException("Failed to read the complete SQLite WAL header.");
-
-                var header = SqliteWalHeader.Parse(headerBytes);
-                boundCodec = PageCodecSupport.Bind(encryption, pageCodec, header.PageSize, out ownsCodec);
-                return new SqliteWalFile(file, header, boundCodec, ownsCodec);
+                    _truncatedAfterCheckpoint = true,
+                };
             }
-            catch
-            {
-                file.Dispose();
-                PageCodecSupport.DisposeOwned(boundCodec, ownsCodec);
-                throw;
-            }
+            if (file.Length < SqliteWalHeader.Size)
+                throw new InvalidDataException("File is too small to contain a SQLite WAL header.");
+
+            Span<byte> headerBytes = stackalloc byte[SqliteWalHeader.Size];
+            if (file.Read(0, headerBytes) != headerBytes.Length)
+                throw new InvalidDataException("Failed to read the complete SQLite WAL header.");
+
+            var header = SqliteWalHeader.Parse(headerBytes);
+            boundCodec = PageCodecSupport.Bind(encryption, pageCodec, header.PageSize, out ownsCodec);
+            return new SqliteWalFile(file, header, boundCodec, ownsCodec);
         }
+        catch
+        {
+            file.Dispose();
+            PageCodecSupport.DisposeOwned(boundCodec, ownsCodec);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Asynchronously opens an existing WAL after validating its header. A
+    /// partial or corrupt frame tail is left for <see cref="ScanRecoveryAsync"/>
+    /// to diagnose.
+    /// </summary>
+    public static async ValueTask<SqliteWalFile> OpenAsync(
+        IAsyncFileSystem fileSystem,
+        string path,
+        bool readOnly = false,
+        AhtolaEncryptionOptions? encryption = null,
+        SqliteWalHeader? truncatedHeader = null,
+        IPageCodec? pageCodec = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(fileSystem);
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        PageCodecSupport.RejectCombinedTransforms(encryption, pageCodec);
+
+        var file = await fileSystem.OpenFileAsync(
+            path,
+            FileOpenMode.OpenExisting,
+            readOnly,
+            cancellationToken).ConfigureAwait(false);
+        IPageCodec? boundCodec = null;
+        var ownsCodec = false;
+        try
+        {
+            var length = await file.GetLengthAsync(cancellationToken).ConfigureAwait(false);
+            if (length == 0 && truncatedHeader is not null)
+            {
+                boundCodec = PageCodecSupport.Bind(
+                    encryption,
+                    pageCodec,
+                    truncatedHeader.PageSize,
+                    out ownsCodec);
+                return new SqliteWalFile(file, truncatedHeader, boundCodec, ownsCodec)
+                {
+                    _truncatedAfterCheckpoint = true,
+                };
+            }
+            if (length < SqliteWalHeader.Size)
+                throw new InvalidDataException("File is too small to contain a SQLite WAL header.");
+
+            var headerBytes = new byte[SqliteWalHeader.Size];
+            if (await file.ReadAsync(0, headerBytes, cancellationToken).ConfigureAwait(false)
+                != headerBytes.Length)
+            {
+                throw new InvalidDataException("Failed to read the complete SQLite WAL header.");
+            }
+
+            var header = SqliteWalHeader.Parse(headerBytes);
+            boundCodec = PageCodecSupport.Bind(encryption, pageCodec, header.PageSize, out ownsCodec);
+            return new SqliteWalFile(file, header, boundCodec, ownsCodec);
+        }
+        catch
+        {
+            await file.DisposeAsync().ConfigureAwait(false);
+            PageCodecSupport.DisposeOwned(boundCodec, ownsCodec);
+            throw;
+        }
+    }
 
     /// <summary>
     /// Appends a checksummed page frame. A non-zero
@@ -657,12 +828,53 @@ public sealed class SqliteWalFile : IDisposable
 
         var frameNumber = checked(scan.Info.LastValidFrameNumber + 1);
         var offset = FrameOffset(frameNumber);
-        if (_file.Length != offset)
+        if (GetSyncFile().Length != offset)
             throw new InvalidDataException("SQLite WAL length changed while preparing an append.");
 
         var frame = new byte[checked((int)FrameSize)];
         EncodeFrame(frame, pageNumber, pageData, databaseSizeInPages, scan.LastChecksum);
         AppendAtEnd(offset, frame);
+        return frameNumber;
+    }
+
+    /// <summary>
+    /// Asynchronously appends a checksummed page frame. A non-zero
+    /// <paramref name="databaseSizeInPages"/> marks this frame as committed.
+    /// </summary>
+    public async ValueTask<long> AppendFrameAsync(
+        uint pageNumber,
+        ReadOnlyMemory<byte> pageData,
+        uint databaseSizeInPages = 0,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ThrowIfReadOnly();
+        if (pageNumber == 0)
+            throw new ArgumentOutOfRangeException(nameof(pageNumber), pageNumber, "SQLite WAL page numbers are 1-based.");
+        if (pageData.Length != Header.PageSize)
+        {
+            throw new ArgumentException(
+                $"SQLite WAL page data must be exactly {Header.PageSize} bytes.",
+                nameof(pageData));
+        }
+
+        var file = GetAsyncFile();
+        await MaterializeHeaderAfterCheckpointTruncateAsync(cancellationToken).ConfigureAwait(false);
+        var scan = await ScanCoreAsync(cancellationToken).ConfigureAwait(false);
+        if (scan.Info.StopReason != SqliteWalRecoveryStopReason.EndOfFile)
+        {
+            throw new InvalidDataException(
+                "Cannot append to a SQLite WAL with a partial or invalid frame tail; recover it first.");
+        }
+
+        var frameNumber = checked(scan.Info.LastValidFrameNumber + 1);
+        var offset = FrameOffset(frameNumber);
+        if (await file.GetLengthAsync(cancellationToken).ConfigureAwait(false) != offset)
+            throw new InvalidDataException("SQLite WAL length changed while preparing an append.");
+
+        var frame = new byte[checked((int)FrameSize)];
+        EncodeFrame(frame, pageNumber, pageData.Span, databaseSizeInPages, scan.LastChecksum);
+        await AppendAtEndAsync(offset, frame, cancellationToken).ConfigureAwait(false);
         return frameNumber;
     }
 
@@ -708,7 +920,7 @@ public sealed class SqliteWalFile : IDisposable
 
         var firstFrameNumber = checked(scan.Info.LastValidFrameNumber + 1);
         var baseOffset = FrameOffset(firstFrameNumber);
-        if (_file.Length != baseOffset)
+        if (GetSyncFile().Length != baseOffset)
             throw new InvalidDataException("SQLite WAL length changed while preparing an append.");
 
         var frameSize = checked((int)FrameSize);
@@ -746,8 +958,8 @@ public sealed class SqliteWalFile : IDisposable
                 // One bounded write per frame keeps append granularity identical to
                 // the per-frame path; the win here is the single preceding scan.
                 var expectedLength = checked(writeOffset + frameSize);
-                _file.Write(writeOffset, frame);
-                if (_file.Length != expectedLength)
+                GetSyncFile().Write(writeOffset, frame);
+                if (GetSyncFile().Length != expectedLength)
                     throw new InvalidDataException("Appending a SQLite WAL frame produced an invalid file length.");
 
                 writeOffset = expectedLength;
@@ -761,8 +973,103 @@ public sealed class SqliteWalFile : IDisposable
                 // batch stay as an uncommitted tail: none of them carries the
                 // commit marker, so recovery still discards the whole batch,
                 // and a peer sees exactly the boundary the per-frame path left.
-                if (_file.Length != writeOffset)
-                    _file.SetLength(writeOffset);
+                if (GetSyncFile().Length != writeOffset)
+                    GetSyncFile().SetLength(writeOffset);
+            }
+            catch (Exception rollbackException)
+            {
+                throw new InvalidDataException(
+                    "Appending a SQLite WAL frame batch failed and the original length could not be restored.",
+                    new AggregateException(appendException, rollbackException));
+            }
+
+            throw;
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+
+        return checked(firstFrameNumber + count - 1);
+    }
+
+    /// <summary>
+    /// Asynchronously appends an entire transaction's frames in one pass. Only
+    /// the final frame carries the commit marker.
+    /// </summary>
+    public async ValueTask<long> AppendFramesAsync(
+        ISqliteWalFrameSource frames,
+        uint commitDatabaseSizeInPages,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(frames);
+        ThrowIfDisposed();
+        ThrowIfReadOnly();
+
+        var count = frames.Count;
+        if (count <= 0)
+            throw new ArgumentException("A SQLite WAL frame batch must contain at least one frame.", nameof(frames));
+
+        var file = GetAsyncFile();
+        await MaterializeHeaderAfterCheckpointTruncateAsync(cancellationToken).ConfigureAwait(false);
+        var scan = await ScanCoreAsync(cancellationToken).ConfigureAwait(false);
+        if (scan.Info.StopReason != SqliteWalRecoveryStopReason.EndOfFile)
+        {
+            throw new InvalidDataException(
+                "Cannot append to a SQLite WAL with a partial or invalid frame tail; recover it first.");
+        }
+
+        var firstFrameNumber = checked(scan.Info.LastValidFrameNumber + 1);
+        var baseOffset = FrameOffset(firstFrameNumber);
+        if (await file.GetLengthAsync(cancellationToken).ConfigureAwait(false) != baseOffset)
+            throw new InvalidDataException("SQLite WAL length changed while preparing an append.");
+
+        var frameSize = checked((int)FrameSize);
+        var buffer = ArrayPool<byte>.Shared.Rent(frameSize);
+        var rolling = scan.LastChecksum;
+        var writeOffset = baseOffset;
+
+        try
+        {
+            for (var index = 0; index < count; index++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var pageNumber = frames.GetPageNumber(index);
+                if (pageNumber == 0)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(frames),
+                        pageNumber,
+                        "SQLite WAL page numbers are 1-based.");
+                }
+
+                var databaseSizeInPages = index == count - 1 ? commitDatabaseSizeInPages : 0U;
+                rolling = EncodeFrameFromSource(
+                    buffer,
+                    frameSize,
+                    frames,
+                    index,
+                    pageNumber,
+                    databaseSizeInPages,
+                    rolling);
+
+                var expectedLength = checked(writeOffset + frameSize);
+                await file.WriteAsync(
+                    writeOffset,
+                    buffer.AsMemory(0, frameSize),
+                    cancellationToken).ConfigureAwait(false);
+                if (await file.GetLengthAsync(cancellationToken).ConfigureAwait(false) != expectedLength)
+                    throw new InvalidDataException("Appending a SQLite WAL frame produced an invalid file length.");
+
+                writeOffset = expectedLength;
+            }
+        }
+        catch (Exception appendException)
+        {
+            try
+            {
+                if (await file.GetLengthAsync(CancellationToken.None).ConfigureAwait(false) != writeOffset)
+                    await file.SetLengthAsync(writeOffset, CancellationToken.None).ConfigureAwait(false);
             }
             catch (Exception rollbackException)
             {
@@ -827,6 +1134,31 @@ public sealed class SqliteWalFile : IDisposable
         return checksum;
     }
 
+    private (uint First, uint Second) EncodeFrameFromSource(
+        byte[] destination,
+        int frameSize,
+        ISqliteWalFrameSource frames,
+        int index,
+        uint pageNumber,
+        uint databaseSizeInPages,
+        (uint First, uint Second) previousChecksum)
+    {
+        var pageData = frames.GetPageImage(index);
+        if (pageData.Length != Header.PageSize)
+        {
+            throw new ArgumentException(
+                $"SQLite WAL page data must be exactly {Header.PageSize} bytes.",
+                nameof(frames));
+        }
+
+        return EncodeFrame(
+            destination.AsSpan(0, frameSize),
+            pageNumber,
+            pageData,
+            databaseSizeInPages,
+            previousChecksum);
+    }
+
     /// <summary>
     /// Reads one frame after validating every checksum in its chain from the WAL
     /// header through that frame.
@@ -837,7 +1169,7 @@ public sealed class SqliteWalFile : IDisposable
         if (frameNumber < 1)
             throw new ArgumentOutOfRangeException(nameof(frameNumber), frameNumber, "SQLite WAL frame numbers are 1-based.");
 
-        var fullFrameCount = CompleteFrameCount(_file.Length);
+        var fullFrameCount = CompleteFrameCount(GetSyncFile().Length);
         if (frameNumber > fullFrameCount)
         {
             throw new ArgumentOutOfRangeException(
@@ -854,24 +1186,62 @@ public sealed class SqliteWalFile : IDisposable
             if (currentFrameNumber == frameNumber)
             {
                 var onDiskPageData = frame.AsSpan(SqliteWalFrameHeader.Size);
-                                byte[] pageData;
-                                if (_pageCodec is null)
-                                {
-                                    pageData = onDiskPageData.ToArray();
-                                }
-                                else
-                                {
-                                    pageData = new byte[onDiskPageData.Length];
-                                    PageCodecSupport.Decode(
-                                        _pageCodec,
-                                        PageLocation.Wal,
-                                        frameHeader.PageNumber,
-                                        onDiskPageData,
-                                        pageData);
-                                }
+                byte[] pageData;
+                if (_pageCodec is null)
+                {
+                    pageData = onDiskPageData.ToArray();
+                }
+                else
+                {
+                    pageData = new byte[onDiskPageData.Length];
+                    PageCodecSupport.Decode(
+                        _pageCodec,
+                        PageLocation.Wal,
+                        frameHeader.PageNumber,
+                        onDiskPageData,
+                        pageData);
+                }
 
-                                return new SqliteWalFrame(frameHeader, pageData);
+                return new SqliteWalFrame(frameHeader, pageData);
             }
+
+            previousChecksum = checksum;
+        }
+
+        throw new InvalidOperationException("SQLite WAL frame traversal ended unexpectedly.");
+    }
+
+    /// <summary>
+    /// Asynchronously reads one frame after validating every checksum in its
+    /// chain from the WAL header through that frame.
+    /// </summary>
+    public async ValueTask<SqliteWalFrame> ReadFrameAsync(
+        long frameNumber,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        if (frameNumber < 1)
+            throw new ArgumentOutOfRangeException(nameof(frameNumber), frameNumber, "SQLite WAL frame numbers are 1-based.");
+
+        var fullFrameCount = CompleteFrameCount(
+            await GetAsyncFile().GetLengthAsync(cancellationToken).ConfigureAwait(false));
+        if (frameNumber > fullFrameCount)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(frameNumber),
+                frameNumber,
+                $"Frame number is out of range for {fullFrameCount} complete SQLite WAL frame(s).");
+        }
+
+        var previousChecksum = (Header.Checksum1, Header.Checksum2);
+        for (var currentFrameNumber = 1L; currentFrameNumber <= frameNumber; currentFrameNumber++)
+        {
+            var frame = await ReadFrameBytesAsync(
+                FrameOffset(currentFrameNumber),
+                cancellationToken).ConfigureAwait(false);
+            var frameHeader = ValidateFrame(frame, previousChecksum, out var checksum);
+            if (currentFrameNumber == frameNumber)
+                return DecodeFrame(frame, frameHeader);
 
             previousChecksum = checksum;
         }
@@ -907,7 +1277,7 @@ public sealed class SqliteWalFile : IDisposable
                 "The last SQLite WAL frame number cannot precede the first.");
         }
 
-        var fullFrameCount = CompleteFrameCount(_file.Length);
+        var fullFrameCount = CompleteFrameCount(GetSyncFile().Length);
         if (lastFrameNumber > fullFrameCount)
         {
             throw new ArgumentOutOfRangeException(
@@ -925,7 +1295,7 @@ public sealed class SqliteWalFile : IDisposable
             var frame = rented.AsSpan(0, frameSize);
             for (var frameNumber = 1L; frameNumber <= lastFrameNumber; frameNumber++)
             {
-                var read = _file.Read(FrameOffset(frameNumber), frame);
+                var read = GetSyncFile().Read(FrameOffset(frameNumber), frame);
                 if (read != frame.Length)
                 {
                     throw new InvalidDataException(
@@ -963,6 +1333,78 @@ public sealed class SqliteWalFile : IDisposable
     }
 
     /// <summary>
+    /// Asynchronously reads a contiguous run of frames, validating the checksum
+    /// chain from the WAL header through <paramref name="lastFrameNumber"/>
+    /// exactly once.
+    /// </summary>
+    public async ValueTask<IReadOnlyList<SqliteWalFrame>> ReadFrameRangeAsync(
+        long firstFrameNumber,
+        long lastFrameNumber,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        if (firstFrameNumber < 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(firstFrameNumber),
+                firstFrameNumber,
+                "SQLite WAL frame numbers are 1-based.");
+        }
+        if (lastFrameNumber < firstFrameNumber)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(lastFrameNumber),
+                lastFrameNumber,
+                "The last SQLite WAL frame number cannot precede the first.");
+        }
+
+        var file = GetAsyncFile();
+        var fullFrameCount = CompleteFrameCount(
+            await file.GetLengthAsync(cancellationToken).ConfigureAwait(false));
+        if (lastFrameNumber > fullFrameCount)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(lastFrameNumber),
+                lastFrameNumber,
+                $"Frame number is out of range for {fullFrameCount} complete SQLite WAL frame(s).");
+        }
+
+        var frameSize = checked((int)FrameSize);
+        var results = new List<SqliteWalFrame>(checked((int)(lastFrameNumber - firstFrameNumber + 1)));
+        var previousChecksum = (Header.Checksum1, Header.Checksum2);
+        var rented = ArrayPool<byte>.Shared.Rent(frameSize);
+        try
+        {
+            for (var frameNumber = 1L; frameNumber <= lastFrameNumber; frameNumber++)
+            {
+                var read = await file.ReadAsync(
+                    FrameOffset(frameNumber),
+                    rented.AsMemory(0, frameSize),
+                    cancellationToken).ConfigureAwait(false);
+                if (read != frameSize)
+                {
+                    throw new InvalidDataException(
+                        $"Short read on SQLite WAL frame: expected {frameSize} bytes, got {read} bytes.");
+                }
+
+                var frameHeader = ValidateFrame(
+                    rented.AsSpan(0, frameSize),
+                    previousChecksum,
+                    out var checksum);
+                previousChecksum = checksum;
+                if (frameNumber >= firstFrameNumber)
+                    results.Add(DecodeFrame(rented.AsSpan(0, frameSize), frameHeader));
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rented);
+        }
+
+        return results;
+    }
+
+    /// <summary>
     /// Scans valid frames in order and reports the boundary after the most recent
     /// valid commit. Corrupt or incomplete tails are not treated as committed.
     /// </summary>
@@ -970,6 +1412,17 @@ public sealed class SqliteWalFile : IDisposable
     {
         ThrowIfDisposed();
         return ScanCore().Info;
+    }
+
+    /// <summary>
+    /// Asynchronously scans valid frames in order and reports the boundary after
+    /// the most recent valid commit.
+    /// </summary>
+    public async ValueTask<SqliteWalRecoveryInfo> ScanRecoveryAsync(
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        return (await ScanCoreAsync(cancellationToken).ConfigureAwait(false)).Info;
     }
 
     /// <summary>
@@ -981,18 +1434,48 @@ public sealed class SqliteWalFile : IDisposable
         ThrowIfDisposed();
         ThrowIfReadOnly();
 
+        var file = GetSyncFile();
         var scan = ScanCore();
-        if (_truncatedAfterCheckpoint && _file.Length == 0)
+        if (_truncatedAfterCheckpoint && file.Length == 0)
             return scan.Info;
 
         var targetLength = scan.Info.LastCommittedByteLength;
-        if (_file.Length != targetLength)
+        if (file.Length != targetLength)
         {
-            _file.SetLength(targetLength);
-            if (_file.Length != targetLength)
+            file.SetLength(targetLength);
+            if (file.Length != targetLength)
                 throw new InvalidDataException("SQLite WAL recovery truncation did not reach its requested boundary.");
 
-            _file.FlushToDisk();
+            file.FlushToDisk();
+        }
+
+        return scan.Info;
+    }
+
+    /// <summary>
+    /// Asynchronously truncates and durably flushes every byte after the last
+    /// valid committed frame.
+    /// </summary>
+    public async ValueTask<SqliteWalRecoveryInfo> RecoverToLastCommittedFrameAsync(
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ThrowIfReadOnly();
+
+        var file = GetAsyncFile();
+        var scan = await ScanCoreAsync(cancellationToken).ConfigureAwait(false);
+        var length = await file.GetLengthAsync(cancellationToken).ConfigureAwait(false);
+        if (_truncatedAfterCheckpoint && length == 0)
+            return scan.Info;
+
+        var targetLength = scan.Info.LastCommittedByteLength;
+        if (length != targetLength)
+        {
+            await file.SetLengthAsync(targetLength, cancellationToken).ConfigureAwait(false);
+            if (await file.GetLengthAsync(cancellationToken).ConfigureAwait(false) != targetLength)
+                throw new InvalidDataException("SQLite WAL recovery truncation did not reach its requested boundary.");
+
+            await file.FlushToDiskAsync(cancellationToken).ConfigureAwait(false);
         }
 
         return scan.Info;
@@ -1003,7 +1486,15 @@ public sealed class SqliteWalFile : IDisposable
     {
         ThrowIfDisposed();
         if (!IsReadOnly)
-            _file.FlushToDisk();
+            GetSyncFile().FlushToDisk();
+    }
+
+    /// <summary>Asynchronously flushes WAL bytes and metadata to durable storage.</summary>
+    public async ValueTask FlushAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        if (!IsReadOnly)
+            await GetAsyncFile().FlushToDiskAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -1032,8 +1523,9 @@ public sealed class SqliteWalFile : IDisposable
         if (scan.Info.LastCommittedFrameNumber == 0)
             return;
 
-        _file.SetLength(SqliteWalHeader.Size);
-        if (_file.Length != SqliteWalHeader.Size)
+        var file = GetSyncFile();
+        file.SetLength(SqliteWalHeader.Size);
+        if (file.Length != SqliteWalHeader.Size)
             throw new InvalidDataException("SQLite WAL reset did not reach its header boundary.");
 
         var salt2 = CreateRandomSalt();
@@ -1045,11 +1537,54 @@ public sealed class SqliteWalFile : IDisposable
                 PagerCheckpointedRecoverySequence,
                 _header.ChecksumByteOrder)
             : _header.Restart(salt2);
-        _file.Write(0, replacementHeader.ToArray());
+        file.Write(0, replacementHeader.ToArray());
         _header = replacementHeader;
         _hasCheckpointedRecoveryMarker = publishCheckpointedRecoveryMarker;
 
-        _file.FlushToDisk();
+        file.FlushToDisk();
+    }
+
+    /// <summary>
+    /// Asynchronously reclaims every committed frame after the caller has
+    /// durably installed the same committed view in the main database file.
+    /// </summary>
+    internal async ValueTask ResetAfterDurableCheckpointAsync(
+        bool publishCheckpointedRecoveryMarker,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ThrowIfReadOnly();
+
+        var file = GetAsyncFile();
+        var scan = await ScanCoreAsync(cancellationToken).ConfigureAwait(false);
+        if (scan.Info.StopReason != SqliteWalRecoveryStopReason.EndOfFile
+            || scan.Info.LastValidFrameNumber != scan.Info.LastCommittedFrameNumber)
+        {
+            throw new InvalidDataException(
+                "Cannot reset a SQLite WAL with a partial, corrupt, or uncommitted frame tail.");
+        }
+
+        if (scan.Info.LastCommittedFrameNumber == 0)
+            return;
+
+        await file.SetLengthAsync(SqliteWalHeader.Size, cancellationToken).ConfigureAwait(false);
+        if (await file.GetLengthAsync(cancellationToken).ConfigureAwait(false) != SqliteWalHeader.Size)
+            throw new InvalidDataException("SQLite WAL reset did not reach its header boundary.");
+
+        var salt2 = CreateRandomSalt();
+        var replacementHeader = publishCheckpointedRecoveryMarker
+            ? SqliteWalHeader.Create(
+                _header.PageSize,
+                unchecked(_header.Salt1 + 1),
+                salt2,
+                PagerCheckpointedRecoverySequence,
+                _header.ChecksumByteOrder)
+            : _header.Restart(salt2);
+        await file.WriteAsync(0, replacementHeader.ToArray(), cancellationToken).ConfigureAwait(false);
+        _header = replacementHeader;
+        _hasCheckpointedRecoveryMarker = publishCheckpointedRecoveryMarker;
+
+        await file.FlushToDiskAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -1074,11 +1609,39 @@ public sealed class SqliteWalFile : IDisposable
                 "Cannot truncate a SQLite WAL with a partial, corrupt, or uncommitted frame tail.");
         }
 
-        _file.SetLength(0);
-        if (_file.Length != 0)
+        var file = GetSyncFile();
+        file.SetLength(0);
+        if (file.Length != 0)
             throw new InvalidDataException("SQLite WAL truncation did not reach zero bytes.");
 
-        _file.FlushToDisk();
+        file.FlushToDisk();
+        _truncatedAfterCheckpoint = true;
+    }
+
+    /// <summary>
+    /// Asynchronously truncates the WAL to zero bytes after a caller has durably
+    /// checkpointed its complete committed view.
+    /// </summary>
+    internal async ValueTask TruncateAfterDurableCheckpointAsync(
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ThrowIfReadOnly();
+
+        var file = GetAsyncFile();
+        var scan = await ScanCoreAsync(cancellationToken).ConfigureAwait(false);
+        if (scan.Info.StopReason != SqliteWalRecoveryStopReason.EndOfFile
+            || scan.Info.LastValidFrameNumber != scan.Info.LastCommittedFrameNumber)
+        {
+            throw new InvalidDataException(
+                "Cannot truncate a SQLite WAL with a partial, corrupt, or uncommitted frame tail.");
+        }
+
+        await file.SetLengthAsync(0, cancellationToken).ConfigureAwait(false);
+        if (await file.GetLengthAsync(cancellationToken).ConfigureAwait(false) != 0)
+            throw new InvalidDataException("SQLite WAL truncation did not reach zero bytes.");
+
+        await file.FlushToDiskAsync(cancellationToken).ConfigureAwait(false);
         _truncatedAfterCheckpoint = true;
     }
 
@@ -1088,14 +1651,35 @@ public sealed class SqliteWalFile : IDisposable
         if (_disposed)
             return;
 
+        if (_file is null)
+        {
+            throw new InvalidOperationException(
+                "This SQLite WAL uses asynchronous storage and must be disposed with DisposeAsync.");
+        }
+
         _disposed = true;
-        _file.Dispose();
-                PageCodecSupport.DisposeOwned(_pageCodec, _ownsPageCodec);
+        _file!.Dispose();
+        PageCodecSupport.DisposeOwned(_pageCodec, _ownsPageCodec);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        if (_asyncFile is not null)
+            await _asyncFile.DisposeAsync().ConfigureAwait(false);
+        else
+            _file!.Dispose();
+        PageCodecSupport.DisposeOwned(_pageCodec, _ownsPageCodec);
     }
 
     private ScanState ScanCore()
     {
-        var length = _file.Length;
+        var file = GetSyncFile();
+        var length = file.Length;
         if (_truncatedAfterCheckpoint && length == 0)
         {
             return CreateScanState(
@@ -1112,7 +1696,7 @@ public sealed class SqliteWalFile : IDisposable
         if (_truncatedAfterCheckpoint && length >= SqliteWalHeader.Size)
         {
             var headerBytes = new byte[SqliteWalHeader.Size];
-            if (_file.Read(0, headerBytes) == headerBytes.Length)
+            if (file.Read(0, headerBytes) == headerBytes.Length)
             {
                 _header = SqliteWalHeader.Parse(headerBytes);
                 _truncatedAfterCheckpoint = false;
@@ -1144,7 +1728,7 @@ public sealed class SqliteWalFile : IDisposable
             var frame = rented.AsSpan(0, frameSize);
             for (var frameNumber = 1L; frameNumber <= fullFrameCount; frameNumber++)
             {
-                if (_file.Read(FrameOffset(frameNumber), frame) != frame.Length)
+                if (file.Read(FrameOffset(frameNumber), frame) != frame.Length)
                 {
                     return CreateScanState(
                         lastValidFrameNumber,
@@ -1159,6 +1743,107 @@ public sealed class SqliteWalFile : IDisposable
                 try
                 {
                     frameHeader = ValidateFrame(frame, previousChecksum, out checksum);
+                }
+                catch (InvalidDataException)
+                {
+                    return CreateScanState(
+                        lastValidFrameNumber,
+                        lastCommittedFrameNumber,
+                        lastCommittedDatabaseSizeInPages,
+                        SqliteWalRecoveryStopReason.InvalidFrame,
+                        previousChecksum);
+                }
+
+                lastValidFrameNumber = frameNumber;
+                previousChecksum = checksum;
+                if (frameHeader.IsCommit)
+                {
+                    lastCommittedFrameNumber = frameNumber;
+                    lastCommittedDatabaseSizeInPages = frameHeader.DatabaseSizeInPages;
+                }
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rented);
+        }
+
+        return CreateScanState(
+            lastValidFrameNumber,
+            lastCommittedFrameNumber,
+            lastCommittedDatabaseSizeInPages,
+            hasPartialFrame ? SqliteWalRecoveryStopReason.PartialFrame : SqliteWalRecoveryStopReason.EndOfFile,
+            previousChecksum);
+    }
+
+    private async ValueTask<ScanState> ScanCoreAsync(CancellationToken cancellationToken)
+    {
+        var file = GetAsyncFile();
+        var length = await file.GetLengthAsync(cancellationToken).ConfigureAwait(false);
+        if (_truncatedAfterCheckpoint && length == 0)
+        {
+            return CreateScanState(
+                lastValidFrameNumber: 0,
+                lastCommittedFrameNumber: 0,
+                lastCommittedDatabaseSizeInPages: 0,
+                SqliteWalRecoveryStopReason.EndOfFile,
+                (Header.Checksum1, Header.Checksum2));
+        }
+
+        if (_truncatedAfterCheckpoint && length >= SqliteWalHeader.Size)
+        {
+            var headerBytes = new byte[SqliteWalHeader.Size];
+            if (await file.ReadAsync(0, headerBytes, cancellationToken).ConfigureAwait(false)
+                == headerBytes.Length)
+            {
+                _header = SqliteWalHeader.Parse(headerBytes);
+                _truncatedAfterCheckpoint = false;
+            }
+        }
+
+        var fullFrameCount = CompleteFrameCount(length);
+        var hasPartialFrame = (length - SqliteWalHeader.Size) % FrameSize != 0;
+        var previousChecksum = (Header.Checksum1, Header.Checksum2);
+        var lastValidFrameNumber = 0L;
+        var lastCommittedFrameNumber = 0L;
+        var lastCommittedDatabaseSizeInPages = 0U;
+        if (fullFrameCount == 0)
+        {
+            return CreateScanState(
+                lastValidFrameNumber,
+                lastCommittedFrameNumber,
+                lastCommittedDatabaseSizeInPages,
+                hasPartialFrame ? SqliteWalRecoveryStopReason.PartialFrame : SqliteWalRecoveryStopReason.EndOfFile,
+                previousChecksum);
+        }
+
+        var frameSize = checked((int)FrameSize);
+        var rented = ArrayPool<byte>.Shared.Rent(frameSize);
+        try
+        {
+            for (var frameNumber = 1L; frameNumber <= fullFrameCount; frameNumber++)
+            {
+                if (await file.ReadAsync(
+                    FrameOffset(frameNumber),
+                    rented.AsMemory(0, frameSize),
+                    cancellationToken).ConfigureAwait(false) != frameSize)
+                {
+                    return CreateScanState(
+                        lastValidFrameNumber,
+                        lastCommittedFrameNumber,
+                        lastCommittedDatabaseSizeInPages,
+                        SqliteWalRecoveryStopReason.PartialFrame,
+                        previousChecksum);
+                }
+
+                SqliteWalFrameHeader frameHeader;
+                (uint First, uint Second) checksum;
+                try
+                {
+                    frameHeader = ValidateFrame(
+                        rented.AsSpan(0, frameSize),
+                        previousChecksum,
+                        out checksum);
                 }
                 catch (InvalidDataException)
                 {
@@ -1235,21 +1920,73 @@ public sealed class SqliteWalFile : IDisposable
         return frameHeader;
     }
 
+    private SqliteWalFrame DecodeFrame(
+        ReadOnlySpan<byte> frame,
+        SqliteWalFrameHeader frameHeader)
+    {
+        var onDiskPageData = frame[SqliteWalFrameHeader.Size..];
+        var pageData = new byte[onDiskPageData.Length];
+        if (_pageCodec is null)
+            onDiskPageData.CopyTo(pageData);
+        else
+        {
+            PageCodecSupport.Decode(
+                _pageCodec,
+                PageLocation.Wal,
+                frameHeader.PageNumber,
+                onDiskPageData,
+                pageData);
+        }
+
+        return new SqliteWalFrame(frameHeader, pageData);
+    }
+
     private void AppendAtEnd(long offset, ReadOnlySpan<byte> frame)
     {
         var expectedLength = checked(offset + frame.Length);
         try
         {
-            _file.Write(offset, frame);
-            if (_file.Length != expectedLength)
+            GetSyncFile().Write(offset, frame);
+            if (GetSyncFile().Length != expectedLength)
                 throw new InvalidDataException("Appending a SQLite WAL frame produced an invalid file length.");
         }
         catch (Exception appendException)
         {
             try
             {
-                if (_file.Length != offset)
-                    _file.SetLength(offset);
+                if (GetSyncFile().Length != offset)
+                    GetSyncFile().SetLength(offset);
+            }
+            catch (Exception rollbackException)
+            {
+                throw new InvalidDataException(
+                    "Appending a SQLite WAL frame failed and the original length could not be restored.",
+                    new AggregateException(appendException, rollbackException));
+            }
+
+            throw;
+        }
+    }
+
+    private async ValueTask AppendAtEndAsync(
+        long offset,
+        ReadOnlyMemory<byte> frame,
+        CancellationToken cancellationToken)
+    {
+        var file = GetAsyncFile();
+        var expectedLength = checked(offset + frame.Length);
+        try
+        {
+            await file.WriteAsync(offset, frame, cancellationToken).ConfigureAwait(false);
+            if (await file.GetLengthAsync(cancellationToken).ConfigureAwait(false) != expectedLength)
+                throw new InvalidDataException("Appending a SQLite WAL frame produced an invalid file length.");
+        }
+        catch (Exception appendException)
+        {
+            try
+            {
+                if (await file.GetLengthAsync(CancellationToken.None).ConfigureAwait(false) != offset)
+                    await file.SetLengthAsync(offset, CancellationToken.None).ConfigureAwait(false);
             }
             catch (Exception rollbackException)
             {
@@ -1266,14 +2003,35 @@ public sealed class SqliteWalFile : IDisposable
     {
         if (!_truncatedAfterCheckpoint)
             return;
-        if (_file.Length != 0)
+        var file = GetSyncFile();
+        if (file.Length != 0)
         {
             throw new InvalidDataException(
                 "SQLite WAL changed after a checkpoint truncate; refusing to overwrite an unexpected artifact.");
         }
 
-        _file.Write(position: 0, Header.ToArray());
-        if (_file.Length != SqliteWalHeader.Size)
+        file.Write(position: 0, Header.ToArray());
+        if (file.Length != SqliteWalHeader.Size)
+            throw new InvalidDataException("Recreating a truncated SQLite WAL header produced an invalid file length.");
+
+        _truncatedAfterCheckpoint = false;
+    }
+
+    private async ValueTask MaterializeHeaderAfterCheckpointTruncateAsync(
+        CancellationToken cancellationToken)
+    {
+        if (!_truncatedAfterCheckpoint)
+            return;
+
+        var file = GetAsyncFile();
+        if (await file.GetLengthAsync(cancellationToken).ConfigureAwait(false) != 0)
+        {
+            throw new InvalidDataException(
+                "SQLite WAL changed after a checkpoint truncate; refusing to overwrite an unexpected artifact.");
+        }
+
+        await file.WriteAsync(0, Header.ToArray(), cancellationToken).ConfigureAwait(false);
+        if (await file.GetLengthAsync(cancellationToken).ConfigureAwait(false) != SqliteWalHeader.Size)
             throw new InvalidDataException("Recreating a truncated SQLite WAL header produced an invalid file length.");
 
         _truncatedAfterCheckpoint = false;
@@ -1282,7 +2040,25 @@ public sealed class SqliteWalFile : IDisposable
     private byte[] ReadFrameBytes(long offset)
     {
         var frame = new byte[checked((int)FrameSize)];
-        var read = _file.Read(offset, frame);
+        var read = GetSyncFile().Read(offset, frame);
+        if (read != frame.Length)
+        {
+            throw new InvalidDataException(
+                $"Short read on SQLite WAL frame: expected {frame.Length} bytes, got {read} bytes.");
+        }
+
+        return frame;
+    }
+
+    private async ValueTask<byte[]> ReadFrameBytesAsync(
+        long offset,
+        CancellationToken cancellationToken)
+    {
+        var frame = new byte[checked((int)FrameSize)];
+        var read = await GetAsyncFile().ReadAsync(
+            offset,
+            frame,
+            cancellationToken).ConfigureAwait(false);
         if (read != frame.Length)
         {
             throw new InvalidDataException(
@@ -1323,6 +2099,16 @@ public sealed class SqliteWalFile : IDisposable
     }
 
     private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposed, this);
+
+    private IFile GetSyncFile()
+        => _file
+           ?? throw new InvalidOperationException(
+               "This SQLite WAL uses asynchronous storage; call its asynchronous API.");
+
+    private IAsyncFile GetAsyncFile()
+        => _asyncFile
+           ?? throw new InvalidOperationException(
+               "This SQLite WAL uses synchronous storage; call its synchronous API.");
 
     private static uint CreateRandomSalt()
     {

--- a/src/Ahtola.Core/Storage/SqliteWal.cs
+++ b/src/Ahtola.Core/Storage/SqliteWal.cs
@@ -1518,6 +1518,39 @@ public sealed class SqliteWalFile : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
+    /// Durably discards every frame after <paramref name="lastRetainedFrameNumber"/>.
+    /// </summary>
+    /// <remarks>
+    /// A commit whose durable flush never succeeded still leaves checksum-valid,
+    /// commit-marked frames in the file, so hiding them in memory would only make
+    /// this process disagree with a peer that reads the same WAL. The writer that
+    /// abandoned the commit removes them instead, which is the durable equivalent
+    /// of the rollback SQLite performs when a WAL write fails. Unlike
+    /// <see cref="RecoverToLastCommittedFrameAsync"/> this trims to an explicit
+    /// boundary rather than to whatever the file currently says was committed.
+    /// </remarks>
+    internal async ValueTask TruncateToFrameAsync(
+        long lastRetainedFrameNumber,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ThrowIfReadOnly();
+        ArgumentOutOfRangeException.ThrowIfNegative(lastRetainedFrameNumber);
+
+        var file = GetAsyncFile();
+        var targetLength = LengthForFrameCount(lastRetainedFrameNumber);
+        var length = await file.GetLengthAsync(cancellationToken).ConfigureAwait(false);
+        if (length <= targetLength)
+            return;
+
+        await file.SetLengthAsync(targetLength, cancellationToken).ConfigureAwait(false);
+        if (await file.GetLengthAsync(cancellationToken).ConfigureAwait(false) != targetLength)
+            throw new InvalidDataException("SQLite WAL rollback truncation did not reach its requested boundary.");
+
+        await file.FlushToDiskAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Reclaims every committed frame after the caller has durably installed the
     /// same committed view in the main database file.
     /// </summary>

--- a/src/Ahtola.Core/Storage/SqliteWalSharedMemoryLocks.cs
+++ b/src/Ahtola.Core/Storage/SqliteWalSharedMemoryLocks.cs
@@ -18,7 +18,9 @@ namespace Ahtola.Core.Storage;
 /// process can still be using it. See
 /// <c>docs/wal-interoperability-contract.md</c> for the normative lock-byte map.
 /// </remarks>
-internal sealed class SqliteWalSharedMemoryLocks : ISqlitePagerLockCoordinator
+internal sealed class SqliteWalSharedMemoryLocks :
+    ISqlitePagerLockCoordinator,
+    IAsyncSqlitePagerLockCoordinator
 {
     private const long WriteLockOffset = 120;
     private const long RecoveryLockOffset = 122;
@@ -77,6 +79,48 @@ internal sealed class SqliteWalSharedMemoryLocks : ISqlitePagerLockCoordinator
             length: 1,
             timeout,
             allowCreate: true);
+
+    public ValueTask<IDisposable> AcquireAsync(
+        SqlitePagerLockOperation operation,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+        => AcquireAsync(operation, timeout, pagerReadOnly: true, cancellationToken);
+
+    internal ValueTask<IDisposable> AcquireAsync(
+        SqlitePagerLockOperation operation,
+        TimeSpan timeout,
+        bool pagerReadOnly,
+        CancellationToken cancellationToken = default)
+        => operation switch
+        {
+            SqlitePagerLockOperation.Reader => AcquireReaderAsync(timeout, pagerReadOnly, cancellationToken),
+            SqlitePagerLockOperation.Writer => AcquireExclusiveRangeAsync(
+                operation,
+                WriteLockOffset,
+                length: 1,
+                timeout,
+                allowCreate: true,
+                cancellationToken),
+            SqlitePagerLockOperation.Checkpoint => AcquireExclusiveRangeAsync(
+                operation,
+                WriteLockOffset,
+                LockRangeLength,
+                timeout,
+                allowCreate: true,
+                cancellationToken),
+            _ => throw new ArgumentOutOfRangeException(nameof(operation), operation, "Unknown SQLite WAL lock operation."),
+        };
+
+    public ValueTask<IDisposable> AcquireRecoveryAsync(
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+        => AcquireExclusiveRangeAsync(
+            SqlitePagerLockOperation.Writer,
+            RecoveryLockOffset,
+            length: 1,
+            timeout,
+            allowCreate: true,
+            cancellationToken);
 
     private IDisposable AcquireReader(TimeSpan timeout, bool pagerReadOnly)
     {
@@ -141,6 +185,7 @@ internal sealed class SqliteWalSharedMemoryLocks : ISqlitePagerLockCoordinator
                         _activeRangeCount++;
                         return new RangeLease(this, lease);
                     }
+
                 }
                 catch (IOException exception)
                 {
@@ -154,6 +199,100 @@ internal sealed class SqliteWalSharedMemoryLocks : ISqlitePagerLockCoordinator
 
             if (!WaitForRetry(timeout, stopwatch))
                 throw CreateBusyException(operation, timeout, contention as IOException);
+        }
+    }
+
+    private async ValueTask<IDisposable> AcquireReaderAsync(
+        TimeSpan timeout,
+        bool pagerReadOnly,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        EnsureCarrierExists(allowCreate: !pagerReadOnly);
+        var stopwatch = StartTimeout(timeout);
+        var attempt = 0;
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            lock (_gate)
+            {
+                ThrowIfFailed();
+                if (_readerReferenceCount != 0)
+                {
+                    _readerReferenceCount++;
+                    return new ReaderLease(this);
+                }
+
+                for (var slot = 0; slot < ReaderLockCount; slot++)
+                {
+                    if (_byteRangeLocks.TryAcquireShared(
+                            FirstReaderLockOffset + slot,
+                            length: 1,
+                            out var lease)
+                        && lease is not null)
+                    {
+                        _readerLockOffset = FirstReaderLockOffset + slot;
+                        _readerLease = lease;
+                        _readerReferenceCount = 1;
+                        _activeRangeCount++;
+                        return new ReaderLease(this);
+                    }
+                }
+            }
+
+            if (!await SqliteBusyBackoff
+                    .WaitAsync(attempt++, timeout, stopwatch, cancellationToken)
+                    .ConfigureAwait(false))
+            {
+                throw CreateBusyException(SqlitePagerLockOperation.Reader, timeout, innerException: null);
+            }
+        }
+    }
+
+    private async ValueTask<IDisposable> AcquireExclusiveRangeAsync(
+        SqlitePagerLockOperation operation,
+        long offset,
+        long length,
+        TimeSpan timeout,
+        bool allowCreate,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        EnsureCarrierExists(allowCreate);
+        var stopwatch = StartTimeout(timeout);
+        var attempt = 0;
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Exception? contention = null;
+            lock (_gate)
+            {
+                ThrowIfFailed();
+                try
+                {
+                    if (_byteRangeLocks.TryAcquireExclusive(offset, length, out var lease)
+                        && lease is not null)
+                    {
+                        _activeRangeCount++;
+                        return new RangeLease(this, lease);
+                    }
+                }
+                catch (IOException exception)
+                {
+                    contention = exception;
+                }
+                catch (UnauthorizedAccessException exception)
+                {
+                    contention = exception;
+                }
+            }
+
+            if (!await SqliteBusyBackoff
+                    .WaitAsync(attempt++, timeout, stopwatch, cancellationToken)
+                    .ConfigureAwait(false))
+            {
+                throw CreateBusyException(operation, timeout, contention as IOException);
+            }
         }
     }
 

--- a/src/Ahtola.Data.Sqlite.Browser/Ahtola.Data.Sqlite.Browser.csproj
+++ b/src/Ahtola.Data.Sqlite.Browser/Ahtola.Data.Sqlite.Browser.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+  <PropertyGroup>
+    <TargetFrameworks>$(AhtolaTargetFrameworks)</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RootNamespace>Ahtola.Data.Sqlite.Browser</RootNamespace>
+    <AssemblyName>Devolutions.Ahtola.Data.Sqlite.Browser</AssemblyName>
+
+    <PackageId>Devolutions.Ahtola.Data.Sqlite.Browser</PackageId>
+    <Title>Ahtola SQLite-compatible provider for browser WebAssembly</Title>
+    <Description>Browser WebAssembly support for the pure-managed Ahtola ADO.NET provider, with OPFS persistence through a dedicated Web Worker.</Description>
+    <Authors>Devolutions</Authors>
+    <PackageTags>ahtola;sqlite;database;ado.net;browser;webassembly;wasm;opfs;blazor;devolutions</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/Devolutions/ahtola</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Devolutions/ahtola</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <IsAotCompatible>true</IsAotCompatible>
+    <IsTrimmable>true</IsTrimmable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <SupportedPlatform Include="browser" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Ahtola.Data.Sqlite\Ahtola.Data.Sqlite.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="README.md" />
+  </ItemGroup>
+</Project>

--- a/src/Ahtola.Data.Sqlite.Browser/Ahtola.Data.Sqlite.Browser.csproj
+++ b/src/Ahtola.Data.Sqlite.Browser/Ahtola.Data.Sqlite.Browser.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Ahtola.Data.Sqlite\Ahtola.Data.Sqlite.csproj" />
+    <ProjectReference Include="..\Ahtola.Data\Ahtola.Data.csproj" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserAesGcmResult.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserAesGcmResult.cs
@@ -1,0 +1,17 @@
+namespace Ahtola.Data.Sqlite.Browser;
+
+/// <summary>An AES-GCM ciphertext and its separate AHTLA authentication tag.</summary>
+public sealed class AhtolaBrowserAesGcmResult
+{
+    internal AhtolaBrowserAesGcmResult(byte[] ciphertext, byte[] tag)
+    {
+        Ciphertext = ciphertext;
+        Tag = tag;
+    }
+
+    /// <summary>The encrypted bytes, excluding the authentication tag.</summary>
+    public byte[] Ciphertext { get; }
+
+    /// <summary>The 16-byte authentication tag.</summary>
+    public byte[] Tag { get; }
+}

--- a/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserCapabilities.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserCapabilities.cs
@@ -1,0 +1,18 @@
+namespace Ahtola.Data.Sqlite.Browser;
+
+/// <summary>Browser features required by the Ahtola OPFS backend.</summary>
+public readonly record struct AhtolaBrowserCapabilities(
+    bool IsCrossOriginIsolated,
+    bool HasSharedArrayBuffer,
+    bool HasOriginPrivateFileSystem,
+    bool HasSynchronousAccessHandles,
+    bool HasWebLocks)
+{
+    /// <summary>Whether every required browser feature is available.</summary>
+    public bool IsSupported =>
+        IsCrossOriginIsolated
+        && HasSharedArrayBuffer
+        && HasOriginPrivateFileSystem
+        && HasSynchronousAccessHandles
+        && HasWebLocks;
+}

--- a/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserCapabilities.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserCapabilities.cs
@@ -15,4 +15,29 @@ public readonly record struct AhtolaBrowserCapabilities(
         && HasOriginPrivateFileSystem
         && HasSynchronousAccessHandles
         && HasWebLocks;
+
+    /// <summary>
+    /// Names of the required browser features that are not available. Used
+    /// to produce a precise diagnostic instead of a single all-or-nothing
+    /// message, so a caller (including CI tooling) can distinguish "this
+    /// browser truly lacks OPFS" from a broader, unexpected regression.
+    /// </summary>
+    public IReadOnlyList<string> MissingCapabilities
+    {
+        get
+        {
+            var missing = new List<string>();
+            if (!IsCrossOriginIsolated)
+                missing.Add("cross-origin isolation");
+            if (!HasSharedArrayBuffer)
+                missing.Add("SharedArrayBuffer");
+            if (!HasOriginPrivateFileSystem)
+                missing.Add("Origin Private File System");
+            if (!HasSynchronousAccessHandles)
+                missing.Add("Origin Private File System synchronous access handles");
+            if (!HasWebLocks)
+                missing.Add("Web Locks");
+            return missing;
+        }
+    }
 }

--- a/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserCryptoDiagnostics.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserCryptoDiagnostics.cs
@@ -89,6 +89,31 @@ public static class AhtolaBrowserCryptoDiagnostics
             var plaintextMatches = CryptographicOperations.FixedTimeEquals(
                 decrypted,
                 vector.Plaintext);
+            var tamperedTag = encrypted.Tag.ToArray();
+            try
+            {
+                tamperedTag[0] ^= 0x80;
+                try
+                {
+                    var unexpected = await service
+                        .DecryptAsync(
+                            encrypted.Ciphertext,
+                            tamperedTag,
+                            vector.Nonce,
+                            vector.AssociatedData)
+                        .ConfigureAwait(false);
+                    CryptographicOperations.ZeroMemory(unexpected);
+                    return false;
+                }
+                catch (AuthenticationTagMismatchException)
+                {
+                }
+            }
+            finally
+            {
+                CryptographicOperations.ZeroMemory(tamperedTag);
+            }
+
             return ciphertextMatches && tagMatches && plaintextMatches;
         }
         finally

--- a/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserCryptoDiagnostics.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserCryptoDiagnostics.cs
@@ -1,0 +1,118 @@
+using System.Runtime.Versioning;
+using System.Security.Cryptography;
+using Ahtola.Core.Storage;
+using Ahtola.Data.Sqlite.Browser.Interop;
+
+namespace Ahtola.Data.Sqlite.Browser;
+
+/// <summary>Browser-facing known-answer diagnostics for Web Crypto integration tests.</summary>
+[SupportedOSPlatform("browser")]
+public static class AhtolaBrowserCryptoDiagnostics
+{
+    /// <summary>Runs PBKDF2, AES-128-GCM, AES-256-GCM, AAD, and key-release checks.</summary>
+    public static async ValueTask<AhtolaBrowserCryptoDiagnosticResult> RunKnownAnswersAsync()
+    {
+        await AhtolaBrowserCryptoRuntime.InitializeAsync().ConfigureAwait(false);
+        var retainedKeysBefore = BrowserCryptoInterop.GetRetainedKeyCount();
+
+        var expectedPasswordKey = AhtolaBrowserCryptoKnownAnswers.GetPasswordKey();
+        var actualPasswordKey = await AhtolaBrowserCryptoService
+            .DerivePasswordKeyBytesAsync(AhtolaBrowserCryptoKnownAnswers.Password)
+            .ConfigureAwait(false);
+        bool passwordMatches;
+        try
+        {
+            passwordMatches = CryptographicOperations.FixedTimeEquals(
+                expectedPasswordKey,
+                actualPasswordKey);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(expectedPasswordKey);
+            CryptographicOperations.ZeroMemory(actualPasswordKey);
+        }
+
+        bool aes128Matches;
+        using (var vector = AhtolaBrowserCryptoKnownAnswers.GetAes128())
+        {
+            aes128Matches = await VerifyAesGcmAsync(
+                    AhtolaEncryptionCipher.Aes128Gcm,
+                    vector)
+                .ConfigureAwait(false);
+        }
+
+        bool aes256Matches;
+        using (var vector = AhtolaBrowserCryptoKnownAnswers.GetAes256())
+        {
+            aes256Matches = await VerifyAesGcmAsync(
+                    AhtolaEncryptionCipher.Aes256Gcm,
+                    vector)
+                .ConfigureAwait(false);
+        }
+
+        var retainedKeysAfter = BrowserCryptoInterop.GetRetainedKeyCount();
+        return new AhtolaBrowserCryptoDiagnosticResult(
+            passwordMatches,
+            aes128Matches,
+            aes256Matches,
+            retainedKeysBefore,
+            retainedKeysAfter);
+    }
+
+    private static async ValueTask<bool> VerifyAesGcmAsync(
+        AhtolaEncryptionCipher cipher,
+        AhtolaBrowserAesGcmKnownAnswer vector)
+    {
+        await using var service = await AhtolaBrowserCryptoService
+            .CreateAsync(cipher, vector.Key)
+            .ConfigureAwait(false);
+        var encrypted = await service
+            .EncryptAsync(
+                vector.Plaintext,
+                vector.Nonce,
+                vector.AssociatedData)
+            .ConfigureAwait(false);
+        byte[]? decrypted = null;
+        try
+        {
+            var ciphertextMatches = CryptographicOperations.FixedTimeEquals(
+                encrypted.Ciphertext,
+                vector.Ciphertext);
+            var tagMatches = CryptographicOperations.FixedTimeEquals(encrypted.Tag, vector.Tag);
+            decrypted = await service
+                .DecryptAsync(
+                    encrypted.Ciphertext,
+                    encrypted.Tag,
+                    vector.Nonce,
+                    vector.AssociatedData)
+                .ConfigureAwait(false);
+            var plaintextMatches = CryptographicOperations.FixedTimeEquals(
+                decrypted,
+                vector.Plaintext);
+            return ciphertextMatches && tagMatches && plaintextMatches;
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(encrypted.Ciphertext);
+            CryptographicOperations.ZeroMemory(encrypted.Tag);
+            if (decrypted is not null)
+                CryptographicOperations.ZeroMemory(decrypted);
+        }
+    }
+}
+
+/// <summary>Results from the browser Web Crypto known-answer diagnostic.</summary>
+public readonly record struct AhtolaBrowserCryptoDiagnosticResult(
+    bool PasswordV1Matches,
+    bool Aes128GcmMatches,
+    bool Aes256GcmMatches,
+    int RetainedKeysBefore,
+    int RetainedKeysAfter)
+{
+    /// <summary>Whether all vectors matched and the diagnostic released every key it created.</summary>
+    public bool Succeeded =>
+        PasswordV1Matches
+        && Aes128GcmMatches
+        && Aes256GcmMatches
+        && RetainedKeysAfter == RetainedKeysBefore;
+}

--- a/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserCryptoKnownAnswers.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserCryptoKnownAnswers.cs
@@ -1,0 +1,78 @@
+using System.Security.Cryptography;
+
+namespace Ahtola.Data.Sqlite.Browser;
+
+internal static class AhtolaBrowserCryptoKnownAnswers
+{
+    internal const string Password = "ahtola-browser-test";
+
+    internal static byte[] GetPasswordKey()
+        => Convert.FromHexString("F320F26F76939AF6E9D2F8997A4B40B13A78BDC088F0178DA97C66748CD562F5");
+
+    internal static AhtolaBrowserAesGcmKnownAnswer GetAes128()
+        => new(
+            key: Convert.FromHexString("FEFFE9928665731C6D6A8F9467308308"),
+            nonce: Convert.FromHexString("CAFEBABEFACEDBADDECAF888"),
+            plaintext: Convert.FromHexString(
+                "D9313225F88406E5A55909C5AFF5269A"
+                + "86A7A9531534F7DA2E4C303D8A318A72"
+                + "1C3C0C95956809532FCF0E2449A6B525"
+                + "B16AEDF5AA0DE657BA637B39"),
+            associatedData: Convert.FromHexString("FEEDFACEDEADBEEFFEEDFACEDEADBEEFABADDAD2"),
+            ciphertext: Convert.FromHexString(
+                "42831EC2217774244B7221B784D0D49C"
+                + "E3AA212F2C02A4E035C17E2329ACA12E"
+                + "21D514B25466931C7D8F6A5AAC84AA05"
+                + "1BA30B396A0AAC973D58E091"),
+            tag: Convert.FromHexString("5BC94FBC3221A5DB94FAE95AE7121A47"));
+
+    internal static AhtolaBrowserAesGcmKnownAnswer GetAes256()
+        => new(
+            key: new byte[32],
+            nonce: new byte[AhtolaBrowserCryptoParameters.AesGcmNonceSize],
+            plaintext: new byte[16],
+            associatedData: [],
+            ciphertext: Convert.FromHexString("CEA7403D4D606B6E074EC5D3BAF39D18"),
+            tag: Convert.FromHexString("D0D1C8A799996BF0265B98B5D48AB919"));
+}
+
+internal sealed class AhtolaBrowserAesGcmKnownAnswer : IDisposable
+{
+    internal AhtolaBrowserAesGcmKnownAnswer(
+        byte[] key,
+        byte[] nonce,
+        byte[] plaintext,
+        byte[] associatedData,
+        byte[] ciphertext,
+        byte[] tag)
+    {
+        Key = key;
+        Nonce = nonce;
+        Plaintext = plaintext;
+        AssociatedData = associatedData;
+        Ciphertext = ciphertext;
+        Tag = tag;
+    }
+
+    internal byte[] Key { get; }
+
+    internal byte[] Nonce { get; }
+
+    internal byte[] Plaintext { get; }
+
+    internal byte[] AssociatedData { get; }
+
+    internal byte[] Ciphertext { get; }
+
+    internal byte[] Tag { get; }
+
+    public void Dispose()
+    {
+        CryptographicOperations.ZeroMemory(Key);
+        CryptographicOperations.ZeroMemory(Nonce);
+        CryptographicOperations.ZeroMemory(Plaintext);
+        CryptographicOperations.ZeroMemory(AssociatedData);
+        CryptographicOperations.ZeroMemory(Ciphertext);
+        CryptographicOperations.ZeroMemory(Tag);
+    }
+}

--- a/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserCryptoParameters.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserCryptoParameters.cs
@@ -1,0 +1,36 @@
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Data.Sqlite.Browser;
+
+/// <summary>Stable Web Crypto parameters used by Ahtola encrypted pages.</summary>
+public static class AhtolaBrowserCryptoParameters
+{
+    /// <summary>The passphrase scheme implemented by the browser crypto service.</summary>
+    public const string PasswordSchemeId = AhtolaPasswordEncryption.SchemeIdV1;
+
+    /// <summary>The UTF-8 domain salt for <see cref="PasswordSchemeId"/>.</summary>
+    public const string PasswordSalt = AhtolaPasswordEncryption.DomainSaltV1;
+
+    /// <summary>The PBKDF2 iteration count for <see cref="PasswordSchemeId"/>.</summary>
+    public const int PasswordIterations = AhtolaPasswordEncryption.Pbkdf2IterationsV1;
+
+    /// <summary>The AES-256 key size produced by <see cref="PasswordSchemeId"/>.</summary>
+    public const int PasswordKeySize = 32;
+
+    /// <summary>The nonce size stored in every AHTLA AES-GCM page.</summary>
+    public const int AesGcmNonceSize = 12;
+
+    /// <summary>The authentication tag size stored in every AHTLA AES-GCM page.</summary>
+    public const int AesGcmTagSize = 16;
+
+    internal static int GetKeySize(AhtolaEncryptionCipher cipher)
+        => cipher switch
+        {
+            AhtolaEncryptionCipher.Aes128Gcm => 16,
+            AhtolaEncryptionCipher.Aes256Gcm => 32,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(cipher),
+                cipher,
+                "Browser Web Crypto supports only AHTLA AES-128-GCM and AES-256-GCM."),
+        };
+}

--- a/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserCryptoParameters.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserCryptoParameters.cs
@@ -33,4 +33,20 @@ public static class AhtolaBrowserCryptoParameters
                 cipher,
                 "Browser Web Crypto supports only AHTLA AES-128-GCM and AES-256-GCM."),
         };
+
+    /// <summary>
+    /// Maps the provider-level cipher enum onto the storage cipher whose numeric
+    /// value is written into the AHTLA page 1 header. The two enums do not share
+    /// numeric values, so this must always convert by name.
+    /// </summary>
+    internal static Core.Storage.AhtolaEncryptionCipher ToStorageCipher(AhtolaEncryptionCipher cipher)
+        => cipher switch
+        {
+            AhtolaEncryptionCipher.Aes128Gcm => Core.Storage.AhtolaEncryptionCipher.Aes128Gcm,
+            AhtolaEncryptionCipher.Aes256Gcm => Core.Storage.AhtolaEncryptionCipher.Aes256Gcm,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(cipher),
+                cipher,
+                "Browser Web Crypto supports only AHTLA AES-128-GCM and AES-256-GCM."),
+        };
 }

--- a/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserCryptoService.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserCryptoService.cs
@@ -1,0 +1,212 @@
+using System.Runtime.Versioning;
+using System.Security.Cryptography;
+using Ahtola.Core.Storage;
+using Ahtola.Data.Sqlite.Browser.Interop;
+
+namespace Ahtola.Data.Sqlite.Browser;
+
+/// <summary>
+/// Provides AHTLA-compatible PBKDF2-HMAC-SHA256 and AES-GCM through browser Web Crypto.
+/// </summary>
+[SupportedOSPlatform("browser")]
+public sealed class AhtolaBrowserCryptoService : IDisposable, IAsyncDisposable
+{
+    private int _keyHandle;
+
+    private AhtolaBrowserCryptoService(AhtolaEncryptionCipher cipher, int keyHandle)
+    {
+        Cipher = cipher;
+        _keyHandle = keyHandle;
+    }
+
+    /// <summary>The AHTLA AES-GCM cipher represented by this service.</summary>
+    public AhtolaEncryptionCipher Cipher { get; }
+
+    /// <summary>
+    /// Derives a non-extractable AES-256-GCM key using <c>Ahtola.Password.v1</c>.
+    /// </summary>
+    public static async ValueTask<AhtolaBrowserCryptoService> CreateFromPasswordAsync(string password)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(password);
+
+        await AhtolaBrowserCryptoRuntime.InitializeAsync().ConfigureAwait(false);
+        var handle = await BrowserCryptoInterop.CreatePasswordKeyAsync(
+                password,
+                AhtolaBrowserCryptoParameters.PasswordSalt,
+                AhtolaBrowserCryptoParameters.PasswordIterations,
+                AhtolaBrowserCryptoParameters.PasswordKeySize * 8)
+            .ConfigureAwait(false);
+        return new AhtolaBrowserCryptoService(AhtolaEncryptionCipher.Aes256Gcm, handle);
+    }
+
+    /// <summary>Imports an exact AES-128 or AES-256 key as a non-extractable Web Crypto key.</summary>
+    public static async ValueTask<AhtolaBrowserCryptoService> CreateAsync(
+        AhtolaEncryptionCipher cipher,
+        ReadOnlyMemory<byte> key)
+    {
+        var requiredKeySize = AhtolaBrowserCryptoParameters.GetKeySize(cipher);
+        if (key.Length != requiredKeySize)
+        {
+            throw new ArgumentException(
+                $"{cipher} requires a {requiredKeySize}-byte key, but the supplied key has {key.Length} bytes.",
+                nameof(key));
+        }
+
+        var keyCopy = key.ToArray();
+        try
+        {
+            await AhtolaBrowserCryptoRuntime.InitializeAsync().ConfigureAwait(false);
+            var handle = await BrowserCryptoInterop.ImportAesGcmKeyAsync(keyCopy).ConfigureAwait(false);
+            return new AhtolaBrowserCryptoService(cipher, handle);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(keyCopy);
+        }
+    }
+
+    /// <summary>
+    /// Derives the raw 32-byte <c>Ahtola.Password.v1</c> key for interoperability diagnostics.
+    /// The caller owns and should clear the returned key.
+    /// </summary>
+    public static async ValueTask<byte[]> DerivePasswordKeyBytesAsync(string password)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(password);
+
+        await AhtolaBrowserCryptoRuntime.InitializeAsync().ConfigureAwait(false);
+        using var result = await BrowserCryptoInterop.DerivePasswordBitsAsync(
+                password,
+                AhtolaBrowserCryptoParameters.PasswordSalt,
+                AhtolaBrowserCryptoParameters.PasswordIterations,
+                AhtolaBrowserCryptoParameters.PasswordKeySize * 8)
+            .ConfigureAwait(false);
+        var key = BrowserCryptoInterop.ConsumeByteArray(result);
+        if (key.Length != AhtolaBrowserCryptoParameters.PasswordKeySize)
+        {
+            CryptographicOperations.ZeroMemory(key);
+            throw new CryptographicException("Web Crypto returned an invalid Ahtola.Password.v1 key length.");
+        }
+
+        return key;
+    }
+
+    /// <summary>Encrypts bytes with a caller-supplied AHTLA nonce and associated data.</summary>
+    public async ValueTask<AhtolaBrowserAesGcmResult> EncryptAsync(
+        ReadOnlyMemory<byte> plaintext,
+        ReadOnlyMemory<byte> nonce,
+        ReadOnlyMemory<byte> associatedData = default)
+    {
+        ValidateNonce(nonce);
+        var keyHandle = GetKeyHandle();
+        var plaintextCopy = plaintext.ToArray();
+        var nonceCopy = nonce.ToArray();
+        var associatedDataCopy = associatedData.ToArray();
+        try
+        {
+            using var result = await BrowserCryptoInterop.EncryptAesGcmAsync(
+                    keyHandle,
+                    nonceCopy,
+                    plaintextCopy,
+                    associatedDataCopy)
+                .ConfigureAwait(false);
+            var combined = BrowserCryptoInterop.ConsumeByteArray(result);
+            try
+            {
+                if (combined.Length != plaintext.Length + AhtolaBrowserCryptoParameters.AesGcmTagSize)
+                    throw new CryptographicException("Web Crypto returned an invalid AES-GCM ciphertext length.");
+
+                var ciphertext = combined.AsSpan(0, plaintext.Length).ToArray();
+                var tag = combined.AsSpan(plaintext.Length).ToArray();
+                return new AhtolaBrowserAesGcmResult(ciphertext, tag);
+            }
+            finally
+            {
+                CryptographicOperations.ZeroMemory(combined);
+            }
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(plaintextCopy);
+            CryptographicOperations.ZeroMemory(nonceCopy);
+            CryptographicOperations.ZeroMemory(associatedDataCopy);
+        }
+    }
+
+    /// <summary>Authenticates and decrypts bytes using separate AHTLA tag, nonce, and associated data.</summary>
+    public async ValueTask<byte[]> DecryptAsync(
+        ReadOnlyMemory<byte> ciphertext,
+        ReadOnlyMemory<byte> tag,
+        ReadOnlyMemory<byte> nonce,
+        ReadOnlyMemory<byte> associatedData = default)
+    {
+        ValidateNonce(nonce);
+        if (tag.Length != AhtolaBrowserCryptoParameters.AesGcmTagSize)
+        {
+            throw new ArgumentException(
+                $"AHTLA AES-GCM tags must be exactly {AhtolaBrowserCryptoParameters.AesGcmTagSize} bytes.",
+                nameof(tag));
+        }
+
+        var keyHandle = GetKeyHandle();
+        var ciphertextCopy = ciphertext.ToArray();
+        var tagCopy = tag.ToArray();
+        var nonceCopy = nonce.ToArray();
+        var associatedDataCopy = associatedData.ToArray();
+        try
+        {
+            using var result = await BrowserCryptoInterop.DecryptAesGcmAsync(
+                    keyHandle,
+                    nonceCopy,
+                    ciphertextCopy,
+                    tagCopy,
+                    associatedDataCopy)
+                .ConfigureAwait(false);
+            var plaintext = BrowserCryptoInterop.ConsumeByteArray(result);
+            if (plaintext.Length != ciphertext.Length)
+            {
+                CryptographicOperations.ZeroMemory(plaintext);
+                throw new CryptographicException("Web Crypto returned an invalid AES-GCM plaintext length.");
+            }
+
+            return plaintext;
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(ciphertextCopy);
+            CryptographicOperations.ZeroMemory(tagCopy);
+            CryptographicOperations.ZeroMemory(nonceCopy);
+            CryptographicOperations.ZeroMemory(associatedDataCopy);
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        var keyHandle = Interlocked.Exchange(ref _keyHandle, 0);
+        if (keyHandle != 0)
+            BrowserCryptoInterop.ReleaseKey(keyHandle);
+    }
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    private int GetKeyHandle()
+    {
+        ObjectDisposedException.ThrowIf(_keyHandle == 0, this);
+        return _keyHandle;
+    }
+
+    private static void ValidateNonce(ReadOnlyMemory<byte> nonce)
+    {
+        if (nonce.Length != AhtolaBrowserCryptoParameters.AesGcmNonceSize)
+        {
+            throw new ArgumentException(
+                $"AHTLA AES-GCM nonces must be exactly {AhtolaBrowserCryptoParameters.AesGcmNonceSize} bytes.",
+                nameof(nonce));
+        }
+    }
+}

--- a/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserCryptoService.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserCryptoService.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices.JavaScript;
 using System.Runtime.Versioning;
 using System.Security.Cryptography;
 using Ahtola.Core.Storage;
@@ -154,21 +155,35 @@ public sealed class AhtolaBrowserCryptoService : IDisposable, IAsyncDisposable
         var associatedDataCopy = associatedData.ToArray();
         try
         {
-            using var result = await BrowserCryptoInterop.DecryptAesGcmAsync(
-                    keyHandle,
-                    nonceCopy,
-                    ciphertextCopy,
-                    tagCopy,
-                    associatedDataCopy)
-                .ConfigureAwait(false);
-            var plaintext = BrowserCryptoInterop.ConsumeByteArray(result);
-            if (plaintext.Length != ciphertext.Length)
+            JSObject result;
+            try
             {
-                CryptographicOperations.ZeroMemory(plaintext);
-                throw new CryptographicException("Web Crypto returned an invalid AES-GCM plaintext length.");
+                result = await BrowserCryptoInterop.DecryptAesGcmAsync(
+                        keyHandle,
+                        nonceCopy,
+                        ciphertextCopy,
+                        tagCopy,
+                        associatedDataCopy)
+                    .ConfigureAwait(false);
             }
+            catch (JSException exception) when (
+                exception.Message.Contains("OperationError", StringComparison.Ordinal))
+            {
+                throw new AuthenticationTagMismatchException(
+                    "The AHTLA AES-GCM authentication tag does not match.",
+                    exception);
+            }
+            using (result)
+            {
+                var plaintext = BrowserCryptoInterop.ConsumeByteArray(result);
+                if (plaintext.Length != ciphertext.Length)
+                {
+                    CryptographicOperations.ZeroMemory(plaintext);
+                    throw new CryptographicException("Web Crypto returned an invalid AES-GCM plaintext length.");
+                }
 
-            return plaintext;
+                return plaintext;
+            }
         }
         finally
         {

--- a/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserDataSource.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserDataSource.cs
@@ -13,6 +13,7 @@ public sealed class AhtolaBrowserDataSource : DbDataSource, IManagedDatabaseFact
 {
     private readonly object _gate = new();
     private readonly AhtolaBrowserOptions _options;
+    private readonly bool _ownsOptions;
     private readonly AhtolaBrowserEncryptionOptions? _encryption;
     private readonly string _memoryName = "ahtola-browser-memory-" + Guid.NewGuid().ToString("N");
     private IManagedDatabaseAdapter? _memoryOwner;
@@ -22,12 +23,19 @@ public sealed class AhtolaBrowserDataSource : DbDataSource, IManagedDatabaseFact
     private bool _disposed;
 
     public AhtolaBrowserDataSource(AhtolaBrowserOptions options)
+        : this(options ?? throw new ArgumentNullException(nameof(options)), ownsOptions: false)
     {
-        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
 
-        // Snapshot the key material so the caller can dispose its options object
-        // immediately without breaking a data source that opens storage lazily.
-        _encryption = options.Encryption?.CreateOwnedCopy();
+    private AhtolaBrowserDataSource(AhtolaBrowserOptions options, bool ownsOptions)
+    {
+        _options = options;
+        _ownsOptions = ownsOptions;
+
+        // Options this instance created are disposed with it, so their single copy
+        // of the key is the one used and zeroed. Caller-owned options may be
+        // disposed at any time, so take an independent snapshot instead.
+        _encryption = ownsOptions ? null : options.Encryption?.CreateOwnedCopy();
     }
 
     public AhtolaBrowserDataSource(
@@ -36,7 +44,9 @@ public sealed class AhtolaBrowserDataSource : DbDataSource, IManagedDatabaseFact
         int sharedBufferSize = AhtolaBrowserOptions.DefaultSharedBufferSize,
         bool readOnly = false,
         AhtolaBrowserEncryptionOptions? encryption = null)
-        : this(new AhtolaBrowserOptions(databasePath, ownedDirectory, sharedBufferSize, readOnly, encryption))
+        : this(
+            new AhtolaBrowserOptions(databasePath, ownedDirectory, sharedBufferSize, readOnly, encryption),
+            ownsOptions: true)
     {
     }
 
@@ -45,7 +55,9 @@ public sealed class AhtolaBrowserDataSource : DbDataSource, IManagedDatabaseFact
         int sharedBufferSize = AhtolaBrowserOptions.DefaultSharedBufferSize,
         bool readOnly = false,
         AhtolaBrowserEncryptionOptions? encryption = null)
-        : this(new AhtolaBrowserOptions(databasePath, sharedBufferSize, readOnly, encryption))
+        : this(
+            new AhtolaBrowserOptions(databasePath, sharedBufferSize, readOnly, encryption),
+            ownsOptions: true)
     {
     }
 
@@ -210,7 +222,7 @@ public sealed class AhtolaBrowserDataSource : DbDataSource, IManagedDatabaseFact
             }
             finally
             {
-                _encryption?.Dispose();
+                ReleaseKeyMaterial();
             }
             return;
         }
@@ -222,7 +234,7 @@ public sealed class AhtolaBrowserDataSource : DbDataSource, IManagedDatabaseFact
         }
         catch
         {
-            _encryption?.Dispose();
+            ReleaseKeyMaterial();
             return;
         }
 
@@ -232,8 +244,21 @@ public sealed class AhtolaBrowserDataSource : DbDataSource, IManagedDatabaseFact
         }
         finally
         {
-            _encryption?.Dispose();
+            ReleaseKeyMaterial();
         }
+    }
+
+    private AhtolaBrowserEncryptionOptions? EffectiveEncryption => _encryption ?? _options.Encryption;
+
+    /// <summary>
+    /// Zeros this instance's key material and, when it created the options itself,
+    /// the copy those options hold. Runs on every disposal and failure path.
+    /// </summary>
+    private void ReleaseKeyMaterial()
+    {
+        _encryption?.Dispose();
+        if (_ownsOptions)
+            _options.Dispose();
     }
 
     private async Task<StorageState> InitializeAsync()
@@ -243,12 +268,13 @@ public sealed class AhtolaBrowserDataSource : DbDataSource, IManagedDatabaseFact
         BrowserEncryptedPersistence? encryption = null;
         try
         {
-            if (_encryption is { } encryptionOptions)
+            if (EffectiveEncryption is { } encryptionOptions)
             {
                 var cipher = await AhtolaBrowserWebCryptoPageCipher
                     .CreateAsync(encryptionOptions)
                     .ConfigureAwait(false);
                 encryption = new BrowserEncryptedPersistence(new AhtolaAsyncPageTransformer(cipher));
+                encryption.RegisterDatabase(_options.DatabasePath);
             }
 
             persistent = await OpfsAsyncFileSystem

--- a/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserDataSource.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserDataSource.cs
@@ -14,6 +14,8 @@ public sealed class AhtolaBrowserDataSource : DbDataSource, IManagedDatabaseFact
     private readonly object _gate = new();
     private readonly AhtolaBrowserOptions _options;
     private readonly AhtolaBrowserEncryptionOptions? _encryption;
+    private readonly string _memoryName = "ahtola-browser-memory-" + Guid.NewGuid().ToString("N");
+    private IManagedDatabaseAdapter? _memoryOwner;
     private Task<StorageState>? _initialization;
     private TaskCompletionSource? _connectionsDrained;
     private int _activeConnections;
@@ -55,6 +57,8 @@ public sealed class AhtolaBrowserDataSource : DbDataSource, IManagedDatabaseFact
 
     bool IManagedDatabaseFactory.IsReadOnly => _options.IsReadOnly;
 
+    bool IManagedDatabaseFactory.IsSharedMemory => _options.IsInMemory;
+
     public new SqliteConnection CreateConnection()
     {
         ThrowIfDisposed();
@@ -95,6 +99,23 @@ public sealed class AhtolaBrowserDataSource : DbDataSource, IManagedDatabaseFact
     async ValueTask<IManagedDatabaseAdapter> IManagedDatabaseFactory.OpenDatabaseAsync(
         CancellationToken cancellationToken)
     {
+        if (_options.IsInMemory)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            EnsureMemoryDatabase();
+            AddConnectionReference();
+            try
+            {
+                var inner = global::Ahtola.ManagedSharedMemoryDatabase.Open(_memoryName);
+                return new BrowserInMemoryManagedDatabaseAdapter(inner, ReleaseConnection);
+            }
+            catch
+            {
+                ReleaseConnection();
+                throw;
+            }
+        }
+
         Task<StorageState> initialization;
         lock (_gate)
         {
@@ -119,14 +140,7 @@ public sealed class AhtolaBrowserDataSource : DbDataSource, IManagedDatabaseFact
             }
             throw;
         }
-        lock (_gate)
-        {
-            ObjectDisposedException.ThrowIf(_disposed, this);
-            checked
-            {
-                _activeConnections++;
-            }
-        }
+        AddConnectionReference();
 
         try
         {
@@ -167,6 +181,7 @@ public sealed class AhtolaBrowserDataSource : DbDataSource, IManagedDatabaseFact
     {
         Task<StorageState>? initialization;
         Task? drained = null;
+        IManagedDatabaseAdapter? memoryOwner;
         lock (_gate)
         {
             if (_disposed)
@@ -174,6 +189,8 @@ public sealed class AhtolaBrowserDataSource : DbDataSource, IManagedDatabaseFact
 
             _disposed = true;
             initialization = _initialization;
+            memoryOwner = _memoryOwner;
+            _memoryOwner = null;
             if (_activeConnections != 0)
             {
                 _connectionsDrained = new TaskCompletionSource(
@@ -186,7 +203,15 @@ public sealed class AhtolaBrowserDataSource : DbDataSource, IManagedDatabaseFact
             await drained.ConfigureAwait(false);
         if (initialization is null)
         {
-            _encryption?.Dispose();
+            try
+            {
+                if (memoryOwner is not null)
+                    await memoryOwner.DisposeAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                _encryption?.Dispose();
+            }
             return;
         }
 
@@ -270,6 +295,27 @@ public sealed class AhtolaBrowserDataSource : DbDataSource, IManagedDatabaseFact
         }
 
         drained?.TrySetResult();
+    }
+
+    private void AddConnectionReference()
+    {
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            checked
+            {
+                _activeConnections++;
+            }
+        }
+    }
+
+    private void EnsureMemoryDatabase()
+    {
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            _memoryOwner ??= global::Ahtola.ManagedSharedMemoryDatabase.Open(_memoryName);
+        }
     }
 
     private void ThrowIfDisposed()

--- a/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserDataSource.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserDataSource.cs
@@ -13,6 +13,7 @@ public sealed class AhtolaBrowserDataSource : DbDataSource, IManagedDatabaseFact
 {
     private readonly object _gate = new();
     private readonly AhtolaBrowserOptions _options;
+    private readonly AhtolaBrowserEncryptionOptions? _encryption;
     private Task<StorageState>? _initialization;
     private TaskCompletionSource? _connectionsDrained;
     private int _activeConnections;
@@ -21,22 +22,28 @@ public sealed class AhtolaBrowserDataSource : DbDataSource, IManagedDatabaseFact
     public AhtolaBrowserDataSource(AhtolaBrowserOptions options)
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
+
+        // Snapshot the key material so the caller can dispose its options object
+        // immediately without breaking a data source that opens storage lazily.
+        _encryption = options.Encryption?.CreateOwnedCopy();
     }
 
     public AhtolaBrowserDataSource(
         string databasePath,
         string ownedDirectory,
         int sharedBufferSize = AhtolaBrowserOptions.DefaultSharedBufferSize,
-        bool readOnly = false)
-        : this(new AhtolaBrowserOptions(databasePath, ownedDirectory, sharedBufferSize, readOnly))
+        bool readOnly = false,
+        AhtolaBrowserEncryptionOptions? encryption = null)
+        : this(new AhtolaBrowserOptions(databasePath, ownedDirectory, sharedBufferSize, readOnly, encryption))
     {
     }
 
     public AhtolaBrowserDataSource(
         string databasePath,
         int sharedBufferSize = AhtolaBrowserOptions.DefaultSharedBufferSize,
-        bool readOnly = false)
-        : this(new AhtolaBrowserOptions(databasePath, sharedBufferSize, readOnly))
+        bool readOnly = false,
+        AhtolaBrowserEncryptionOptions? encryption = null)
+        : this(new AhtolaBrowserOptions(databasePath, sharedBufferSize, readOnly, encryption))
     {
     }
 
@@ -178,7 +185,10 @@ public sealed class AhtolaBrowserDataSource : DbDataSource, IManagedDatabaseFact
         if (drained is not null)
             await drained.ConfigureAwait(false);
         if (initialization is null)
+        {
+            _encryption?.Dispose();
             return;
+        }
 
         StorageState storage;
         try
@@ -187,18 +197,35 @@ public sealed class AhtolaBrowserDataSource : DbDataSource, IManagedDatabaseFact
         }
         catch
         {
+            _encryption?.Dispose();
             return;
         }
 
-        await storage.DisposeAsync().ConfigureAwait(false);
+        try
+        {
+            await storage.DisposeAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            _encryption?.Dispose();
+        }
     }
 
     private async Task<StorageState> InitializeAsync()
     {
         OpfsAsyncFileSystem? persistent = null;
         BrowserMirroredFileSystem? mirror = null;
+        BrowserEncryptedPersistence? encryption = null;
         try
         {
+            if (_encryption is { } encryptionOptions)
+            {
+                var cipher = await AhtolaBrowserWebCryptoPageCipher
+                    .CreateAsync(encryptionOptions)
+                    .ConfigureAwait(false);
+                encryption = new BrowserEncryptedPersistence(new AhtolaAsyncPageTransformer(cipher));
+            }
+
             persistent = await OpfsAsyncFileSystem
                 .CreateAsync(
                     _options.OwnedDirectory,
@@ -209,14 +236,17 @@ public sealed class AhtolaBrowserDataSource : DbDataSource, IManagedDatabaseFact
                 .CreateAsync(
                     persistent,
                     _options.OwnedDirectory,
+                    encryption: encryption,
                     cancellationToken: CancellationToken.None)
                 .ConfigureAwait(false);
-            return new StorageState(persistent, mirror);
+            return new StorageState(persistent, mirror, encryption);
         }
         catch
         {
             if (mirror is not null)
                 await mirror.DisposeAsync().ConfigureAwait(false);
+            if (encryption is not null)
+                await encryption.DisposeAsync().ConfigureAwait(false);
             if (persistent is not null)
                 await persistent.DisposeAsync().ConfigureAwait(false);
             throw;
@@ -254,11 +284,17 @@ public sealed class AhtolaBrowserDataSource : DbDataSource, IManagedDatabaseFact
             + "Use the corresponding asynchronous API.");
 
     private sealed class StorageState(
-        OpfsAsyncFileSystem persistent,
-        BrowserMirroredFileSystem mirror) : IAsyncDisposable
+        IBrowserPersistentStore persistent,
+        BrowserMirroredFileSystem mirror,
+        BrowserEncryptedPersistence? encryption) : IAsyncDisposable
     {
         public BrowserMirroredFileSystem Mirror { get; } = mirror;
 
+        /// <summary>
+        /// Drains and persists first, then releases the Web Crypto key, then closes
+        /// OPFS. Releasing the key earlier would fail pending encrypted writes, and
+        /// closing OPFS earlier would drop bytes the mirror still owes.
+        /// </summary>
         public async ValueTask DisposeAsync()
         {
             try
@@ -267,7 +303,15 @@ public sealed class AhtolaBrowserDataSource : DbDataSource, IManagedDatabaseFact
             }
             finally
             {
-                await persistent.DisposeAsync().ConfigureAwait(false);
+                try
+                {
+                    if (encryption is not null)
+                        await encryption.DisposeAsync().ConfigureAwait(false);
+                }
+                finally
+                {
+                    await persistent.DisposeAsync().ConfigureAwait(false);
+                }
             }
         }
     }

--- a/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserDataSource.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserDataSource.cs
@@ -1,0 +1,274 @@
+using System.Data.Common;
+using System.Runtime.Versioning;
+using Ahtola.Core;
+using Ahtola.Data.Sqlite.Browser.Storage;
+
+namespace Ahtola.Data.Sqlite.Browser;
+
+/// <summary>
+/// Creates asynchronously opened SQLite-compatible connections backed by browser OPFS.
+/// </summary>
+[SupportedOSPlatform("browser")]
+public sealed class AhtolaBrowserDataSource : DbDataSource, IManagedDatabaseFactory
+{
+    private readonly object _gate = new();
+    private readonly AhtolaBrowserOptions _options;
+    private Task<StorageState>? _initialization;
+    private TaskCompletionSource? _connectionsDrained;
+    private int _activeConnections;
+    private bool _disposed;
+
+    public AhtolaBrowserDataSource(AhtolaBrowserOptions options)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    public AhtolaBrowserDataSource(
+        string databasePath,
+        string ownedDirectory,
+        int sharedBufferSize = AhtolaBrowserOptions.DefaultSharedBufferSize,
+        bool readOnly = false)
+        : this(new AhtolaBrowserOptions(databasePath, ownedDirectory, sharedBufferSize, readOnly))
+    {
+    }
+
+    public AhtolaBrowserDataSource(
+        string databasePath,
+        int sharedBufferSize = AhtolaBrowserOptions.DefaultSharedBufferSize,
+        bool readOnly = false)
+        : this(new AhtolaBrowserOptions(databasePath, sharedBufferSize, readOnly))
+    {
+    }
+
+    public AhtolaBrowserOptions Options => _options;
+
+    public override string ConnectionString => _options.ConnectionString;
+
+    string IManagedDatabaseFactory.DataSource => _options.DatabasePath;
+
+    bool IManagedDatabaseFactory.IsReadOnly => _options.IsReadOnly;
+
+    public new SqliteConnection CreateConnection()
+    {
+        ThrowIfDisposed();
+        return new SqliteConnection(ConnectionString, this);
+    }
+
+    public global::Ahtola.AhtolaConnection CreateAhtolaConnection()
+    {
+        ThrowIfDisposed();
+        return new global::Ahtola.AhtolaConnection(ConnectionString, this);
+    }
+
+    public new async ValueTask<SqliteConnection> OpenConnectionAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var connection = CreateConnection();
+        try
+        {
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            return connection;
+        }
+        catch
+        {
+            await connection.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    protected override DbConnection CreateDbConnection() => CreateConnection();
+
+    protected override DbConnection OpenDbConnection()
+        => throw BrowserSyncNotSupported("opening");
+
+    protected override async ValueTask<DbConnection> OpenDbConnectionAsync(
+        CancellationToken cancellationToken = default)
+        => await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+
+    async ValueTask<IManagedDatabaseAdapter> IManagedDatabaseFactory.OpenDatabaseAsync(
+        CancellationToken cancellationToken)
+    {
+        Task<StorageState> initialization;
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            initialization = _initialization ??= InitializeAsync();
+        }
+
+        StorageState storage;
+        try
+        {
+            storage = await initialization.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            lock (_gate)
+            {
+                if (ReferenceEquals(_initialization, initialization)
+                    && initialization.IsFaulted)
+                {
+                    _initialization = null;
+                }
+            }
+            throw;
+        }
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            checked
+            {
+                _activeConnections++;
+            }
+        }
+
+        try
+        {
+            var inner = ManagedDatabaseAdapter.OpenFile(
+                _options.DatabasePath,
+                storage.Mirror,
+                readOnly: _options.IsReadOnly);
+            return new BrowserManagedDatabaseAdapter(
+                inner,
+                storage.Mirror,
+                ReleaseConnection);
+        }
+        catch
+        {
+            ReleaseConnection();
+            throw;
+        }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (!disposing)
+        {
+            base.Dispose(disposing);
+            return;
+        }
+
+        lock (_gate)
+        {
+            if (_disposed)
+                return;
+        }
+
+        throw BrowserSyncNotSupported("disposing");
+    }
+
+    protected override async ValueTask DisposeAsyncCore()
+    {
+        Task<StorageState>? initialization;
+        Task? drained = null;
+        lock (_gate)
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            initialization = _initialization;
+            if (_activeConnections != 0)
+            {
+                _connectionsDrained = new TaskCompletionSource(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                drained = _connectionsDrained.Task;
+            }
+        }
+
+        if (drained is not null)
+            await drained.ConfigureAwait(false);
+        if (initialization is null)
+            return;
+
+        StorageState storage;
+        try
+        {
+            storage = await initialization.ConfigureAwait(false);
+        }
+        catch
+        {
+            return;
+        }
+
+        await storage.DisposeAsync().ConfigureAwait(false);
+    }
+
+    private async Task<StorageState> InitializeAsync()
+    {
+        OpfsAsyncFileSystem? persistent = null;
+        BrowserMirroredFileSystem? mirror = null;
+        try
+        {
+            persistent = await OpfsAsyncFileSystem
+                .CreateAsync(
+                    _options.OwnedDirectory,
+                    _options.SharedBufferSize,
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+            mirror = await BrowserMirroredFileSystem
+                .CreateAsync(
+                    persistent,
+                    _options.OwnedDirectory,
+                    cancellationToken: CancellationToken.None)
+                .ConfigureAwait(false);
+            return new StorageState(persistent, mirror);
+        }
+        catch
+        {
+            if (mirror is not null)
+                await mirror.DisposeAsync().ConfigureAwait(false);
+            if (persistent is not null)
+                await persistent.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private void ReleaseConnection()
+    {
+        TaskCompletionSource? drained = null;
+        lock (_gate)
+        {
+            if (_activeConnections <= 0)
+                throw new InvalidOperationException("Browser data-source connection accounting underflow.");
+
+            _activeConnections--;
+            if (_activeConnections == 0)
+            {
+                drained = _connectionsDrained;
+                _connectionsDrained = null;
+            }
+        }
+
+        drained?.TrySetResult();
+    }
+
+    private void ThrowIfDisposed()
+    {
+        lock (_gate)
+            ObjectDisposedException.ThrowIf(_disposed, this);
+    }
+
+    private static PlatformNotSupportedException BrowserSyncNotSupported(string operation)
+        => new(
+            $"Synchronous {operation} is not supported by the browser data source. "
+            + "Use the corresponding asynchronous API.");
+
+    private sealed class StorageState(
+        OpfsAsyncFileSystem persistent,
+        BrowserMirroredFileSystem mirror) : IAsyncDisposable
+    {
+        public BrowserMirroredFileSystem Mirror { get; } = mirror;
+
+        public async ValueTask DisposeAsync()
+        {
+            try
+            {
+                await Mirror.DisposeAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                await persistent.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserDatabaseLockedException.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserDatabaseLockedException.cs
@@ -1,0 +1,18 @@
+namespace Ahtola.Data.Sqlite.Browser;
+
+/// <summary>
+/// Raised when another browser tab or worker owns the requested OPFS database.
+/// </summary>
+public sealed class AhtolaBrowserDatabaseLockedException : IOException
+{
+    internal AhtolaBrowserDatabaseLockedException(string lockName, Exception innerException)
+        : base(
+            $"The browser database '{lockName}' is already open in another tab or worker.",
+            innerException)
+    {
+        LockName = lockName;
+    }
+
+    /// <summary>The logical Web Lock name requested by the data source.</summary>
+    public string LockName { get; }
+}

--- a/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserEncryptionOptions.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserEncryptionOptions.cs
@@ -1,0 +1,130 @@
+using System.Security.Cryptography;
+using System.Text;
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Data.Sqlite.Browser;
+
+/// <summary>
+/// Immutable key material for a browser database encrypted with Ahtola's AHTLA
+/// page format. Instances hold secrets, so they are never serialized into a
+/// connection string and should be disposed once the owning data source has
+/// been created.
+/// </summary>
+/// <remarks>
+/// The browser derives and imports keys through Web Crypto, so the resulting
+/// AES-GCM key never leaves the JavaScript realm as extractable material. The
+/// on-disk bytes match the desktop <see cref="AhtolaEncryptionOptions"/> format
+/// exactly, so a database written by one can be opened by the other.
+/// </remarks>
+public sealed class AhtolaBrowserEncryptionOptions : IDisposable
+{
+    private byte[]? _secret;
+
+    private AhtolaBrowserEncryptionOptions(
+        AhtolaEncryptionCipher cipher,
+        byte[] secret,
+        bool isPasswordDerived)
+    {
+        Cipher = cipher;
+        _secret = secret;
+        IsPasswordDerived = isPasswordDerived;
+    }
+
+    /// <summary>The AHTLA cipher id stored in the encrypted page 1 header.</summary>
+    public AhtolaEncryptionCipher Cipher { get; }
+
+    /// <summary>Whether the key is derived from a passphrase rather than supplied directly.</summary>
+    public bool IsPasswordDerived { get; }
+
+    /// <summary>
+    /// The passphrase scheme used when <see cref="IsPasswordDerived"/> is true,
+    /// otherwise <see langword="null"/>.
+    /// </summary>
+    public string? PasswordSchemeId
+        => IsPasswordDerived ? AhtolaBrowserCryptoParameters.PasswordSchemeId : null;
+
+    /// <summary>
+    /// Derives an AES-256-GCM key from <paramref name="password"/> using
+    /// <c>Ahtola.Password.v1</c> (PBKDF2-HMAC-SHA256, 210,000 iterations).
+    /// </summary>
+    public static AhtolaBrowserEncryptionOptions FromPassword(string password)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(password);
+        return new AhtolaBrowserEncryptionOptions(
+            AhtolaEncryptionCipher.Aes256Gcm,
+            Encoding.UTF8.GetBytes(password),
+            isPasswordDerived: true);
+    }
+
+    /// <summary>Uses an exact AES-128 or AES-256 key.</summary>
+    public static AhtolaBrowserEncryptionOptions FromKey(
+        AhtolaEncryptionCipher cipher,
+        ReadOnlySpan<byte> key)
+    {
+        var requiredKeySize = AhtolaBrowserCryptoParameters.GetKeySize(cipher);
+        if (key.Length != requiredKeySize)
+        {
+            throw new ArgumentException(
+                $"{cipher} requires a {requiredKeySize}-byte key, but the supplied key has {key.Length} bytes.",
+                nameof(key));
+        }
+
+        return new AhtolaBrowserEncryptionOptions(cipher, key.ToArray(), isPasswordDerived: false);
+    }
+
+    /// <summary>Uses an exact AES-128 or AES-256 key in Ahtola's hexadecimal representation.</summary>
+    public static AhtolaBrowserEncryptionOptions FromHex(AhtolaEncryptionCipher cipher, string hexKey)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(hexKey);
+
+        byte[] key;
+        try
+        {
+            key = Convert.FromHexString(hexKey.Trim());
+        }
+        catch (FormatException exception)
+        {
+            throw new ArgumentException("Encryption keys must be hexadecimal.", nameof(hexKey), exception);
+        }
+
+        try
+        {
+            return FromKey(cipher, key);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(key);
+        }
+    }
+
+    /// <summary>Zeros this instance's copy of the passphrase or key material.</summary>
+    public void Dispose()
+    {
+        var secret = Interlocked.Exchange(ref _secret, null);
+        if (secret is not null)
+            CryptographicOperations.ZeroMemory(secret);
+    }
+
+    internal AhtolaBrowserEncryptionOptions CreateOwnedCopy()
+    {
+        var secret = _secret ?? throw new ObjectDisposedException(nameof(AhtolaBrowserEncryptionOptions));
+        return new AhtolaBrowserEncryptionOptions(Cipher, secret.AsSpan().ToArray(), IsPasswordDerived);
+    }
+
+    /// <summary>
+    /// Creates the Web Crypto key handle for this configuration. The caller owns
+    /// the returned service and must dispose it to release the JavaScript key.
+    /// </summary>
+    [System.Runtime.Versioning.SupportedOSPlatform("browser")]
+    internal async ValueTask<AhtolaBrowserCryptoService> CreateCryptoServiceAsync()
+    {
+        var secret = _secret ?? throw new ObjectDisposedException(nameof(AhtolaBrowserEncryptionOptions));
+        if (!IsPasswordDerived)
+            return await AhtolaBrowserCryptoService.CreateAsync(Cipher, secret).ConfigureAwait(false);
+
+        // Web Crypto's PBKDF2 binding takes the passphrase as a string, so the
+        // transient managed copy is unavoidable; it is not retained here.
+        var password = Encoding.UTF8.GetString(secret);
+        return await AhtolaBrowserCryptoService.CreateFromPasswordAsync(password).ConfigureAwait(false);
+    }
+}

--- a/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserOptions.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserOptions.cs
@@ -5,12 +5,14 @@ namespace Ahtola.Data.Sqlite.Browser;
 /// <summary>
 /// Configures an Ahtola database stored in an application-owned OPFS directory.
 /// </summary>
-public sealed class AhtolaBrowserOptions
+public sealed class AhtolaBrowserOptions : IDisposable
 {
     /// <summary>
     /// The default shared transfer buffer size used by the OPFS worker.
     /// </summary>
     public const int DefaultSharedBufferSize = 1024 * 1024;
+
+    private AhtolaBrowserEncryptionOptions? _encryption;
 
     /// <summary>
     /// Creates immutable browser database options.
@@ -21,11 +23,16 @@ public sealed class AhtolaBrowserOptions
     /// <param name="ownedDirectory">The relative OPFS directory exclusively owned by this data source.</param>
     /// <param name="sharedBufferSize">The OPFS worker transfer buffer size, in bytes.</param>
     /// <param name="readOnly">Whether connections reject database mutations.</param>
+    /// <param name="encryption">
+    /// Optional AHTLA page-encryption key material. It is copied, never placed in
+    /// <see cref="ConnectionString"/>, and released when these options are disposed.
+    /// </param>
     public AhtolaBrowserOptions(
         string databasePath,
         string ownedDirectory,
         int sharedBufferSize = DefaultSharedBufferSize,
-        bool readOnly = false)
+        bool readOnly = false,
+        AhtolaBrowserEncryptionOptions? encryption = null)
     {
         OwnedDirectory = NormalizePath(ownedDirectory, nameof(ownedDirectory));
         DatabasePath = NormalizePath(databasePath, nameof(databasePath));
@@ -40,7 +47,10 @@ public sealed class AhtolaBrowserOptions
         ArgumentOutOfRangeException.ThrowIfGreaterThan(sharedBufferSize, 64 * 1024 * 1024);
         SharedBufferSize = sharedBufferSize;
         IsReadOnly = readOnly;
+        _encryption = encryption?.CreateOwnedCopy();
 
+        // Key material is deliberately absent here: a connection string is routinely
+        // logged, cached, and compared, so it must never carry a passphrase or key.
         ConnectionString = new SqliteConnectionStringBuilder
         {
             DataSource = DatabasePath,
@@ -56,13 +66,31 @@ public sealed class AhtolaBrowserOptions
     public AhtolaBrowserOptions(
         string databasePath,
         int sharedBufferSize = DefaultSharedBufferSize,
-        bool readOnly = false)
+        bool readOnly = false,
+        AhtolaBrowserEncryptionOptions? encryption = null)
         : this(
             databasePath,
             GetParentDirectory(databasePath),
             sharedBufferSize,
-            readOnly)
+            readOnly,
+            encryption)
     {
+    }
+
+    /// <summary>
+    /// Gets this instance's copy of the AHTLA encryption key material, or
+    /// <see langword="null"/> when the database is stored unencrypted.
+    /// </summary>
+    public AhtolaBrowserEncryptionOptions? Encryption => _encryption;
+
+    /// <summary>Whether OPFS content is encrypted with Ahtola's AHTLA page format.</summary>
+    public bool IsEncrypted => _encryption is not null;
+
+    /// <summary>Zeros this instance's copy of the encryption key material.</summary>
+    public void Dispose()
+    {
+        var encryption = Interlocked.Exchange(ref _encryption, null);
+        encryption?.Dispose();
     }
 
     /// <summary>Gets the normalized database path relative to the OPFS root.</summary>

--- a/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserOptions.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserOptions.cs
@@ -1,0 +1,126 @@
+using Ahtola.Data.Sqlite;
+
+namespace Ahtola.Data.Sqlite.Browser;
+
+/// <summary>
+/// Configures an Ahtola database stored in an application-owned OPFS directory.
+/// </summary>
+public sealed class AhtolaBrowserOptions
+{
+    /// <summary>
+    /// The default shared transfer buffer size used by the OPFS worker.
+    /// </summary>
+    public const int DefaultSharedBufferSize = 1024 * 1024;
+
+    /// <summary>
+    /// Creates immutable browser database options.
+    /// </summary>
+    /// <param name="databasePath">
+    /// A relative OPFS database path located below <paramref name="ownedDirectory"/>.
+    /// </param>
+    /// <param name="ownedDirectory">The relative OPFS directory exclusively owned by this data source.</param>
+    /// <param name="sharedBufferSize">The OPFS worker transfer buffer size, in bytes.</param>
+    /// <param name="readOnly">Whether connections reject database mutations.</param>
+    public AhtolaBrowserOptions(
+        string databasePath,
+        string ownedDirectory,
+        int sharedBufferSize = DefaultSharedBufferSize,
+        bool readOnly = false)
+    {
+        OwnedDirectory = NormalizePath(ownedDirectory, nameof(ownedDirectory));
+        DatabasePath = NormalizePath(databasePath, nameof(databasePath));
+        if (!DatabasePath.StartsWith(OwnedDirectory + "/", StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"Browser database path '{DatabasePath}' must be below owned OPFS directory '{OwnedDirectory}'.",
+                nameof(databasePath));
+        }
+
+        ArgumentOutOfRangeException.ThrowIfLessThan(sharedBufferSize, 64 * 1024);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(sharedBufferSize, 64 * 1024 * 1024);
+        SharedBufferSize = sharedBufferSize;
+        IsReadOnly = readOnly;
+
+        ConnectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = DatabasePath,
+            Mode = readOnly ? SqliteOpenMode.ReadOnly : SqliteOpenMode.ReadWriteCreate,
+            LocalProvider = AhtolaLocalProvider.Managed,
+            Pooling = false,
+        }.ConnectionString;
+    }
+
+    /// <summary>
+    /// Creates options whose owned directory is the database path's parent directory.
+    /// </summary>
+    public AhtolaBrowserOptions(
+        string databasePath,
+        int sharedBufferSize = DefaultSharedBufferSize,
+        bool readOnly = false)
+        : this(
+            databasePath,
+            GetParentDirectory(databasePath),
+            sharedBufferSize,
+            readOnly)
+    {
+    }
+
+    /// <summary>Gets the normalized database path relative to the OPFS root.</summary>
+    public string DatabasePath { get; }
+
+    /// <summary>Gets the normalized OPFS directory owned by this data source.</summary>
+    public string OwnedDirectory { get; }
+
+    /// <summary>Gets the normalized OPFS directory owned by this data source.</summary>
+    public string OwnedDirectoryPath => OwnedDirectory;
+
+    /// <summary>Gets the OPFS worker transfer buffer size, in bytes.</summary>
+    public int SharedBufferSize { get; }
+
+    /// <summary>Gets whether connections are read-only.</summary>
+    public bool IsReadOnly { get; }
+
+    /// <summary>Gets whether connections are read-only.</summary>
+    public bool ReadOnly => IsReadOnly;
+
+    /// <summary>Gets the managed-provider connection string exposed by created connections.</summary>
+    public string ConnectionString { get; }
+
+    private static string NormalizePath(string path, string parameterName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path, parameterName);
+        var normalized = path.Replace('\\', '/');
+        if (normalized.StartsWith('/') || normalized.EndsWith('/'))
+        {
+            throw new ArgumentException(
+                "Browser OPFS paths must be normalized relative paths without leading or trailing separators.",
+                parameterName);
+        }
+
+        var segments = normalized.Split('/');
+        if (segments.Any(static segment =>
+                segment is "" or "." or ".."
+                || segment.IndexOfAny(['\0', '\r', '\n']) >= 0))
+        {
+            throw new ArgumentException(
+                "Browser OPFS paths must be relative and cannot contain empty, current, or parent segments.",
+                parameterName);
+        }
+
+        return string.Join('/', segments);
+    }
+
+    private static string GetParentDirectory(string databasePath)
+    {
+        var normalized = NormalizePath(databasePath, nameof(databasePath));
+        var separator = normalized.LastIndexOf('/');
+        if (separator <= 0)
+        {
+            throw new ArgumentException(
+                "The browser database path must include an owned parent directory.",
+                nameof(databasePath));
+        }
+
+        return normalized[..separator];
+    }
+}

--- a/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserOptions.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserOptions.cs
@@ -34,13 +34,33 @@ public sealed class AhtolaBrowserOptions : IDisposable
         bool readOnly = false,
         AhtolaBrowserEncryptionOptions? encryption = null)
     {
-        OwnedDirectory = NormalizePath(ownedDirectory, nameof(ownedDirectory));
-        DatabasePath = NormalizePath(databasePath, nameof(databasePath));
-        if (!DatabasePath.StartsWith(OwnedDirectory + "/", StringComparison.Ordinal))
+        IsInMemory = string.Equals(databasePath, ":memory:", StringComparison.Ordinal);
+        if (IsInMemory)
         {
-            throw new ArgumentException(
-                $"Browser database path '{DatabasePath}' must be below owned OPFS directory '{OwnedDirectory}'.",
-                nameof(databasePath));
+            if (!string.Equals(ownedDirectory, ":memory:", StringComparison.Ordinal))
+            {
+                throw new ArgumentException(
+                    "An in-memory browser data source must use ':memory:' as its owned directory.",
+                    nameof(ownedDirectory));
+            }
+            if (readOnly)
+                throw new ArgumentException("An empty in-memory browser database cannot be opened read-only.", nameof(readOnly));
+            if (encryption is not null)
+                throw new NotSupportedException("Encryption is not applicable to an in-memory browser database.");
+
+            OwnedDirectory = ":memory:";
+            DatabasePath = ":memory:";
+        }
+        else
+        {
+            OwnedDirectory = NormalizePath(ownedDirectory, nameof(ownedDirectory));
+            DatabasePath = NormalizePath(databasePath, nameof(databasePath));
+            if (!DatabasePath.StartsWith(OwnedDirectory + "/", StringComparison.Ordinal))
+            {
+                throw new ArgumentException(
+                    $"Browser database path '{DatabasePath}' must be below owned OPFS directory '{OwnedDirectory}'.",
+                    nameof(databasePath));
+            }
         }
 
         ArgumentOutOfRangeException.ThrowIfLessThan(sharedBufferSize, 64 * 1024);
@@ -54,7 +74,12 @@ public sealed class AhtolaBrowserOptions : IDisposable
         ConnectionString = new SqliteConnectionStringBuilder
         {
             DataSource = DatabasePath,
-            Mode = readOnly ? SqliteOpenMode.ReadOnly : SqliteOpenMode.ReadWriteCreate,
+            Mode = IsInMemory
+                ? SqliteOpenMode.Memory
+                : readOnly
+                    ? SqliteOpenMode.ReadOnly
+                    : SqliteOpenMode.ReadWriteCreate,
+            Cache = IsInMemory ? SqliteCacheMode.Shared : SqliteCacheMode.Default,
             LocalProvider = AhtolaLocalProvider.Managed,
             Pooling = false,
         }.ConnectionString;
@@ -85,6 +110,9 @@ public sealed class AhtolaBrowserOptions : IDisposable
 
     /// <summary>Whether OPFS content is encrypted with Ahtola's AHTLA page format.</summary>
     public bool IsEncrypted => _encryption is not null;
+
+    /// <summary>Whether this data source is process-memory-only and does not initialize OPFS.</summary>
+    public bool IsInMemory { get; }
 
     /// <summary>Zeros this instance's copy of the encryption key material.</summary>
     public void Dispose()
@@ -140,6 +168,9 @@ public sealed class AhtolaBrowserOptions : IDisposable
 
     private static string GetParentDirectory(string databasePath)
     {
+        if (string.Equals(databasePath, ":memory:", StringComparison.Ordinal))
+            return ":memory:";
+
         var normalized = NormalizePath(databasePath, nameof(databasePath));
         var separator = normalized.LastIndexOf('/');
         if (separator <= 0)

--- a/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserRuntime.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserRuntime.cs
@@ -102,4 +102,14 @@ internal static partial class BrowserInterop
 
     [JSImport("deleteFile", ModuleName)]
     internal static partial Task DeleteFileAsync(int contextId, string path);
+
+    [JSImport("replaceFileAtomically", ModuleName)]
+    internal static partial Task ReplaceFileAtomicallyAsync(
+        int contextId,
+        string sourcePath,
+        string destinationPath,
+        bool replaceEmptyDestination);
+
+    [JSImport("cancelCurrentOperation", ModuleName)]
+    internal static partial void CancelCurrentOperation(int contextId);
 }

--- a/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserRuntime.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserRuntime.cs
@@ -124,6 +124,9 @@ internal static partial class BrowserInterop
     [JSImport("deleteFile", ModuleName)]
     internal static partial Task DeleteFileAsync(int contextId, string path);
 
+    [JSImport("listFiles", ModuleName)]
+    internal static partial Task<string> ListFilesAsync(int contextId, string directoryPath);
+
     [JSImport("replaceFileAtomically", ModuleName)]
     internal static partial Task ReplaceFileAtomicallyAsync(
         int contextId,

--- a/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserRuntime.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserRuntime.cs
@@ -1,0 +1,105 @@
+using System.Runtime.InteropServices.JavaScript;
+using System.Runtime.Versioning;
+
+namespace Ahtola.Data.Sqlite.Browser;
+
+/// <summary>Initializes and inspects the browser runtime used by Ahtola OPFS storage.</summary>
+[SupportedOSPlatform("browser")]
+public static class AhtolaBrowserRuntime
+{
+    private const string ModuleName = "Devolutions.Ahtola.Data.Sqlite.Browser";
+    private const string ModuleUrl =
+        "../_content/Devolutions.Ahtola.Data.Sqlite.Browser/ahtola-opfs.mjs";
+    private static readonly object Gate = new();
+    private static Task? s_moduleInitialization;
+
+    /// <summary>Loads the packaged JavaScript module once for the current browser runtime.</summary>
+    public static Task InitializeAsync()
+    {
+        if (!OperatingSystem.IsBrowser())
+        {
+            throw new PlatformNotSupportedException(
+                "Ahtola browser storage is supported only by a .NET browser WebAssembly runtime.");
+        }
+
+        lock (Gate)
+            return s_moduleInitialization ??= JSHost.ImportAsync(ModuleName, ModuleUrl);
+    }
+
+    /// <summary>Returns the browser features available to the OPFS backend.</summary>
+    public static async ValueTask<AhtolaBrowserCapabilities> GetCapabilitiesAsync()
+    {
+        await InitializeAsync().ConfigureAwait(false);
+        var mask = BrowserInterop.GetCapabilityMask();
+        return new AhtolaBrowserCapabilities(
+            IsCrossOriginIsolated: (mask & BrowserInterop.CrossOriginIsolated) != 0,
+            HasSharedArrayBuffer: (mask & BrowserInterop.SharedArrayBuffer) != 0,
+            HasOriginPrivateFileSystem: (mask & BrowserInterop.OriginPrivateFileSystem) != 0,
+            HasSynchronousAccessHandles: (mask & BrowserInterop.SynchronousAccessHandle) != 0,
+            HasWebLocks: (mask & BrowserInterop.WebLocks) != 0);
+    }
+}
+
+[SupportedOSPlatform("browser")]
+internal static partial class BrowserInterop
+{
+    internal const int CrossOriginIsolated = 1 << 0;
+    internal const int SharedArrayBuffer = 1 << 1;
+    internal const int OriginPrivateFileSystem = 1 << 2;
+    internal const int SynchronousAccessHandle = 1 << 3;
+    internal const int WebLocks = 1 << 4;
+    private const string ModuleName = "Devolutions.Ahtola.Data.Sqlite.Browser";
+
+    [JSImport("getCapabilityMask", ModuleName)]
+    internal static partial int GetCapabilityMask();
+
+    [JSImport("createContext", ModuleName)]
+    internal static partial Task<int> CreateContextAsync(string lockName, int sharedBufferSize);
+
+    [JSImport("disposeContext", ModuleName)]
+    internal static partial Task DisposeContextAsync(int contextId);
+
+    [JSImport("fileExists", ModuleName)]
+    internal static partial Task<bool> FileExistsAsync(int contextId, string path);
+
+    [JSImport("openFile", ModuleName)]
+    internal static partial Task<int> OpenFileAsync(
+        int contextId,
+        string path,
+        int mode,
+        bool readOnly);
+
+    [JSImport("getLength", ModuleName)]
+    internal static partial Task<double> GetLengthAsync(int contextId, int handleId);
+
+    [JSImport("readFile", ModuleName)]
+    [return: JSMarshalAs<JSType.Promise<JSType.Object>>]
+    internal static partial Task<JSObject> ReadFileAsync(
+        int contextId,
+        int handleId,
+        double position,
+        int length);
+
+    [JSImport("unwrapByteArray", ModuleName)]
+    [return: JSMarshalAs<JSType.Array<JSType.Number>>]
+    internal static partial byte[] UnwrapByteArray(JSObject value);
+
+    [JSImport("writeFile", ModuleName)]
+    internal static partial Task<int> WriteFileAsync(
+        int contextId,
+        int handleId,
+        double position,
+        byte[] source);
+
+    [JSImport("setLength", ModuleName)]
+    internal static partial Task SetLengthAsync(int contextId, int handleId, double length);
+
+    [JSImport("flushFile", ModuleName)]
+    internal static partial Task FlushFileAsync(int contextId, int handleId);
+
+    [JSImport("closeFile", ModuleName)]
+    internal static partial Task CloseFileAsync(int contextId, int handleId);
+
+    [JSImport("deleteFile", ModuleName)]
+    internal static partial Task DeleteFileAsync(int contextId, string path);
+}

--- a/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserRuntime.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserRuntime.cs
@@ -14,7 +14,7 @@ public static class AhtolaBrowserRuntime
     private static Task? s_moduleInitialization;
 
     /// <summary>Loads the packaged JavaScript module once for the current browser runtime.</summary>
-    public static Task InitializeAsync()
+    public static async Task InitializeAsync()
     {
         if (!OperatingSystem.IsBrowser())
         {
@@ -22,8 +22,23 @@ public static class AhtolaBrowserRuntime
                 "Ahtola browser storage is supported only by a .NET browser WebAssembly runtime.");
         }
 
+        Task initialization;
         lock (Gate)
-            return s_moduleInitialization ??= JSHost.ImportAsync(ModuleName, ModuleUrl);
+            initialization = s_moduleInitialization ??= JSHost.ImportAsync(ModuleName, ModuleUrl);
+
+        try
+        {
+            await initialization.ConfigureAwait(false);
+        }
+        catch
+        {
+            lock (Gate)
+            {
+                if (ReferenceEquals(s_moduleInitialization, initialization))
+                    s_moduleInitialization = null;
+            }
+            throw;
+        }
     }
 
     /// <summary>Returns the browser features available to the OPFS backend.</summary>
@@ -73,23 +88,29 @@ internal static partial class BrowserInterop
     internal static partial Task<double> GetLengthAsync(int contextId, int handleId);
 
     [JSImport("readFile", ModuleName)]
-    [return: JSMarshalAs<JSType.Promise<JSType.Object>>]
-    internal static partial Task<JSObject> ReadFileAsync(
+    internal static partial Task<int> ReadFileAsync(
         int contextId,
         int handleId,
         double position,
         int length);
 
-    [JSImport("unwrapByteArray", ModuleName)]
-    [return: JSMarshalAs<JSType.Array<JSType.Number>>]
-    internal static partial byte[] UnwrapByteArray(JSObject value);
+    [JSImport("copyFromSharedBuffer", ModuleName)]
+    internal static partial int CopyFromSharedBuffer(
+        int contextId,
+        [JSMarshalAs<JSType.MemoryView>] ArraySegment<byte> destination,
+        int length);
+
+    [JSImport("copyToSharedBuffer", ModuleName)]
+    internal static partial int CopyToSharedBuffer(
+        int contextId,
+        [JSMarshalAs<JSType.MemoryView>] ArraySegment<byte> source);
 
     [JSImport("writeFile", ModuleName)]
     internal static partial Task<int> WriteFileAsync(
         int contextId,
         int handleId,
         double position,
-        byte[] source);
+        int length);
 
     [JSImport("setLength", ModuleName)]
     internal static partial Task SetLengthAsync(int contextId, int handleId, double length);
@@ -106,10 +127,14 @@ internal static partial class BrowserInterop
     [JSImport("replaceFileAtomically", ModuleName)]
     internal static partial Task ReplaceFileAtomicallyAsync(
         int contextId,
+        int operationId,
         string sourcePath,
         string destinationPath,
         bool replaceEmptyDestination);
 
-    [JSImport("cancelCurrentOperation", ModuleName)]
-    internal static partial void CancelCurrentOperation(int contextId);
+    [JSImport("allocateOperationId", ModuleName)]
+    internal static partial int AllocateOperationId(int contextId);
+
+    [JSImport("cancelOperation", ModuleName)]
+    internal static partial void CancelOperation(int contextId, int operationId);
 }

--- a/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserRuntime.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserRuntime.cs
@@ -46,11 +46,18 @@ public static class AhtolaBrowserRuntime
     {
         await InitializeAsync().ConfigureAwait(false);
         var mask = BrowserInterop.GetCapabilityMask();
+        var hasOriginPrivateFileSystem = (mask & BrowserInterop.OriginPrivateFileSystem) != 0;
+        // Synchronous access handle support is never inferred from unrelated
+        // feature checks: it is probed for real, inside a worker, because a
+        // browser can expose Worker and OPFS directory access while still
+        // lacking (or throwing from) createSyncAccessHandle itself.
+        var hasSynchronousAccessHandles = hasOriginPrivateFileSystem
+            && await BrowserInterop.ProbeSynchronousAccessHandleSupportAsync().ConfigureAwait(false);
         return new AhtolaBrowserCapabilities(
             IsCrossOriginIsolated: (mask & BrowserInterop.CrossOriginIsolated) != 0,
             HasSharedArrayBuffer: (mask & BrowserInterop.SharedArrayBuffer) != 0,
-            HasOriginPrivateFileSystem: (mask & BrowserInterop.OriginPrivateFileSystem) != 0,
-            HasSynchronousAccessHandles: (mask & BrowserInterop.SynchronousAccessHandle) != 0,
+            HasOriginPrivateFileSystem: hasOriginPrivateFileSystem,
+            HasSynchronousAccessHandles: hasSynchronousAccessHandles,
             HasWebLocks: (mask & BrowserInterop.WebLocks) != 0);
     }
 }
@@ -61,12 +68,14 @@ internal static partial class BrowserInterop
     internal const int CrossOriginIsolated = 1 << 0;
     internal const int SharedArrayBuffer = 1 << 1;
     internal const int OriginPrivateFileSystem = 1 << 2;
-    internal const int SynchronousAccessHandle = 1 << 3;
-    internal const int WebLocks = 1 << 4;
+    internal const int WebLocks = 1 << 3;
     private const string ModuleName = "Devolutions.Ahtola.Data.Sqlite.Browser";
 
     [JSImport("getCapabilityMask", ModuleName)]
     internal static partial int GetCapabilityMask();
+
+    [JSImport("probeSynchronousAccessHandleSupport", ModuleName)]
+    internal static partial Task<bool> ProbeSynchronousAccessHandleSupportAsync();
 
     [JSImport("createContext", ModuleName)]
     internal static partial Task<int> CreateContextAsync(string lockName, int sharedBufferSize);

--- a/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserStorageDiagnostics.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserStorageDiagnostics.cs
@@ -1,4 +1,5 @@
 using System.Runtime.Versioning;
+using Ahtola.Core;
 using Ahtola.Core.Storage;
 using Ahtola.Data.Sqlite.Browser.Storage;
 
@@ -28,6 +29,7 @@ public static class AhtolaBrowserStorageDiagnostics
         var lockRejected = false;
         var positionalIoMatches = false;
         var atomicReplaceMatches = false;
+        var managedPersistenceMatches = false;
         var details = string.Empty;
         await using var fileSystem = await OpfsAsyncFileSystem
             .CreateAsync(lockName, sharedBufferSize, cancellationToken)
@@ -129,11 +131,76 @@ public static class AhtolaBrowserStorageDiagnostics
             await fileSystem.DeleteFileAsync(destinationPath, CancellationToken.None).ConfigureAwait(false);
         }
 
+        var managedRoot = $"managed-{id}";
+        var managedPath = $"{managedRoot}/main.db";
+        await using (var persistent = await OpfsAsyncFileSystem
+                         .CreateAsync($"{lockName}-managed", sharedBufferSize, cancellationToken)
+                         .ConfigureAwait(false))
+        {
+            await using var mirror = await BrowserMirroredFileSystem
+                .CreateAsync(
+                    persistent,
+                    managedRoot,
+                    cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+            using var database = ManagedDatabaseAdapter.OpenFile(managedPath, mirror);
+            var connection = await database.ConnectAsync(cancellationToken).ConfigureAwait(false);
+            await ExecuteToCompletionAsync(
+                connection,
+                "CREATE TABLE probe(value INTEGER NOT NULL)",
+                cancellationToken).ConfigureAwait(false);
+            await ExecuteToCompletionAsync(
+                connection,
+                "INSERT INTO probe(value) VALUES (42)",
+                cancellationToken).ConfigureAwait(false);
+            await mirror.FlushPendingAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        await using (var persistent = await OpfsAsyncFileSystem
+                         .CreateAsync($"{lockName}-managed", sharedBufferSize, cancellationToken)
+                         .ConfigureAwait(false))
+        {
+            await using var mirror = await BrowserMirroredFileSystem
+                .CreateAsync(
+                    persistent,
+                    managedRoot,
+                    cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+            using var database = ManagedDatabaseAdapter.OpenFile(managedPath, mirror);
+            var connection = await database.ConnectAsync(cancellationToken).ConfigureAwait(false);
+            await using var statement = await connection
+                .PrepareAsync("SELECT value FROM probe", cancellationToken)
+                .ConfigureAwait(false);
+            managedPersistenceMatches =
+                await statement.StepAsync(cancellationToken).ConfigureAwait(false)
+                    == StatementStepResult.Row
+                && statement.GetValue(0).AsInteger() == 42
+                && await statement.StepAsync(cancellationToken).ConfigureAwait(false)
+                    == StatementStepResult.Done;
+            database.Dispose();
+            await mirror.DeleteAllPersistentFilesAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+
         return new AhtolaBrowserStorageDiagnosticResult(
             lockRejected,
             positionalIoMatches,
             atomicReplaceMatches,
+            managedPersistenceMatches,
             details);
+    }
+
+    private static async ValueTask ExecuteToCompletionAsync(
+        IManagedConnectionAdapter connection,
+        string sql,
+        CancellationToken cancellationToken)
+    {
+        await using var statement = await connection
+            .PrepareAsync(sql, cancellationToken)
+            .ConfigureAwait(false);
+        while (await statement.StepAsync(cancellationToken).ConfigureAwait(false)
+               == StatementStepResult.Row)
+        {
+        }
     }
 
     private static int FindFirstMismatch(ReadOnlySpan<byte> expected, ReadOnlySpan<byte> actual)
@@ -153,11 +220,13 @@ public readonly record struct AhtolaBrowserStorageDiagnosticResult(
     bool CompetingContextRejected,
     bool PositionalIoMatches,
     bool AtomicReplaceMatches,
+    bool ManagedPersistenceMatches,
     string Details)
 {
     /// <summary>Whether every OPFS diagnostic check passed.</summary>
     public bool Succeeded =>
         CompetingContextRejected
         && PositionalIoMatches
-        && AtomicReplaceMatches;
+        && AtomicReplaceMatches
+        && ManagedPersistenceMatches;
 }

--- a/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserStorageDiagnostics.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/AhtolaBrowserStorageDiagnostics.cs
@@ -1,0 +1,163 @@
+using System.Runtime.Versioning;
+using Ahtola.Core.Storage;
+using Ahtola.Data.Sqlite.Browser.Storage;
+
+namespace Ahtola.Data.Sqlite.Browser;
+
+/// <summary>Browser-facing diagnostics for the managed OPFS transport.</summary>
+[SupportedOSPlatform("browser")]
+public static class AhtolaBrowserStorageDiagnostics
+{
+    /// <summary>
+    /// Verifies feature detection, cross-context locking, chunked positional I/O,
+    /// persistence, and crash-safe atomic replacement.
+    /// </summary>
+    public static async ValueTask<AhtolaBrowserStorageDiagnosticResult> RunAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var id = Guid.NewGuid().ToString("N");
+        var lockName = $"diagnostic-{id}";
+        var dataPath = $"{id}/data.db";
+        var sourcePath = $"{id}/replace-source.db";
+        var destinationPath = $"{id}/replace-destination.db";
+        const int sharedBufferSize = 64 * 1024;
+        var source = new byte[sharedBufferSize * 2 + 137];
+        for (var index = 0; index < source.Length; index++)
+            source[index] = (byte)((index * 29 + 7) & 0xff);
+
+        var lockRejected = false;
+        var positionalIoMatches = false;
+        var atomicReplaceMatches = false;
+        var details = string.Empty;
+        await using var fileSystem = await OpfsAsyncFileSystem
+            .CreateAsync(lockName, sharedBufferSize, cancellationToken)
+            .ConfigureAwait(false);
+        try
+        {
+            try
+            {
+                await using var competing = await OpfsAsyncFileSystem
+                    .CreateAsync(lockName, sharedBufferSize, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (AhtolaBrowserDatabaseLockedException)
+            {
+                lockRejected = true;
+            }
+
+            await using (var file = await fileSystem
+                             .OpenFileAsync(
+                                 dataPath,
+                                 FileOpenMode.CreateNew,
+                                 cancellationToken: cancellationToken)
+                             .ConfigureAwait(false))
+            {
+                await file.WriteAsync(11, source, cancellationToken).ConfigureAwait(false);
+                await file.FlushToDiskAsync(cancellationToken).ConfigureAwait(false);
+                var destination = new byte[source.Length];
+                var read = await file
+                    .ReadAsync(11, destination, cancellationToken)
+                    .ConfigureAwait(false);
+                var actualLength = await file
+                    .GetLengthAsync(cancellationToken)
+                    .ConfigureAwait(false);
+                var mismatch = source.AsSpan().SequenceEqual(destination)
+                    ? -1
+                    : FindFirstMismatch(source, destination);
+                positionalIoMatches =
+                    actualLength == source.Length + 11
+                    && read == source.Length
+                    && mismatch == -1;
+                details = $"pos(length={actualLength},read={read},mismatch={mismatch})";
+            }
+
+            await using (var sourceFile = await fileSystem
+                             .OpenFileAsync(
+                                 sourcePath,
+                                 FileOpenMode.CreateNew,
+                                 cancellationToken: cancellationToken)
+                             .ConfigureAwait(false))
+            {
+                await sourceFile.WriteAsync(0, source, cancellationToken).ConfigureAwait(false);
+                await sourceFile.FlushToDiskAsync(cancellationToken).ConfigureAwait(false);
+            }
+            await using (await fileSystem
+                             .OpenFileAsync(
+                                 destinationPath,
+                                 FileOpenMode.CreateNew,
+                                 cancellationToken: cancellationToken)
+                             .ConfigureAwait(false))
+            {
+            }
+
+            await fileSystem
+                .ReplaceFileAtomicallyAsync(
+                    sourcePath,
+                    destinationPath,
+                    replaceEmptyDestination: true,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            await using (var destinationFile = await fileSystem
+                             .OpenFileAsync(
+                                 destinationPath,
+                                 FileOpenMode.OpenExisting,
+                                 readOnly: true,
+                                 cancellationToken)
+                             .ConfigureAwait(false))
+            {
+                var destination = new byte[source.Length];
+                var read = await destinationFile
+                    .ReadAsync(0, destination, cancellationToken)
+                    .ConfigureAwait(false);
+                var sourceExists = await fileSystem
+                    .FileExistsAsync(sourcePath, cancellationToken)
+                    .ConfigureAwait(false);
+                var mismatch = source.AsSpan().SequenceEqual(destination)
+                    ? -1
+                    : FindFirstMismatch(source, destination);
+                atomicReplaceMatches =
+                    !sourceExists
+                    && read == source.Length
+                    && mismatch == -1;
+                details += $";atomic(source={sourceExists},read={read},mismatch={mismatch})";
+            }
+        }
+        finally
+        {
+            await fileSystem.DeleteFileAsync(dataPath, CancellationToken.None).ConfigureAwait(false);
+            await fileSystem.DeleteFileAsync(sourcePath, CancellationToken.None).ConfigureAwait(false);
+            await fileSystem.DeleteFileAsync(destinationPath, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        return new AhtolaBrowserStorageDiagnosticResult(
+            lockRejected,
+            positionalIoMatches,
+            atomicReplaceMatches,
+            details);
+    }
+
+    private static int FindFirstMismatch(ReadOnlySpan<byte> expected, ReadOnlySpan<byte> actual)
+    {
+        var count = Math.Min(expected.Length, actual.Length);
+        for (var index = 0; index < count; index++)
+        {
+            if (expected[index] != actual[index])
+                return index;
+        }
+        return count;
+    }
+}
+
+/// <summary>Results from the managed OPFS transport diagnostic.</summary>
+public readonly record struct AhtolaBrowserStorageDiagnosticResult(
+    bool CompetingContextRejected,
+    bool PositionalIoMatches,
+    bool AtomicReplaceMatches,
+    string Details)
+{
+    /// <summary>Whether every OPFS diagnostic check passed.</summary>
+    public bool Succeeded =>
+        CompetingContextRejected
+        && PositionalIoMatches
+        && AtomicReplaceMatches;
+}

--- a/src/Ahtola.Data.Sqlite.Browser/BrowserInMemoryManagedDatabaseAdapter.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/BrowserInMemoryManagedDatabaseAdapter.cs
@@ -1,0 +1,56 @@
+using System.Runtime.Versioning;
+using Ahtola.Core;
+
+namespace Ahtola.Data.Sqlite.Browser;
+
+[SupportedOSPlatform("browser")]
+internal sealed class BrowserInMemoryManagedDatabaseAdapter(
+    IManagedDatabaseAdapter inner,
+    Action released) : IManagedDatabaseAdapter
+{
+    private int _disposed;
+
+    public IManagedConnectionAdapter Connect()
+        => throw BrowserManagedAdapterErrors.SyncNotSupported("connecting");
+
+    public async ValueTask<IManagedConnectionAdapter> ConnectAsync(
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        return await inner.ConnectAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public IManagedConnectionAdapter Connection
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return inner.Connection;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+            return;
+        throw BrowserManagedAdapterErrors.SyncNotSupported("disposing the in-memory database");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        try
+        {
+            await inner.DisposeAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            released();
+        }
+    }
+
+    private void ThrowIfDisposed()
+        => ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+}

--- a/src/Ahtola.Data.Sqlite.Browser/BrowserManagedAdapters.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/BrowserManagedAdapters.cs
@@ -132,7 +132,10 @@ internal sealed class BrowserManagedDatabaseAdapter(
 [SupportedOSPlatform("browser")]
 internal sealed class BrowserManagedConnectionAdapter(
     IManagedConnectionAdapter inner,
-    BrowserMirroredFileSystem mirror) : IManagedConnectionAdapter
+    BrowserMirroredFileSystem mirror) :
+    IManagedConnectionAdapter,
+    IManagedConnectionAdapterDecorator,
+    IManagedConnectionDurabilityBoundary
 {
     private int _disposed;
 
@@ -213,8 +216,12 @@ internal sealed class BrowserManagedConnectionAdapter(
         string columnName,
         long rowId,
         bool readOnly = false)
-        => throw new PlatformNotSupportedException(
-            "Incremental blob I/O has only a synchronous managed API and is not supported by browser connections.");
+    {
+        ThrowIfDisposed();
+        return new BrowserManagedIncrementalBlobAdapter(
+            inner.OpenBlob(databaseName, tableName, columnName, rowId, readOnly),
+            mirror);
+    }
 
     public void RegisterScalarFunction(
         string name,
@@ -269,8 +276,73 @@ internal sealed class BrowserManagedConnectionAdapter(
         string sourceName)
         => throw BrowserManagedAdapterErrors.BackupNotSupported();
 
+    public ValueTask CopySnapshotToAsync(
+        IManagedConnectionAdapter destination,
+        CancellationToken cancellationToken = default)
+        => CopySnapshotToAsync(destination, "main", "main", cancellationToken);
+
+    public async ValueTask CopySnapshotToAsync(
+        IManagedConnectionAdapter destination,
+        string destinationName,
+        string sourceName,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        Exception? failure = null;
+        try
+        {
+            await inner
+                .CopySnapshotToAsync(
+                    destination,
+                    destinationName,
+                    sourceName,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            failure = exception;
+        }
+
+        failure = await BrowserManagedAdapterErrors
+            .FlushAndCombineAsync(mirror, failure)
+            .ConfigureAwait(false);
+        if (failure is not null)
+            ExceptionDispatchInfo.Capture(failure).Throw();
+    }
+
     public void ApplySnapshotPragmaHeader(int schemaVersion, int userVersion, int applicationId)
         => throw BrowserManagedAdapterErrors.BackupNotSupported();
+
+    public async ValueTask ApplySnapshotPragmaHeaderAsync(
+        int schemaVersion,
+        int userVersion,
+        int applicationId,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        Exception? failure = null;
+        try
+        {
+            await inner
+                .ApplySnapshotPragmaHeaderAsync(
+                    schemaVersion,
+                    userVersion,
+                    applicationId,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            failure = exception;
+        }
+
+        failure = await BrowserManagedAdapterErrors
+            .FlushAndCombineAsync(mirror, failure)
+            .ConfigureAwait(false);
+        if (failure is not null)
+            ExceptionDispatchInfo.Capture(failure).Throw();
+    }
 
     public void Dispose()
     {
@@ -298,6 +370,108 @@ internal sealed class BrowserManagedConnectionAdapter(
         }
         if (failure is not null)
             ExceptionDispatchInfo.Capture(failure).Throw();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        Exception? failure = null;
+        try
+        {
+            await inner.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            failure = exception;
+        }
+
+        failure = await BrowserManagedAdapterErrors
+            .FlushAndCombineAsync(mirror, failure)
+            .ConfigureAwait(false);
+        if (failure is not null)
+            ExceptionDispatchInfo.Capture(failure).Throw();
+    }
+
+    private void ThrowIfDisposed()
+        => ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+
+    internal IManagedConnectionAdapter Inner => inner;
+
+    IManagedConnectionAdapter IManagedConnectionAdapterDecorator.InnerConnectionAdapter
+        => inner;
+
+    ValueTask IManagedConnectionDurabilityBoundary.SynchronizeAsync()
+        => mirror.FlushPendingAsync(CancellationToken.None);
+
+    internal BrowserMirroredFileSystem Mirror => mirror;
+}
+
+[SupportedOSPlatform("browser")]
+internal sealed class BrowserManagedIncrementalBlobAdapter(
+    IManagedIncrementalBlobAdapter inner,
+    BrowserMirroredFileSystem mirror) : IManagedIncrementalBlobAdapter
+{
+    private int _disposed;
+
+    public long Length
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return inner.Length;
+        }
+    }
+
+    public int Read(long offset, Span<byte> destination)
+    {
+        ThrowIfDisposed();
+        throw BrowserManagedAdapterErrors.SyncNotSupported("incremental blob reads");
+    }
+
+    public void Write(long offset, ReadOnlySpan<byte> source)
+    {
+        ThrowIfDisposed();
+        throw BrowserManagedAdapterErrors.SyncNotSupported("incremental blob writes");
+    }
+
+    public async ValueTask<int> ReadAsync(
+        long offset,
+        Memory<byte> destination,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        return await inner.ReadAsync(offset, destination, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask WriteAsync(
+        long offset,
+        ReadOnlyMemory<byte> source,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        Exception? failure = null;
+        try
+        {
+            await inner.WriteAsync(offset, source, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            failure = exception;
+        }
+
+        failure = await BrowserManagedAdapterErrors
+            .FlushAndCombineAsync(mirror, failure)
+            .ConfigureAwait(false);
+        if (failure is not null)
+            ExceptionDispatchInfo.Capture(failure).Throw();
+    }
+
+    public void Dispose()
+    {
+        ThrowIfDisposed();
+        throw BrowserManagedAdapterErrors.SyncNotSupported("incremental blob disposal");
     }
 
     public async ValueTask DisposeAsync()
@@ -544,8 +718,8 @@ internal static class BrowserManagedAdapterErrors
 
     internal static PlatformNotSupportedException BackupNotSupported()
         => new(
-            "Backup and snapshot copying have only synchronous managed APIs and are not "
-            + "supported by browser connections.");
+            "Synchronous backup and snapshot copying are not supported by browser connections. "
+            + "Use the corresponding asynchronous API.");
 
     internal static void ThrowIfPending(BrowserMirroredFileSystem mirror, string operation)
     {

--- a/src/Ahtola.Data.Sqlite.Browser/BrowserManagedAdapters.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/BrowserManagedAdapters.cs
@@ -1,0 +1,580 @@
+using System.Runtime.ExceptionServices;
+using System.Runtime.Versioning;
+using Ahtola.Core;
+using Ahtola.Core.Storage;
+using Ahtola.Data.Sqlite.Browser.Storage;
+
+namespace Ahtola.Data.Sqlite.Browser;
+
+[SupportedOSPlatform("browser")]
+internal sealed class BrowserManagedDatabaseAdapter(
+    IManagedDatabaseAdapter inner,
+    BrowserMirroredFileSystem mirror,
+    Action released) : IManagedDatabaseAdapter
+{
+    private readonly object _gate = new();
+    private BrowserManagedConnectionAdapter? _connection;
+    private int _disposed;
+
+    public IManagedConnectionAdapter Connect()
+        => throw BrowserManagedAdapterErrors.SyncNotSupported("connecting");
+
+    public async ValueTask<IManagedConnectionAdapter> ConnectAsync(
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        IManagedConnectionAdapter? connected = null;
+        Exception? failure = null;
+        try
+        {
+            connected = await inner.ConnectAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            failure = exception;
+        }
+
+        failure = await BrowserManagedAdapterErrors
+            .FlushAndCombineAsync(mirror, failure)
+            .ConfigureAwait(false);
+        if (failure is not null)
+            ExceptionDispatchInfo.Capture(failure).Throw();
+
+        lock (_gate)
+        {
+            ThrowIfDisposed();
+            return _connection ??= new BrowserManagedConnectionAdapter(connected!, mirror);
+        }
+    }
+
+    public IManagedConnectionAdapter Connection
+    {
+        get
+        {
+            lock (_gate)
+            {
+                ThrowIfDisposed();
+                return _connection
+                    ?? throw new InvalidOperationException("The browser database has not been connected.");
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        Exception? failure = null;
+        try
+        {
+            try
+            {
+                inner.Dispose();
+            }
+            catch (Exception exception)
+            {
+                failure = exception;
+            }
+            try
+            {
+                BrowserManagedAdapterErrors.ThrowIfPending(mirror, "disposing the database");
+            }
+            catch (Exception exception)
+            {
+                failure = failure is null
+                    ? exception
+                    : new AggregateException(failure, exception);
+            }
+        }
+        finally
+        {
+            released();
+        }
+        if (failure is not null)
+            ExceptionDispatchInfo.Capture(failure).Throw();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        Exception? failure = null;
+        try
+        {
+            await inner.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            failure = exception;
+        }
+
+        try
+        {
+            failure = await BrowserManagedAdapterErrors
+                .FlushAndCombineAsync(mirror, failure)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            released();
+        }
+
+        if (failure is not null)
+            ExceptionDispatchInfo.Capture(failure).Throw();
+    }
+
+    private void ThrowIfDisposed()
+        => ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+}
+
+[SupportedOSPlatform("browser")]
+internal sealed class BrowserManagedConnectionAdapter(
+    IManagedConnectionAdapter inner,
+    BrowserMirroredFileSystem mirror) : IManagedConnectionAdapter
+{
+    private int _disposed;
+
+    public bool HasAttachedDatabases
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return inner.HasAttachedDatabases;
+        }
+    }
+
+    public TimeSpan BusyTimeout
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return inner.BusyTimeout;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            inner.BusyTimeout = value;
+        }
+    }
+
+    public ManagedConnectionHooks Hooks
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return inner.Hooks;
+        }
+    }
+
+    public IManagedStatementAdapter Prepare(string sql)
+    {
+        ThrowIfDisposed();
+        return new BrowserManagedStatementAdapter(inner.Prepare(sql), mirror);
+    }
+
+    public async ValueTask<IManagedStatementAdapter> PrepareAsync(
+        string sql,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        IManagedStatementAdapter? statement = null;
+        Exception? failure = null;
+        try
+        {
+            statement = await inner.PrepareAsync(sql, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            failure = exception;
+        }
+
+        failure = await BrowserManagedAdapterErrors
+            .FlushAndCombineAsync(mirror, failure)
+            .ConfigureAwait(false);
+        if (failure is not null)
+        {
+            if (statement is not null)
+                await statement.DisposeAsync().ConfigureAwait(false);
+            ExceptionDispatchInfo.Capture(failure).Throw();
+        }
+
+        return new BrowserManagedStatementAdapter(statement!, mirror);
+    }
+
+    public void ResetForPooling()
+        => throw new PlatformNotSupportedException(
+            "Browser-managed connections are owned by their data source and do not support pooling.");
+
+    public IManagedIncrementalBlobAdapter OpenBlob(
+        string databaseName,
+        string tableName,
+        string columnName,
+        long rowId,
+        bool readOnly = false)
+        => throw new PlatformNotSupportedException(
+            "Incremental blob I/O has only a synchronous managed API and is not supported by browser connections.");
+
+    public void RegisterScalarFunction(
+        string name,
+        int arity,
+        Func<IReadOnlyList<SqlValue>, SqlValue> function)
+    {
+        ThrowIfDisposed();
+        inner.RegisterScalarFunction(name, arity, function);
+    }
+
+    public int UnregisterScalarFunctions(string name)
+    {
+        ThrowIfDisposed();
+        return inner.UnregisterScalarFunctions(name);
+    }
+
+    public void RegisterAggregateFunction(
+        string name,
+        int arity,
+        SqlValue seed,
+        Func<SqlValue, IReadOnlyList<SqlValue>, SqlValue> step,
+        Func<SqlValue, SqlValue> finalize)
+    {
+        ThrowIfDisposed();
+        inner.RegisterAggregateFunction(name, arity, seed, step, finalize);
+    }
+
+    public int UnregisterAggregateFunctions(string name)
+    {
+        ThrowIfDisposed();
+        return inner.UnregisterAggregateFunctions(name);
+    }
+
+    public void RegisterCollation(string name, Func<string, string, int> compare)
+    {
+        ThrowIfDisposed();
+        inner.RegisterCollation(name, compare);
+    }
+
+    public bool UnregisterCollation(string name)
+    {
+        ThrowIfDisposed();
+        return inner.UnregisterCollation(name);
+    }
+
+    public void CopySnapshotTo(IManagedConnectionAdapter destination)
+        => throw BrowserManagedAdapterErrors.BackupNotSupported();
+
+    public void CopySnapshotTo(
+        IManagedConnectionAdapter destination,
+        string destinationName,
+        string sourceName)
+        => throw BrowserManagedAdapterErrors.BackupNotSupported();
+
+    public void ApplySnapshotPragmaHeader(int schemaVersion, int userVersion, int applicationId)
+        => throw BrowserManagedAdapterErrors.BackupNotSupported();
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        Exception? failure = null;
+        try
+        {
+            inner.Dispose();
+        }
+        catch (Exception exception)
+        {
+            failure = exception;
+        }
+        try
+        {
+            BrowserManagedAdapterErrors.ThrowIfPending(mirror, "disposing the connection");
+        }
+        catch (Exception exception)
+        {
+            failure = failure is null
+                ? exception
+                : new AggregateException(failure, exception);
+        }
+        if (failure is not null)
+            ExceptionDispatchInfo.Capture(failure).Throw();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        Exception? failure = null;
+        try
+        {
+            await inner.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            failure = exception;
+        }
+
+        failure = await BrowserManagedAdapterErrors
+            .FlushAndCombineAsync(mirror, failure)
+            .ConfigureAwait(false);
+        if (failure is not null)
+            ExceptionDispatchInfo.Capture(failure).Throw();
+    }
+
+    private void ThrowIfDisposed()
+        => ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+}
+
+[SupportedOSPlatform("browser")]
+internal sealed class BrowserManagedStatementAdapter(
+    IManagedStatementAdapter inner,
+    BrowserMirroredFileSystem mirror) : IManagedStatementAdapter
+{
+    private int _disposed;
+
+    public int ParameterCount
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return inner.ParameterCount;
+        }
+    }
+
+    public ManagedParameterMetadata ParameterMetadata => new(this);
+
+    public int RowsAffected
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return inner.RowsAffected;
+        }
+    }
+
+    public void Bind(int index, SqlValue value)
+    {
+        ThrowIfDisposed();
+        inner.Bind(index, value);
+    }
+
+    public int GetParameterIndex(string name)
+    {
+        ThrowIfDisposed();
+        return inner.GetParameterIndex(name);
+    }
+
+    public StatementStepResult Step()
+    {
+        ThrowIfDisposed();
+        return inner.Step();
+    }
+
+    public StatementStepResult Step(CancellationToken cancellationToken)
+    {
+        ThrowIfDisposed();
+        return inner.Step(cancellationToken);
+    }
+
+    public async ValueTask<StatementStepResult> StepAsync(
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        var result = default(StatementStepResult);
+        Exception? failure = null;
+        try
+        {
+            result = await inner.StepAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            failure = exception;
+        }
+
+        failure = await BrowserManagedAdapterErrors
+            .FlushAndCombineAsync(mirror, failure)
+            .ConfigureAwait(false);
+        if (failure is not null)
+            ExceptionDispatchInfo.Capture(failure).Throw();
+        return result;
+    }
+
+    public bool HasRows()
+    {
+        ThrowIfDisposed();
+        return inner.HasRows();
+    }
+
+    public void Reset()
+    {
+        ThrowIfDisposed();
+        inner.Reset();
+    }
+
+    public async ValueTask ResetAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        Exception? failure = null;
+        try
+        {
+            await inner.ResetAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            failure = exception;
+        }
+
+        failure = await BrowserManagedAdapterErrors
+            .FlushAndCombineAsync(mirror, failure)
+            .ConfigureAwait(false);
+        if (failure is not null)
+            ExceptionDispatchInfo.Capture(failure).Throw();
+    }
+
+    public void ClearBindings()
+    {
+        ThrowIfDisposed();
+        inner.ClearBindings();
+    }
+
+    public SqlValue GetValue(int ordinal)
+    {
+        ThrowIfDisposed();
+        return inner.GetValue(ordinal);
+    }
+
+    public string GetColumnName(int ordinal)
+    {
+        ThrowIfDisposed();
+        return inner.GetColumnName(ordinal);
+    }
+
+    public int GetColumnCount()
+    {
+        ThrowIfDisposed();
+        return inner.GetColumnCount();
+    }
+
+    public ManagedResultValue GetResultValue(int ordinal)
+    {
+        ThrowIfDisposed();
+        return inner.GetResultValue(ordinal);
+    }
+
+    public ManagedResultColumn GetResultColumn(int ordinal)
+    {
+        ThrowIfDisposed();
+        return inner.GetResultColumn(ordinal);
+    }
+
+    public int GetResultColumnCount()
+    {
+        ThrowIfDisposed();
+        return inner.GetResultColumnCount();
+    }
+
+    public string? GetParameterName(int index)
+    {
+        ThrowIfDisposed();
+        return inner.GetParameterName(index);
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        Exception? failure = null;
+        try
+        {
+            inner.Dispose();
+        }
+        catch (Exception exception)
+        {
+            failure = exception;
+        }
+        try
+        {
+            BrowserManagedAdapterErrors.ThrowIfPending(mirror, "disposing the statement");
+        }
+        catch (Exception exception)
+        {
+            failure = failure is null
+                ? exception
+                : new AggregateException(failure, exception);
+        }
+        if (failure is not null)
+            ExceptionDispatchInfo.Capture(failure).Throw();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        Exception? failure = null;
+        try
+        {
+            await inner.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            failure = exception;
+        }
+
+        failure = await BrowserManagedAdapterErrors
+            .FlushAndCombineAsync(mirror, failure)
+            .ConfigureAwait(false);
+        if (failure is not null)
+            ExceptionDispatchInfo.Capture(failure).Throw();
+    }
+
+    private void ThrowIfDisposed()
+        => ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+}
+
+[SupportedOSPlatform("browser")]
+internal static class BrowserManagedAdapterErrors
+{
+    internal static PlatformNotSupportedException SyncNotSupported(string operation)
+        => new(
+            $"Synchronous {operation} is not supported by browser-managed databases. "
+            + "Use the corresponding asynchronous API.");
+
+    internal static PlatformNotSupportedException BackupNotSupported()
+        => new(
+            "Backup and snapshot copying have only synchronous managed APIs and are not "
+            + "supported by browser connections.");
+
+    internal static void ThrowIfPending(BrowserMirroredFileSystem mirror, string operation)
+    {
+        if (mirror.HasPendingMutations)
+        {
+            throw new PlatformNotSupportedException(
+                $"Synchronous {operation} cannot persist pending browser database mutations. "
+                + "Use asynchronous disposal.");
+        }
+    }
+
+    internal static async ValueTask<Exception?> FlushAndCombineAsync(
+        BrowserMirroredFileSystem mirror,
+        Exception? failure)
+    {
+        try
+        {
+            await mirror.FlushPendingAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception flushFailure)
+        {
+            failure = failure is null
+                ? flushFailure
+                : new AggregateException(
+                    "The browser database operation and durable mirror flush both failed.",
+                    failure,
+                    flushFailure);
+        }
+
+        return failure;
+    }
+}

--- a/src/Ahtola.Data.Sqlite.Browser/Interop/BrowserCryptoInterop.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Interop/BrowserCryptoInterop.cs
@@ -12,7 +12,7 @@ internal static class AhtolaBrowserCryptoRuntime
     private static readonly object Gate = new();
     private static Task? s_moduleInitialization;
 
-    internal static Task InitializeAsync()
+    internal static async Task InitializeAsync()
     {
         if (!OperatingSystem.IsBrowser())
         {
@@ -20,8 +20,23 @@ internal static class AhtolaBrowserCryptoRuntime
                 "Ahtola browser cryptography is supported only by a .NET browser WebAssembly runtime.");
         }
 
+        Task initialization;
         lock (Gate)
-            return s_moduleInitialization ??= JSHost.ImportAsync(ModuleName, ModuleUrl);
+            initialization = s_moduleInitialization ??= JSHost.ImportAsync(ModuleName, ModuleUrl);
+
+        try
+        {
+            await initialization.ConfigureAwait(false);
+        }
+        catch
+        {
+            lock (Gate)
+            {
+                if (ReferenceEquals(s_moduleInitialization, initialization))
+                    s_moduleInitialization = null;
+            }
+            throw;
+        }
     }
 }
 

--- a/src/Ahtola.Data.Sqlite.Browser/Interop/BrowserCryptoInterop.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Interop/BrowserCryptoInterop.cs
@@ -1,0 +1,77 @@
+using System.Runtime.InteropServices.JavaScript;
+using System.Runtime.Versioning;
+
+namespace Ahtola.Data.Sqlite.Browser.Interop;
+
+[SupportedOSPlatform("browser")]
+internal static class AhtolaBrowserCryptoRuntime
+{
+    private const string ModuleName = "Devolutions.Ahtola.Data.Sqlite.Browser.Crypto";
+    private const string ModuleUrl =
+        "../_content/Devolutions.Ahtola.Data.Sqlite.Browser/ahtola-crypto.mjs";
+    private static readonly object Gate = new();
+    private static Task? s_moduleInitialization;
+
+    internal static Task InitializeAsync()
+    {
+        if (!OperatingSystem.IsBrowser())
+        {
+            throw new PlatformNotSupportedException(
+                "Ahtola browser cryptography is supported only by a .NET browser WebAssembly runtime.");
+        }
+
+        lock (Gate)
+            return s_moduleInitialization ??= JSHost.ImportAsync(ModuleName, ModuleUrl);
+    }
+}
+
+[SupportedOSPlatform("browser")]
+internal static partial class BrowserCryptoInterop
+{
+    private const string ModuleName = "Devolutions.Ahtola.Data.Sqlite.Browser.Crypto";
+
+    [JSImport("createPasswordKey", ModuleName)]
+    internal static partial Task<int> CreatePasswordKeyAsync(
+        string password,
+        string salt,
+        int iterations,
+        int keyLengthBits);
+
+    [JSImport("derivePasswordBits", ModuleName)]
+    [return: JSMarshalAs<JSType.Promise<JSType.Object>>]
+    internal static partial Task<JSObject> DerivePasswordBitsAsync(
+        string password,
+        string salt,
+        int iterations,
+        int outputLengthBits);
+
+    [JSImport("importAesGcmKey", ModuleName)]
+    internal static partial Task<int> ImportAesGcmKeyAsync(byte[] key);
+
+    [JSImport("encryptAesGcm", ModuleName)]
+    [return: JSMarshalAs<JSType.Promise<JSType.Object>>]
+    internal static partial Task<JSObject> EncryptAesGcmAsync(
+        int keyHandle,
+        byte[] nonce,
+        byte[] plaintext,
+        byte[] associatedData);
+
+    [JSImport("decryptAesGcm", ModuleName)]
+    [return: JSMarshalAs<JSType.Promise<JSType.Object>>]
+    internal static partial Task<JSObject> DecryptAesGcmAsync(
+        int keyHandle,
+        byte[] nonce,
+        byte[] ciphertext,
+        byte[] tag,
+        byte[] associatedData);
+
+    [JSImport("consumeByteArray", ModuleName)]
+    [return: JSMarshalAs<JSType.Array<JSType.Number>>]
+    internal static partial byte[] ConsumeByteArray(JSObject value);
+
+    [JSImport("releaseKey", ModuleName)]
+    internal static partial void ReleaseKey(int keyHandle);
+
+    [JSImport("getRetainedKeyCount", ModuleName)]
+    internal static partial int GetRetainedKeyCount();
+}

--- a/src/Ahtola.Data.Sqlite.Browser/Interop/OpfsWorkerClient.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Interop/OpfsWorkerClient.cs
@@ -1,0 +1,128 @@
+using System.Runtime.Versioning;
+
+namespace Ahtola.Data.Sqlite.Browser.Interop;
+
+[SupportedOSPlatform("browser")]
+internal sealed class OpfsWorkerClient : IAsyncDisposable
+{
+    private const long MaximumSafeJavaScriptInteger = 9_007_199_254_740_991;
+    private int _contextId;
+
+    private OpfsWorkerClient(int contextId)
+    {
+        _contextId = contextId;
+    }
+
+    public static async ValueTask<OpfsWorkerClient> CreateAsync(
+        string lockName,
+        int sharedBufferSize,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(lockName);
+        ArgumentOutOfRangeException.ThrowIfLessThan(sharedBufferSize, 64 * 1024);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        await AhtolaBrowserRuntime.InitializeAsync().ConfigureAwait(false);
+        var contextId = await BrowserInterop
+            .CreateContextAsync(lockName, sharedBufferSize)
+            .WaitAsync(cancellationToken)
+            .ConfigureAwait(false);
+        return new OpfsWorkerClient(contextId);
+    }
+
+    public Task<bool> FileExistsAsync(string path, CancellationToken cancellationToken)
+        => BrowserInterop.FileExistsAsync(GetContextId(), path).WaitAsync(cancellationToken);
+
+    public Task<int> OpenFileAsync(
+        string path,
+        int mode,
+        bool readOnly,
+        CancellationToken cancellationToken)
+        => BrowserInterop
+            .OpenFileAsync(GetContextId(), path, mode, readOnly)
+            .WaitAsync(cancellationToken);
+
+    public async ValueTask<long> GetLengthAsync(int handleId, CancellationToken cancellationToken)
+    {
+        var length = await BrowserInterop
+            .GetLengthAsync(GetContextId(), handleId)
+            .WaitAsync(cancellationToken)
+            .ConfigureAwait(false);
+        if (length < 0 || length > MaximumSafeJavaScriptInteger || Math.Truncate(length) != length)
+            throw new IOException("The OPFS worker returned an invalid file length.");
+        return (long)length;
+    }
+
+    public async Task<byte[]> ReadAsync(
+        int handleId,
+        long position,
+        int length,
+        CancellationToken cancellationToken)
+    {
+        ValidatePosition(position);
+        ArgumentOutOfRangeException.ThrowIfNegative(length);
+        using var result = await BrowserInterop
+            .ReadFileAsync(GetContextId(), handleId, position, length)
+            .WaitAsync(cancellationToken)
+            .ConfigureAwait(false);
+        return BrowserInterop.UnwrapByteArray(result);
+    }
+
+    public Task<int> WriteAsync(
+        int handleId,
+        long position,
+        byte[] source,
+        CancellationToken cancellationToken)
+    {
+        ValidatePosition(position);
+        ArgumentNullException.ThrowIfNull(source);
+        return BrowserInterop
+            .WriteFileAsync(GetContextId(), handleId, position, source)
+            .WaitAsync(cancellationToken);
+    }
+
+    public Task SetLengthAsync(
+        int handleId,
+        long length,
+        CancellationToken cancellationToken)
+    {
+        ValidatePosition(length);
+        return BrowserInterop
+            .SetLengthAsync(GetContextId(), handleId, length)
+            .WaitAsync(cancellationToken);
+    }
+
+    public Task FlushAsync(int handleId, CancellationToken cancellationToken)
+        => BrowserInterop.FlushFileAsync(GetContextId(), handleId).WaitAsync(cancellationToken);
+
+    public Task CloseAsync(int handleId, CancellationToken cancellationToken)
+        => BrowserInterop.CloseFileAsync(GetContextId(), handleId).WaitAsync(cancellationToken);
+
+    public Task DeleteAsync(string path, CancellationToken cancellationToken)
+        => BrowserInterop.DeleteFileAsync(GetContextId(), path).WaitAsync(cancellationToken);
+
+    public async ValueTask DisposeAsync()
+    {
+        var contextId = Interlocked.Exchange(ref _contextId, 0);
+        if (contextId != 0)
+            await BrowserInterop.DisposeContextAsync(contextId).ConfigureAwait(false);
+    }
+
+    private int GetContextId()
+    {
+        ObjectDisposedException.ThrowIf(_contextId == 0, this);
+        return _contextId;
+    }
+
+    private static void ValidatePosition(long value)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(value);
+        if (value > MaximumSafeJavaScriptInteger)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(value),
+                value,
+                "OPFS offsets must fit exactly in a JavaScript Number.");
+        }
+    }
+}

--- a/src/Ahtola.Data.Sqlite.Browser/Interop/OpfsWorkerClient.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Interop/OpfsWorkerClient.cs
@@ -169,6 +169,19 @@ internal sealed class OpfsWorkerClient : IAsyncDisposable
         await BrowserInterop.DeleteFileAsync(GetContextId(), path).ConfigureAwait(false);
     }
 
+    public async Task<IReadOnlyList<string>> ListFilesAsync(
+        string directoryPath,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var result = await BrowserInterop
+            .ListFilesAsync(GetContextId(), directoryPath)
+            .ConfigureAwait(false);
+        return string.IsNullOrEmpty(result)
+            ? []
+            : result.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+    }
+
     public async Task ReplaceFileAtomicallyAsync(
         string sourcePath,
         string destinationPath,

--- a/src/Ahtola.Data.Sqlite.Browser/Interop/OpfsWorkerClient.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Interop/OpfsWorkerClient.cs
@@ -101,6 +101,27 @@ internal sealed class OpfsWorkerClient : IAsyncDisposable
     public Task DeleteAsync(string path, CancellationToken cancellationToken)
         => BrowserInterop.DeleteFileAsync(GetContextId(), path).WaitAsync(cancellationToken);
 
+    public async Task ReplaceFileAtomicallyAsync(
+        string sourcePath,
+        string destinationPath,
+        bool replaceEmptyDestination,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var contextId = GetContextId();
+        using var registration = cancellationToken.UnsafeRegister(
+            static state => BrowserInterop.CancelCurrentOperation((int)state!),
+            contextId);
+        await BrowserInterop
+            .ReplaceFileAtomicallyAsync(
+                contextId,
+                sourcePath,
+                destinationPath,
+                replaceEmptyDestination)
+            .WaitAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     public async ValueTask DisposeAsync()
     {
         var contextId = Interlocked.Exchange(ref _contextId, 0);

--- a/src/Ahtola.Data.Sqlite.Browser/Interop/OpfsWorkerClient.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Interop/OpfsWorkerClient.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 
 namespace Ahtola.Data.Sqlite.Browser.Interop;
@@ -6,11 +7,14 @@ namespace Ahtola.Data.Sqlite.Browser.Interop;
 internal sealed class OpfsWorkerClient : IAsyncDisposable
 {
     private const long MaximumSafeJavaScriptInteger = 9_007_199_254_740_991;
+    private readonly SemaphoreSlim _sharedBufferGate = new(1, 1);
+    private readonly int _sharedBufferSize;
     private int _contextId;
 
-    private OpfsWorkerClient(int contextId)
+    private OpfsWorkerClient(int contextId, int sharedBufferSize)
     {
         _contextId = contextId;
+        _sharedBufferSize = sharedBufferSize;
     }
 
     public static async ValueTask<OpfsWorkerClient> CreateAsync(
@@ -25,81 +29,145 @@ internal sealed class OpfsWorkerClient : IAsyncDisposable
         await AhtolaBrowserRuntime.InitializeAsync().ConfigureAwait(false);
         var contextId = await BrowserInterop
             .CreateContextAsync(lockName, sharedBufferSize)
-            .WaitAsync(cancellationToken)
             .ConfigureAwait(false);
-        return new OpfsWorkerClient(contextId);
+        return new OpfsWorkerClient(contextId, sharedBufferSize);
     }
 
-    public Task<bool> FileExistsAsync(string path, CancellationToken cancellationToken)
-        => BrowserInterop.FileExistsAsync(GetContextId(), path).WaitAsync(cancellationToken);
+    public async Task<bool> FileExistsAsync(string path, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return await BrowserInterop.FileExistsAsync(GetContextId(), path).ConfigureAwait(false);
+    }
 
-    public Task<int> OpenFileAsync(
+    public async Task<int> OpenFileAsync(
         string path,
         int mode,
         bool readOnly,
         CancellationToken cancellationToken)
-        => BrowserInterop
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return await BrowserInterop
             .OpenFileAsync(GetContextId(), path, mode, readOnly)
-            .WaitAsync(cancellationToken);
+            .ConfigureAwait(false);
+    }
 
     public async ValueTask<long> GetLengthAsync(int handleId, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var length = await BrowserInterop
             .GetLengthAsync(GetContextId(), handleId)
-            .WaitAsync(cancellationToken)
             .ConfigureAwait(false);
         if (length < 0 || length > MaximumSafeJavaScriptInteger || Math.Truncate(length) != length)
             throw new IOException("The OPFS worker returned an invalid file length.");
         return (long)length;
     }
 
-    public async Task<byte[]> ReadAsync(
+    public async ValueTask<int> ReadAsync(
         int handleId,
         long position,
-        int length,
+        Memory<byte> destination,
         CancellationToken cancellationToken)
     {
         ValidatePosition(position);
-        ArgumentOutOfRangeException.ThrowIfNegative(length);
-        using var result = await BrowserInterop
-            .ReadFileAsync(GetContextId(), handleId, position, length)
-            .WaitAsync(cancellationToken)
-            .ConfigureAwait(false);
-        return BrowserInterop.UnwrapByteArray(result);
+        if (destination.IsEmpty)
+            return 0;
+
+        await _sharedBufferGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var contextId = GetContextId();
+            var total = 0;
+            while (total < destination.Length)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var count = Math.Min(destination.Length - total, _sharedBufferSize);
+                var read = await BrowserInterop
+                    .ReadFileAsync(contextId, handleId, position + total, count)
+                    .ConfigureAwait(false);
+                if ((uint)read > (uint)count)
+                    throw new IOException("The OPFS worker returned an invalid read length.");
+                if (read == 0)
+                    break;
+
+                CopyFromSharedBuffer(contextId, destination.Slice(total, read));
+                total += read;
+                if (read < count)
+                    break;
+            }
+            return total;
+        }
+        finally
+        {
+            _sharedBufferGate.Release();
+        }
     }
 
-    public Task<int> WriteAsync(
+    public async ValueTask WriteAsync(
         int handleId,
         long position,
-        byte[] source,
+        ReadOnlyMemory<byte> source,
         CancellationToken cancellationToken)
     {
         ValidatePosition(position);
-        ArgumentNullException.ThrowIfNull(source);
-        return BrowserInterop
-            .WriteFileAsync(GetContextId(), handleId, position, source)
-            .WaitAsync(cancellationToken);
+        if (source.IsEmpty)
+            return;
+
+        await _sharedBufferGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var contextId = GetContextId();
+            var total = 0;
+            while (total < source.Length)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var count = Math.Min(source.Length - total, _sharedBufferSize);
+                CopyToSharedBuffer(contextId, source.Slice(total, count));
+                var written = await BrowserInterop
+                    .WriteFileAsync(contextId, handleId, position + total, count)
+                    .ConfigureAwait(false);
+                if (written != count)
+                {
+                    throw new IOException(
+                        $"The OPFS worker wrote {written} of {count} requested bytes.");
+                }
+                total += written;
+            }
+        }
+        finally
+        {
+            _sharedBufferGate.Release();
+        }
     }
 
-    public Task SetLengthAsync(
+    public async Task SetLengthAsync(
         int handleId,
         long length,
         CancellationToken cancellationToken)
     {
         ValidatePosition(length);
-        return BrowserInterop
+        cancellationToken.ThrowIfCancellationRequested();
+        await BrowserInterop
             .SetLengthAsync(GetContextId(), handleId, length)
-            .WaitAsync(cancellationToken);
+            .ConfigureAwait(false);
     }
 
-    public Task FlushAsync(int handleId, CancellationToken cancellationToken)
-        => BrowserInterop.FlushFileAsync(GetContextId(), handleId).WaitAsync(cancellationToken);
+    public async Task FlushAsync(int handleId, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await BrowserInterop.FlushFileAsync(GetContextId(), handleId).ConfigureAwait(false);
+    }
 
-    public Task CloseAsync(int handleId, CancellationToken cancellationToken)
-        => BrowserInterop.CloseFileAsync(GetContextId(), handleId).WaitAsync(cancellationToken);
+    public async Task CloseAsync(int handleId, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await BrowserInterop.CloseFileAsync(GetContextId(), handleId).ConfigureAwait(false);
+    }
 
-    public Task DeleteAsync(string path, CancellationToken cancellationToken)
-        => BrowserInterop.DeleteFileAsync(GetContextId(), path).WaitAsync(cancellationToken);
+    public async Task DeleteAsync(string path, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await BrowserInterop.DeleteFileAsync(GetContextId(), path).ConfigureAwait(false);
+    }
 
     public async Task ReplaceFileAtomicallyAsync(
         string sourcePath,
@@ -107,19 +175,44 @@ internal sealed class OpfsWorkerClient : IAsyncDisposable
         bool replaceEmptyDestination,
         CancellationToken cancellationToken)
     {
-        cancellationToken.ThrowIfCancellationRequested();
-        var contextId = GetContextId();
-        using var registration = cancellationToken.UnsafeRegister(
-            static state => BrowserInterop.CancelCurrentOperation((int)state!),
-            contextId);
-        await BrowserInterop
-            .ReplaceFileAtomicallyAsync(
-                contextId,
-                sourcePath,
-                destinationPath,
-                replaceEmptyDestination)
-            .WaitAsync(cancellationToken)
-            .ConfigureAwait(false);
+        await _sharedBufferGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var contextId = GetContextId();
+            var operationId = BrowserInterop.AllocateOperationId(contextId);
+            var cancellationState = new CancellationState(contextId, operationId);
+            using var registration = cancellationToken.UnsafeRegister(
+                static state =>
+                {
+                    var cancellation = (CancellationState)state!;
+                    BrowserInterop.CancelOperation(
+                        cancellation.ContextId,
+                        cancellation.OperationId);
+                },
+                cancellationState);
+            try
+            {
+                await BrowserInterop
+                    .ReplaceFileAtomicallyAsync(
+                        contextId,
+                        operationId,
+                        sourcePath,
+                        destinationPath,
+                        replaceEmptyDestination)
+                    .ConfigureAwait(false);
+            }
+            catch (System.Runtime.InteropServices.JavaScript.JSException exception) when (
+                cancellationToken.IsCancellationRequested
+                && exception.Message.Contains("AbortError", StringComparison.Ordinal))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                throw;
+            }
+        }
+        finally
+        {
+            _sharedBufferGate.Release();
+        }
     }
 
     public async ValueTask DisposeAsync()
@@ -127,6 +220,7 @@ internal sealed class OpfsWorkerClient : IAsyncDisposable
         var contextId = Interlocked.Exchange(ref _contextId, 0);
         if (contextId != 0)
             await BrowserInterop.DisposeContextAsync(contextId).ConfigureAwait(false);
+        _sharedBufferGate.Dispose();
     }
 
     private int GetContextId()
@@ -146,4 +240,39 @@ internal sealed class OpfsWorkerClient : IAsyncDisposable
                 "OPFS offsets must fit exactly in a JavaScript Number.");
         }
     }
+
+    private static void CopyFromSharedBuffer(int contextId, Memory<byte> destination)
+    {
+        byte[]? temporary = null;
+        if (!MemoryMarshal.TryGetArray((ReadOnlyMemory<byte>)destination, out var segment))
+        {
+            temporary = new byte[destination.Length];
+            segment = new ArraySegment<byte>(temporary);
+        }
+
+        var copied = BrowserInterop.CopyFromSharedBuffer(
+            contextId,
+            segment,
+            destination.Length);
+        if (copied != destination.Length)
+            throw new IOException("The OPFS shared buffer returned an invalid copy length.");
+        if (temporary is not null)
+            temporary.AsMemory().CopyTo(destination);
+    }
+
+    private static void CopyToSharedBuffer(int contextId, ReadOnlyMemory<byte> source)
+    {
+        byte[]? temporary = null;
+        if (!MemoryMarshal.TryGetArray(source, out var segment))
+        {
+            temporary = source.ToArray();
+            segment = new ArraySegment<byte>(temporary);
+        }
+
+        var copied = BrowserInterop.CopyToSharedBuffer(contextId, segment);
+        if (copied != source.Length)
+            throw new IOException("The OPFS shared buffer accepted an invalid copy length.");
+    }
+
+    private sealed record CancellationState(int ContextId, int OperationId);
 }

--- a/src/Ahtola.Data.Sqlite.Browser/Properties/AssemblyInfo.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Ahtola.Tests")]

--- a/src/Ahtola.Data.Sqlite.Browser/Storage/AhtolaAsyncPageTransformer.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Storage/AhtolaAsyncPageTransformer.cs
@@ -1,0 +1,180 @@
+using System.Runtime.Versioning;
+using System.Security.Cryptography;
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Data.Sqlite.Browser.Storage;
+
+/// <summary>
+/// Bridges <see cref="AhtolaBrowserCryptoService"/> (Web Crypto) to the
+/// asynchronous page cipher used by encrypted OPFS persistence.
+/// </summary>
+[SupportedOSPlatform("browser")]
+internal sealed class AhtolaBrowserWebCryptoPageCipher(AhtolaBrowserCryptoService service)
+    : IAhtolaAsyncPageCipher
+{
+    /// <inheritdoc />
+    public Core.Storage.AhtolaEncryptionCipher Cipher
+        => AhtolaBrowserCryptoParameters.ToStorageCipher(service.Cipher);
+
+    /// <inheritdoc />
+    public async ValueTask<AhtolaBrowserAesGcmResult> EncryptAsync(
+        ReadOnlyMemory<byte> plaintext,
+        ReadOnlyMemory<byte> nonce,
+        ReadOnlyMemory<byte> associatedData,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return await service.EncryptAsync(plaintext, nonce, associatedData).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<byte[]> DecryptAsync(
+        ReadOnlyMemory<byte> ciphertext,
+        ReadOnlyMemory<byte> tag,
+        ReadOnlyMemory<byte> nonce,
+        ReadOnlyMemory<byte> associatedData,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return await service
+            .DecryptAsync(ciphertext, tag, nonce, associatedData)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync() => service.DisposeAsync();
+
+    internal static async ValueTask<IAhtolaAsyncPageCipher> CreateAsync(
+        AhtolaBrowserEncryptionOptions encryption)
+    {
+        var service = await encryption.CreateCryptoServiceAsync().ConfigureAwait(false);
+        try
+        {
+            return new AhtolaBrowserWebCryptoPageCipher(service);
+        }
+        catch
+        {
+            await service.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+}
+
+/// <summary>
+/// Encrypts and decrypts complete SQLite pages in Ahtola's AHTLA version 0
+/// format using an asynchronous AES-GCM primitive.
+/// </summary>
+/// <remarks>
+/// The produced bytes are identical to the desktop
+/// <c>AhtolaPageEncryption</c> output: page 1 keeps a visible 100-byte header
+/// beginning with the AHTLA magic and authenticates it as associated data,
+/// every page stores a 16-byte tag followed by a 12-byte nonce in the
+/// <see cref="AhtolaEncryptedPageFormat.MetadataSize"/> reserved bytes, and no
+/// other page carries associated data.
+/// </remarks>
+internal sealed class AhtolaAsyncPageTransformer(IAhtolaAsyncPageCipher cipher) : IAsyncDisposable
+{
+    /// <summary>Reserved bytes every encrypted page requires.</summary>
+    internal const int ReservedBytes = AhtolaEncryptedPageFormat.MetadataSize;
+
+    /// <summary>The AHTLA cipher id recorded in encrypted page 1 headers.</summary>
+    internal Core.Storage.AhtolaEncryptionCipher Cipher => cipher.Cipher;
+
+    /// <summary>Encrypts one whole plaintext page.</summary>
+    internal async ValueTask<byte[]> EncryptPageAsync(
+        ReadOnlyMemory<byte> page,
+        uint pageNumber,
+        CancellationToken cancellationToken)
+    {
+        var pageSize = ValidatePage(page.Length, pageNumber);
+        AhtolaEncryptedPageFormat.ValidatePlaintextReservedBytes(page.Span, pageNumber);
+
+        var encrypted = new byte[pageSize];
+        if (pageNumber == 1)
+            AhtolaEncryptedPageFormat.WriteEncryptedHeaderPrefix(encrypted, page.Span, Cipher);
+
+        var regions = AhtolaEncryptedPageFormat.Describe(pageSize, pageNumber);
+        var nonce = new byte[AhtolaEncryptedPageFormat.NonceSize];
+        RandomNumberGenerator.Fill(nonce);
+        nonce.CopyTo(encrypted.AsSpan(regions.NonceOffset));
+
+        var associatedData = encrypted
+            .AsMemory(regions.AssociatedDataOffset, regions.AssociatedDataLength);
+        var result = await cipher
+            .EncryptAsync(
+                page.Slice(regions.PayloadOffset, regions.PayloadLength),
+                nonce,
+                associatedData,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        if (result.Ciphertext.Length != regions.PayloadLength
+            || result.Tag.Length != AhtolaEncryptedPageFormat.TagSize)
+        {
+            throw new CryptographicException(
+                "The asynchronous AES-GCM provider returned an unexpected ciphertext or tag length.");
+        }
+
+        result.Ciphertext.CopyTo(encrypted.AsSpan(regions.PayloadOffset));
+        result.Tag.CopyTo(encrypted.AsSpan(regions.TagOffset));
+        return encrypted;
+    }
+
+    /// <summary>Authenticates and decrypts one whole encrypted page.</summary>
+    internal async ValueTask<byte[]> DecryptPageAsync(
+        ReadOnlyMemory<byte> encryptedPage,
+        uint pageNumber,
+        CancellationToken cancellationToken)
+    {
+        var pageSize = ValidatePage(encryptedPage.Length, pageNumber);
+        if (pageNumber == 1)
+            AhtolaEncryptedPageFormat.ValidateEncryptedHeader(encryptedPage.Span, Cipher);
+
+        var plaintext = new byte[pageSize];
+        if (pageNumber == 1)
+            AhtolaEncryptedPageFormat.RestorePlaintextHeaderPrefix(plaintext, encryptedPage.Span);
+
+        var regions = AhtolaEncryptedPageFormat.Describe(pageSize, pageNumber);
+        byte[] payload;
+        try
+        {
+            payload = await cipher
+                .DecryptAsync(
+                    encryptedPage.Slice(regions.PayloadOffset, regions.PayloadLength),
+                    encryptedPage.Slice(regions.TagOffset, AhtolaEncryptedPageFormat.TagSize),
+                    encryptedPage.Slice(regions.NonceOffset, AhtolaEncryptedPageFormat.NonceSize),
+                    encryptedPage.Slice(regions.AssociatedDataOffset, regions.AssociatedDataLength),
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (CryptographicException exception)
+        {
+            throw AhtolaEncryptedPageFormat.CreateAuthenticationFailure(pageNumber, exception);
+        }
+
+        try
+        {
+            if (payload.Length != regions.PayloadLength)
+                throw AhtolaEncryptedPageFormat.CreateAuthenticationFailure(pageNumber, inner: null);
+
+            payload.CopyTo(plaintext.AsSpan(regions.PayloadOffset));
+            return plaintext;
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(payload);
+        }
+    }
+
+    private static int ValidatePage(int length, uint pageNumber)
+    {
+        if (pageNumber == 0)
+            throw new ArgumentOutOfRangeException(nameof(pageNumber), "SQLite page numbers are 1-based.");
+        _ = SqlitePageSize.Encode(length);
+        AhtolaEncryptedPageFormat.ValidatePageSize(length);
+        return length;
+    }
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync() => cipher.DisposeAsync();
+}

--- a/src/Ahtola.Data.Sqlite.Browser/Storage/AhtolaBrowserReservedSpaceCodec.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Storage/AhtolaBrowserReservedSpaceCodec.cs
@@ -1,0 +1,51 @@
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Data.Sqlite.Browser.Storage;
+
+/// <summary>
+/// Reserves the bytes Ahtola page encryption needs without transforming page
+/// content, so the browser engine keeps operating on plaintext while OPFS
+/// persistence encrypts asynchronously through Web Crypto.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Web Crypto is promise-based, so it cannot satisfy the synchronous
+/// <see cref="IPageCodec"/> contract that the desktop encryption codec
+/// implements. Binding this codec still forces the pager to create databases
+/// with <see cref="AhtolaEncryptedPageFormat.MetadataSize"/> reserved bytes per
+/// page from creation onward, and to reject an existing database whose reserved
+/// space does not match, which is exactly the layout the asynchronous transform
+/// needs for the 16-byte tag and 12-byte nonce it stores per page.
+/// </para>
+/// <para>
+/// The identity transform is deliberate: pages, WAL frames, and journal records
+/// stay plaintext inside the in-memory mirror and are encrypted only on their way
+/// to durable OPFS storage.
+/// </para>
+/// </remarks>
+internal sealed class AhtolaBrowserReservedSpaceCodec : IPageCodec
+{
+    private static readonly PageCodecId Id = CreateId();
+
+    /// <inheritdoc />
+    public PageCodecId CodecId => Id;
+
+    /// <inheritdoc />
+    public byte RequiredReservedBytes => checked((byte)AhtolaEncryptedPageFormat.MetadataSize);
+
+    /// <inheritdoc />
+    public void EncodePage(PageCodecContext context, ReadOnlySpan<byte> input, Span<byte> output)
+        => input.CopyTo(output);
+
+    /// <inheritdoc />
+    public void DecodePage(PageCodecContext context, ReadOnlySpan<byte> input, Span<byte> output)
+        => input.CopyTo(output);
+
+    private static PageCodecId CreateId()
+    {
+        Span<byte> id = stackalloc byte[16];
+        "ahtola-browser-r"u8.CopyTo(id);
+        id[15] = AhtolaEncryptedPageFormat.MetadataSize;
+        return new PageCodecId(id);
+    }
+}

--- a/src/Ahtola.Data.Sqlite.Browser/Storage/BrowserEncryptedPersistence.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Storage/BrowserEncryptedPersistence.cs
@@ -96,13 +96,20 @@ internal sealed class BrowserWalChainUpdate(
 /// </summary>
 internal sealed class BrowserLoadPlan(
     IReadOnlyList<(string Path, BrowserPersistedFileKind Kind)> files,
-    IReadOnlyList<string> transientArtifacts)
+    IReadOnlyList<string> transientArtifacts,
+    IReadOnlyList<string> ignoredPaths)
 {
     /// <summary>Files to load, in an order where every base path precedes its sidecars.</summary>
     internal IReadOnlyList<(string Path, BrowserPersistedFileKind Kind)> Files { get; } = files;
 
     /// <summary>Abandoned engine temporaries that are safe to discard.</summary>
     internal IReadOnlyList<string> TransientArtifacts { get; } = transientArtifacts;
+
+    /// <summary>
+    /// Paths that carry no content the encrypted engine can use and are left
+    /// untouched rather than decrypted or deleted.
+    /// </summary>
+    internal IReadOnlyList<string> IgnoredPaths { get; } = ignoredPaths;
 }
 
 /// <summary>
@@ -296,6 +303,7 @@ internal sealed class BrowserEncryptedPersistence(AhtolaAsyncPageTransformer pag
 
         var loadable = new List<(string Path, BrowserPersistedFileKind Kind)>();
         var transient = new List<string>();
+        var ignored = new List<string>();
         var present = new HashSet<string>(ordered, StringComparer.Ordinal);
         foreach (var path in ordered)
         {
@@ -305,10 +313,24 @@ internal sealed class BrowserEncryptedPersistence(AhtolaAsyncPageTransformer pag
                 continue;
             }
 
-            loadable.Add((path, MapRole(path, _roles.Resolve(path, probeHeader(path), present.Contains))));
+            var role = _roles.Resolve(path, probeHeader(path), present.Contains);
+            if (role == BrowserPersistedFileRole.MvccLog)
+            {
+                // Rejecting MVCC belongs on the write path, where it stops row data
+                // from reaching OPFS in the clear. Throwing here instead would let a
+                // single stray -log file permanently block opening a healthy
+                // database, including the empty one a rejected MVCC enable leaves
+                // behind. Ignore it: a -log beside an encrypted database is always an
+                // orphan, and beside a plaintext one the database itself reports the
+                // real problem.
+                ignored.Add(path);
+                continue;
+            }
+
+            loadable.Add((path, MapRole(path, role)));
         }
 
-        return new BrowserLoadPlan(loadable, transient);
+        return new BrowserLoadPlan(loadable, transient, ignored);
     }
 
     /// <summary>
@@ -406,13 +428,39 @@ internal sealed class BrowserEncryptedPersistence(AhtolaAsyncPageTransformer pag
                 + $"which is not covered by whole {pageSize}-byte pages within its {fileLength}-byte image.");
         }
 
-        return ReadRegion(
+        var capture = ReadRegion(
             BrowserPersistedFileKind.Database,
             file,
             start,
             checked((int)(end - start)),
             pageSize,
             journalChecksumNonce: 0);
+        if (start == 0)
+            RejectMvccHeader(path, capture.Bytes);
+        return capture;
+    }
+
+    /// <summary>
+    /// Refuses a header that switches the database into MVCC mode.
+    /// </summary>
+    /// <remarks>
+    /// MVCC has to be rejected here rather than when its logical log is first
+    /// written, because the pager persists the new header first. Failing later
+    /// would leave a database permanently marked MVCC whose log can never be
+    /// written, so every reopen would fail. Refusing the header instead aborts the
+    /// mode switch while the pager can still roll it back.
+    /// </remarks>
+    private static void RejectMvccHeader(string path, ReadOnlySpan<byte> page)
+    {
+        if (page.Length <= 19)
+            return;
+        if (page[18] != (byte)SqliteFileFormatVersion.Mvcc && page[19] != (byte)SqliteFileFormatVersion.Mvcc)
+            return;
+
+        throw new NotSupportedException(
+            $"Encrypted browser storage cannot host MVCC database '{path}'. "
+            + "The engine writes the MVCC logical log outside the page codec, so enabling MVCC would place row "
+            + "data in OPFS unencrypted. Use the default journal mode for encrypted browser databases.");
     }
 
     private BrowserPlaintextCapture CaptureWal(

--- a/src/Ahtola.Data.Sqlite.Browser/Storage/BrowserEncryptedPersistence.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Storage/BrowserEncryptedPersistence.cs
@@ -1,0 +1,816 @@
+using System.Buffers.Binary;
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Data.Sqlite.Browser.Storage;
+
+/// <summary>How a persisted OPFS file participates in AHTLA page encryption.</summary>
+internal enum BrowserPersistedFileKind
+{
+    /// <summary>A page-structured SQLite database, including attached and VACUUM targets.</summary>
+    Database,
+
+    /// <summary>A write-ahead log whose frame bodies are encrypted.</summary>
+    Wal,
+
+    /// <summary>A DELETE-mode rollback journal whose page records are encrypted.</summary>
+    Journal,
+
+    /// <summary>Content that is never encrypted, such as the rebuildable WAL index.</summary>
+    Passthrough,
+}
+
+/// <summary>
+/// A unit-aligned plaintext region captured while the managed engine mutates the
+/// in-memory mirror, together with the layout facts needed to encrypt it later.
+/// </summary>
+/// <remarks>
+/// Capturing whole pages, frames, or journal records at write time makes the
+/// asynchronous transform independent of how the engine happened to split its
+/// writes, and preserves the engine's exact durability ordering because each
+/// captured region reflects the file at that point in the operation stream.
+/// </remarks>
+internal sealed class BrowserPlaintextCapture(
+    BrowserPersistedFileKind kind,
+    long position,
+    byte[] bytes,
+    int pageSize,
+    uint journalChecksumNonce)
+{
+    internal BrowserPersistedFileKind Kind { get; } = kind;
+
+    internal long Position { get; } = position;
+
+    internal byte[] Bytes { get; } = bytes;
+
+    /// <summary>The page size in force for this region, or zero for passthrough content.</summary>
+    internal int PageSize { get; } = pageSize;
+
+    /// <summary>The rollback journal checksum nonce, valid only for journal records.</summary>
+    internal uint JournalChecksumNonce { get; } = journalChecksumNonce;
+}
+
+/// <summary>
+/// A transformed region ready to be written to OPFS, plus the WAL chain state to
+/// commit once that write succeeds.
+/// </summary>
+internal sealed class BrowserPersistedWrite(
+    long position,
+    byte[] bytes,
+    string path,
+    BrowserWalChainUpdate? walUpdate)
+{
+    internal long Position { get; } = position;
+
+    internal byte[] Bytes { get; } = bytes;
+
+    internal string Path { get; } = path;
+
+    internal BrowserWalChainUpdate? WalUpdate { get; } = walUpdate;
+}
+
+/// <summary>The WAL rolling-checksum state produced by transforming one WAL region.</summary>
+internal sealed class BrowserWalChainUpdate(
+    bool resetsChain,
+    int frameSize,
+    (uint First, uint Second) seed,
+    SqliteWalChecksumByteOrder byteOrder,
+    int firstFrameIndex,
+    List<(uint First, uint Second)> frameChecksums)
+{
+    internal bool ResetsChain { get; } = resetsChain;
+
+    internal int FrameSize { get; } = frameSize;
+
+    internal (uint First, uint Second) Seed { get; } = seed;
+
+    internal SqliteWalChecksumByteOrder ByteOrder { get; } = byteOrder;
+
+    internal int FirstFrameIndex { get; } = firstFrameIndex;
+
+    internal List<(uint First, uint Second)> FrameChecksums { get; } = frameChecksums;
+}
+
+/// <summary>
+/// Converts between the plaintext image the managed engine operates on and the
+/// exact AHTLA-encrypted image stored in OPFS.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Database pages, WAL frame bodies, and rollback journal page records are
+/// encrypted with the same layout the desktop engine writes, so files round-trip
+/// between browser and desktop byte-for-byte. WAL and journal headers stay in the
+/// clear exactly as SQLite defines them; the rolling WAL checksums and per-record
+/// journal checksums are recomputed over the encrypted bytes, matching what the
+/// desktop pager produces when a page codec is bound.
+/// </para>
+/// <para>
+/// Nothing here is a browser-specific container: an encrypted OPFS file is a
+/// plain Ahtola encrypted database, WAL, or journal.
+/// </para>
+/// </remarks>
+internal sealed class BrowserEncryptedPersistence(AhtolaAsyncPageTransformer pages) : IAsyncDisposable
+{
+    private const int WalHeaderSize = SqliteWalHeader.Size;
+    private const int WalFrameHeaderSize = SqliteWalFrameHeader.Size;
+
+    private readonly Dictionary<string, WalChain> _walChains = new(StringComparer.Ordinal);
+
+    /// <summary>Classifies a persisted path by SQLite's file naming conventions.</summary>
+    internal static BrowserPersistedFileKind Classify(string path)
+    {
+        if (path.EndsWith("-wal", StringComparison.Ordinal))
+            return BrowserPersistedFileKind.Wal;
+        if (path.EndsWith("-journal", StringComparison.Ordinal))
+            return BrowserPersistedFileKind.Journal;
+        if (path.EndsWith("-shm", StringComparison.Ordinal))
+            return BrowserPersistedFileKind.Passthrough;
+        return BrowserPersistedFileKind.Database;
+    }
+
+    /// <summary>
+    /// Expands a just-completed engine write to whole pages, WAL frames, or journal
+    /// records and copies that region out of <paramref name="file"/>.
+    /// </summary>
+    internal BrowserPlaintextCapture Capture(string path, long position, int length, IFile file)
+    {
+        var kind = Classify(path);
+        if (kind == BrowserPersistedFileKind.Passthrough)
+            return ReadRegion(kind, file, position, length, pageSize: 0, journalChecksumNonce: 0);
+
+        var fileLength = file.Length;
+        return kind switch
+        {
+            BrowserPersistedFileKind.Database => CaptureDatabase(path, position, length, file, fileLength),
+            BrowserPersistedFileKind.Wal => CaptureWal(path, position, length, file, fileLength),
+            BrowserPersistedFileKind.Journal => CaptureJournal(path, position, length, file, fileLength),
+            _ => ReadRegion(kind, file, position, length, pageSize: 0, journalChecksumNonce: 0),
+        };
+    }
+
+    /// <summary>
+    /// Encrypts a captured region without mutating chain state, so a failed or
+    /// cancelled OPFS write leaves the transform exactly where it started.
+    /// </summary>
+    internal async ValueTask<BrowserPersistedWrite> PrepareAsync(
+        string path,
+        BrowserPlaintextCapture capture,
+        CancellationToken cancellationToken)
+        => capture.Kind switch
+        {
+            BrowserPersistedFileKind.Passthrough
+                => new BrowserPersistedWrite(capture.Position, capture.Bytes, path, walUpdate: null),
+            BrowserPersistedFileKind.Database
+                => await PrepareDatabaseAsync(path, capture, cancellationToken).ConfigureAwait(false),
+            BrowserPersistedFileKind.Wal
+                => await PrepareWalAsync(path, capture, cancellationToken).ConfigureAwait(false),
+            BrowserPersistedFileKind.Journal
+                => await PrepareJournalAsync(path, capture, cancellationToken).ConfigureAwait(false),
+            _ => throw new InvalidOperationException($"Unknown persisted browser file kind {capture.Kind}."),
+        };
+
+    /// <summary>Commits WAL chain state after its transformed bytes reached OPFS.</summary>
+    internal void CommitWrite(BrowserPersistedWrite write)
+    {
+        if (write.WalUpdate is not { } update)
+            return;
+
+        if (!_walChains.TryGetValue(write.Path, out var chain))
+        {
+            chain = new WalChain();
+            _walChains[write.Path] = chain;
+        }
+
+        if (update.ResetsChain)
+        {
+            chain.FrameSize = update.FrameSize;
+            chain.Seed = update.Seed;
+            chain.ByteOrder = update.ByteOrder;
+            chain.FrameChecksums.Clear();
+            chain.Initialized = true;
+        }
+
+        if (update.FrameChecksums.Count == 0)
+            return;
+
+        if (chain.FrameChecksums.Count > update.FirstFrameIndex)
+            chain.FrameChecksums.RemoveRange(update.FirstFrameIndex, chain.FrameChecksums.Count - update.FirstFrameIndex);
+        chain.FrameChecksums.AddRange(update.FrameChecksums);
+    }
+
+    /// <summary>Forgets any cached state for a recreated file.</summary>
+    internal void NotifyCreated(string path) => _walChains.Remove(path);
+
+    /// <summary>Forgets any cached state for a deleted file.</summary>
+    internal void NotifyDeleted(string path) => _walChains.Remove(path);
+
+    /// <summary>Moves cached state along with an atomically replaced file.</summary>
+    internal void NotifyReplaced(string sourcePath, string destinationPath)
+    {
+        if (_walChains.Remove(sourcePath, out var chain))
+            _walChains[destinationPath] = chain;
+        else
+            _walChains.Remove(destinationPath);
+    }
+
+    /// <summary>Drops WAL frame checksums that a truncation removed.</summary>
+    internal void NotifyLengthSet(string path, long length)
+    {
+        if (!_walChains.TryGetValue(path, out var chain) || !chain.Initialized || chain.FrameSize <= 0)
+            return;
+        if (length < WalHeaderSize)
+        {
+            chain.FrameChecksums.Clear();
+            return;
+        }
+
+        var frameCount = checked((int)((length - WalHeaderSize) / chain.FrameSize));
+        if (chain.FrameChecksums.Count > frameCount)
+            chain.FrameChecksums.RemoveRange(frameCount, chain.FrameChecksums.Count - frameCount);
+    }
+
+    /// <summary>
+    /// Decrypts a complete OPFS image into the plaintext the managed engine reads,
+    /// rebuilding the WAL rolling-checksum chain so later appends stay valid.
+    /// </summary>
+    internal async ValueTask<byte[]> DecryptImageAsync(
+        string path,
+        byte[] encryptedImage,
+        CancellationToken cancellationToken)
+    {
+        var kind = Classify(path);
+        _walChains.Remove(path);
+        return kind switch
+        {
+            BrowserPersistedFileKind.Passthrough => encryptedImage,
+            BrowserPersistedFileKind.Database
+                => await DecryptDatabaseImageAsync(encryptedImage, cancellationToken).ConfigureAwait(false),
+            BrowserPersistedFileKind.Wal
+                => await DecryptWalImageAsync(path, encryptedImage, cancellationToken).ConfigureAwait(false),
+            BrowserPersistedFileKind.Journal
+                => await DecryptJournalImageAsync(encryptedImage, cancellationToken).ConfigureAwait(false),
+            _ => encryptedImage,
+        };
+    }
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync()
+    {
+        _walChains.Clear();
+        return pages.DisposeAsync();
+    }
+
+    private BrowserPlaintextCapture CaptureDatabase(
+        string path,
+        long position,
+        int length,
+        IFile file,
+        long fileLength)
+    {
+        var pageSize = ReadDatabasePageSize(path, file, fileLength);
+        var start = position / pageSize * pageSize;
+        var end = (position + length + pageSize - 1) / pageSize * pageSize;
+        if (end > fileLength)
+        {
+            throw new InvalidDataException(
+                $"Encrypted browser database '{path}' received a write ending at {position + length}, "
+                + $"which is not covered by whole {pageSize}-byte pages within its {fileLength}-byte image.");
+        }
+
+        return ReadRegion(
+            BrowserPersistedFileKind.Database,
+            file,
+            start,
+            checked((int)(end - start)),
+            pageSize,
+            journalChecksumNonce: 0);
+    }
+
+    private BrowserPlaintextCapture CaptureWal(
+        string path,
+        long position,
+        int length,
+        IFile file,
+        long fileLength)
+    {
+        if (fileLength < WalHeaderSize)
+        {
+            if (position + length > WalHeaderSize)
+            {
+                throw new InvalidDataException(
+                    $"Encrypted browser WAL '{path}' received bytes past its header before the header existed.");
+            }
+
+            return ReadRegion(
+                BrowserPersistedFileKind.Passthrough,
+                file,
+                position,
+                length,
+                pageSize: 0,
+                journalChecksumNonce: 0);
+        }
+
+        var header = new byte[WalHeaderSize];
+        ReadExact(file, 0, header, path);
+        int pageSize;
+        try
+        {
+            pageSize = SqliteWalHeader.Parse(header).PageSize;
+        }
+        catch (InvalidDataException) when (position + length <= WalHeaderSize)
+        {
+            // The engine is (re)establishing this WAL header. Header bytes are
+            // plaintext in both images, so persist them verbatim; the next header
+            // write re-establishes the encrypted checksum chain.
+            return ReadRegion(
+                BrowserPersistedFileKind.Passthrough,
+                file,
+                position,
+                length,
+                pageSize: 0,
+                journalChecksumNonce: 0);
+        }
+        catch (InvalidDataException exception)
+        {
+            throw new InvalidDataException(
+                $"Encrypted browser WAL '{path}' received frame bytes at {position} while its header was unreadable, "
+                + "so the frame page image cannot be encrypted.",
+                exception);
+        }
+
+        var frameSize = WalFrameHeaderSize + pageSize;
+        var start = position < WalHeaderSize
+            ? 0
+            : WalHeaderSize + ((position - WalHeaderSize) / frameSize * frameSize);
+        var end = position + length;
+        if (end > WalHeaderSize)
+        {
+            var frames = (end - WalHeaderSize + frameSize - 1) / frameSize;
+            end = WalHeaderSize + (frames * frameSize);
+        }
+        else
+        {
+            end = WalHeaderSize;
+        }
+
+        if (end > fileLength)
+        {
+            throw new InvalidDataException(
+                $"Encrypted browser WAL '{path}' received a write ending at {position + length}, "
+                + $"which is not covered by whole {frameSize}-byte frames within its {fileLength}-byte image.");
+        }
+
+        return ReadRegion(
+            BrowserPersistedFileKind.Wal,
+            file,
+            start,
+            checked((int)(end - start)),
+            pageSize,
+            journalChecksumNonce: 0);
+    }
+
+    private static BrowserPlaintextCapture CaptureJournal(
+        string path,
+        long position,
+        int length,
+        IFile file,
+        long fileLength)
+    {
+        var headerLength = checked((int)Math.Min(SqliteRollbackJournalFormat.HeaderSize, fileLength));
+        var header = new byte[headerLength];
+        ReadExact(file, 0, header, path);
+        if (!SqliteRollbackJournalFormat.TryReadLayout(
+                header,
+                out _,
+                out var checksumNonce,
+                out var pageSize,
+                out var sectorSize))
+        {
+            if (position + length > SqliteRollbackJournalFormat.HeaderSize)
+            {
+                throw new InvalidDataException(
+                    $"Encrypted browser rollback journal '{path}' received bytes at {position} while its header was "
+                    + "unreadable, so page records cannot be encrypted.");
+            }
+
+            // Header not established yet (or being invalidated): persist verbatim.
+            return ReadRegion(
+                BrowserPersistedFileKind.Passthrough,
+                file,
+                position,
+                length,
+                pageSize: 0,
+                journalChecksumNonce: 0);
+        }
+
+        var recordSize = SqliteRollbackJournalFormat.GetRecordSize(pageSize);
+        long start;
+        long end;
+        if (position < sectorSize)
+        {
+            start = 0;
+            end = Math.Min(sectorSize, fileLength);
+            if (position + length > sectorSize)
+            {
+                throw new InvalidDataException(
+                    $"Encrypted browser rollback journal '{path}' received a write spanning its header sector and page records.");
+            }
+        }
+        else
+        {
+            var recordIndex = (position - sectorSize) / recordSize;
+            start = sectorSize + (recordIndex * recordSize);
+            var lastIndex = (position + length - sectorSize + recordSize - 1) / recordSize;
+            end = sectorSize + (lastIndex * recordSize);
+            if (end > fileLength)
+            {
+                // The engine builds a record from three writes (page number, page
+                // image, checksum). Persist nothing until the record is complete:
+                // the encrypted image needs the whole page to derive its checksum,
+                // and a record only becomes meaningful once its checksum lands.
+                return new BrowserPlaintextCapture(
+                    BrowserPersistedFileKind.Passthrough,
+                    position,
+                    [],
+                    pageSize: 0,
+                    journalChecksumNonce: 0);
+            }
+        }
+
+        return ReadRegion(
+            position < sectorSize ? BrowserPersistedFileKind.Passthrough : BrowserPersistedFileKind.Journal,
+            file,
+            start,
+            checked((int)(end - start)),
+            pageSize,
+            checksumNonce);
+    }
+
+    private async ValueTask<BrowserPersistedWrite> PrepareDatabaseAsync(
+        string path,
+        BrowserPlaintextCapture capture,
+        CancellationToken cancellationToken)
+    {
+        var pageSize = capture.PageSize;
+        var encrypted = new byte[capture.Bytes.Length];
+        var firstPageNumber = checked((uint)(capture.Position / pageSize)) + 1;
+        for (var offset = 0; offset < capture.Bytes.Length; offset += pageSize)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var pageNumber = checked(firstPageNumber + (uint)(offset / pageSize));
+            var page = await pages
+                .EncryptPageAsync(capture.Bytes.AsMemory(offset, pageSize), pageNumber, cancellationToken)
+                .ConfigureAwait(false);
+            page.CopyTo(encrypted.AsSpan(offset));
+        }
+
+        return new BrowserPersistedWrite(capture.Position, encrypted, path, walUpdate: null);
+    }
+
+    private async ValueTask<BrowserPersistedWrite> PrepareWalAsync(
+        string path,
+        BrowserPlaintextCapture capture,
+        CancellationToken cancellationToken)
+    {
+        var frameSize = WalFrameHeaderSize + capture.PageSize;
+        var encrypted = capture.Bytes.AsSpan().ToArray();
+        var offset = 0;
+        var resetsChain = false;
+        var seed = default((uint First, uint Second));
+        var byteOrder = SqliteWalChecksumByteOrder.LittleEndian;
+
+        if (capture.Position == 0)
+        {
+            // The WAL header is plaintext in both images and its checksum covers only
+            // itself, so it seeds the encrypted chain exactly as it seeds the plaintext one.
+            var header = SqliteWalHeader.Parse(capture.Bytes.AsSpan(0, WalHeaderSize));
+            seed = (header.Checksum1, header.Checksum2);
+            byteOrder = header.ChecksumByteOrder;
+            resetsChain = true;
+            offset = WalHeaderSize;
+        }
+
+        var firstFrameIndex = capture.Position == 0
+            ? 0
+            : checked((int)((capture.Position - WalHeaderSize) / frameSize));
+        var chain = _walChains.TryGetValue(path, out var existing) ? existing : EmptyWalChain;
+        var running = resetsChain
+            ? seed
+            : ResolveWalChecksum(path, chain, firstFrameIndex);
+        var effectiveByteOrder = resetsChain ? byteOrder : chain.ByteOrder;
+        var produced = new List<(uint First, uint Second)>();
+
+        for (var frameIndex = firstFrameIndex; offset < encrypted.Length; frameIndex++, offset += frameSize)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var frame = encrypted.AsMemory(offset, frameSize);
+            var frameHeader = SqliteWalFrameHeader.Parse(frame.Span[..WalFrameHeaderSize]);
+            var body = await pages
+                .EncryptPageAsync(
+                    capture.Bytes.AsMemory(offset + WalFrameHeaderSize, capture.PageSize),
+                    frameHeader.PageNumber,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            body.CopyTo(frame.Span[WalFrameHeaderSize..]);
+            running = WriteWalFrameChecksum(frame.Span, effectiveByteOrder, running);
+            produced.Add(running);
+        }
+
+        return new BrowserPersistedWrite(
+            capture.Position,
+            encrypted,
+            path,
+            new BrowserWalChainUpdate(
+                resetsChain,
+                frameSize,
+                seed,
+                resetsChain ? byteOrder : chain.ByteOrder,
+                firstFrameIndex,
+                produced));
+    }
+
+    private async ValueTask<BrowserPersistedWrite> PrepareJournalAsync(
+        string path,
+        BrowserPlaintextCapture capture,
+        CancellationToken cancellationToken)
+    {
+        var pageSize = capture.PageSize;
+        var recordSize = checked((int)SqliteRollbackJournalFormat.GetRecordSize(pageSize));
+        var encrypted = capture.Bytes.AsSpan().ToArray();
+        for (var offset = 0; offset < encrypted.Length; offset += recordSize)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var pageNumber = BinaryPrimitives.ReadUInt32BigEndian(encrypted.AsSpan(offset, recordSize));
+            if (pageNumber == 0)
+                continue;
+
+            var page = await pages
+                .EncryptPageAsync(
+                    capture.Bytes.AsMemory(
+                        offset + SqliteRollbackJournalFormat.RecordPageNumberSize,
+                        pageSize),
+                    pageNumber,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            WriteJournalRecord(encrypted, offset, pageSize, page, capture.JournalChecksumNonce);
+        }
+
+        return new BrowserPersistedWrite(capture.Position, encrypted, path, walUpdate: null);
+    }
+
+    private async ValueTask<byte[]> DecryptDatabaseImageAsync(
+        byte[] encryptedImage,
+        CancellationToken cancellationToken)
+    {
+        if (encryptedImage.Length == 0)
+            return encryptedImage;
+        if (encryptedImage.Length < AhtolaEncryptedPageFormat.SqliteHeaderSize)
+            throw new InvalidDataException("Encrypted browser database image is smaller than a page header.");
+        if (!AhtolaEncryptedPageFormat.IsAhtolaEncrypted(encryptedImage))
+        {
+            throw new InvalidDataException(
+                AhtolaPasswordEncryption.EnsureEncryptedOrNotDatabasePhrase(
+                    "Encryption was requested, but the browser database contains a plaintext SQLite header. "
+                    + "Plaintext fallback is not permitted."));
+        }
+
+        var pageSize = ReadEncodedPageSize(encryptedImage);
+        if (encryptedImage.Length % pageSize != 0)
+            throw new InvalidDataException("Encrypted browser database image is not a whole number of pages.");
+
+        var plaintext = new byte[encryptedImage.Length];
+        for (var offset = 0; offset < encryptedImage.Length; offset += pageSize)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var pageNumber = checked((uint)(offset / pageSize)) + 1;
+            var page = await pages
+                .DecryptPageAsync(encryptedImage.AsMemory(offset, pageSize), pageNumber, cancellationToken)
+                .ConfigureAwait(false);
+            page.CopyTo(plaintext.AsSpan(offset));
+        }
+
+        return plaintext;
+    }
+
+    private async ValueTask<byte[]> DecryptWalImageAsync(
+        string path,
+        byte[] encryptedImage,
+        CancellationToken cancellationToken)
+    {
+        if (encryptedImage.Length < WalHeaderSize)
+            return encryptedImage;
+
+        SqliteWalHeader header;
+        try
+        {
+            header = SqliteWalHeader.Parse(encryptedImage.AsSpan(0, WalHeaderSize));
+        }
+        catch (InvalidDataException)
+        {
+            return encryptedImage;
+        }
+
+        var frameSize = WalFrameHeaderSize + header.PageSize;
+        var plaintext = encryptedImage.AsSpan().ToArray();
+        var chain = new WalChain
+        {
+            Initialized = true,
+            FrameSize = frameSize,
+            Seed = (header.Checksum1, header.Checksum2),
+            ByteOrder = header.ChecksumByteOrder,
+        };
+
+        var encryptedRunning = chain.Seed;
+        var plaintextRunning = chain.Seed;
+        for (var offset = WalHeaderSize; offset + frameSize <= encryptedImage.Length; offset += frameSize)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            SqliteWalFrameHeader frameHeader;
+            try
+            {
+                frameHeader = SqliteWalFrameHeader.Parse(encryptedImage.AsSpan(offset, WalFrameHeaderSize));
+            }
+            catch (InvalidDataException)
+            {
+                break;
+            }
+
+            var expected = ComputeWalFrameChecksum(
+                encryptedImage.AsSpan(offset, frameSize),
+                chain.ByteOrder,
+                encryptedRunning);
+            if (expected != (frameHeader.Checksum1, frameHeader.Checksum2))
+            {
+                // Stop at the first frame that does not belong to this chain, exactly
+                // as the pager's recovery scan does; the tail stays verbatim.
+                break;
+            }
+
+            var body = await pages
+                .DecryptPageAsync(
+                    encryptedImage.AsMemory(offset + WalFrameHeaderSize, header.PageSize),
+                    frameHeader.PageNumber,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            body.CopyTo(plaintext.AsSpan(offset + WalFrameHeaderSize));
+            plaintextRunning = WriteWalFrameChecksum(
+                plaintext.AsSpan(offset, frameSize),
+                chain.ByteOrder,
+                plaintextRunning);
+            encryptedRunning = expected;
+            chain.FrameChecksums.Add(encryptedRunning);
+        }
+
+        _walChains[path] = chain;
+        return plaintext;
+    }
+
+    private async ValueTask<byte[]> DecryptJournalImageAsync(
+        byte[] encryptedImage,
+        CancellationToken cancellationToken)
+    {
+        if (!SqliteRollbackJournalFormat.TryReadLayout(
+                encryptedImage,
+                out _,
+                out var checksumNonce,
+                out var pageSize,
+                out var sectorSize))
+        {
+            return encryptedImage;
+        }
+
+        var recordSize = checked((int)SqliteRollbackJournalFormat.GetRecordSize(pageSize));
+        var plaintext = encryptedImage.AsSpan().ToArray();
+        for (var offset = sectorSize; offset + recordSize <= encryptedImage.Length; offset += recordSize)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var pageNumber = BinaryPrimitives.ReadUInt32BigEndian(encryptedImage.AsSpan(offset));
+            if (pageNumber == 0)
+                break;
+
+            var encryptedPage = encryptedImage.AsMemory(
+                offset + SqliteRollbackJournalFormat.RecordPageNumberSize,
+                pageSize);
+            var storedChecksum = BinaryPrimitives.ReadUInt32BigEndian(
+                encryptedImage.AsSpan(offset + SqliteRollbackJournalFormat.RecordPageNumberSize + pageSize));
+            if (SqliteRollbackJournalFormat.ComputeChecksum(encryptedPage.Span, checksumNonce) != storedChecksum)
+                break;
+
+            var page = await pages
+                .DecryptPageAsync(encryptedPage, pageNumber, cancellationToken)
+                .ConfigureAwait(false);
+            WriteJournalRecord(plaintext, offset, pageSize, page, checksumNonce);
+        }
+
+        return plaintext;
+    }
+
+    private static void WriteJournalRecord(
+        byte[] plaintext,
+        int offset,
+        int pageSize,
+        byte[] page,
+        uint checksumNonce)
+    {
+        page.CopyTo(plaintext.AsSpan(offset + SqliteRollbackJournalFormat.RecordPageNumberSize));
+        BinaryPrimitives.WriteUInt32BigEndian(
+            plaintext.AsSpan(offset + SqliteRollbackJournalFormat.RecordPageNumberSize + pageSize),
+            SqliteRollbackJournalFormat.ComputeChecksum(page, checksumNonce));
+    }
+
+    private static readonly WalChain EmptyWalChain = new();
+
+    private static (uint First, uint Second) ResolveWalChecksum(string path, WalChain chain, int frameIndex)
+    {
+        if (!chain.Initialized)
+        {
+            throw new InvalidDataException(
+                $"Encrypted browser WAL '{path}' received a frame before its header established the checksum chain.");
+        }
+        if (frameIndex == 0)
+            return chain.Seed;
+        if (chain.FrameChecksums.Count < frameIndex)
+        {
+            throw new InvalidDataException(
+                $"Encrypted browser WAL '{path}' received frame {frameIndex + 1} without the preceding encrypted checksum chain.");
+        }
+
+        return chain.FrameChecksums[frameIndex - 1];
+    }
+
+    private static (uint First, uint Second) ComputeWalFrameChecksum(
+        ReadOnlySpan<byte> frame,
+        SqliteWalChecksumByteOrder byteOrder,
+        (uint First, uint Second) previous)
+    {
+        var (First, Second) = SqliteWalChecksum.Calculate(frame[..8], byteOrder, previous.First, previous.Second);
+        return SqliteWalChecksum.Calculate(frame[WalFrameHeaderSize..], byteOrder, First, Second);
+    }
+
+    private static (uint First, uint Second) WriteWalFrameChecksum(
+        Span<byte> frame,
+        SqliteWalChecksumByteOrder byteOrder,
+        (uint First, uint Second) previous)
+    {
+        var checksum = ComputeWalFrameChecksum(frame, byteOrder, previous);
+        BinaryPrimitives.WriteUInt32BigEndian(frame.Slice(16, 4), checksum.First);
+        BinaryPrimitives.WriteUInt32BigEndian(frame.Slice(20, 4), checksum.Second);
+        return checksum;
+    }
+
+    private static int ReadDatabasePageSize(string path, IFile file, long fileLength)
+    {
+        if (fileLength < AhtolaEncryptedPageFormat.SqliteHeaderSize)
+        {
+            throw new InvalidDataException(
+                $"Encrypted browser database '{path}' was written before its {AhtolaEncryptedPageFormat.SqliteHeaderSize}-byte header existed.");
+        }
+
+        var header = new byte[PageCodecHeaderInfo.SqliteBootstrapHeaderLength];
+        ReadExact(file, 0, header, path);
+        return ReadEncodedPageSize(header);
+    }
+
+    private static int ReadEncodedPageSize(ReadOnlySpan<byte> header)
+    {
+        var encoded = BinaryPrimitives.ReadUInt16BigEndian(header[16..]);
+        var pageSize = encoded == 1 ? 65_536 : encoded;
+        _ = SqlitePageSize.Encode(pageSize);
+        return pageSize;
+    }
+
+    private static BrowserPlaintextCapture ReadRegion(
+        BrowserPersistedFileKind kind,
+        IFile file,
+        long position,
+        int length,
+        int pageSize,
+        uint journalChecksumNonce)
+    {
+        var bytes = new byte[length];
+        if (length != 0)
+            ReadExact(file, position, bytes, kind.ToString());
+        return new BrowserPlaintextCapture(kind, position, bytes, pageSize, journalChecksumNonce);
+    }
+
+    private static void ReadExact(IFile file, long position, Span<byte> destination, string path)
+    {
+        if (file.Read(position, destination) != destination.Length)
+        {
+            throw new InvalidDataException(
+                $"Encrypted browser storage could not read {destination.Length} bytes at {position} from '{path}'.");
+        }
+    }
+
+    private sealed class WalChain
+    {
+        public bool Initialized { get; set; }
+
+        public int FrameSize { get; set; }
+
+        public (uint First, uint Second) Seed { get; set; }
+
+        public SqliteWalChecksumByteOrder ByteOrder { get; set; } = SqliteWalChecksumByteOrder.LittleEndian;
+
+        public List<(uint First, uint Second)> FrameChecksums { get; } = [];
+    }
+}

--- a/src/Ahtola.Data.Sqlite.Browser/Storage/BrowserEncryptedPersistence.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Storage/BrowserEncryptedPersistence.cs
@@ -91,6 +91,21 @@ internal sealed class BrowserWalChainUpdate(
 }
 
 /// <summary>
+/// The encryption roles assigned to a persisted directory, separating the files
+/// that must be loaded from the abandoned engine temporaries that must not be.
+/// </summary>
+internal sealed class BrowserLoadPlan(
+    IReadOnlyList<(string Path, BrowserPersistedFileKind Kind)> files,
+    IReadOnlyList<string> transientArtifacts)
+{
+    /// <summary>Files to load, in an order where every base path precedes its sidecars.</summary>
+    internal IReadOnlyList<(string Path, BrowserPersistedFileKind Kind)> Files { get; } = files;
+
+    /// <summary>Abandoned engine temporaries that are safe to discard.</summary>
+    internal IReadOnlyList<string> TransientArtifacts { get; } = transientArtifacts;
+}
+
+/// <summary>
 /// Converts between the plaintext image the managed engine operates on and the
 /// exact AHTLA-encrypted image stored in OPFS.
 /// </summary>
@@ -112,20 +127,48 @@ internal sealed class BrowserEncryptedPersistence(AhtolaAsyncPageTransformer pag
 {
     private const int WalHeaderSize = SqliteWalHeader.Size;
     private const int WalFrameHeaderSize = SqliteWalFrameHeader.Size;
+    private const int RoleProbeLength = 16;
 
     private readonly Dictionary<string, WalChain> _walChains = new(StringComparer.Ordinal);
+    private readonly BrowserPersistedFileRoles _roles = new();
+    private Func<string, bool>? _basePathExists;
 
-    /// <summary>Classifies a persisted path by SQLite's file naming conventions.</summary>
-    internal static BrowserPersistedFileKind Classify(string path)
+    /// <summary>
+    /// Supplies the predicate that reports whether a base database path currently
+    /// exists, so a sidecar can be recognized even before its database is opened.
+    /// </summary>
+    internal void SetBasePathProbe(Func<string, bool> basePathExists)
+        => _basePathExists = basePathExists;
+
+    /// <summary>Declares a path the caller already knows is a database.</summary>
+    internal void RegisterDatabase(string path) => _roles.RegisterDatabase(path);
+
+    /// <summary>
+    /// Resolves the encryption role of a path that the engine is mutating, probing
+    /// its current bytes so a database whose name resembles a sidecar is not
+    /// demoted (and, for <c>-shm</c>, silently persisted in the clear).
+    /// </summary>
+    private BrowserPersistedFileKind ClassifyForWrite(string path, IFile file)
     {
-        if (path.EndsWith("-wal", StringComparison.Ordinal))
-            return BrowserPersistedFileKind.Wal;
-        if (path.EndsWith("-journal", StringComparison.Ordinal))
-            return BrowserPersistedFileKind.Journal;
-        if (path.EndsWith("-shm", StringComparison.Ordinal))
-            return BrowserPersistedFileKind.Passthrough;
-        return BrowserPersistedFileKind.Database;
+        Span<byte> probe = stackalloc byte[RoleProbeLength];
+        var read = file.Length == 0 ? 0 : file.Read(0, probe);
+        var role = _roles.Resolve(path, probe[..Math.Max(read, 0)], _basePathExists);
+        return MapRole(path, role);
     }
+
+    private static BrowserPersistedFileKind MapRole(string path, BrowserPersistedFileRole role)
+        => role switch
+        {
+            BrowserPersistedFileRole.Database => BrowserPersistedFileKind.Database,
+            BrowserPersistedFileRole.Wal => BrowserPersistedFileKind.Wal,
+            BrowserPersistedFileRole.Journal => BrowserPersistedFileKind.Journal,
+            BrowserPersistedFileRole.SharedMemory => BrowserPersistedFileKind.Passthrough,
+            BrowserPersistedFileRole.MvccLog => throw new NotSupportedException(
+                $"Encrypted browser storage cannot host the MVCC logical log '{path}'. "
+                + "The engine writes that log outside the page codec, so enabling MVCC would place row "
+                + "data in OPFS unencrypted. Use the default journal mode for encrypted browser databases."),
+            _ => throw new InvalidOperationException($"Unknown persisted browser file role {role}."),
+        };
 
     /// <summary>
     /// Expands a just-completed engine write to whole pages, WAL frames, or journal
@@ -133,7 +176,7 @@ internal sealed class BrowserEncryptedPersistence(AhtolaAsyncPageTransformer pag
     /// </summary>
     internal BrowserPlaintextCapture Capture(string path, long position, int length, IFile file)
     {
-        var kind = Classify(path);
+        var kind = ClassifyForWrite(path, file);
         if (kind == BrowserPersistedFileKind.Passthrough)
             return ReadRegion(kind, file, position, length, pageSize: 0, journalChecksumNonce: 0);
 
@@ -201,7 +244,11 @@ internal sealed class BrowserEncryptedPersistence(AhtolaAsyncPageTransformer pag
     internal void NotifyCreated(string path) => _walChains.Remove(path);
 
     /// <summary>Forgets any cached state for a deleted file.</summary>
-    internal void NotifyDeleted(string path) => _walChains.Remove(path);
+    internal void NotifyDeleted(string path)
+    {
+        _walChains.Remove(path);
+        _roles.Forget(path);
+    }
 
     /// <summary>Moves cached state along with an atomically replaced file.</summary>
     internal void NotifyReplaced(string sourcePath, string destinationPath)
@@ -210,6 +257,7 @@ internal sealed class BrowserEncryptedPersistence(AhtolaAsyncPageTransformer pag
             _walChains[destinationPath] = chain;
         else
             _walChains.Remove(destinationPath);
+        _roles.Rename(sourcePath, destinationPath);
     }
 
     /// <summary>Drops WAL frame checksums that a truncation removed.</summary>
@@ -229,27 +277,109 @@ internal sealed class BrowserEncryptedPersistence(AhtolaAsyncPageTransformer pag
     }
 
     /// <summary>
-    /// Decrypts a complete OPFS image into the plaintext the managed engine reads,
-    /// rebuilding the WAL rolling-checksum chain so later appends stay valid.
+    /// Assigns encryption roles to every persisted path and separates the abandoned
+    /// engine temporaries that must not be loaded or decrypted.
     /// </summary>
-    internal async ValueTask<byte[]> DecryptImageAsync(
-        string path,
-        byte[] encryptedImage,
+    /// <remarks>
+    /// Paths are resolved shortest-first because a sidecar name is always strictly
+    /// longer than the database it belongs to, so every base path is known before
+    /// anything derived from it is classified.
+    /// </remarks>
+    internal BrowserLoadPlan PlanLoad(
+        IReadOnlyList<string> paths,
+        Func<string, byte[]> probeHeader)
+    {
+        var ordered = paths
+            .OrderBy(static path => path.Length)
+            .ThenBy(static path => path, StringComparer.Ordinal)
+            .ToArray();
+
+        var loadable = new List<(string Path, BrowserPersistedFileKind Kind)>();
+        var transient = new List<string>();
+        var present = new HashSet<string>(ordered, StringComparer.Ordinal);
+        foreach (var path in ordered)
+        {
+            if (BrowserPersistedFileRoles.IsTransientArtifact(path))
+            {
+                transient.Add(path);
+                continue;
+            }
+
+            loadable.Add((path, MapRole(path, _roles.Resolve(path, probeHeader(path), present.Contains))));
+        }
+
+        return new BrowserLoadPlan(loadable, transient);
+    }
+
+    /// <summary>
+    /// Turns the loaded encrypted images into the plaintext the engine reads.
+    /// </summary>
+    /// <remarks>
+    /// A crash can leave a torn page in the main database, so recovery has to run
+    /// in the encrypted domain before any page is authenticated. Hot rollback
+    /// journals are replayed onto the encrypted image first, and a page that still
+    /// fails authentication is satisfied from a committed WAL frame when one exists.
+    /// Only when no recovery source can supply the page does the open fail.
+    /// </remarks>
+    internal async ValueTask<Dictionary<string, byte[]>> DecryptLoadedImagesAsync(
+        BrowserLoadPlan plan,
+        Dictionary<string, byte[]> encryptedImages,
         CancellationToken cancellationToken)
     {
-        var kind = Classify(path);
-        _walChains.Remove(path);
-        return kind switch
+        var plaintext = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+        var walPages = new Dictionary<string, IReadOnlyDictionary<uint, byte[]>>(StringComparer.Ordinal);
+
+        foreach (var (path, kind) in plan.Files)
         {
-            BrowserPersistedFileKind.Passthrough => encryptedImage,
-            BrowserPersistedFileKind.Database
-                => await DecryptDatabaseImageAsync(encryptedImage, cancellationToken).ConfigureAwait(false),
-            BrowserPersistedFileKind.Wal
-                => await DecryptWalImageAsync(path, encryptedImage, cancellationToken).ConfigureAwait(false),
-            BrowserPersistedFileKind.Journal
-                => await DecryptJournalImageAsync(encryptedImage, cancellationToken).ConfigureAwait(false),
-            _ => encryptedImage,
-        };
+            if (kind is not BrowserPersistedFileKind.Wal)
+                continue;
+
+            _walChains.Remove(path);
+            var (Image, CommittedPages) = await DecryptWalImageAsync(
+                    path,
+                    encryptedImages[path],
+                    cancellationToken)
+                .ConfigureAwait(false);
+            plaintext[path] = Image;
+            walPages[path] = CommittedPages;
+        }
+
+        foreach (var (path, kind) in plan.Files)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            switch (kind)
+            {
+                case BrowserPersistedFileKind.Wal:
+                    break;
+                case BrowserPersistedFileKind.Passthrough:
+                    plaintext[path] = encryptedImages[path];
+                    break;
+                case BrowserPersistedFileKind.Journal:
+                    plaintext[path] = await DecryptJournalImageAsync(
+                            encryptedImages[path],
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                    break;
+                case BrowserPersistedFileKind.Database:
+                    {
+                        var image = encryptedImages[path];
+                        if (encryptedImages.TryGetValue(path + "-journal", out var journal))
+                            image = ApplyEncryptedJournalRollback(image, journal);
+                        walPages.TryGetValue(path + "-wal", out var recoveryPages);
+                        plaintext[path] = await DecryptDatabaseImageAsync(
+                                image,
+                                recoveryPages,
+                                cancellationToken)
+                            .ConfigureAwait(false);
+                        break;
+                    }
+
+                default:
+                    throw new InvalidOperationException($"Unknown persisted browser file kind {kind}.");
+            }
+        }
+
+        return plaintext;
     }
 
     /// <inheritdoc />
@@ -559,6 +689,7 @@ internal sealed class BrowserEncryptedPersistence(AhtolaAsyncPageTransformer pag
 
     private async ValueTask<byte[]> DecryptDatabaseImageAsync(
         byte[] encryptedImage,
+        IReadOnlyDictionary<uint, byte[]>? recoveryPages,
         CancellationToken cancellationToken)
     {
         if (encryptedImage.Length == 0)
@@ -582,22 +713,98 @@ internal sealed class BrowserEncryptedPersistence(AhtolaAsyncPageTransformer pag
         {
             cancellationToken.ThrowIfCancellationRequested();
             var pageNumber = checked((uint)(offset / pageSize)) + 1;
-            var page = await pages
-                .DecryptPageAsync(encryptedImage.AsMemory(offset, pageSize), pageNumber, cancellationToken)
-                .ConfigureAwait(false);
+            byte[] page;
+            try
+            {
+                page = await pages
+                    .DecryptPageAsync(encryptedImage.AsMemory(offset, pageSize), pageNumber, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (InvalidDataException) when (
+                recoveryPages is not null
+                && recoveryPages.TryGetValue(pageNumber, out var recovered)
+                && recovered.Length == pageSize)
+            {
+                // A crash during checkpoint can tear a page that a committed WAL
+                // frame still holds. Recovering it here keeps the open alive; the
+                // pager then re-applies the same frame through its own checkpoint.
+                page = recovered;
+            }
+
             page.CopyTo(plaintext.AsSpan(offset));
         }
 
         return plaintext;
     }
 
-    private async ValueTask<byte[]> DecryptWalImageAsync(
+    /// <summary>
+    /// Replays a hot rollback journal's encrypted page images back into the
+    /// encrypted database image, restoring the pre-transaction content before any
+    /// page is authenticated.
+    /// </summary>
+    private static byte[] ApplyEncryptedJournalRollback(byte[] databaseImage, byte[] journalImage)
+    {
+        if (!SqliteRollbackJournalFormat.HasMagic(journalImage))
+            return databaseImage;
+        if (!SqliteRollbackJournalFormat.TryReadLayout(
+                journalImage,
+                out var recordCount,
+                out var checksumNonce,
+                out var pageSize,
+                out var sectorSize))
+        {
+            return databaseImage;
+        }
+
+        var originalPageCount = BinaryPrimitives.ReadUInt32BigEndian(journalImage.AsSpan(16));
+        if (originalPageCount == 0 || databaseImage.Length % pageSize != 0)
+            return databaseImage;
+
+        var recordSize = checked((int)SqliteRollbackJournalFormat.GetRecordSize(pageSize));
+        var restored = databaseImage.AsSpan().ToArray();
+        var applied = 0u;
+        for (var offset = sectorSize; offset + recordSize <= journalImage.Length; offset += recordSize)
+        {
+            if (recordCount != uint.MaxValue && applied >= recordCount)
+                break;
+
+            var pageNumber = BinaryPrimitives.ReadUInt32BigEndian(journalImage.AsSpan(offset));
+            if (pageNumber == 0 || pageNumber > originalPageCount)
+                break;
+
+            var page = journalImage.AsSpan(
+                offset + SqliteRollbackJournalFormat.RecordPageNumberSize,
+                pageSize);
+            var storedChecksum = BinaryPrimitives.ReadUInt32BigEndian(
+                journalImage.AsSpan(offset + SqliteRollbackJournalFormat.RecordPageNumberSize + pageSize));
+            if (SqliteRollbackJournalFormat.ComputeChecksum(page, checksumNonce) != storedChecksum)
+                break;
+
+            var target = checked((int)(pageNumber - 1)) * pageSize;
+            if (target + pageSize > restored.Length)
+                break;
+
+            page.CopyTo(restored.AsSpan(target));
+            applied++;
+        }
+
+        if (applied == 0)
+            return databaseImage;
+
+        var originalLength = checked((int)originalPageCount) * pageSize;
+        if (restored.Length > originalLength)
+            Array.Resize(ref restored, originalLength);
+        return restored;
+    }
+
+    private async ValueTask<(byte[] Image, IReadOnlyDictionary<uint, byte[]> CommittedPages)> DecryptWalImageAsync(
         string path,
         byte[] encryptedImage,
         CancellationToken cancellationToken)
     {
+        var committed = new Dictionary<uint, byte[]>();
         if (encryptedImage.Length < WalHeaderSize)
-            return encryptedImage;
+            return (encryptedImage, committed);
 
         SqliteWalHeader header;
         try
@@ -606,7 +813,7 @@ internal sealed class BrowserEncryptedPersistence(AhtolaAsyncPageTransformer pag
         }
         catch (InvalidDataException)
         {
-            return encryptedImage;
+            return (encryptedImage, committed);
         }
 
         var frameSize = WalFrameHeaderSize + header.PageSize;
@@ -619,6 +826,7 @@ internal sealed class BrowserEncryptedPersistence(AhtolaAsyncPageTransformer pag
             ByteOrder = header.ChecksumByteOrder,
         };
 
+        var pending = new Dictionary<uint, byte[]>();
         var encryptedRunning = chain.Seed;
         var plaintextRunning = chain.Seed;
         for (var offset = WalHeaderSize; offset + frameSize <= encryptedImage.Length; offset += frameSize)
@@ -658,10 +866,20 @@ internal sealed class BrowserEncryptedPersistence(AhtolaAsyncPageTransformer pag
                 plaintextRunning);
             encryptedRunning = expected;
             chain.FrameChecksums.Add(encryptedRunning);
+
+            pending[frameHeader.PageNumber] = body;
+            if (!frameHeader.IsCommit)
+                continue;
+
+            // Only frames up to a commit marker may repair the main database,
+            // mirroring exactly what a checkpoint is allowed to write.
+            foreach (var (pageNumber, image) in pending)
+                committed[pageNumber] = image;
+            pending.Clear();
         }
 
         _walChains[path] = chain;
-        return plaintext;
+        return (plaintext, committed);
     }
 
     private async ValueTask<byte[]> DecryptJournalImageAsync(

--- a/src/Ahtola.Data.Sqlite.Browser/Storage/BrowserMirroredFileSystem.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Storage/BrowserMirroredFileSystem.cs
@@ -36,6 +36,15 @@ internal sealed class BrowserMirroredFileSystem :
 
     public StringComparer PathComparer => StringComparer.Ordinal;
 
+    internal bool HasPendingMutations
+    {
+        get
+        {
+            lock (_gate)
+                return _pending.Count != 0;
+        }
+    }
+
     internal static async ValueTask<BrowserMirroredFileSystem> CreateAsync(
         OpfsAsyncFileSystem persistent,
         string rootDirectory,
@@ -168,46 +177,46 @@ internal sealed class BrowserMirroredFileSystem :
                 switch (operation.Kind)
                 {
                     case OperationKind.Create:
-                    {
-                        var file = await GetWritableFileAsync(
-                            handles,
-                            operation.Path,
-                            cancellationToken).ConfigureAwait(false);
-                        await file.SetLengthAsync(0, cancellationToken).ConfigureAwait(false);
-                        break;
-                    }
+                        {
+                            var file = await GetWritableFileAsync(
+                                handles,
+                                operation.Path,
+                                cancellationToken).ConfigureAwait(false);
+                            await file.SetLengthAsync(0, cancellationToken).ConfigureAwait(false);
+                            break;
+                        }
                     case OperationKind.Write:
-                    {
-                        var file = await GetWritableFileAsync(
-                            handles,
-                            operation.Path,
-                            cancellationToken).ConfigureAwait(false);
-                        await file.WriteAsync(
-                            operation.Position,
-                            operation.Bytes!,
-                            cancellationToken).ConfigureAwait(false);
-                        break;
-                    }
+                        {
+                            var file = await GetWritableFileAsync(
+                                handles,
+                                operation.Path,
+                                cancellationToken).ConfigureAwait(false);
+                            await file.WriteAsync(
+                                operation.Position,
+                                operation.Bytes!,
+                                cancellationToken).ConfigureAwait(false);
+                            break;
+                        }
                     case OperationKind.SetLength:
-                    {
-                        var file = await GetWritableFileAsync(
-                            handles,
-                            operation.Path,
-                            cancellationToken).ConfigureAwait(false);
-                        await file.SetLengthAsync(
-                            operation.Position,
-                            cancellationToken).ConfigureAwait(false);
-                        break;
-                    }
+                        {
+                            var file = await GetWritableFileAsync(
+                                handles,
+                                operation.Path,
+                                cancellationToken).ConfigureAwait(false);
+                            await file.SetLengthAsync(
+                                operation.Position,
+                                cancellationToken).ConfigureAwait(false);
+                            break;
+                        }
                     case OperationKind.Flush:
-                    {
-                        var file = await GetWritableFileAsync(
-                            handles,
-                            operation.Path,
-                            cancellationToken).ConfigureAwait(false);
-                        await file.FlushToDiskAsync(cancellationToken).ConfigureAwait(false);
-                        break;
-                    }
+                        {
+                            var file = await GetWritableFileAsync(
+                                handles,
+                                operation.Path,
+                                cancellationToken).ConfigureAwait(false);
+                            await file.FlushToDiskAsync(cancellationToken).ConfigureAwait(false);
+                            break;
+                        }
                     case OperationKind.Delete:
                         await CloseHandleAsync(handles, operation.Path).ConfigureAwait(false);
                         await _persistent

--- a/src/Ahtola.Data.Sqlite.Browser/Storage/BrowserMirroredFileSystem.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Storage/BrowserMirroredFileSystem.cs
@@ -38,6 +38,7 @@ internal sealed class BrowserMirroredFileSystem :
         _ownsPersistent = ownsPersistent;
         _encryption = encryption;
         _reservedSpaceCodec = encryption is null ? null : new AhtolaBrowserReservedSpaceCodec();
+        encryption?.SetBasePathProbe(_memory.FileExists);
     }
 
     public StringComparer PathComparer => StringComparer.Ordinal;
@@ -346,22 +347,75 @@ internal sealed class BrowserMirroredFileSystem :
         var paths = await _persistent
             .ListFilesAsync(_rootDirectory, cancellationToken)
             .ConfigureAwait(false);
+        if (_encryption is null)
+        {
+            foreach (var path in paths)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Materialize(path, await ReadPersistentImageAsync(path, cancellationToken).ConfigureAwait(false));
+            }
+
+            return;
+        }
+
+        // Abandoned VACUUM and page-migration temporaries must never be decrypted:
+        // they can be preallocated or half-written, and failing on one would block
+        // opening an otherwise healthy database.
+        var probes = new Dictionary<string, byte[]>(StringComparer.Ordinal);
         foreach (var path in paths)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var image = await ReadPersistentImageAsync(path, cancellationToken).ConfigureAwait(false);
-            if (_encryption is not null)
-            {
-                image = await _encryption
-                    .DecryptImageAsync(path, image, cancellationToken)
-                    .ConfigureAwait(false);
-            }
-
-            using var destination = _memory.OpenFile(path, FileOpenMode.CreateNew);
-            destination.SetLength(image.LongLength);
-            if (image.Length != 0)
-                destination.Write(0, image);
+            if (BrowserPersistedFileRoles.IsTransientArtifact(path))
+                continue;
+            probes[path] = await ReadPersistentHeaderAsync(path, cancellationToken).ConfigureAwait(false);
         }
+
+        var plan = _encryption.PlanLoad(
+            paths,
+            path => probes.TryGetValue(path, out var probe) ? probe : []);
+        foreach (var artifact in plan.TransientArtifacts)
+        {
+            await _persistent
+                .DeleteFileAsync(artifact, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        var images = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+        foreach (var (path, _) in plan.Files)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            images[path] = await ReadPersistentImageAsync(path, cancellationToken).ConfigureAwait(false);
+        }
+
+        var plaintext = await _encryption
+            .DecryptLoadedImagesAsync(plan, images, cancellationToken)
+            .ConfigureAwait(false);
+        foreach (var (path, _) in plan.Files)
+            Materialize(path, plaintext[path]);
+    }
+
+    private void Materialize(string path, byte[] image)
+    {
+        using var destination = _memory.OpenFile(path, FileOpenMode.CreateNew);
+        destination.SetLength(image.LongLength);
+        if (image.Length != 0)
+            destination.Write(0, image);
+    }
+
+    private async ValueTask<byte[]> ReadPersistentHeaderAsync(
+        string path,
+        CancellationToken cancellationToken)
+    {
+        await using var source = await _persistent
+            .OpenFileAsync(path, FileOpenMode.OpenExisting, readOnly: true, cancellationToken)
+            .ConfigureAwait(false);
+        var length = await source.GetLengthAsync(cancellationToken).ConfigureAwait(false);
+        if (length == 0)
+            return [];
+
+        var probe = new byte[Math.Min(length, 16)];
+        var read = await source.ReadAsync(0, probe, cancellationToken).ConfigureAwait(false);
+        return read == probe.Length ? probe : probe.AsSpan(0, Math.Max(read, 0)).ToArray();
     }
 
     private async ValueTask<byte[]> ReadPersistentImageAsync(

--- a/src/Ahtola.Data.Sqlite.Browser/Storage/BrowserMirroredFileSystem.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Storage/BrowserMirroredFileSystem.cs
@@ -13,6 +13,7 @@ internal sealed class BrowserMirroredFileSystem :
     IAtomicFileSystem,
     ITemporaryFileSystem,
     IStoragePathResolver,
+    ISnapshotFileIdentity,
     IAsyncDisposable
 {
     private readonly object _gate = new();
@@ -69,6 +70,15 @@ internal sealed class BrowserMirroredFileSystem :
     }
 
     public string GetCanonicalPath(string path) => ValidateOwnedPath(path);
+
+    bool ISnapshotFileIdentity.CanProveDistinctFile(
+        string path,
+        IFileSystem otherFileSystem,
+        string otherPath)
+        => otherFileSystem is BrowserMirroredFileSystem other
+           && !PathComparer.Equals(
+               GetCanonicalPath(path),
+               other.GetCanonicalPath(otherPath));
 
     public bool FileExists(string path)
     {

--- a/src/Ahtola.Data.Sqlite.Browser/Storage/BrowserMirroredFileSystem.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Storage/BrowserMirroredFileSystem.cs
@@ -1,0 +1,486 @@
+using System.Runtime.Versioning;
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Data.Sqlite.Browser.Storage;
+
+/// <summary>
+/// Presents browser OPFS as synchronous in-memory storage to the managed engine
+/// and replays its exact mutations asynchronously at statement boundaries.
+/// </summary>
+[SupportedOSPlatform("browser")]
+internal sealed class BrowserMirroredFileSystem :
+    IFileSystem,
+    IAtomicFileSystem,
+    ITemporaryFileSystem,
+    IStoragePathResolver,
+    IAsyncDisposable
+{
+    private readonly object _gate = new();
+    private readonly SemaphoreSlim _flushGate = new(1, 1);
+    private readonly InMemoryFileSystem _memory = new();
+    private readonly OpfsAsyncFileSystem _persistent;
+    private readonly string _rootDirectory;
+    private readonly bool _ownsPersistent;
+    private List<Operation> _pending = [];
+    private int _disposed;
+
+    private BrowserMirroredFileSystem(
+        OpfsAsyncFileSystem persistent,
+        string rootDirectory,
+        bool ownsPersistent)
+    {
+        _persistent = persistent;
+        _rootDirectory = Normalize(rootDirectory);
+        _ownsPersistent = ownsPersistent;
+    }
+
+    public StringComparer PathComparer => StringComparer.Ordinal;
+
+    internal static async ValueTask<BrowserMirroredFileSystem> CreateAsync(
+        OpfsAsyncFileSystem persistent,
+        string rootDirectory,
+        bool ownsPersistent = false,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(persistent);
+        var fileSystem = new BrowserMirroredFileSystem(
+            persistent,
+            rootDirectory,
+            ownsPersistent);
+        try
+        {
+            await fileSystem.LoadAsync(cancellationToken).ConfigureAwait(false);
+            return fileSystem;
+        }
+        catch
+        {
+            await fileSystem.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    public string GetCanonicalPath(string path) => ValidateOwnedPath(path);
+
+    public bool FileExists(string path)
+    {
+        ThrowIfDisposed();
+        return _memory.FileExists(ValidateOwnedPath(path));
+    }
+
+    public FileWriteStamp? GetWriteStamp(string path)
+    {
+        ThrowIfDisposed();
+        return ((IFileSystem)_memory).GetWriteStamp(ValidateOwnedPath(path));
+    }
+
+    public IFile OpenFile(string path, FileOpenMode mode, bool readOnly = false)
+    {
+        ThrowIfDisposed();
+        var canonicalPath = ValidateOwnedPath(path);
+        var existed = _memory.FileExists(canonicalPath);
+        var file = _memory.OpenFile(canonicalPath, mode, readOnly);
+        if (!readOnly && !existed)
+            Enqueue(Operation.Create(canonicalPath));
+        return new MirroredFile(
+            this,
+            canonicalPath,
+            file,
+            persistMutations: true,
+            deleteOnClose: false);
+    }
+
+    IFile ITemporaryFileSystem.OpenTemporaryFile(string path)
+    {
+        ThrowIfDisposed();
+        var canonicalPath = ValidateOwnedPath(path);
+        var file = _memory.OpenFile(canonicalPath, FileOpenMode.CreateNew);
+        return new MirroredFile(
+            this,
+            canonicalPath,
+            file,
+            persistMutations: false,
+            deleteOnClose: true);
+    }
+
+    public void DeleteFile(string path)
+    {
+        ThrowIfDisposed();
+        var canonicalPath = ValidateOwnedPath(path);
+        _memory.DeleteFile(canonicalPath);
+        Enqueue(Operation.Delete(canonicalPath));
+    }
+
+    void IAtomicFileSystem.ReplaceFileAtomically(
+        string sourcePath,
+        string destinationPath,
+        bool replaceEmptyDestination)
+    {
+        ThrowIfDisposed();
+        var source = ValidateOwnedPath(sourcePath);
+        var destination = ValidateOwnedPath(destinationPath);
+        ((IAtomicFileSystem)_memory).ReplaceFileAtomically(
+            source,
+            destination,
+            replaceEmptyDestination);
+        Enqueue(Operation.Replace(source, destination, replaceEmptyDestination));
+    }
+
+    internal async ValueTask FlushPendingAsync(
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        await FlushPendingCoreAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async ValueTask FlushPendingCoreAsync(CancellationToken cancellationToken)
+    {
+        await _flushGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await ReplayPendingAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _flushGate.Release();
+        }
+    }
+
+    private async ValueTask ReplayPendingAsync(CancellationToken cancellationToken)
+    {
+        List<Operation> operations;
+        lock (_gate)
+        {
+            if (_pending.Count == 0)
+                return;
+            operations = _pending;
+            _pending = [];
+        }
+
+        var handles = new Dictionary<string, IAsyncFile>(StringComparer.Ordinal);
+        var index = 0;
+        Exception? closeError = null;
+        try
+        {
+            for (; index < operations.Count; index++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var operation = operations[index];
+                switch (operation.Kind)
+                {
+                    case OperationKind.Create:
+                    {
+                        var file = await GetWritableFileAsync(
+                            handles,
+                            operation.Path,
+                            cancellationToken).ConfigureAwait(false);
+                        await file.SetLengthAsync(0, cancellationToken).ConfigureAwait(false);
+                        break;
+                    }
+                    case OperationKind.Write:
+                    {
+                        var file = await GetWritableFileAsync(
+                            handles,
+                            operation.Path,
+                            cancellationToken).ConfigureAwait(false);
+                        await file.WriteAsync(
+                            operation.Position,
+                            operation.Bytes!,
+                            cancellationToken).ConfigureAwait(false);
+                        break;
+                    }
+                    case OperationKind.SetLength:
+                    {
+                        var file = await GetWritableFileAsync(
+                            handles,
+                            operation.Path,
+                            cancellationToken).ConfigureAwait(false);
+                        await file.SetLengthAsync(
+                            operation.Position,
+                            cancellationToken).ConfigureAwait(false);
+                        break;
+                    }
+                    case OperationKind.Flush:
+                    {
+                        var file = await GetWritableFileAsync(
+                            handles,
+                            operation.Path,
+                            cancellationToken).ConfigureAwait(false);
+                        await file.FlushToDiskAsync(cancellationToken).ConfigureAwait(false);
+                        break;
+                    }
+                    case OperationKind.Delete:
+                        await CloseHandleAsync(handles, operation.Path).ConfigureAwait(false);
+                        await _persistent
+                            .DeleteFileAsync(operation.Path, cancellationToken)
+                            .ConfigureAwait(false);
+                        break;
+                    case OperationKind.Replace:
+                        await CloseHandleAsync(handles, operation.Path).ConfigureAwait(false);
+                        await CloseHandleAsync(handles, operation.DestinationPath!).ConfigureAwait(false);
+                        await _persistent
+                            .ReplaceFileAtomicallyAsync(
+                                operation.Path,
+                                operation.DestinationPath!,
+                                operation.ReplaceEmptyDestination,
+                                cancellationToken)
+                            .ConfigureAwait(false);
+                        break;
+                    default:
+                        throw new InvalidOperationException(
+                            $"Unknown mirrored storage operation {operation.Kind}.");
+                }
+            }
+        }
+        catch
+        {
+            lock (_gate)
+                _pending.InsertRange(0, operations.GetRange(index, operations.Count - index));
+            throw;
+        }
+        finally
+        {
+            foreach (var file in handles.Values)
+            {
+                try
+                {
+                    await file.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (Exception exception)
+                {
+                    closeError ??= exception;
+                }
+            }
+        }
+
+        if (closeError is not null)
+            throw closeError;
+    }
+
+    internal async ValueTask DeleteAllPersistentFilesAsync(
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        await FlushPendingAsync(cancellationToken).ConfigureAwait(false);
+        var paths = await _persistent
+            .ListFilesAsync(_rootDirectory, cancellationToken)
+            .ConfigureAwait(false);
+        foreach (var path in paths)
+        {
+            await _persistent
+                .DeleteFileAsync(path, cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        try
+        {
+            await FlushPendingCoreAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+        finally
+        {
+            _flushGate.Dispose();
+            if (_ownsPersistent)
+                await _persistent.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private async ValueTask LoadAsync(CancellationToken cancellationToken)
+    {
+        var paths = await _persistent
+            .ListFilesAsync(_rootDirectory, cancellationToken)
+            .ConfigureAwait(false);
+        foreach (var path in paths)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await using var source = await _persistent
+                .OpenFileAsync(
+                    path,
+                    FileOpenMode.OpenExisting,
+                    readOnly: true,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            var length = await source.GetLengthAsync(cancellationToken).ConfigureAwait(false);
+            using var destination = _memory.OpenFile(path, FileOpenMode.CreateNew);
+            destination.SetLength(length);
+            var buffer = new byte[1024 * 1024];
+            var position = 0L;
+            while (position < length)
+            {
+                var count = checked((int)Math.Min(buffer.Length, length - position));
+                var read = await source
+                    .ReadAsync(position, buffer.AsMemory(0, count), cancellationToken)
+                    .ConfigureAwait(false);
+                if (read != count)
+                {
+                    throw new InvalidDataException(
+                        $"OPFS file '{path}' was truncated while loading the managed database.");
+                }
+                destination.Write(position, buffer.AsSpan(0, count));
+                position += count;
+            }
+        }
+    }
+
+    private async ValueTask<IAsyncFile> GetWritableFileAsync(
+        Dictionary<string, IAsyncFile> handles,
+        string path,
+        CancellationToken cancellationToken)
+    {
+        if (handles.TryGetValue(path, out var file))
+            return file;
+        file = await _persistent
+            .OpenFileAsync(
+                path,
+                FileOpenMode.OpenOrCreate,
+                readOnly: false,
+                cancellationToken)
+            .ConfigureAwait(false);
+        handles.Add(path, file);
+        return file;
+    }
+
+    private static async ValueTask CloseHandleAsync(
+        Dictionary<string, IAsyncFile> handles,
+        string path)
+    {
+        if (!handles.Remove(path, out var file))
+            return;
+        await file.DisposeAsync().ConfigureAwait(false);
+    }
+
+    private void Enqueue(Operation operation)
+    {
+        lock (_gate)
+            _pending.Add(operation);
+    }
+
+    private string ValidateOwnedPath(string path)
+    {
+        var normalized = Normalize(path);
+        if (!normalized.StartsWith(_rootDirectory + "/", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Browser database path '{normalized}' is outside owned directory '{_rootDirectory}'.");
+        }
+        return normalized;
+    }
+
+    private static string Normalize(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        var normalized = path.Replace('\\', '/').Trim('/');
+        var segments = normalized.Split('/');
+        if (segments.Any(static segment =>
+                segment is "" or "." or ".."
+                || segment.IndexOfAny(['\0', '\r', '\n']) >= 0))
+        {
+            throw new ArgumentException("Browser database paths must be relative and normalized.", nameof(path));
+        }
+        return string.Join('/', segments);
+    }
+
+    private void ThrowIfDisposed()
+        => ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+
+    private enum OperationKind
+    {
+        Create,
+        Write,
+        SetLength,
+        Flush,
+        Delete,
+        Replace,
+    }
+
+    private sealed record Operation(
+        OperationKind Kind,
+        string Path,
+        long Position = 0,
+        byte[]? Bytes = null,
+        string? DestinationPath = null,
+        bool ReplaceEmptyDestination = false)
+    {
+        public static Operation Create(string path) => new(OperationKind.Create, path);
+
+        public static Operation Write(string path, long position, ReadOnlySpan<byte> source)
+            => new(OperationKind.Write, path, position, source.ToArray());
+
+        public static Operation SetLength(string path, long length)
+            => new(OperationKind.SetLength, path, length);
+
+        public static Operation Flush(string path) => new(OperationKind.Flush, path);
+
+        public static Operation Delete(string path) => new(OperationKind.Delete, path);
+
+        public static Operation Replace(
+            string sourcePath,
+            string destinationPath,
+            bool replaceEmptyDestination)
+            => new(
+                OperationKind.Replace,
+                sourcePath,
+                DestinationPath: destinationPath,
+                ReplaceEmptyDestination: replaceEmptyDestination);
+    }
+
+    private sealed class MirroredFile(
+        BrowserMirroredFileSystem owner,
+        string path,
+        IFile inner,
+        bool persistMutations,
+        bool deleteOnClose) : IFile
+    {
+        private int _disposed;
+
+        public long Length => inner.Length;
+
+        public bool IsReadOnly => inner.IsReadOnly;
+
+        public int Read(long position, Span<byte> destination)
+        {
+            ThrowIfDisposed();
+            return inner.Read(position, destination);
+        }
+
+        public void Write(long position, ReadOnlySpan<byte> source)
+        {
+            ThrowIfDisposed();
+            inner.Write(position, source);
+            if (persistMutations)
+                owner.Enqueue(Operation.Write(path, position, source));
+        }
+
+        public void SetLength(long length)
+        {
+            ThrowIfDisposed();
+            inner.SetLength(length);
+            if (persistMutations)
+                owner.Enqueue(Operation.SetLength(path, length));
+        }
+
+        public void FlushToDisk()
+        {
+            ThrowIfDisposed();
+            inner.FlushToDisk();
+            if (persistMutations)
+                owner.Enqueue(Operation.Flush(path));
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                return;
+            inner.Dispose();
+            if (deleteOnClose)
+                owner._memory.DeleteFile(path);
+        }
+
+        private void ThrowIfDisposed()
+            => ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+    }
+}

--- a/src/Ahtola.Data.Sqlite.Browser/Storage/BrowserMirroredFileSystem.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Storage/BrowserMirroredFileSystem.cs
@@ -1,41 +1,53 @@
-using System.Runtime.Versioning;
 using Ahtola.Core.Storage;
 
 namespace Ahtola.Data.Sqlite.Browser.Storage;
 
 /// <summary>
-/// Presents browser OPFS as synchronous in-memory storage to the managed engine
-/// and replays its exact mutations asynchronously at statement boundaries.
+/// Presents a browser persistent store as synchronous in-memory storage to the
+/// managed engine and replays its exact mutations asynchronously at statement
+/// boundaries, optionally encrypting them on the way out.
 /// </summary>
-[SupportedOSPlatform("browser")]
 internal sealed class BrowserMirroredFileSystem :
     IFileSystem,
     IAtomicFileSystem,
     ITemporaryFileSystem,
     IStoragePathResolver,
     ISnapshotFileIdentity,
+    IPageCodecSource,
     IAsyncDisposable
 {
     private readonly object _gate = new();
     private readonly SemaphoreSlim _flushGate = new(1, 1);
     private readonly InMemoryFileSystem _memory = new();
-    private readonly OpfsAsyncFileSystem _persistent;
+    private readonly IBrowserPersistentStore _persistent;
+    private readonly BrowserEncryptedPersistence? _encryption;
+    private readonly AhtolaBrowserReservedSpaceCodec? _reservedSpaceCodec;
     private readonly string _rootDirectory;
     private readonly bool _ownsPersistent;
     private List<Operation> _pending = [];
     private int _disposed;
 
     private BrowserMirroredFileSystem(
-        OpfsAsyncFileSystem persistent,
+        IBrowserPersistentStore persistent,
         string rootDirectory,
-        bool ownsPersistent)
+        bool ownsPersistent,
+        BrowserEncryptedPersistence? encryption)
     {
         _persistent = persistent;
         _rootDirectory = Normalize(rootDirectory);
         _ownsPersistent = ownsPersistent;
+        _encryption = encryption;
+        _reservedSpaceCodec = encryption is null ? null : new AhtolaBrowserReservedSpaceCodec();
     }
 
     public StringComparer PathComparer => StringComparer.Ordinal;
+
+    /// <summary>
+    /// Forces the managed engine to reserve the bytes AHTLA encryption metadata
+    /// needs while it keeps reading and writing plaintext pages. Encryption itself
+    /// happens asynchronously on the way to OPFS.
+    /// </summary>
+    IPageCodec? IPageCodecSource.PageCodec => _reservedSpaceCodec;
 
     internal bool HasPendingMutations
     {
@@ -47,16 +59,18 @@ internal sealed class BrowserMirroredFileSystem :
     }
 
     internal static async ValueTask<BrowserMirroredFileSystem> CreateAsync(
-        OpfsAsyncFileSystem persistent,
+        IBrowserPersistentStore persistent,
         string rootDirectory,
         bool ownsPersistent = false,
+        BrowserEncryptedPersistence? encryption = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(persistent);
         var fileSystem = new BrowserMirroredFileSystem(
             persistent,
             rootDirectory,
-            ownsPersistent);
+            ownsPersistent,
+            encryption);
         try
         {
             await fileSystem.LoadAsync(cancellationToken).ConfigureAwait(false);
@@ -193,6 +207,7 @@ internal sealed class BrowserMirroredFileSystem :
                                 operation.Path,
                                 cancellationToken).ConfigureAwait(false);
                             await file.SetLengthAsync(0, cancellationToken).ConfigureAwait(false);
+                            _encryption?.NotifyCreated(operation.Path);
                             break;
                         }
                     case OperationKind.Write:
@@ -201,10 +216,25 @@ internal sealed class BrowserMirroredFileSystem :
                                 handles,
                                 operation.Path,
                                 cancellationToken).ConfigureAwait(false);
+                            if (_encryption is null || operation.Capture is null)
+                            {
+                                await file.WriteAsync(
+                                    operation.Position,
+                                    operation.Bytes!,
+                                    cancellationToken).ConfigureAwait(false);
+                                break;
+                            }
+
+                            var prepared = await _encryption
+                                .PrepareAsync(operation.Path, operation.Capture, cancellationToken)
+                                .ConfigureAwait(false);
+                            if (prepared.Bytes.Length == 0)
+                                break;
                             await file.WriteAsync(
-                                operation.Position,
-                                operation.Bytes!,
+                                prepared.Position,
+                                prepared.Bytes,
                                 cancellationToken).ConfigureAwait(false);
+                            _encryption.CommitWrite(prepared);
                             break;
                         }
                     case OperationKind.SetLength:
@@ -216,6 +246,7 @@ internal sealed class BrowserMirroredFileSystem :
                             await file.SetLengthAsync(
                                 operation.Position,
                                 cancellationToken).ConfigureAwait(false);
+                            _encryption?.NotifyLengthSet(operation.Path, operation.Position);
                             break;
                         }
                     case OperationKind.Flush:
@@ -232,6 +263,7 @@ internal sealed class BrowserMirroredFileSystem :
                         await _persistent
                             .DeleteFileAsync(operation.Path, cancellationToken)
                             .ConfigureAwait(false);
+                        _encryption?.NotifyDeleted(operation.Path);
                         break;
                     case OperationKind.Replace:
                         await CloseHandleAsync(handles, operation.Path).ConfigureAwait(false);
@@ -243,6 +275,7 @@ internal sealed class BrowserMirroredFileSystem :
                                 operation.ReplaceEmptyDestination,
                                 cancellationToken)
                             .ConfigureAwait(false);
+                        _encryption?.NotifyReplaced(operation.Path, operation.DestinationPath!);
                         break;
                     default:
                         throw new InvalidOperationException(
@@ -316,33 +349,49 @@ internal sealed class BrowserMirroredFileSystem :
         foreach (var path in paths)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await using var source = await _persistent
-                .OpenFileAsync(
-                    path,
-                    FileOpenMode.OpenExisting,
-                    readOnly: true,
-                    cancellationToken)
-                .ConfigureAwait(false);
-            var length = await source.GetLengthAsync(cancellationToken).ConfigureAwait(false);
-            using var destination = _memory.OpenFile(path, FileOpenMode.CreateNew);
-            destination.SetLength(length);
-            var buffer = new byte[1024 * 1024];
-            var position = 0L;
-            while (position < length)
+            var image = await ReadPersistentImageAsync(path, cancellationToken).ConfigureAwait(false);
+            if (_encryption is not null)
             {
-                var count = checked((int)Math.Min(buffer.Length, length - position));
-                var read = await source
-                    .ReadAsync(position, buffer.AsMemory(0, count), cancellationToken)
+                image = await _encryption
+                    .DecryptImageAsync(path, image, cancellationToken)
                     .ConfigureAwait(false);
-                if (read != count)
-                {
-                    throw new InvalidDataException(
-                        $"OPFS file '{path}' was truncated while loading the managed database.");
-                }
-                destination.Write(position, buffer.AsSpan(0, count));
-                position += count;
             }
+
+            using var destination = _memory.OpenFile(path, FileOpenMode.CreateNew);
+            destination.SetLength(image.LongLength);
+            if (image.Length != 0)
+                destination.Write(0, image);
         }
+    }
+
+    private async ValueTask<byte[]> ReadPersistentImageAsync(
+        string path,
+        CancellationToken cancellationToken)
+    {
+        await using var source = await _persistent
+            .OpenFileAsync(
+                path,
+                FileOpenMode.OpenExisting,
+                readOnly: true,
+                cancellationToken)
+            .ConfigureAwait(false);
+        var length = await source.GetLengthAsync(cancellationToken).ConfigureAwait(false);
+        var image = new byte[checked((int)length)];
+        var position = 0;
+        while (position < image.Length)
+        {
+            var read = await source
+                .ReadAsync(position, image.AsMemory(position), cancellationToken)
+                .ConfigureAwait(false);
+            if (read <= 0)
+            {
+                throw new InvalidDataException(
+                    $"OPFS file '{path}' was truncated while loading the managed database.");
+            }
+            position += read;
+        }
+
+        return image;
     }
 
     private async ValueTask<IAsyncFile> GetWritableFileAsync(
@@ -422,12 +471,16 @@ internal sealed class BrowserMirroredFileSystem :
         long Position = 0,
         byte[]? Bytes = null,
         string? DestinationPath = null,
-        bool ReplaceEmptyDestination = false)
+        bool ReplaceEmptyDestination = false,
+        BrowserPlaintextCapture? Capture = null)
     {
         public static Operation Create(string path) => new(OperationKind.Create, path);
 
         public static Operation Write(string path, long position, ReadOnlySpan<byte> source)
             => new(OperationKind.Write, path, position, source.ToArray());
+
+        public static Operation CapturedWrite(string path, BrowserPlaintextCapture capture)
+            => new(OperationKind.Write, path, capture.Position, Capture: capture);
 
         public static Operation SetLength(string path, long length)
             => new(OperationKind.SetLength, path, length);
@@ -470,8 +523,13 @@ internal sealed class BrowserMirroredFileSystem :
         {
             ThrowIfDisposed();
             inner.Write(position, source);
-            if (persistMutations)
-                owner.Enqueue(Operation.Write(path, position, source));
+            if (!persistMutations)
+                return;
+            owner.Enqueue(owner._encryption is { } encryption
+                ? Operation.CapturedWrite(
+                    path,
+                    encryption.Capture(path, position, source.Length, inner))
+                : Operation.Write(path, position, source));
         }
 
         public void SetLength(long length)
@@ -503,3 +561,4 @@ internal sealed class BrowserMirroredFileSystem :
             => ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
     }
 }
+

--- a/src/Ahtola.Data.Sqlite.Browser/Storage/BrowserPersistedFileRoles.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Storage/BrowserPersistedFileRoles.cs
@@ -1,0 +1,218 @@
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Data.Sqlite.Browser.Storage;
+
+/// <summary>The role a persisted OPFS file plays for AHTLA page encryption.</summary>
+internal enum BrowserPersistedFileRole
+{
+    /// <summary>A page-structured SQLite database: main, attached, or a VACUUM target.</summary>
+    Database,
+
+    /// <summary>A write-ahead log whose frame bodies are encrypted.</summary>
+    Wal,
+
+    /// <summary>A DELETE-mode rollback journal whose page records are encrypted.</summary>
+    Journal,
+
+    /// <summary>The rebuildable WAL index, which carries no page content.</summary>
+    SharedMemory,
+
+    /// <summary>An MVCC logical log, which the engine writes outside the page codec.</summary>
+    MvccLog,
+}
+
+/// <summary>
+/// Resolves persisted OPFS paths to encryption roles by anchoring sidecars to
+/// databases that are actually known, instead of trusting a filename suffix.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A suffix test alone is unsafe: a perfectly legal database can be named
+/// <c>notes-shm</c> or attached as <c>archive-wal</c>, and treating it as a
+/// sidecar would either corrupt it or, for <c>-shm</c>, write its pages to OPFS
+/// in the clear. A path is only a sidecar when the database it would belong to
+/// is itself known, and a content probe vetoes the classification when the file
+/// still looks like a database.
+/// </para>
+/// <para>
+/// Databases are discovered in open order at run time (the engine always opens a
+/// database before its sidecars) and in shortest-path-first order at load time,
+/// which guarantees a base path is resolved before anything derived from it.
+/// </para>
+/// </remarks>
+internal sealed class BrowserPersistedFileRoles
+{
+    // EmbeddedFileStore builds these names with Guid.NewGuid():N, so an exact
+    // shape match proves the file is an engine temporary rather than user data.
+    private static readonly string[] TransientPrefixes = [".vacuum-", ".page-size-"];
+    private const string TransientSuffix = ".tmp";
+    private const string MvccUpgradeSuffix = ".v4-upgrade";
+    private const int GuidHexLength = 32;
+
+    private static readonly (string Suffix, BrowserPersistedFileRole Role)[] SidecarSuffixes =
+    [
+        ("-journal", BrowserPersistedFileRole.Journal),
+        ("-wal", BrowserPersistedFileRole.Wal),
+        ("-shm", BrowserPersistedFileRole.SharedMemory),
+        ("-log", BrowserPersistedFileRole.MvccLog),
+    ];
+
+    private readonly Dictionary<string, BrowserPersistedFileRole> _roles = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _databases = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Whether <paramref name="path"/> has the exact shape of an engine temporary.
+    /// </summary>
+    /// <remarks>
+    /// This is a <em>load-time</em> question only. A live VACUUM or page-size
+    /// migration writes its rebuilt database through the persisted mirror at one
+    /// of these paths and then publishes it atomically, so treating the name as
+    /// "not real data" while the engine is writing would push a plaintext database
+    /// to OPFS. During a load, by contrast, nothing holds these files and they are
+    /// provably abandoned. <see cref="Classify"/> therefore never consults this.
+    /// </remarks>
+    internal static bool IsTransientArtifact(string path)
+    {
+        if (path.EndsWith(MvccUpgradeSuffix, StringComparison.Ordinal))
+            return true;
+
+        var candidate = path.AsSpan();
+        foreach (var (suffix, _) in SidecarSuffixes)
+        {
+            if (candidate.EndsWith(suffix, StringComparison.Ordinal))
+            {
+                candidate = candidate[..^suffix.Length];
+                break;
+            }
+        }
+
+        if (!candidate.EndsWith(TransientSuffix, StringComparison.Ordinal))
+            return false;
+
+        candidate = candidate[..^TransientSuffix.Length];
+        if (candidate.Length < GuidHexLength)
+            return false;
+
+        var guid = candidate[^GuidHexLength..];
+        foreach (var character in guid)
+        {
+            if (!char.IsAsciiHexDigitLower(character))
+                return false;
+        }
+
+        var head = candidate[..^GuidHexLength];
+        foreach (var prefix in TransientPrefixes)
+        {
+            if (head.EndsWith(prefix, StringComparison.Ordinal))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>Declares a path that is known to be a database up front.</summary>
+    internal void RegisterDatabase(string path)
+    {
+        _databases.Add(path);
+        _roles[path] = BrowserPersistedFileRole.Database;
+    }
+
+    /// <summary>Forgets a deleted path so a later file reusing the name is reclassified.</summary>
+    internal void Forget(string path)
+    {
+        _roles.Remove(path);
+        _databases.Remove(path);
+    }
+
+    /// <summary>Moves a role along with an atomically replaced file.</summary>
+    internal void Rename(string sourcePath, string destinationPath)
+    {
+        var moved = _roles.Remove(sourcePath, out var role);
+        _databases.Remove(sourcePath);
+        if (!moved)
+        {
+            _roles.Remove(destinationPath);
+            _databases.Remove(destinationPath);
+            return;
+        }
+
+        _roles[destinationPath] = role;
+        if (role == BrowserPersistedFileRole.Database)
+            _databases.Add(destinationPath);
+        else
+            _databases.Remove(destinationPath);
+    }
+
+    /// <summary>
+    /// Resolves the role of <paramref name="path"/>. <paramref name="probeHeader"/>
+    /// supplies the first bytes of the file when they are available, so a database
+    /// whose name merely looks like a sidecar is never demoted, and a genuine
+    /// sidecar is still recognized when its base database is absent.
+    /// </summary>
+    internal BrowserPersistedFileRole Resolve(
+        string path,
+        ReadOnlySpan<byte> probeHeader,
+        Func<string, bool>? basePathExists = null)
+    {
+        if (_roles.TryGetValue(path, out var known))
+            return known;
+
+        var role = Classify(path, probeHeader, basePathExists);
+        _roles[path] = role;
+        if (role == BrowserPersistedFileRole.Database)
+            _databases.Add(path);
+        return role;
+    }
+
+    private BrowserPersistedFileRole Classify(
+        string path,
+        ReadOnlySpan<byte> probeHeader,
+        Func<string, bool>? basePathExists)
+    {
+        foreach (var (suffix, role) in SidecarSuffixes)
+        {
+            if (!path.EndsWith(suffix, StringComparison.Ordinal))
+                continue;
+
+            var basePath = path[..^suffix.Length];
+            if (basePath.Length == 0)
+                break;
+
+            // A sidecar never begins with a database magic. If this one does, the
+            // name collided with a real database and the sidecar role is wrong.
+            if (LooksLikeDatabase(probeHeader))
+                return BrowserPersistedFileRole.Database;
+
+            // Positive identification first: a WAL and a finalized journal are
+            // self-describing, so they stay recognizable even when their database
+            // is missing. Otherwise the base database has to be known or present.
+            if (role == BrowserPersistedFileRole.Wal && LooksLikeWal(probeHeader))
+                return role;
+            if (role == BrowserPersistedFileRole.Journal && LooksLikeJournal(probeHeader))
+                return role;
+            if (_databases.Contains(basePath) || basePathExists?.Invoke(basePath) == true)
+                return role;
+
+            break;
+        }
+
+        return BrowserPersistedFileRole.Database;
+    }
+
+    private static bool LooksLikeDatabase(ReadOnlySpan<byte> probeHeader)
+        => AhtolaEncryptedPageFormat.IsAhtolaEncrypted(probeHeader)
+           || (probeHeader.Length >= AhtolaEncryptedPageFormat.SqliteHeaderMagic.Length
+               && probeHeader[..AhtolaEncryptedPageFormat.SqliteHeaderMagic.Length]
+                   .SequenceEqual(AhtolaEncryptedPageFormat.SqliteHeaderMagic));
+
+    private static bool LooksLikeWal(ReadOnlySpan<byte> probeHeader)
+    {
+        if (probeHeader.Length < 4)
+            return false;
+        var magic = System.Buffers.Binary.BinaryPrimitives.ReadUInt32BigEndian(probeHeader);
+        return magic is SqliteWalHeader.LittleEndianChecksumMagic or SqliteWalHeader.BigEndianChecksumMagic;
+    }
+
+    private static bool LooksLikeJournal(ReadOnlySpan<byte> probeHeader)
+        => SqliteRollbackJournalFormat.HasMagic(probeHeader);
+}

--- a/src/Ahtola.Data.Sqlite.Browser/Storage/BrowserStorageExceptionMapper.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Storage/BrowserStorageExceptionMapper.cs
@@ -1,0 +1,25 @@
+using System.Runtime.InteropServices.JavaScript;
+
+namespace Ahtola.Data.Sqlite.Browser.Storage;
+
+internal static class BrowserStorageExceptionMapper
+{
+    public static Exception Map(JSException exception, string path, string operation)
+    {
+        if (HasName(exception, "NotFoundError"))
+            return new FileNotFoundException($"OPFS could not {operation} '{path}' because it does not exist.", path, exception);
+        if (HasName(exception, "QuotaExceededError"))
+            return new IOException($"OPFS quota was exceeded while trying to {operation} '{path}'.", exception);
+        if (HasName(exception, "NoModificationAllowedError"))
+            return new UnauthorizedAccessException($"OPFS denied {operation} access to '{path}'.", exception);
+        if (HasName(exception, "InvalidModificationError"))
+            return new IOException($"OPFS could not {operation} '{path}' because the destination already exists.", exception);
+        if (HasName(exception, "InvalidStateError"))
+            return new IOException($"OPFS could not {operation} '{path}' because its handle is not in a valid state.", exception);
+
+        return new IOException($"OPFS failed to {operation} '{path}': {exception.Message}", exception);
+    }
+
+    private static bool HasName(JSException exception, string name)
+        => exception.Message.Contains(name, StringComparison.Ordinal);
+}

--- a/src/Ahtola.Data.Sqlite.Browser/Storage/BrowserStorageExceptionMapper.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Storage/BrowserStorageExceptionMapper.cs
@@ -1,10 +1,8 @@
-using System.Runtime.InteropServices.JavaScript;
-
 namespace Ahtola.Data.Sqlite.Browser.Storage;
 
 internal static class BrowserStorageExceptionMapper
 {
-    public static Exception Map(JSException exception, string path, string operation)
+    public static Exception Map(Exception exception, string path, string operation)
     {
         if (HasName(exception, "NotFoundError"))
             return new FileNotFoundException($"OPFS could not {operation} '{path}' because it does not exist.", path, exception);
@@ -20,6 +18,6 @@ internal static class BrowserStorageExceptionMapper
         return new IOException($"OPFS failed to {operation} '{path}': {exception.Message}", exception);
     }
 
-    private static bool HasName(JSException exception, string name)
+    private static bool HasName(Exception exception, string name)
         => exception.Message.Contains(name, StringComparison.Ordinal);
 }

--- a/src/Ahtola.Data.Sqlite.Browser/Storage/IAhtolaAsyncPageCipher.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Storage/IAhtolaAsyncPageCipher.cs
@@ -1,0 +1,39 @@
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Data.Sqlite.Browser.Storage;
+
+/// <summary>
+/// The asynchronous AES-GCM primitive used to build AHTLA pages. The browser
+/// implementation is backed by Web Crypto, whose API is promise-based and can
+/// therefore never satisfy the synchronous <see cref="IPageCodec"/> contract the
+/// desktop engine uses.
+/// </summary>
+/// <remarks>
+/// Keeping this seam abstract lets the managed test suite drive the exact same
+/// page, WAL, and journal transforms with <c>System.Security.Cryptography</c> so
+/// browser output can be proven byte-identical to desktop output.
+/// </remarks>
+internal interface IAhtolaAsyncPageCipher : IAsyncDisposable
+{
+    /// <summary>The AHTLA cipher id written into encrypted page 1 headers.</summary>
+    Core.Storage.AhtolaEncryptionCipher Cipher { get; }
+
+    /// <summary>Encrypts <paramref name="plaintext"/> and returns its ciphertext and tag.</summary>
+    ValueTask<AhtolaBrowserAesGcmResult> EncryptAsync(
+        ReadOnlyMemory<byte> plaintext,
+        ReadOnlyMemory<byte> nonce,
+        ReadOnlyMemory<byte> associatedData,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Authenticates and decrypts <paramref name="ciphertext"/>. Implementations
+    /// throw <see cref="System.Security.Cryptography.CryptographicException"/>
+    /// (or a subclass) when the tag does not match.
+    /// </summary>
+    ValueTask<byte[]> DecryptAsync(
+        ReadOnlyMemory<byte> ciphertext,
+        ReadOnlyMemory<byte> tag,
+        ReadOnlyMemory<byte> nonce,
+        ReadOnlyMemory<byte> associatedData,
+        CancellationToken cancellationToken);
+}

--- a/src/Ahtola.Data.Sqlite.Browser/Storage/IBrowserPersistentStore.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Storage/IBrowserPersistentStore.cs
@@ -1,0 +1,33 @@
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Data.Sqlite.Browser.Storage;
+
+/// <summary>
+/// The durable store behind <see cref="BrowserMirroredFileSystem"/>. In a browser
+/// this is OPFS through the dedicated worker; the seam exists so the mirror,
+/// including encrypted persistence, can be exercised end to end off-browser.
+/// </summary>
+internal interface IBrowserPersistentStore : IAsyncDisposable
+{
+    /// <summary>Lists every persisted file below <paramref name="directory"/>.</summary>
+    ValueTask<IReadOnlyList<string>> ListFilesAsync(
+        string directory,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Opens a persisted file.</summary>
+    ValueTask<IAsyncFile> OpenFileAsync(
+        string path,
+        FileOpenMode mode,
+        bool readOnly = false,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Deletes a persisted file.</summary>
+    ValueTask DeleteFileAsync(string path, CancellationToken cancellationToken = default);
+
+    /// <summary>Atomically publishes <paramref name="sourcePath"/> over <paramref name="destinationPath"/>.</summary>
+    ValueTask ReplaceFileAtomicallyAsync(
+        string sourcePath,
+        string destinationPath,
+        bool replaceEmptyDestination,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Ahtola.Data.Sqlite.Browser/Storage/OpfsAsyncFile.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Storage/OpfsAsyncFile.cs
@@ -53,11 +53,9 @@ internal sealed class OpfsAsyncFile : IAsyncFile
 
         try
         {
-            var bytes = await _client
-                .ReadAsync(handleId, position, destination.Length, cancellationToken)
+            return await _client
+                .ReadAsync(handleId, position, destination, cancellationToken)
                 .ConfigureAwait(false);
-            bytes.CopyTo(destination);
-            return bytes.Length;
         }
         catch (JSException exception)
         {
@@ -78,15 +76,9 @@ internal sealed class OpfsAsyncFile : IAsyncFile
         var handleId = GetHandleId();
         try
         {
-            var bytes = source.ToArray();
-            var written = await _client
-                .WriteAsync(handleId, position, bytes, cancellationToken)
+            await _client
+                .WriteAsync(handleId, position, source, cancellationToken)
                 .ConfigureAwait(false);
-            if (written != bytes.Length)
-            {
-                throw new IOException(
-                    $"OPFS wrote {written} of {bytes.Length} requested bytes to '{_path}'.");
-            }
         }
         catch (JSException exception)
         {

--- a/src/Ahtola.Data.Sqlite.Browser/Storage/OpfsAsyncFile.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Storage/OpfsAsyncFile.cs
@@ -1,0 +1,152 @@
+using System.Runtime.InteropServices.JavaScript;
+using System.Runtime.Versioning;
+using Ahtola.Core.Storage;
+using Ahtola.Data.Sqlite.Browser.Interop;
+
+namespace Ahtola.Data.Sqlite.Browser.Storage;
+
+[SupportedOSPlatform("browser")]
+internal sealed class OpfsAsyncFile : IAsyncFile
+{
+    private readonly OpfsWorkerClient _client;
+    private readonly string _path;
+    private readonly bool _deleteOnClose;
+    private int _handleId;
+
+    public OpfsAsyncFile(
+        OpfsWorkerClient client,
+        string path,
+        int handleId,
+        bool readOnly,
+        bool deleteOnClose)
+    {
+        _client = client;
+        _path = path;
+        _handleId = handleId;
+        IsReadOnly = readOnly;
+        _deleteOnClose = deleteOnClose;
+    }
+
+    public bool IsReadOnly { get; }
+
+    public async ValueTask<long> GetLengthAsync(CancellationToken cancellationToken = default)
+    {
+        var handleId = GetHandleId();
+        try
+        {
+            return await _client.GetLengthAsync(handleId, cancellationToken).ConfigureAwait(false);
+        }
+        catch (JSException exception)
+        {
+            throw BrowserStorageExceptionMapper.Map(exception, _path, "read the length of");
+        }
+    }
+
+    public async ValueTask<int> ReadAsync(
+        long position,
+        Memory<byte> destination,
+        CancellationToken cancellationToken = default)
+    {
+        var handleId = GetHandleId();
+        if (destination.IsEmpty)
+            return 0;
+
+        try
+        {
+            var bytes = await _client
+                .ReadAsync(handleId, position, destination.Length, cancellationToken)
+                .ConfigureAwait(false);
+            bytes.CopyTo(destination);
+            return bytes.Length;
+        }
+        catch (JSException exception)
+        {
+            throw BrowserStorageExceptionMapper.Map(exception, _path, "read");
+        }
+    }
+
+    public async ValueTask WriteAsync(
+        long position,
+        ReadOnlyMemory<byte> source,
+        CancellationToken cancellationToken = default)
+    {
+        if (IsReadOnly)
+            throw new InvalidOperationException("Cannot write to a read-only OPFS file.");
+        if (source.IsEmpty)
+            return;
+
+        var handleId = GetHandleId();
+        try
+        {
+            var bytes = source.ToArray();
+            var written = await _client
+                .WriteAsync(handleId, position, bytes, cancellationToken)
+                .ConfigureAwait(false);
+            if (written != bytes.Length)
+            {
+                throw new IOException(
+                    $"OPFS wrote {written} of {bytes.Length} requested bytes to '{_path}'.");
+            }
+        }
+        catch (JSException exception)
+        {
+            throw BrowserStorageExceptionMapper.Map(exception, _path, "write");
+        }
+    }
+
+    public async ValueTask SetLengthAsync(
+        long length,
+        CancellationToken cancellationToken = default)
+    {
+        if (IsReadOnly)
+            throw new InvalidOperationException("Cannot change the length of a read-only OPFS file.");
+
+        var handleId = GetHandleId();
+        try
+        {
+            await _client.SetLengthAsync(handleId, length, cancellationToken).ConfigureAwait(false);
+        }
+        catch (JSException exception)
+        {
+            throw BrowserStorageExceptionMapper.Map(exception, _path, "set the length of");
+        }
+    }
+
+    public async ValueTask FlushToDiskAsync(CancellationToken cancellationToken = default)
+    {
+        var handleId = GetHandleId();
+        try
+        {
+            await _client.FlushAsync(handleId, cancellationToken).ConfigureAwait(false);
+        }
+        catch (JSException exception)
+        {
+            throw BrowserStorageExceptionMapper.Map(exception, _path, "flush");
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        var handleId = Interlocked.Exchange(ref _handleId, 0);
+        if (handleId == 0)
+            return;
+
+        try
+        {
+            await _client.CloseAsync(handleId, CancellationToken.None).ConfigureAwait(false);
+            if (_deleteOnClose)
+                await _client.DeleteAsync(_path, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (JSException exception)
+        {
+            throw BrowserStorageExceptionMapper.Map(exception, _path, "close");
+        }
+    }
+
+    private int GetHandleId()
+    {
+        var handleId = Volatile.Read(ref _handleId);
+        ObjectDisposedException.ThrowIf(handleId == 0, this);
+        return handleId;
+    }
+}

--- a/src/Ahtola.Data.Sqlite.Browser/Storage/OpfsAsyncFileSystem.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Storage/OpfsAsyncFileSystem.cs
@@ -1,0 +1,211 @@
+using System.Runtime.InteropServices.JavaScript;
+using System.Runtime.Versioning;
+using Ahtola.Core.Storage;
+using Ahtola.Data.Sqlite.Browser.Interop;
+
+namespace Ahtola.Data.Sqlite.Browser.Storage;
+
+[SupportedOSPlatform("browser")]
+internal sealed class OpfsAsyncFileSystem :
+    IAsyncFileSystem,
+    IAsyncAtomicFileSystem,
+    IAsyncTemporaryFileSystem,
+    IStoragePathResolver,
+    IAsyncDisposable
+{
+    internal const int DefaultSharedBufferSize = 1024 * 1024;
+    private readonly OpfsWorkerClient _client;
+    private int _disposed;
+
+    private OpfsAsyncFileSystem(OpfsWorkerClient client)
+    {
+        _client = client;
+    }
+
+    public StringComparer PathComparer => StringComparer.Ordinal;
+
+    public static async ValueTask<OpfsAsyncFileSystem> CreateAsync(
+        string lockName,
+        int sharedBufferSize = DefaultSharedBufferSize,
+        CancellationToken cancellationToken = default)
+    {
+        var canonicalLockName = Canonicalize(lockName);
+        var capabilities = await AhtolaBrowserRuntime.GetCapabilitiesAsync().ConfigureAwait(false);
+        if (!capabilities.IsSupported)
+        {
+            throw new PlatformNotSupportedException(
+                "Ahtola OPFS requires cross-origin isolation, SharedArrayBuffer, "
+                + "Origin Private File System synchronous handles, module workers, and Web Locks.");
+        }
+
+        try
+        {
+            var client = await OpfsWorkerClient
+                .CreateAsync(canonicalLockName, sharedBufferSize, cancellationToken)
+                .ConfigureAwait(false);
+            return new OpfsAsyncFileSystem(client);
+        }
+        catch (JSException exception) when (
+            exception.Message.Contains("NoModificationAllowedError", StringComparison.Ordinal))
+        {
+            throw new AhtolaBrowserDatabaseLockedException(canonicalLockName, exception);
+        }
+        catch (JSException exception)
+        {
+            throw BrowserStorageExceptionMapper.Map(
+                exception,
+                canonicalLockName,
+                "initialize browser storage for");
+        }
+    }
+
+    public string GetCanonicalPath(string path) => Canonicalize(path);
+
+    public async ValueTask<bool> FileExistsAsync(
+        string path,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        var canonicalPath = Canonicalize(path);
+        try
+        {
+            return await _client
+                .FileExistsAsync(canonicalPath, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (JSException exception)
+        {
+            throw BrowserStorageExceptionMapper.Map(exception, canonicalPath, "inspect");
+        }
+    }
+
+    public async ValueTask<IAsyncFile> OpenFileAsync(
+        string path,
+        FileOpenMode mode,
+        bool readOnly = false,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        var canonicalPath = Canonicalize(path);
+        try
+        {
+            var handleId = await _client
+                .OpenFileAsync(canonicalPath, (int)mode, readOnly, cancellationToken)
+                .ConfigureAwait(false);
+            return new OpfsAsyncFile(_client, canonicalPath, handleId, readOnly, deleteOnClose: false);
+        }
+        catch (JSException exception)
+        {
+            throw BrowserStorageExceptionMapper.Map(exception, canonicalPath, "open");
+        }
+    }
+
+    public async ValueTask<IAsyncFile> OpenTemporaryFileAsync(
+        string path,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        var canonicalPath = Canonicalize(path);
+        try
+        {
+            var handleId = await _client
+                .OpenFileAsync(
+                    canonicalPath,
+                    (int)FileOpenMode.CreateNew,
+                    readOnly: false,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return new OpfsAsyncFile(_client, canonicalPath, handleId, readOnly: false, deleteOnClose: true);
+        }
+        catch (JSException exception)
+        {
+            throw BrowserStorageExceptionMapper.Map(exception, canonicalPath, "create temporary file");
+        }
+    }
+
+    public async ValueTask DeleteFileAsync(
+        string path,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        var canonicalPath = Canonicalize(path);
+        try
+        {
+            await _client.DeleteAsync(canonicalPath, cancellationToken).ConfigureAwait(false);
+        }
+        catch (JSException exception)
+        {
+            throw BrowserStorageExceptionMapper.Map(exception, canonicalPath, "delete");
+        }
+    }
+
+    public async ValueTask ReplaceFileAtomicallyAsync(
+        string sourcePath,
+        string destinationPath,
+        bool replaceEmptyDestination,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        var canonicalSource = Canonicalize(sourcePath);
+        var canonicalDestination = Canonicalize(destinationPath);
+        if (PathComparer.Equals(canonicalSource, canonicalDestination))
+        {
+            throw new IOException(
+                "Atomic file replacement requires distinct source and destination paths.");
+        }
+
+        try
+        {
+            await _client
+                .ReplaceFileAtomicallyAsync(
+                    canonicalSource,
+                    canonicalDestination,
+                    replaceEmptyDestination,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (JSException exception)
+        {
+            throw BrowserStorageExceptionMapper.Map(
+                exception,
+                $"{canonicalSource}' -> '{canonicalDestination}",
+                "atomically replace");
+        }
+    }
+
+    public ValueTask<FileWriteStamp?> GetWriteStampAsync(
+        string path,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        cancellationToken.ThrowIfCancellationRequested();
+        return ValueTask.FromResult<FileWriteStamp?>(null);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) == 0)
+            await _client.DisposeAsync().ConfigureAwait(false);
+    }
+
+    private static string Canonicalize(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        var normalized = path.Replace('\\', '/');
+        if (normalized.StartsWith('/'))
+            throw new ArgumentException("OPFS paths must be relative to the origin-private root.", nameof(path));
+
+        var segments = normalized.Split('/');
+        if (segments.Any(static segment => segment is "" or "." or ".."))
+        {
+            throw new ArgumentException(
+                "OPFS paths cannot contain empty, current, or parent segments.",
+                nameof(path));
+        }
+
+        return string.Join('/', segments);
+    }
+
+    private void ThrowIfDisposed()
+        => ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+}

--- a/src/Ahtola.Data.Sqlite.Browser/Storage/OpfsAsyncFileSystem.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Storage/OpfsAsyncFileSystem.cs
@@ -11,6 +11,7 @@ internal sealed class OpfsAsyncFileSystem :
     IAsyncAtomicFileSystem,
     IAsyncTemporaryFileSystem,
     IStoragePathResolver,
+    IBrowserPersistentStore,
     IAsyncDisposable
 {
     internal const int DefaultSharedBufferSize = 1024 * 1024;
@@ -139,7 +140,7 @@ internal sealed class OpfsAsyncFileSystem :
         }
     }
 
-    internal async ValueTask<IReadOnlyList<string>> ListFilesAsync(
+    public async ValueTask<IReadOnlyList<string>> ListFilesAsync(
         string directoryPath,
         CancellationToken cancellationToken = default)
     {

--- a/src/Ahtola.Data.Sqlite.Browser/Storage/OpfsAsyncFileSystem.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Storage/OpfsAsyncFileSystem.cs
@@ -139,6 +139,24 @@ internal sealed class OpfsAsyncFileSystem :
         }
     }
 
+    internal async ValueTask<IReadOnlyList<string>> ListFilesAsync(
+        string directoryPath,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        var canonicalPath = Canonicalize(directoryPath);
+        try
+        {
+            return await _client
+                .ListFilesAsync(canonicalPath, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (JSException exception)
+        {
+            throw BrowserStorageExceptionMapper.Map(exception, canonicalPath, "enumerate");
+        }
+    }
+
     public async ValueTask ReplaceFileAtomicallyAsync(
         string sourcePath,
         string destinationPath,
@@ -196,7 +214,9 @@ internal sealed class OpfsAsyncFileSystem :
             throw new ArgumentException("OPFS paths must be relative to the origin-private root.", nameof(path));
 
         var segments = normalized.Split('/');
-        if (segments.Any(static segment => segment is "" or "." or ".."))
+        if (segments.Any(static segment =>
+                segment is "" or "." or ".."
+                || segment.IndexOfAny(['\0', '\r', '\n']) >= 0))
         {
             throw new ArgumentException(
                 "OPFS paths cannot contain empty, current, or parent segments.",

--- a/src/Ahtola.Data.Sqlite.Browser/Storage/OpfsAsyncFileSystem.cs
+++ b/src/Ahtola.Data.Sqlite.Browser/Storage/OpfsAsyncFileSystem.cs
@@ -36,7 +36,8 @@ internal sealed class OpfsAsyncFileSystem :
         {
             throw new PlatformNotSupportedException(
                 "Ahtola OPFS requires cross-origin isolation, SharedArrayBuffer, "
-                + "Origin Private File System synchronous handles, module workers, and Web Locks.");
+                + "Origin Private File System synchronous handles, module workers, and Web Locks. "
+                + $"Missing in this browser: {string.Join(", ", capabilities.MissingCapabilities)}.");
         }
 
         try
@@ -207,7 +208,15 @@ internal sealed class OpfsAsyncFileSystem :
             await _client.DisposeAsync().ConfigureAwait(false);
     }
 
-    private static string Canonicalize(string path)
+    // Reserved for the OPFS worker's own atomic-replacement intent journal
+    // (see ahtola-opfs-worker.mjs). Rejecting it here, at every public path
+    // boundary (open/exists/delete/list/replace, which also covers ATTACH,
+    // backup, and VACUUM destinations), guarantees no database, WAL,
+    // journal, or backup file can ever be given a name that collides with an
+    // internal journal slot.
+    private const string ReservedPathPrefix = ".ahtola-replace-";
+
+    internal static string Canonicalize(string path)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(path);
         var normalized = path.Replace('\\', '/');
@@ -221,6 +230,14 @@ internal sealed class OpfsAsyncFileSystem :
         {
             throw new ArgumentException(
                 "OPFS paths cannot contain empty, current, or parent segments.",
+                nameof(path));
+        }
+
+        if (segments.Any(static segment =>
+                segment.StartsWith(ReservedPathPrefix, StringComparison.Ordinal)))
+        {
+            throw new ArgumentException(
+                $"OPFS path segments cannot start with the reserved prefix '{ReservedPathPrefix}'.",
                 nameof(path));
         }
 

--- a/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-crypto.mjs
+++ b/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-crypto.mjs
@@ -1,0 +1,198 @@
+const retainedKeys = new Map();
+let nextKeyHandle = 1;
+
+function getSubtleCrypto() {
+    const subtle = globalThis.crypto?.subtle;
+    if (!subtle) {
+        throw new Error("The browser does not provide the Web Crypto SubtleCrypto API.");
+    }
+
+    return subtle;
+}
+
+function retainKey(key) {
+    const handle = nextKeyHandle++;
+    retainedKeys.set(handle, key);
+    return handle;
+}
+
+function getKey(handle) {
+    const key = retainedKeys.get(handle);
+    if (!key) {
+        throw new Error(`Unknown or released Web Crypto key handle ${handle}.`);
+    }
+
+    return key;
+}
+
+function copyBytes(value, name) {
+    if (value instanceof Uint8Array) {
+        return value;
+    }
+
+    if (Array.isArray(value)) {
+        return Uint8Array.from(value);
+    }
+
+    throw new TypeError(`${name} must be a byte array.`);
+}
+
+function clearBytes(original, bytes) {
+    bytes.fill(0);
+    if (original !== bytes && typeof original?.fill === "function") {
+        original.fill(0);
+    }
+}
+
+export async function createPasswordKey(password, salt, iterations, keyLengthBits) {
+    const subtle = getSubtleCrypto();
+    const encoder = new TextEncoder();
+    const passwordBytes = encoder.encode(password);
+    const saltBytes = encoder.encode(salt);
+    try {
+        const material = await subtle.importKey(
+            "raw",
+            passwordBytes,
+            "PBKDF2",
+            false,
+            ["deriveKey"]);
+        const key = await subtle.deriveKey(
+            {
+                name: "PBKDF2",
+                salt: saltBytes,
+                iterations,
+                hash: "SHA-256",
+            },
+            material,
+            { name: "AES-GCM", length: keyLengthBits },
+            false,
+            ["encrypt", "decrypt"]);
+        return retainKey(key);
+    } finally {
+        passwordBytes.fill(0);
+        saltBytes.fill(0);
+    }
+}
+
+export async function derivePasswordBits(password, salt, iterations, outputLengthBits) {
+    const subtle = getSubtleCrypto();
+    const encoder = new TextEncoder();
+    const passwordBytes = encoder.encode(password);
+    const saltBytes = encoder.encode(salt);
+    try {
+        const material = await subtle.importKey(
+            "raw",
+            passwordBytes,
+            "PBKDF2",
+            false,
+            ["deriveBits"]);
+        const bits = await subtle.deriveBits(
+            {
+                name: "PBKDF2",
+                salt: saltBytes,
+                iterations,
+                hash: "SHA-256",
+            },
+            material,
+            outputLengthBits);
+        return new Uint8Array(bits);
+    } finally {
+        passwordBytes.fill(0);
+        saltBytes.fill(0);
+    }
+}
+
+export async function importAesGcmKey(key) {
+    const subtle = getSubtleCrypto();
+    const keyBytes = copyBytes(key, "key");
+    try {
+        if (keyBytes.byteLength !== 16 && keyBytes.byteLength !== 32) {
+            throw new Error("AHTLA AES-GCM keys must be exactly 16 or 32 bytes.");
+        }
+
+        const cryptoKey = await subtle.importKey(
+            "raw",
+            keyBytes,
+            "AES-GCM",
+            false,
+            ["encrypt", "decrypt"]);
+        return retainKey(cryptoKey);
+    } finally {
+        clearBytes(key, keyBytes);
+    }
+}
+
+export async function encryptAesGcm(keyHandle, nonce, plaintext, associatedData) {
+    const subtle = getSubtleCrypto();
+    const nonceBytes = copyBytes(nonce, "nonce");
+    const plaintextBytes = copyBytes(plaintext, "plaintext");
+    const associatedDataBytes = copyBytes(associatedData, "associatedData");
+    try {
+        const encrypted = await subtle.encrypt(
+            {
+                name: "AES-GCM",
+                iv: nonceBytes,
+                additionalData: associatedDataBytes,
+                tagLength: 128,
+            },
+            getKey(keyHandle),
+            plaintextBytes);
+        return new Uint8Array(encrypted);
+    } finally {
+        clearBytes(nonce, nonceBytes);
+        clearBytes(plaintext, plaintextBytes);
+        clearBytes(associatedData, associatedDataBytes);
+    }
+}
+
+export async function decryptAesGcm(
+    keyHandle,
+    nonce,
+    ciphertext,
+    tag,
+    associatedData) {
+    const subtle = getSubtleCrypto();
+    const nonceBytes = copyBytes(nonce, "nonce");
+    const ciphertextBytes = copyBytes(ciphertext, "ciphertext");
+    const tagBytes = copyBytes(tag, "tag");
+    const associatedDataBytes = copyBytes(associatedData, "associatedData");
+    const combined = new Uint8Array(ciphertextBytes.byteLength + tagBytes.byteLength);
+    combined.set(ciphertextBytes);
+    combined.set(tagBytes, ciphertextBytes.byteLength);
+    try {
+        const decrypted = await subtle.decrypt(
+            {
+                name: "AES-GCM",
+                iv: nonceBytes,
+                additionalData: associatedDataBytes,
+                tagLength: 128,
+            },
+            getKey(keyHandle),
+            combined);
+        return new Uint8Array(decrypted);
+    } finally {
+        combined.fill(0);
+        clearBytes(nonce, nonceBytes);
+        clearBytes(ciphertext, ciphertextBytes);
+        clearBytes(tag, tagBytes);
+        clearBytes(associatedData, associatedDataBytes);
+    }
+}
+
+export function consumeByteArray(value) {
+    const bytes = copyBytes(value, "value");
+    const result = Array.from(bytes);
+    bytes.fill(0);
+    queueMicrotask(() => result.fill(0));
+    return result;
+}
+
+export function releaseKey(keyHandle) {
+    if (!retainedKeys.delete(keyHandle)) {
+        throw new Error(`Unknown or already released Web Crypto key handle ${keyHandle}.`);
+    }
+}
+
+export function getRetainedKeyCount() {
+    return retainedKeys.size;
+}

--- a/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-crypto.mjs
+++ b/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-crypto.mjs
@@ -44,6 +44,15 @@ function clearBytes(original, bytes) {
     }
 }
 
+function normalizeError(error) {
+    const name = error?.name ?? "Error";
+    const message = error?.message ?? String(error);
+    const normalized = new Error(`${name}: ${message}`);
+    normalized.name = name;
+    normalized.stack = `${name}: ${message}`;
+    return normalized;
+}
+
 export async function createPasswordKey(password, salt, iterations, keyLengthBits) {
     const subtle = getSubtleCrypto();
     const encoder = new TextEncoder();
@@ -160,16 +169,20 @@ export async function decryptAesGcm(
     combined.set(ciphertextBytes);
     combined.set(tagBytes, ciphertextBytes.byteLength);
     try {
-        const decrypted = await subtle.decrypt(
-            {
-                name: "AES-GCM",
-                iv: nonceBytes,
-                additionalData: associatedDataBytes,
-                tagLength: 128,
-            },
-            getKey(keyHandle),
-            combined);
-        return new Uint8Array(decrypted);
+        try {
+            const decrypted = await subtle.decrypt(
+                {
+                    name: "AES-GCM",
+                    iv: nonceBytes,
+                    additionalData: associatedDataBytes,
+                    tagLength: 128,
+                },
+                getKey(keyHandle),
+                combined);
+            return new Uint8Array(decrypted);
+        } catch (error) {
+            throw normalizeError(error);
+        }
     } finally {
         combined.fill(0);
         clearBytes(nonce, nonceBytes);

--- a/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs-capability-probe-worker.mjs
+++ b/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs-capability-probe-worker.mjs
@@ -1,0 +1,29 @@
+// A minimal, dedicated worker used only to probe real support for
+// createSyncAccessHandle (see ahtola-opfs.mjs's
+// runSynchronousAccessHandleProbeInWorker). Kept as its own packaged,
+// same-origin script - not a blob: URL - so the probe is allowed under the
+// same restrictive Content-Security-Policy (for example
+// "worker-src 'self'", with no "blob:") that already allows the real
+// storage worker (ahtola-opfs-worker.mjs) to load. A blob:-URL worker would
+// be blocked by such a CSP even though the real worker works fine under it,
+// making the probe report a false negative.
+self.addEventListener("message", async () => {
+    const name = `.ahtola-capability-probe-${crypto.randomUUID()}`;
+    try {
+        const root = await navigator.storage.getDirectory();
+        const fileHandle = await root.getFileHandle(name, { create: true });
+        try {
+            const access = await fileHandle.createSyncAccessHandle();
+            access.close();
+        } finally {
+            await root.removeEntry(name).catch(() => {});
+        }
+        self.postMessage({ ok: true });
+    } catch (error) {
+        self.postMessage({
+            ok: false,
+            name: error?.name ?? "Error",
+            message: error?.message ?? String(error),
+        });
+    }
+});

--- a/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs-worker.mjs
+++ b/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs-worker.mjs
@@ -21,12 +21,11 @@ const textDecoder = new TextDecoder();
 // database's reopen or replay hide or corrupt another database that merely
 // happens to share the reserved prefix.
 const RESERVED_PATH_PREFIX = ".ahtola-replace-";
-// The exact shape of a live journal slot's filename: the reserved prefix, a
-// 64-character SHA-256 hex digest of the owning lock's full identity, and a
-// ".0"/".1" double-buffer suffix (see lockDigest). Only this exact shape is
+// The exact filenames of the two live journal slots (see
+// initializeIntentJournal/INTENT_SLOT_NAMES). Only these exact names are
 // hidden from directory listings, so a reserved-prefixed name that isn't one
 // of the two live slots is never silently swallowed by an over-broad filter.
-const RESERVED_INTENT_SLOT_PATTERN = /^\.ahtola-replace-[0-9a-f]{64}\.[01]$/u;
+const RESERVED_INTENT_SLOT_PATTERN = /^\.ahtola-replace-journal\.[01]$/u;
 
 function errorPayload(error) {
     return {
@@ -120,23 +119,17 @@ function checksum(value) {
     return hash >>> 0;
 }
 
-// A cryptographic digest of the full lock identity, not a 32-bit rolling
-// hash: two distinct lock names (for example two tenants' database paths)
-// must never plausibly collide on the journal slot filename this produces.
-// Every record additionally carries the full lock name (see writeIntent and
-// readIntentSlot), so even an astronomically unlikely digest collision is
-// detected and isolated rather than silently recovering another lock's
-// intent.
-async function lockDigest(value) {
-    const bytes = textEncoder.encode(value);
-    const digest = await crypto.subtle.digest("SHA-256", bytes);
-    return [...new Uint8Array(digest)]
-        .map(byte => byte.toString(16).padStart(2, "0"))
-        .join("");
-}
+// Fixed slot filenames used inside the lock's OWN resolved directory (see
+// initializeIntentJournal). Nesting the journal there - rather than hashing
+// the lock name into a filename shared by every database at the OPFS root -
+// makes two different locks sharing a slot structurally impossible instead
+// of merely unlikely: normalizePath/resolveDirectory resolve distinct lock
+// names to distinct directories, and the exclusive Web Lock already
+// guarantees only one worker touches a given directory's slots at a time.
+const INTENT_SLOT_NAMES = [".ahtola-replace-journal.0", ".ahtola-replace-journal.1"];
 
-async function openIntentSlot(name) {
-    const file = await root.getFileHandle(name, { create: true });
+async function openIntentSlot(directory, name) {
+    const file = await directory.getFileHandle(name, { create: true });
     return file.createSyncAccessHandle();
 }
 
@@ -164,9 +157,10 @@ function readIntentSlot(access, expectedLockName) {
             return { invalid: true };
         }
         // A well-formed record for a different lock identity means this
-        // slot's filename collided with another database's (see
-        // lockDigest). That is not corruption: leave the foreign record
-        // alone for its owner and treat this lock's journal as empty.
+        // slot was somehow shared with another lock. That is not
+        // corruption: leave the foreign record alone for its owner and
+        // treat this lock's journal as empty. Kept as defense in depth on
+        // top of the directory-scoped, per-lock slot location above.
         if (record.lockName !== expectedLockName)
             return { foreign: true };
         return { record };
@@ -200,10 +194,10 @@ function writeIntent(payload) {
 
 async function initializeIntentJournal(lockName) {
     currentLockName = lockName;
-    const prefix = `.ahtola-replace-${await lockDigest(lockName)}`;
+    const directory = await resolveDirectory(lockName, true);
     intentSlots.push(
-        await openIntentSlot(`${prefix}.0`),
-        await openIntentSlot(`${prefix}.1`));
+        await openIntentSlot(directory, INTENT_SLOT_NAMES[0]),
+        await openIntentSlot(directory, INTENT_SLOT_NAMES[1]));
 
     const decoded = intentSlots.map(access => readIntentSlot(access, lockName));
     const valid = decoded

--- a/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs-worker.mjs
+++ b/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs-worker.mjs
@@ -250,7 +250,7 @@ function requireUnreferenced(entry) {
     }
 }
 
-async function copyEntry(source, destinationPath) {
+async function copyEntry(source, destinationPath, operationId = 0) {
     requireUnreferenced(source);
     const destination = await getOrOpenEntry(destinationPath, true);
     requireUnreferenced(destination);
@@ -260,7 +260,7 @@ async function copyEntry(source, destinationPath) {
     const buffer = new Uint8Array(Math.min(sharedBytes.length, 1024 * 1024));
     let position = 0;
     while (position < sourceSize) {
-        if (Atomics.load(control, 0) !== 0)
+        if (operationId !== 0 && Atomics.load(control, 1) === operationId)
             throw new DOMException("The OPFS operation was cancelled.", "AbortError");
         const count = Math.min(buffer.length, sourceSize - position);
         const target = buffer.subarray(0, count);
@@ -337,7 +337,8 @@ async function rollbackPreparedReplacement(payload) {
 async function replaceFileAtomically(
     sourcePath,
     destinationPath,
-    replaceEmptyDestination) {
+    replaceEmptyDestination,
+    operationId) {
     const sourceNormalized = normalizePath(sourcePath).join("/");
     const destinationNormalized = normalizePath(destinationPath).join("/");
     if (sourceNormalized === destinationNormalized)
@@ -368,7 +369,7 @@ async function replaceFileAtomically(
     };
     writeIntent(intent);
     try {
-        await copyEntry(source, destinationNormalized);
+        await copyEntry(source, destinationNormalized, operationId);
     } catch (error) {
         await rollbackPreparedReplacement(intent);
         throw error;
@@ -461,7 +462,8 @@ self.addEventListener("message", async event => {
                 await replaceFileAtomically(
                     event.data.sourcePath,
                     event.data.destinationPath,
-                    event.data.replaceEmptyDestination);
+                    event.data.replaceEmptyDestination,
+                    event.data.operationId);
                 result = 0;
                 break;
             case "dispose":

--- a/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs-worker.mjs
+++ b/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs-worker.mjs
@@ -29,7 +29,11 @@ function normalizePath(value) {
         throw new TypeError("OPFS paths must be relative to the origin-private root.");
 
     const segments = normalized.split("/");
-    if (segments.some(segment => segment === "" || segment === "." || segment === ".."))
+    if (segments.some(segment =>
+        segment === ""
+        || segment === "."
+        || segment === ".."
+        || /[\0\r\n]/u.test(segment)))
         throw new TypeError("OPFS paths cannot contain empty, current, or parent segments.");
     return segments;
 }
@@ -58,6 +62,31 @@ async function tryGetFile(path) {
             return undefined;
         throw error;
     }
+}
+
+async function resolveDirectory(path, create = false) {
+    const segments = normalizePath(path);
+    let directory = root;
+    for (const segment of segments)
+        directory = await directory.getDirectoryHandle(segment, { create });
+    return directory;
+}
+
+async function listFiles(path) {
+    const directory = await resolveDirectory(path, true);
+    const files = [];
+    async function visit(current, prefix) {
+        for await (const [name, handle] of current.entries()) {
+            const relative = `${prefix}/${name}`;
+            if (handle.kind === "directory")
+                await visit(handle, relative);
+            else if (!name.startsWith(".ahtola-replace-"))
+                files.push(relative);
+        }
+    }
+    await visit(directory, path);
+    files.sort();
+    return files.join("\n");
 }
 
 function checksum(value) {
@@ -457,6 +486,9 @@ self.addEventListener("message", async event => {
             case "delete":
                 await deleteFile(event.data.path);
                 result = 0;
+                break;
+            case "list":
+                result = await listFiles(event.data.directoryPath);
                 break;
             case "replace":
                 await replaceFileAtomically(

--- a/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs-worker.mjs
+++ b/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs-worker.mjs
@@ -1,0 +1,230 @@
+let root;
+let sharedBytes;
+let lockRelease;
+let lockRequest;
+let nextHandleId = 0;
+
+const entriesByPath = new Map();
+const viewsByHandle = new Map();
+
+function errorPayload(error) {
+    return {
+        name: error?.name ?? "Error",
+        message: error?.message ?? String(error),
+        code: error?.code,
+    };
+}
+
+function normalizePath(value) {
+    if (typeof value !== "string" || value.trim() === "")
+        throw new TypeError("An OPFS path is required.");
+
+    const normalized = value.replaceAll("\\", "/");
+    if (normalized.startsWith("/"))
+        throw new TypeError("OPFS paths must be relative to the origin-private root.");
+
+    const segments = normalized.split("/");
+    if (segments.some(segment => segment === "" || segment === "." || segment === ".."))
+        throw new TypeError("OPFS paths cannot contain empty, current, or parent segments.");
+    return segments;
+}
+
+async function resolveParent(path, createDirectories) {
+    const segments = normalizePath(path);
+    const name = segments.pop();
+    let directory = root;
+    for (const segment of segments) {
+        directory = await directory.getDirectoryHandle(segment, {
+            create: createDirectories,
+        });
+    }
+    return { directory, name, path: [...segments, name].join("/") };
+}
+
+async function tryGetFile(path) {
+    try {
+        const resolved = await resolveParent(path, false);
+        return {
+            ...resolved,
+            file: await resolved.directory.getFileHandle(resolved.name),
+        };
+    } catch (error) {
+        if (error?.name === "NotFoundError")
+            return undefined;
+        throw error;
+    }
+}
+
+async function acquireLock(lockName) {
+    let readyResolve;
+    const ready = new Promise(resolve => readyResolve = resolve);
+    const held = new Promise(resolve => lockRelease = resolve);
+    lockRequest = navigator.locks.request(
+        `ahtola:${lockName}`,
+        { mode: "exclusive", ifAvailable: true },
+        async lock => {
+            readyResolve(Boolean(lock));
+            if (lock)
+                await held;
+        });
+    if (!await ready) {
+        lockRelease = undefined;
+        throw new DOMException(
+            `The browser database '${lockName}' is open in another tab or worker.`,
+            "NoModificationAllowedError");
+    }
+}
+
+async function openFile(path, mode, readOnly) {
+    if (!Number.isInteger(mode) || mode < 0 || mode > 2)
+        throw new RangeError("The OPFS open mode is invalid.");
+
+    const segments = normalizePath(path);
+    const normalized = segments.join("/");
+    let entry = entriesByPath.get(normalized);
+    if (!entry) {
+        const existing = await tryGetFile(normalized);
+        if (mode === 0 && !existing)
+            throw new DOMException(`The OPFS file '${normalized}' does not exist.`, "NotFoundError");
+        if (mode === 2 && existing)
+            throw new DOMException(`The OPFS file '${normalized}' already exists.`, "InvalidModificationError");
+
+        const resolved = existing ?? await resolveParent(normalized, true);
+        const file = existing?.file
+            ?? await resolved.directory.getFileHandle(resolved.name, { create: true });
+        const access = await file.createSyncAccessHandle();
+        entry = {
+            path: normalized,
+            directory: resolved.directory,
+            name: resolved.name,
+            access,
+            references: 0,
+        };
+        entriesByPath.set(normalized, entry);
+    } else if (mode === 2) {
+        throw new DOMException(`The OPFS file '${normalized}' already exists.`, "InvalidModificationError");
+    }
+
+    const handleId = ++nextHandleId;
+    entry.references++;
+    viewsByHandle.set(handleId, { entry, readOnly });
+    return handleId;
+}
+
+function view(handleId) {
+    const value = viewsByHandle.get(handleId);
+    if (!value)
+        throw new DOMException(`Unknown OPFS handle '${handleId}'.`, "InvalidStateError");
+    return value;
+}
+
+function closeView(handleId) {
+    const value = view(handleId);
+    viewsByHandle.delete(handleId);
+    value.entry.references--;
+}
+
+async function deleteFile(path) {
+    const normalized = normalizePath(path).join("/");
+    const entry = entriesByPath.get(normalized);
+    if (entry) {
+        if (entry.references !== 0)
+            throw new DOMException(`The OPFS file '${normalized}' is still open.`, "InvalidStateError");
+        entry.access.close();
+        entriesByPath.delete(normalized);
+        await entry.directory.removeEntry(entry.name);
+        return;
+    }
+
+    const existing = await tryGetFile(normalized);
+    if (existing)
+        await existing.directory.removeEntry(existing.name);
+}
+
+async function dispose() {
+    viewsByHandle.clear();
+    for (const entry of entriesByPath.values())
+        entry.access.close();
+    entriesByPath.clear();
+
+    lockRelease?.();
+    lockRelease = undefined;
+    await lockRequest;
+    lockRequest = undefined;
+}
+
+self.addEventListener("message", async event => {
+    const { id, type } = event.data;
+    try {
+        let result;
+        switch (type) {
+            case "initialize":
+                if (root)
+                    throw new DOMException("The OPFS worker is already initialized.", "InvalidStateError");
+                sharedBytes = new Uint8Array(event.data.shared);
+                root = await navigator.storage.getDirectory();
+                await acquireLock(event.data.lockName);
+                result = 0;
+                break;
+            case "exists":
+                result = Boolean(await tryGetFile(event.data.path));
+                break;
+            case "open":
+                result = await openFile(
+                    event.data.path,
+                    event.data.mode,
+                    event.data.readOnly);
+                break;
+            case "length":
+                result = view(event.data.handleId).entry.access.getSize();
+                break;
+            case "read": {
+                const value = view(event.data.handleId);
+                const destination = sharedBytes.subarray(0, event.data.length);
+                result = value.entry.access.read(destination, { at: event.data.position });
+                break;
+            }
+            case "write": {
+                const value = view(event.data.handleId);
+                if (value.readOnly)
+                    throw new DOMException("The OPFS file is read-only.", "NoModificationAllowedError");
+                const source = sharedBytes.subarray(0, event.data.length);
+                result = value.entry.access.write(source, { at: event.data.position });
+                break;
+            }
+            case "truncate": {
+                const value = view(event.data.handleId);
+                if (value.readOnly)
+                    throw new DOMException("The OPFS file is read-only.", "NoModificationAllowedError");
+                value.entry.access.truncate(event.data.length);
+                result = 0;
+                break;
+            }
+            case "flush": {
+                const value = view(event.data.handleId);
+                if (!value.readOnly)
+                    value.entry.access.flush();
+                result = 0;
+                break;
+            }
+            case "close":
+                closeView(event.data.handleId);
+                result = 0;
+                break;
+            case "delete":
+                await deleteFile(event.data.path);
+                result = 0;
+                break;
+            case "dispose":
+                await dispose();
+                result = 0;
+                break;
+            default:
+                throw new Error(`Unknown Ahtola OPFS worker operation '${type}'.`);
+        }
+
+        self.postMessage({ id, result });
+    } catch (error) {
+        self.postMessage({ id, error: errorPayload(error) });
+    }
+});

--- a/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs-worker.mjs
+++ b/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs-worker.mjs
@@ -1,11 +1,16 @@
 let root;
 let sharedBytes;
+let control;
 let lockRelease;
 let lockRequest;
 let nextHandleId = 0;
+let intentGeneration = 0;
 
 const entriesByPath = new Map();
 const viewsByHandle = new Map();
+const intentSlots = [];
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
 
 function errorPayload(error) {
     return {
@@ -55,6 +60,94 @@ async function tryGetFile(path) {
     }
 }
 
+function checksum(value) {
+    const bytes = textEncoder.encode(value);
+    let hash = 0x811c9dc5;
+    for (const byte of bytes) {
+        hash ^= byte;
+        hash = Math.imul(hash, 0x01000193);
+    }
+    return hash >>> 0;
+}
+
+function lockHash(value) {
+    return checksum(value).toString(16).padStart(8, "0");
+}
+
+async function openIntentSlot(name) {
+    const file = await root.getFileHandle(name, { create: true });
+    return file.createSyncAccessHandle();
+}
+
+function readIntentSlot(access) {
+    const size = access.getSize();
+    if (size === 0)
+        return { empty: true };
+
+    try {
+        const bytes = new Uint8Array(size);
+        if (access.read(bytes, { at: 0 }) !== size)
+            return { invalid: true };
+        const envelope = JSON.parse(textDecoder.decode(bytes));
+        if (typeof envelope?.body !== "string"
+            || !Number.isInteger(envelope.checksum)
+            || checksum(envelope.body) !== envelope.checksum) {
+            return { invalid: true };
+        }
+
+        const record = JSON.parse(envelope.body);
+        if (record?.version !== 1
+            || !Number.isSafeInteger(record.generation)
+            || record.generation < 1) {
+            return { invalid: true };
+        }
+        return { record };
+    } catch {
+        return { invalid: true };
+    }
+}
+
+function writeIntent(payload) {
+    const generation = intentGeneration + 1;
+    const body = JSON.stringify({ version: 1, generation, payload });
+    const bytes = textEncoder.encode(JSON.stringify({
+        body,
+        checksum: checksum(body),
+    }));
+    for (const access of intentSlots) {
+        access.truncate(0);
+        const written = access.write(bytes, { at: 0 });
+        if (written !== bytes.length)
+            throw new DOMException("The OPFS replacement intent was only partially written.", "DataError");
+        access.truncate(bytes.length);
+        access.flush();
+    }
+    intentGeneration = generation;
+}
+
+async function initializeIntentJournal(lockName) {
+    const prefix = `.ahtola-replace-${lockHash(lockName)}`;
+    intentSlots.push(
+        await openIntentSlot(`${prefix}.0`),
+        await openIntentSlot(`${prefix}.1`));
+
+    const decoded = intentSlots.map(readIntentSlot);
+    const valid = decoded
+        .filter(value => value.record)
+        .map(value => value.record)
+        .sort((left, right) => right.generation - left.generation);
+    if (valid.length === 0 && decoded.some(value => value.invalid)) {
+        throw new DOMException(
+            "Both OPFS atomic-replacement intent records are invalid.",
+            "DataError");
+    }
+
+    const latest = valid[0];
+    intentGeneration = latest?.generation ?? 0;
+    if (latest?.payload)
+        await recoverReplacement(latest.payload);
+}
+
 async function acquireLock(lockName) {
     let readyResolve;
     const ready = new Promise(resolve => readyResolve = resolve);
@@ -75,35 +168,43 @@ async function acquireLock(lockName) {
     }
 }
 
+async function getOrOpenEntry(path, create) {
+    const normalized = normalizePath(path).join("/");
+    let entry = entriesByPath.get(normalized);
+    if (entry)
+        return entry;
+
+    const existing = await tryGetFile(normalized);
+    if (!existing && !create)
+        return undefined;
+
+    const resolved = existing ?? await resolveParent(normalized, true);
+    const file = existing?.file
+        ?? await resolved.directory.getFileHandle(resolved.name, { create: true });
+    const access = await file.createSyncAccessHandle();
+    entry = {
+        path: normalized,
+        directory: resolved.directory,
+        name: resolved.name,
+        access,
+        references: 0,
+    };
+    entriesByPath.set(normalized, entry);
+    return entry;
+}
+
 async function openFile(path, mode, readOnly) {
     if (!Number.isInteger(mode) || mode < 0 || mode > 2)
         throw new RangeError("The OPFS open mode is invalid.");
 
     const segments = normalizePath(path);
     const normalized = segments.join("/");
-    let entry = entriesByPath.get(normalized);
-    if (!entry) {
-        const existing = await tryGetFile(normalized);
-        if (mode === 0 && !existing)
-            throw new DOMException(`The OPFS file '${normalized}' does not exist.`, "NotFoundError");
-        if (mode === 2 && existing)
-            throw new DOMException(`The OPFS file '${normalized}' already exists.`, "InvalidModificationError");
-
-        const resolved = existing ?? await resolveParent(normalized, true);
-        const file = existing?.file
-            ?? await resolved.directory.getFileHandle(resolved.name, { create: true });
-        const access = await file.createSyncAccessHandle();
-        entry = {
-            path: normalized,
-            directory: resolved.directory,
-            name: resolved.name,
-            access,
-            references: 0,
-        };
-        entriesByPath.set(normalized, entry);
-    } else if (mode === 2) {
+    const existing = entriesByPath.get(normalized) ?? await getOrOpenEntry(normalized, false);
+    if (mode === 0 && !existing)
+        throw new DOMException(`The OPFS file '${normalized}' does not exist.`, "NotFoundError");
+    if (mode === 2 && existing)
         throw new DOMException(`The OPFS file '${normalized}' already exists.`, "InvalidModificationError");
-    }
+    const entry = existing ?? await getOrOpenEntry(normalized, true);
 
     const handleId = ++nextHandleId;
     entry.references++;
@@ -141,11 +242,150 @@ async function deleteFile(path) {
         await existing.directory.removeEntry(existing.name);
 }
 
+function requireUnreferenced(entry) {
+    if (entry.references !== 0) {
+        throw new DOMException(
+            `The OPFS file '${entry.path}' is still open.`,
+            "InvalidStateError");
+    }
+}
+
+async function copyEntry(source, destinationPath) {
+    requireUnreferenced(source);
+    const destination = await getOrOpenEntry(destinationPath, true);
+    requireUnreferenced(destination);
+    const sourceSize = source.access.getSize();
+    destination.access.truncate(0);
+
+    const buffer = new Uint8Array(Math.min(sharedBytes.length, 1024 * 1024));
+    let position = 0;
+    while (position < sourceSize) {
+        if (Atomics.load(control, 0) !== 0)
+            throw new DOMException("The OPFS operation was cancelled.", "AbortError");
+        const count = Math.min(buffer.length, sourceSize - position);
+        const target = buffer.subarray(0, count);
+        const read = source.access.read(target, { at: position });
+        if (read !== count) {
+            throw new DOMException(
+                `Atomic replacement read ${read} of ${count} bytes from '${source.path}'.`,
+                "DataError");
+        }
+        const written = destination.access.write(target, { at: position });
+        if (written !== count) {
+            throw new DOMException(
+                `Atomic replacement wrote ${written} of ${count} bytes to '${destination.path}'.`,
+                "DataError");
+        }
+        position += count;
+    }
+
+    destination.access.truncate(sourceSize);
+    destination.access.flush();
+}
+
+async function removeReplacementSource(path) {
+    const normalized = normalizePath(path).join("/");
+    const entry = entriesByPath.get(normalized);
+    if (entry) {
+        requireUnreferenced(entry);
+        entry.access.close();
+        entriesByPath.delete(normalized);
+        await entry.directory.removeEntry(entry.name);
+        return;
+    }
+
+    const existing = await tryGetFile(normalized);
+    if (existing)
+        await existing.directory.removeEntry(existing.name);
+}
+
+async function recoverReplacement(payload) {
+    if (payload?.type !== "replace")
+        throw new DOMException("The OPFS replacement intent type is invalid.", "DataError");
+
+    if (payload.phase === "prepared") {
+        const source = await getOrOpenEntry(payload.sourcePath, false);
+        if (!source) {
+            await rollbackPreparedReplacement(payload);
+            return;
+        }
+        await copyEntry(source, payload.destinationPath);
+        payload = { ...payload, phase: "destination-flushed" };
+        writeIntent(payload);
+    } else if (payload.phase !== "destination-flushed") {
+        throw new DOMException("The OPFS replacement intent phase is invalid.", "DataError");
+    }
+
+    await removeReplacementSource(payload.sourcePath);
+    writeIntent(null);
+}
+
+async function rollbackPreparedReplacement(payload) {
+    if (payload.destinationExisted) {
+        const destination = await getOrOpenEntry(payload.destinationPath, false);
+        if (destination) {
+            requireUnreferenced(destination);
+            destination.access.truncate(0);
+            destination.access.flush();
+        }
+    } else {
+        await removeReplacementSource(payload.destinationPath);
+    }
+    writeIntent(null);
+}
+
+async function replaceFileAtomically(
+    sourcePath,
+    destinationPath,
+    replaceEmptyDestination) {
+    const sourceNormalized = normalizePath(sourcePath).join("/");
+    const destinationNormalized = normalizePath(destinationPath).join("/");
+    if (sourceNormalized === destinationNormalized)
+        throw new DOMException("Atomic replacement requires distinct paths.", "InvalidModificationError");
+
+    const source = await getOrOpenEntry(sourceNormalized, false);
+    if (!source)
+        throw new DOMException(`The OPFS file '${sourceNormalized}' does not exist.`, "NotFoundError");
+    requireUnreferenced(source);
+
+    const destination = await getOrOpenEntry(destinationNormalized, false);
+    if (destination) {
+        requireUnreferenced(destination);
+        if (!replaceEmptyDestination || destination.access.getSize() !== 0) {
+            throw new DOMException(
+                `The OPFS destination '${destinationNormalized}' is not replaceable.`,
+                "InvalidModificationError");
+        }
+    }
+
+    source.access.flush();
+    const intent = {
+        type: "replace",
+        sourcePath: sourceNormalized,
+        destinationPath: destinationNormalized,
+        destinationExisted: Boolean(destination),
+        phase: "prepared",
+    };
+    writeIntent(intent);
+    try {
+        await copyEntry(source, destinationNormalized);
+    } catch (error) {
+        await rollbackPreparedReplacement(intent);
+        throw error;
+    }
+    writeIntent({ ...intent, phase: "destination-flushed" });
+    await removeReplacementSource(sourceNormalized);
+    writeIntent(null);
+}
+
 async function dispose() {
     viewsByHandle.clear();
     for (const entry of entriesByPath.values())
         entry.access.close();
     entriesByPath.clear();
+    for (const access of intentSlots)
+        access.close();
+    intentSlots.length = 0;
 
     lockRelease?.();
     lockRelease = undefined;
@@ -162,8 +402,10 @@ self.addEventListener("message", async event => {
                 if (root)
                     throw new DOMException("The OPFS worker is already initialized.", "InvalidStateError");
                 sharedBytes = new Uint8Array(event.data.shared);
+                control = new Int32Array(event.data.control);
                 root = await navigator.storage.getDirectory();
                 await acquireLock(event.data.lockName);
+                await initializeIntentJournal(event.data.lockName);
                 result = 0;
                 break;
             case "exists":
@@ -213,6 +455,13 @@ self.addEventListener("message", async event => {
                 break;
             case "delete":
                 await deleteFile(event.data.path);
+                result = 0;
+                break;
+            case "replace":
+                await replaceFileAtomically(
+                    event.data.sourcePath,
+                    event.data.destinationPath,
+                    event.data.replaceEmptyDestination);
                 result = 0;
                 break;
             case "dispose":

--- a/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs-worker.mjs
+++ b/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs-worker.mjs
@@ -5,12 +5,28 @@ let lockRelease;
 let lockRequest;
 let nextHandleId = 0;
 let intentGeneration = 0;
+let currentLockName;
 
 const entriesByPath = new Map();
 const viewsByHandle = new Map();
 const intentSlots = [];
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
+
+// Filenames using this prefix are reserved for the worker's own atomic-
+// replacement intent journal (see initializeIntentJournal). No public path
+// operation may create, open, delete, or list a path whose last segment
+// starts with it, so a real database, WAL, journal, or backup destination
+// can never collide with an internal journal slot - which would let one
+// database's reopen or replay hide or corrupt another database that merely
+// happens to share the reserved prefix.
+const RESERVED_PATH_PREFIX = ".ahtola-replace-";
+// The exact shape of a live journal slot's filename: the reserved prefix, a
+// 64-character SHA-256 hex digest of the owning lock's full identity, and a
+// ".0"/".1" double-buffer suffix (see lockDigest). Only this exact shape is
+// hidden from directory listings, so a reserved-prefixed name that isn't one
+// of the two live slots is never silently swallowed by an over-broad filter.
+const RESERVED_INTENT_SLOT_PATTERN = /^\.ahtola-replace-[0-9a-f]{64}\.[01]$/u;
 
 function errorPayload(error) {
     return {
@@ -35,6 +51,11 @@ function normalizePath(value) {
         || segment === ".."
         || /[\0\r\n]/u.test(segment)))
         throw new TypeError("OPFS paths cannot contain empty, current, or parent segments.");
+    if (segments.some(segment => segment.startsWith(RESERVED_PATH_PREFIX))) {
+        throw new DOMException(
+            `OPFS path segments cannot start with the reserved prefix '${RESERVED_PATH_PREFIX}'.`,
+            "NotAllowedError");
+    }
     return segments;
 }
 
@@ -80,7 +101,7 @@ async function listFiles(path) {
             const relative = `${prefix}/${name}`;
             if (handle.kind === "directory")
                 await visit(handle, relative);
-            else if (!name.startsWith(".ahtola-replace-"))
+            else if (!RESERVED_INTENT_SLOT_PATTERN.test(name))
                 files.push(relative);
         }
     }
@@ -99,8 +120,19 @@ function checksum(value) {
     return hash >>> 0;
 }
 
-function lockHash(value) {
-    return checksum(value).toString(16).padStart(8, "0");
+// A cryptographic digest of the full lock identity, not a 32-bit rolling
+// hash: two distinct lock names (for example two tenants' database paths)
+// must never plausibly collide on the journal slot filename this produces.
+// Every record additionally carries the full lock name (see writeIntent and
+// readIntentSlot), so even an astronomically unlikely digest collision is
+// detected and isolated rather than silently recovering another lock's
+// intent.
+async function lockDigest(value) {
+    const bytes = textEncoder.encode(value);
+    const digest = await crypto.subtle.digest("SHA-256", bytes);
+    return [...new Uint8Array(digest)]
+        .map(byte => byte.toString(16).padStart(2, "0"))
+        .join("");
 }
 
 async function openIntentSlot(name) {
@@ -108,7 +140,7 @@ async function openIntentSlot(name) {
     return file.createSyncAccessHandle();
 }
 
-function readIntentSlot(access) {
+function readIntentSlot(access, expectedLockName) {
     const size = access.getSize();
     if (size === 0)
         return { empty: true };
@@ -125,11 +157,18 @@ function readIntentSlot(access) {
         }
 
         const record = JSON.parse(envelope.body);
-        if (record?.version !== 1
+        if (record?.version !== 2
             || !Number.isSafeInteger(record.generation)
-            || record.generation < 1) {
+            || record.generation < 1
+            || typeof record.lockName !== "string") {
             return { invalid: true };
         }
+        // A well-formed record for a different lock identity means this
+        // slot's filename collided with another database's (see
+        // lockDigest). That is not corruption: leave the foreign record
+        // alone for its owner and treat this lock's journal as empty.
+        if (record.lockName !== expectedLockName)
+            return { foreign: true };
         return { record };
     } catch {
         return { invalid: true };
@@ -138,7 +177,12 @@ function readIntentSlot(access) {
 
 function writeIntent(payload) {
     const generation = intentGeneration + 1;
-    const body = JSON.stringify({ version: 1, generation, payload });
+    const body = JSON.stringify({
+        version: 2,
+        generation,
+        lockName: currentLockName,
+        payload,
+    });
     const bytes = textEncoder.encode(JSON.stringify({
         body,
         checksum: checksum(body),
@@ -155,12 +199,13 @@ function writeIntent(payload) {
 }
 
 async function initializeIntentJournal(lockName) {
-    const prefix = `.ahtola-replace-${lockHash(lockName)}`;
+    currentLockName = lockName;
+    const prefix = `.ahtola-replace-${await lockDigest(lockName)}`;
     intentSlots.push(
         await openIntentSlot(`${prefix}.0`),
         await openIntentSlot(`${prefix}.1`));
 
-    const decoded = intentSlots.map(readIntentSlot);
+    const decoded = intentSlots.map(access => readIntentSlot(access, lockName));
     const valid = decoded
         .filter(value => value.record)
         .map(value => value.record)

--- a/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs.mjs
+++ b/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs.mjs
@@ -75,9 +75,11 @@ export async function createContext(lockName, sharedBufferSize) {
         type: "module",
     });
     const shared = new SharedArrayBuffer(sharedBufferSize);
+    const control = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
     const value = {
         worker,
         shared,
+        control,
         bytes: new Uint8Array(shared),
         pending: new Map(),
         nextRequestId: 0,
@@ -101,7 +103,12 @@ export async function createContext(lockName, sharedBufferSize) {
     const contextId = ++nextContextId;
     contexts.set(contextId, value);
     try {
-        await request(value, { type: "initialize", lockName, shared });
+        await request(value, {
+            type: "initialize",
+            lockName,
+            shared,
+            control: control.buffer,
+        });
         return contextId;
     } catch (error) {
         contexts.delete(contextId);
@@ -224,4 +231,24 @@ export function closeFile(contextId, handleId) {
 export function deleteFile(contextId, path) {
     const value = context(contextId);
     return enqueue(value, () => request(value, { type: "delete", path }));
+}
+
+export function replaceFileAtomically(
+    contextId,
+    sourcePath,
+    destinationPath,
+    replaceEmptyDestination) {
+    const value = context(contextId);
+    Atomics.store(value.control, 0, 0);
+    return enqueue(value, () => request(value, {
+        type: "replace",
+        sourcePath,
+        destinationPath,
+        replaceEmptyDestination,
+    }));
+}
+
+export function cancelCurrentOperation(contextId) {
+    const value = context(contextId);
+    Atomics.store(value.control, 0, 1);
 }

--- a/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs.mjs
+++ b/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs.mjs
@@ -87,32 +87,15 @@ function hasSynchronousAccessHandlePrerequisites() {
 // off-limits on the main thread) that creates, opens, and closes a
 // throwaway OPFS file with a synchronous access handle, reporting whether
 // the browser actually supports it rather than inferring support from
-// unrelated feature checks.
+// unrelated feature checks. Uses the real, packaged
+// ahtola-opfs-capability-probe-worker.mjs script - a same-origin URL, the
+// same way the real storage worker is loaded - rather than a blob: URL, so
+// the probe is not blocked by a Content-Security-Policy that allows the
+// real worker but does not allow blob: workers.
 async function runSynchronousAccessHandleProbeInWorker() {
-    const workerSource = `
-        self.addEventListener("message", async () => {
-            const name = ".ahtola-capability-probe-" + crypto.randomUUID();
-            try {
-                const root = await navigator.storage.getDirectory();
-                const fileHandle = await root.getFileHandle(name, { create: true });
-                try {
-                    const access = await fileHandle.createSyncAccessHandle();
-                    access.close();
-                } finally {
-                    await root.removeEntry(name).catch(() => {});
-                }
-                self.postMessage({ ok: true });
-            } catch (error) {
-                self.postMessage({
-                    ok: false,
-                    name: error?.name ?? "Error",
-                    message: error?.message ?? String(error),
-                });
-            }
-        });
-    `;
-    const workerUrl = URL.createObjectURL(new Blob([workerSource], { type: "text/javascript" }));
-    const worker = new Worker(workerUrl, { type: "module" });
+    const worker = new Worker(
+        new URL("./ahtola-opfs-capability-probe-worker.mjs", import.meta.url),
+        { type: "module" });
     try {
         return await new Promise(resolve => {
             worker.addEventListener("message", event => resolve(event.data), { once: true });
@@ -125,7 +108,6 @@ async function runSynchronousAccessHandleProbeInWorker() {
         });
     } finally {
         worker.terminate();
-        URL.revokeObjectURL(workerUrl);
     }
 }
 

--- a/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs.mjs
+++ b/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs.mjs
@@ -239,6 +239,14 @@ export function deleteFile(contextId, path) {
     return enqueue(value, () => request(value, { type: "delete", path }));
 }
 
+export function listFiles(contextId, directoryPath) {
+    const value = context(contextId);
+    return enqueue(value, () => request(value, {
+        type: "list",
+        directoryPath,
+    }));
+}
+
 export function replaceFileAtomically(
     contextId,
     operationId,

--- a/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs.mjs
+++ b/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs.mjs
@@ -1,0 +1,227 @@
+const contexts = new Map();
+let nextContextId = 0;
+
+function requiredFeatures() {
+    return globalThis.crossOriginIsolated
+        && typeof SharedArrayBuffer !== "undefined"
+        && typeof Worker !== "undefined"
+        && typeof navigator.storage?.getDirectory === "function"
+        && typeof navigator.locks?.request === "function";
+}
+
+function context(contextId) {
+    const value = contexts.get(contextId);
+    if (!value)
+        throw new Error(`Unknown Ahtola OPFS context '${contextId}'.`);
+    return value;
+}
+
+function deserializeError(value) {
+    const error = new Error(value?.message ?? "The Ahtola OPFS worker failed.");
+    error.name = value?.name ?? "Error";
+    error.code = value?.code;
+    return error;
+}
+
+function request(value, message) {
+    const id = ++value.nextRequestId;
+    return new Promise((resolve, reject) => {
+        value.pending.set(id, { resolve, reject });
+        value.worker.postMessage({ ...message, id });
+    });
+}
+
+function enqueue(value, operation) {
+    const result = value.queue.then(operation, operation);
+    value.queue = result.catch(() => {});
+    return result;
+}
+
+function failContext(value, error) {
+    for (const pending of value.pending.values())
+        pending.reject(error);
+    value.pending.clear();
+}
+
+export function getCapabilityMask() {
+    let mask = 0;
+    if (globalThis.crossOriginIsolated)
+        mask |= 1 << 0;
+    if (typeof SharedArrayBuffer !== "undefined")
+        mask |= 1 << 1;
+    if (typeof navigator.storage?.getDirectory === "function")
+        mask |= 1 << 2;
+    // The synchronous handle method is worker-only and some browsers don't
+    // expose FileSystemFileHandle's constructor on the window global.
+    if (typeof Worker !== "undefined"
+        && typeof navigator.storage?.getDirectory === "function") {
+        mask |= 1 << 3;
+    }
+    if (typeof navigator.locks?.request === "function")
+        mask |= 1 << 4;
+    return mask;
+}
+
+export async function createContext(lockName, sharedBufferSize) {
+    if (!requiredFeatures())
+        throw new Error("Ahtola OPFS requires cross-origin isolation, SharedArrayBuffer, OPFS, module workers, and Web Locks.");
+    if (!Number.isInteger(sharedBufferSize)
+        || sharedBufferSize < 64 * 1024
+        || sharedBufferSize > 64 * 1024 * 1024) {
+        throw new RangeError("The Ahtola OPFS shared buffer must be between 64 KiB and 64 MiB.");
+    }
+
+    const worker = new Worker(new URL("./ahtola-opfs-worker.mjs", import.meta.url), {
+        type: "module",
+    });
+    const shared = new SharedArrayBuffer(sharedBufferSize);
+    const value = {
+        worker,
+        shared,
+        bytes: new Uint8Array(shared),
+        pending: new Map(),
+        nextRequestId: 0,
+        queue: Promise.resolve(),
+    };
+    worker.addEventListener("message", event => {
+        const pending = value.pending.get(event.data?.id);
+        if (!pending)
+            return;
+
+        value.pending.delete(event.data.id);
+        if (event.data.error)
+            pending.reject(deserializeError(event.data.error));
+        else
+            pending.resolve(event.data.result);
+    });
+    worker.addEventListener("error", event => {
+        failContext(value, new Error(event.message || "The Ahtola OPFS worker terminated."));
+    });
+
+    const contextId = ++nextContextId;
+    contexts.set(contextId, value);
+    try {
+        await request(value, { type: "initialize", lockName, shared });
+        return contextId;
+    } catch (error) {
+        contexts.delete(contextId);
+        worker.terminate();
+        throw error;
+    }
+}
+
+export async function disposeContext(contextId) {
+    const value = contexts.get(contextId);
+    if (!value)
+        return;
+
+    contexts.delete(contextId);
+    try {
+        await enqueue(value, () => request(value, { type: "dispose" }));
+    } finally {
+        value.worker.terminate();
+        failContext(value, new Error("The Ahtola OPFS context was disposed."));
+    }
+}
+
+export function fileExists(contextId, path) {
+    const value = context(contextId);
+    return enqueue(value, () => request(value, { type: "exists", path }));
+}
+
+export function openFile(contextId, path, mode, readOnly) {
+    const value = context(contextId);
+    return enqueue(value, () => request(value, {
+        type: "open",
+        path,
+        mode,
+        readOnly,
+    }));
+}
+
+export function getLength(contextId, handleId) {
+    const value = context(contextId);
+    return enqueue(value, () => request(value, { type: "length", handleId }));
+}
+
+export async function readFile(contextId, handleId, position, length) {
+    const value = context(contextId);
+    if (!Number.isSafeInteger(position) || position < 0)
+        throw new RangeError("The OPFS read position is invalid.");
+    if (!Number.isSafeInteger(length) || length < 0)
+        throw new RangeError("The OPFS read length is invalid.");
+
+    return enqueue(value, async () => {
+        const result = new Uint8Array(length);
+        let total = 0;
+        while (total < length) {
+            const count = Math.min(length - total, value.bytes.length);
+            const read = await request(value, {
+                type: "read",
+                handleId,
+                position: position + total,
+                length: count,
+            });
+            if (read === 0)
+                break;
+
+            result.set(value.bytes.subarray(0, read), total);
+            total += read;
+            if (read < count)
+                break;
+        }
+
+        return total === result.length ? result : result.slice(0, total);
+    });
+}
+
+export function unwrapByteArray(value) {
+    return Array.from(value);
+}
+
+export async function writeFile(contextId, handleId, position, source) {
+    const value = context(contextId);
+    if (!Number.isSafeInteger(position) || position < 0)
+        throw new RangeError("The OPFS write position is invalid.");
+
+    const bytes = source instanceof Uint8Array ? source : new Uint8Array(source);
+    return enqueue(value, async () => {
+        let total = 0;
+        while (total < bytes.length) {
+            const count = Math.min(bytes.length - total, value.bytes.length);
+            value.bytes.set(bytes.subarray(total, total + count), 0);
+            const written = await request(value, {
+                type: "write",
+                handleId,
+                position: position + total,
+                length: count,
+            });
+            if (written !== count)
+                throw new Error(`The OPFS worker wrote ${written} of ${count} requested bytes.`);
+            total += written;
+        }
+        return total;
+    });
+}
+
+export function setLength(contextId, handleId, length) {
+    const value = context(contextId);
+    if (!Number.isSafeInteger(length) || length < 0)
+        throw new RangeError("The OPFS file length is invalid.");
+    return enqueue(value, () => request(value, { type: "truncate", handleId, length }));
+}
+
+export function flushFile(contextId, handleId) {
+    const value = context(contextId);
+    return enqueue(value, () => request(value, { type: "flush", handleId }));
+}
+
+export function closeFile(contextId, handleId) {
+    const value = context(contextId);
+    return enqueue(value, () => request(value, { type: "close", handleId }));
+}
+
+export function deleteFile(contextId, path) {
+    const value = context(contextId);
+    return enqueue(value, () => request(value, { type: "delete", path }));
+}

--- a/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs.mjs
+++ b/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs.mjs
@@ -1,6 +1,16 @@
 const contexts = new Map();
 let nextContextId = 0;
 
+// Transient failures a fresh probe file can still legitimately hit (for
+// example another tab racing to clean up its own probe run); worth a couple
+// of retries before concluding the browser truly lacks support.
+const TRANSIENT_ACCESS_HANDLE_ERRORS = new Set([
+    "NoModificationAllowedError",
+    "InvalidStateError",
+]);
+const SYNCHRONOUS_ACCESS_HANDLE_PROBE_ATTEMPTS = 3;
+const SYNCHRONOUS_ACCESS_HANDLE_PROBE_RETRY_DELAY_MS = 20;
+
 function requiredFeatures() {
     return globalThis.crossOriginIsolated
         && typeof SharedArrayBuffer !== "undefined"
@@ -48,6 +58,10 @@ function failContext(value, error) {
     value.pending.clear();
 }
 
+function delay(milliseconds) {
+    return new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
 export function getCapabilityMask() {
     let mask = 0;
     if (globalThis.crossOriginIsolated)
@@ -56,15 +70,88 @@ export function getCapabilityMask() {
         mask |= 1 << 1;
     if (typeof navigator.storage?.getDirectory === "function")
         mask |= 1 << 2;
-    // The synchronous handle method is worker-only and some browsers don't
-    // expose FileSystemFileHandle's constructor on the window global.
-    if (typeof Worker !== "undefined"
-        && typeof navigator.storage?.getDirectory === "function") {
-        mask |= 1 << 3;
-    }
     if (typeof navigator.locks?.request === "function")
-        mask |= 1 << 4;
+        mask |= 1 << 3;
     return mask;
+}
+
+function hasSynchronousAccessHandlePrerequisites() {
+    // The synchronous handle method is worker-only and some browsers don't
+    // expose FileSystemFileHandle's constructor on the window global, so
+    // there is no point spinning up a probe worker without these first.
+    return typeof Worker !== "undefined"
+        && typeof navigator.storage?.getDirectory === "function";
+}
+
+// Spins up a short-lived dedicated worker (createSyncAccessHandle is
+// off-limits on the main thread) that creates, opens, and closes a
+// throwaway OPFS file with a synchronous access handle, reporting whether
+// the browser actually supports it rather than inferring support from
+// unrelated feature checks.
+async function runSynchronousAccessHandleProbeInWorker() {
+    const workerSource = `
+        self.addEventListener("message", async () => {
+            const name = ".ahtola-capability-probe-" + crypto.randomUUID();
+            try {
+                const root = await navigator.storage.getDirectory();
+                const fileHandle = await root.getFileHandle(name, { create: true });
+                try {
+                    const access = await fileHandle.createSyncAccessHandle();
+                    access.close();
+                } finally {
+                    await root.removeEntry(name).catch(() => {});
+                }
+                self.postMessage({ ok: true });
+            } catch (error) {
+                self.postMessage({
+                    ok: false,
+                    name: error?.name ?? "Error",
+                    message: error?.message ?? String(error),
+                });
+            }
+        });
+    `;
+    const workerUrl = URL.createObjectURL(new Blob([workerSource], { type: "text/javascript" }));
+    const worker = new Worker(workerUrl, { type: "module" });
+    try {
+        return await new Promise(resolve => {
+            worker.addEventListener("message", event => resolve(event.data), { once: true });
+            worker.addEventListener("error", event => resolve({
+                ok: false,
+                name: "WorkerError",
+                message: event?.message || "The OPFS capability probe worker failed to start.",
+            }), { once: true });
+            worker.postMessage("probe");
+        });
+    } finally {
+        worker.terminate();
+        URL.revokeObjectURL(workerUrl);
+    }
+}
+
+// Applies the probe/retry policy on top of an injectable single-attempt
+// prober so the retry and error-classification logic can be unit tested
+// without a real Worker/OPFS-capable host.
+export async function evaluateSynchronousAccessHandleSupport(
+    runProbeOnce = runSynchronousAccessHandleProbeInWorker,
+    attempts = SYNCHRONOUS_ACCESS_HANDLE_PROBE_ATTEMPTS,
+    retryDelayMs = SYNCHRONOUS_ACCESS_HANDLE_PROBE_RETRY_DELAY_MS) {
+    if (!hasSynchronousAccessHandlePrerequisites())
+        return false;
+
+    let outcome;
+    for (let attempt = 0; attempt < attempts; attempt++) {
+        outcome = await runProbeOnce();
+        if (outcome.ok || !TRANSIENT_ACCESS_HANDLE_ERRORS.has(outcome.name))
+            break;
+        if (attempt < attempts - 1)
+            await delay(retryDelayMs * (attempt + 1));
+    }
+    return Boolean(outcome?.ok);
+}
+
+export function probeSynchronousAccessHandleSupport() {
+    return evaluateSynchronousAccessHandleSupport();
 }
 
 export async function createContext(lockName, sharedBufferSize) {

--- a/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs.mjs
+++ b/src/Ahtola.Data.Sqlite.Browser/wwwroot/ahtola-opfs.mjs
@@ -17,8 +17,13 @@ function context(contextId) {
 }
 
 function deserializeError(value) {
-    const error = new Error(value?.message ?? "The Ahtola OPFS worker failed.");
-    error.name = value?.name ?? "Error";
+    const name = value?.name ?? "Error";
+    const message = value?.message ?? "The Ahtola OPFS worker failed.";
+    const error = new Error(`${name}: ${message}`);
+    error.name = name;
+    // .NET marshals Error.stack for promise rejections. Normalize it so error
+    // names survive V8, SpiderMonkey, and JavaScriptCore stack differences.
+    error.stack = `${name}: ${message}`;
     error.code = value?.code;
     return error;
 }
@@ -75,7 +80,8 @@ export async function createContext(lockName, sharedBufferSize) {
         type: "module",
     });
     const shared = new SharedArrayBuffer(sharedBufferSize);
-    const control = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    const control = new Int32Array(
+        new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2));
     const value = {
         worker,
         shared,
@@ -83,6 +89,7 @@ export async function createContext(lockName, sharedBufferSize) {
         bytes: new Uint8Array(shared),
         pending: new Map(),
         nextRequestId: 0,
+        nextOperationId: 0,
         queue: Promise.resolve(),
     };
     worker.addEventListener("message", event => {
@@ -151,64 +158,63 @@ export function getLength(contextId, handleId) {
     return enqueue(value, () => request(value, { type: "length", handleId }));
 }
 
-export async function readFile(contextId, handleId, position, length) {
+export function readFile(contextId, handleId, position, length) {
     const value = context(contextId);
     if (!Number.isSafeInteger(position) || position < 0)
         throw new RangeError("The OPFS read position is invalid.");
     if (!Number.isSafeInteger(length) || length < 0)
         throw new RangeError("The OPFS read length is invalid.");
 
-    return enqueue(value, async () => {
-        const result = new Uint8Array(length);
-        let total = 0;
-        while (total < length) {
-            const count = Math.min(length - total, value.bytes.length);
-            const read = await request(value, {
-                type: "read",
-                handleId,
-                position: position + total,
-                length: count,
-            });
-            if (read === 0)
-                break;
-
-            result.set(value.bytes.subarray(0, read), total);
-            total += read;
-            if (read < count)
-                break;
-        }
-
-        return total === result.length ? result : result.slice(0, total);
-    });
+    if (length > value.bytes.length)
+        throw new RangeError("The OPFS read exceeds the shared buffer size.");
+    return enqueue(value, () => request(value, {
+        type: "read",
+        handleId,
+        position,
+        length,
+    }));
 }
 
-export function unwrapByteArray(value) {
-    return Array.from(value);
+export function copyFromSharedBuffer(contextId, destination, length) {
+    const value = context(contextId);
+    if (!Number.isInteger(length)
+        || length < 0
+        || length > destination.byteLength
+        || length > value.bytes.length) {
+        throw new RangeError("The OPFS shared-buffer read length is invalid.");
+    }
+    try {
+        destination.set(value.bytes.subarray(0, length));
+        return length;
+    } finally {
+        destination.dispose();
+    }
 }
 
-export async function writeFile(contextId, handleId, position, source) {
+export function copyToSharedBuffer(contextId, source) {
+    const value = context(contextId);
+    if (source.byteLength > value.bytes.length)
+        throw new RangeError("The OPFS shared-buffer write exceeds its capacity.");
+    try {
+        source.copyTo(value.bytes);
+        return source.byteLength;
+    } finally {
+        source.dispose();
+    }
+}
+
+export function writeFile(contextId, handleId, position, length) {
     const value = context(contextId);
     if (!Number.isSafeInteger(position) || position < 0)
         throw new RangeError("The OPFS write position is invalid.");
-
-    const bytes = source instanceof Uint8Array ? source : new Uint8Array(source);
-    return enqueue(value, async () => {
-        let total = 0;
-        while (total < bytes.length) {
-            const count = Math.min(bytes.length - total, value.bytes.length);
-            value.bytes.set(bytes.subarray(total, total + count), 0);
-            const written = await request(value, {
-                type: "write",
-                handleId,
-                position: position + total,
-                length: count,
-            });
-            if (written !== count)
-                throw new Error(`The OPFS worker wrote ${written} of ${count} requested bytes.`);
-            total += written;
-        }
-        return total;
-    });
+    if (!Number.isInteger(length) || length < 0 || length > value.bytes.length)
+        throw new RangeError("The OPFS write length is invalid.");
+    return enqueue(value, () => request(value, {
+        type: "write",
+        handleId,
+        position,
+        length,
+    }));
 }
 
 export function setLength(contextId, handleId, length) {
@@ -235,20 +241,37 @@ export function deleteFile(contextId, path) {
 
 export function replaceFileAtomically(
     contextId,
+    operationId,
     sourcePath,
     destinationPath,
     replaceEmptyDestination) {
     const value = context(contextId);
-    Atomics.store(value.control, 0, 0);
-    return enqueue(value, () => request(value, {
-        type: "replace",
-        sourcePath,
-        destinationPath,
-        replaceEmptyDestination,
-    }));
+    return enqueue(value, async () => {
+        Atomics.store(value.control, 0, operationId);
+        try {
+            return await request(value, {
+                type: "replace",
+                operationId,
+                sourcePath,
+                destinationPath,
+                replaceEmptyDestination,
+            });
+        } finally {
+            Atomics.compareExchange(value.control, 0, operationId, 0);
+            Atomics.compareExchange(value.control, 1, operationId, 0);
+        }
+    });
 }
 
-export function cancelCurrentOperation(contextId) {
+export function allocateOperationId(contextId) {
     const value = context(contextId);
-    Atomics.store(value.control, 0, 1);
+    value.nextOperationId = value.nextOperationId >= 0x7ffffffe
+        ? 1
+        : value.nextOperationId + 1;
+    return value.nextOperationId;
+}
+
+export function cancelOperation(contextId, operationId) {
+    const value = context(contextId);
+    Atomics.store(value.control, 1, operationId);
 }

--- a/src/Ahtola.Data.Sqlite/Properties/AssemblyInfo.cs
+++ b/src/Ahtola.Data.Sqlite/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Ahtola.Tests")]
+[assembly: InternalsVisibleTo("Devolutions.Ahtola.Data.Sqlite.Browser")]

--- a/src/Ahtola.Data.Sqlite/SqliteBlob.cs
+++ b/src/Ahtola.Data.Sqlite/SqliteBlob.cs
@@ -7,7 +7,7 @@ namespace Ahtola.Data.Sqlite;
 public class SqliteBlob : Stream
 {
     private readonly MemoryStream? _stream;
-    private readonly IManagedIncrementalBlobAdapter? _managedBlob;
+    private IManagedIncrementalBlobAdapter? _managedBlob;
     private readonly SqliteConnection? _connection;
     private readonly string? _databaseName;
     private readonly string? _tableName;
@@ -38,6 +38,12 @@ public class SqliteBlob : Stream
             throw new InvalidOperationException(Properties.Resources.SqlBlobRequiresOpenConnection);
         if (!connection.Capabilities.SupportsIncrementalBlob)
             throw new NotSupportedException("Incremental blob I/O is not supported by this connection.");
+        if (connection.RequiresAsyncExecution)
+        {
+            throw new PlatformNotSupportedException(
+                "Synchronous incremental blob opening is not supported by browser-managed databases. "
+                + "Use SqliteConnection.OpenBlobAsync.");
+        }
 
         _connection = connection;
         _databaseName = databaseName;
@@ -65,6 +71,25 @@ public class SqliteBlob : Stream
         }
 
         _stream = new MemoryStream(GetBlobValue(connection, databaseName, tableName, columnName, rowid), writable: true);
+    }
+
+    private SqliteBlob(
+        SqliteConnection connection,
+        string databaseName,
+        string tableName,
+        string columnName,
+        long rowid,
+        bool readOnly,
+        IManagedIncrementalBlobAdapter managedBlob)
+    {
+        _connection = connection;
+        _databaseName = databaseName;
+        _tableName = tableName;
+        _columnName = columnName;
+        _rowId = rowid;
+        _readOnly = readOnly;
+        _managedBlob = managedBlob;
+        connection.ManagedBlobOpened(this);
     }
 
     internal SqliteBlob(byte[] value)
@@ -115,10 +140,21 @@ public class SqliteBlob : Stream
         if (_managedBlob is not null)
         {
             ThrowIfDisposed();
+            ThrowIfBrowserSyncOperation("flushing");
             return;
         }
 
         Persist();
+    }
+
+    public override Task FlushAsync(CancellationToken cancellationToken)
+    {
+        ThrowIfDisposed();
+        cancellationToken.ThrowIfCancellationRequested();
+        if (_managedBlob is not null)
+            return Task.CompletedTask;
+
+        return GetStream().FlushAsync(cancellationToken);
     }
 
     public override int Read(byte[] buffer, int offset, int count)
@@ -126,12 +162,51 @@ public class SqliteBlob : Stream
         ValidateBuffer(buffer, offset, count);
         if (_managedBlob is not null)
         {
+            ThrowIfDisposed();
+            ThrowIfBrowserSyncOperation("reading");
             var read = ExecuteManaged(blob => blob.Read(GetManagedPosition(), buffer.AsSpan(offset, count)));
             _position += read;
             return read;
         }
 
         return GetStream().Read(buffer, offset, count);
+    }
+
+    public override async ValueTask<int> ReadAsync(
+        Memory<byte> buffer,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        cancellationToken.ThrowIfCancellationRequested();
+        if (_managedBlob is null)
+            return await GetStream().ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            var read = await _managedBlob
+                .ReadAsync(GetManagedPosition(), buffer, cancellationToken)
+                .ConfigureAwait(false);
+            _position += read;
+            return read;
+        }
+        catch (ManagedBlobException exception)
+        {
+            throw ToSqliteException(exception);
+        }
+        catch (EmbeddedSqlException exception)
+        {
+            throw SqliteCommand.ToSqliteException(exception);
+        }
+    }
+
+    public override Task<int> ReadAsync(
+        byte[] buffer,
+        int offset,
+        int count,
+        CancellationToken cancellationToken)
+    {
+        ValidateBuffer(buffer, offset, count);
+        return ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
     }
 
     public override long Seek(long offset, SeekOrigin origin)
@@ -179,6 +254,8 @@ public class SqliteBlob : Stream
             throw new NotSupportedException(Properties.Resources.WriteNotSupported);
 
         ValidateBuffer(buffer, offset, count);
+        if (_managedBlob is not null)
+            ThrowIfBrowserSyncOperation("writing");
         if (count == 0)
             return;
 
@@ -208,10 +285,69 @@ public class SqliteBlob : Stream
         Persist();
     }
 
+    public override async ValueTask WriteAsync(
+        ReadOnlyMemory<byte> buffer,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        cancellationToken.ThrowIfCancellationRequested();
+        if (_readOnly)
+            throw new NotSupportedException(Properties.Resources.WriteNotSupported);
+        if (buffer.IsEmpty)
+            return;
+
+        if (_managedBlob is not null)
+        {
+            if (_connection?.HasOpenReader == true)
+                throw new SqliteException(Properties.Resources.SqliteNativeError(5, "database is locked"), 5);
+            if (_connection?.IsReadOnly == true)
+                throw new SqliteException(Properties.Resources.SqliteNativeError(8, "attempt to write a readonly database"), 8);
+            if (GetManagedPosition() > Length || buffer.Length > Length - GetManagedPosition())
+                throw new NotSupportedException(Properties.Resources.ResizeNotSupported);
+
+            try
+            {
+                await _managedBlob
+                    .WriteAsync(GetManagedPosition(), buffer, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (ManagedBlobException exception)
+            {
+                throw ToSqliteException(exception);
+            }
+            catch (EmbeddedSqlException exception)
+            {
+                throw SqliteCommand.ToSqliteException(exception);
+            }
+
+            _position += buffer.Length;
+            return;
+        }
+
+        var stream = GetStream();
+        if (stream.Position + buffer.Length > stream.Length)
+            throw new NotSupportedException(Properties.Resources.ResizeNotSupported);
+
+        await stream.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+        Persist();
+    }
+
+    public override Task WriteAsync(
+        byte[] buffer,
+        int offset,
+        int count,
+        CancellationToken cancellationToken)
+    {
+        ValidateBuffer(buffer, offset, count);
+        return WriteAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+    }
+
     protected override void Dispose(bool disposing)
     {
         if (disposing && !_disposed)
         {
+            if (_managedBlob is not null)
+                ThrowIfBrowserSyncOperation("disposal");
             try
             {
                 _managedBlob?.Dispose();
@@ -227,7 +363,88 @@ public class SqliteBlob : Stream
         base.Dispose(disposing);
     }
 
+    public override async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        Exception? disposalError = null;
+        try
+        {
+            var managedBlob = Interlocked.Exchange(ref _managedBlob, null);
+            if (managedBlob is not null)
+                await managedBlob.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            disposalError = exception;
+        }
+        finally
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        if (disposalError is not null)
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(disposalError).Throw();
+    }
+
     internal void CloseFromConnection() => Dispose();
+
+    internal ValueTask CloseFromConnectionAsync() => DisposeAsync();
+
+    internal static ValueTask<SqliteBlob> OpenAsync(
+        SqliteConnection connection,
+        string databaseName,
+        string tableName,
+        string columnName,
+        long rowid,
+        bool readOnly,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        ArgumentNullException.ThrowIfNull(databaseName);
+        ArgumentNullException.ThrowIfNull(tableName);
+        ArgumentNullException.ThrowIfNull(columnName);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (connection.State != ConnectionState.Open)
+            throw new InvalidOperationException(Properties.Resources.SqlBlobRequiresOpenConnection);
+        if (!connection.Capabilities.SupportsIncrementalBlob)
+            throw new NotSupportedException("Incremental blob I/O is not supported by this connection.");
+
+        if (!connection.IsManagedConnection)
+        {
+            return ValueTask.FromResult(
+                new SqliteBlob(connection, databaseName, tableName, columnName, rowid, readOnly));
+        }
+
+        try
+        {
+            var adapter = connection.ManagedConnection.OpenBlob(
+                databaseName,
+                tableName,
+                columnName,
+                rowid,
+                readOnly);
+            return ValueTask.FromResult(
+                new SqliteBlob(
+                    connection,
+                    databaseName,
+                    tableName,
+                    columnName,
+                    rowid,
+                    readOnly,
+                    adapter));
+        }
+        catch (ManagedBlobException exception)
+        {
+            throw ToSqliteException(exception);
+        }
+        catch (EmbeddedSqlException exception)
+        {
+            throw SqliteCommand.ToSqliteException(exception);
+        }
+    }
 
     private MemoryStream GetStream()
     {
@@ -321,5 +538,15 @@ public class SqliteBlob : Stream
     private void ThrowIfDisposed()
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
+    }
+
+    private void ThrowIfBrowserSyncOperation(string operation)
+    {
+        if (_connection?.RequiresAsyncExecution == true)
+        {
+            throw new PlatformNotSupportedException(
+                $"Synchronous incremental blob {operation} is not supported by browser-managed databases. "
+                + "Use the corresponding asynchronous Stream API.");
+        }
     }
 }

--- a/src/Ahtola.Data.Sqlite/SqliteCommand.cs
+++ b/src/Ahtola.Data.Sqlite/SqliteCommand.cs
@@ -285,6 +285,12 @@ public class SqliteCommand : DbCommand
         cancellationToken.ThrowIfCancellationRequested();
         if (Connection?.AhtolaConnection is not null)
             return ExecuteAhtolaAsync(behavior, cancellationToken);
+        if (Connection?.IsManagedConnection == true)
+        {
+            return _cancellation.RunAsync<DbDataReader>(
+                token => ExecuteManagedLocalAsync(behavior, token),
+                cancellationToken);
+        }
         return _cancellation.RunAsync<DbDataReader>(
             token => Execute("ExecuteReader", behavior, token),
             cancellationToken);
@@ -439,6 +445,83 @@ public class SqliteCommand : DbCommand
         {
             throw ToSqliteException(ex);
         }
+        _hasOpenReader = true;
+        return new SqliteDataReader(this, recordsAffected, behavior, CloseReader);
+    }
+
+    private async ValueTask<DbDataReader> ExecuteManagedLocalAsync(
+        CommandBehavior behavior,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        EnsureExecutable("ExecuteReader");
+        if (Connection?.IsReadOnly == true && IsWriteCommand(CommandText))
+            throw new SqliteException(Properties.Resources.SqliteNativeError(8, "attempt to write a readonly database"), 8);
+        if (IsEmptyCommand(CommandText))
+        {
+            _hasOpenReader = true;
+            return new SqliteDataReader(this, -1, behavior, CloseReader);
+        }
+
+        if (Connection?.HasOpenReader == true && IsReaderBlockingCommand(CommandText))
+        {
+            var timeout = CommandTimeout == 0
+                ? Timeout.InfiniteTimeSpan
+                : TimeSpan.FromSeconds(CommandTimeout);
+            if (!Connection.WaitForNoOpenReader(timeout, cancellationToken))
+                throw new SqliteException(Properties.Resources.SqliteNativeError(5, "database is locked"), 5);
+        }
+
+        var recordsAffected = 0;
+        var hadRecordsAffectedStatement = false;
+        var statements = SplitStatements(CommandText);
+        try
+        {
+            for (var i = 0; i < statements.Count; i++)
+            {
+                if (TryHandleFacadeStatement(statements[i], out var sql))
+                    continue;
+
+                cancellationToken.ThrowIfCancellationRequested();
+                var statement = await PrepareSingleStatementAsync(sql, cancellationToken).ConfigureAwait(false);
+                if (statement.ColumnCount > 0)
+                {
+                    _hasOpenReader = true;
+                    return new SqliteDataReader(
+                        this,
+                        statement,
+                        statements[i],
+                        statements.Skip(i + 1).ToList(),
+                        recordsAffected,
+                        hadRecordsAffectedStatement,
+                        behavior,
+                        CloseReader);
+                }
+
+                try
+                {
+                    while (await statement.ReadAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                    }
+
+                    if (CountsRowsAffected(statements[i]))
+                    {
+                        hadRecordsAffectedStatement = true;
+                        recordsAffected += statement.RowsAffected;
+                    }
+                    MarkTransactionCompletedExternally(statements[i]);
+                }
+                finally
+                {
+                    await statement.DisposeAsync().ConfigureAwait(false);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is AhtolaException or EmbeddedSqlException)
+        {
+            throw ToSqliteException(ex);
+        }
+
         _hasOpenReader = true;
         return new SqliteDataReader(this, recordsAffected, behavior, CloseReader);
     }
@@ -744,6 +827,11 @@ public class SqliteCommand : DbCommand
         CancellationToken cancellationToken = default)
         => _cancellation.RunAsync(operation, cancellationToken);
 
+    internal Task<T> RunOperationAsync<T>(
+        Func<CancellationToken, ValueTask<T>> operation,
+        CancellationToken cancellationToken = default)
+        => _cancellation.RunAsync(operation, cancellationToken);
+
     internal void MarkTransactionCompletedExternally(string commandText)
     {
         var completion = SqlTransactionControl.GetCompletion(commandText);
@@ -831,6 +919,42 @@ public class SqliteCommand : DbCommand
         finally
         {
             nativeStatement?.Dispose();
+        }
+    }
+
+    internal async ValueTask<SqliteStatementAdapter> PrepareSingleStatementAsync(
+        string sql,
+        CancellationToken cancellationToken = default)
+    {
+        var connection = Connection!;
+        if (connection.IsManagedReadOnly)
+            ManagedReadOnlySqlGuard.ThrowIfQueryOnlyIsDisabled(sql);
+        sql = RewriteFacadeStatement(sql, connection);
+        if (!connection.IsManagedConnection)
+            return PrepareSingleStatement(sql);
+
+        connection.ManagedConnection.BusyTimeout =
+            CommandTimeout == 0 ? Timeout.InfiniteTimeSpan : TimeSpan.FromSeconds(CommandTimeout);
+        IManagedStatementAdapter? managedStatement = null;
+        try
+        {
+            managedStatement = await connection.ManagedConnection
+                .PrepareAsync(sql, cancellationToken)
+                .ConfigureAwait(false);
+            BindManagedParameters(managedStatement);
+
+            var statement = SqliteStatementAdapter.FromManaged(managedStatement);
+            managedStatement = null;
+            return statement;
+        }
+        catch (EmbeddedSqlException ex)
+        {
+            throw ToSqliteException(ex, sql);
+        }
+        finally
+        {
+            if (managedStatement is not null)
+                await managedStatement.DisposeAsync().ConfigureAwait(false);
         }
     }
 

--- a/src/Ahtola.Data.Sqlite/SqliteCommand.cs
+++ b/src/Ahtola.Data.Sqlite/SqliteCommand.cs
@@ -149,6 +149,7 @@ public class SqliteCommand : DbCommand
 
     public override int ExecuteNonQuery()
     {
+        ThrowIfSynchronousBrowserOperation("ExecuteNonQueryAsync");
         using var reader = _cancellation.Run(
             token => Execute("ExecuteNonQuery", CommandBehavior.Default, token));
         while (reader.Read())
@@ -163,6 +164,7 @@ public class SqliteCommand : DbCommand
 
     public override object? ExecuteScalar()
     {
+        ThrowIfSynchronousBrowserOperation("ExecuteScalarAsync");
         using var reader = _cancellation.Run(
             token => Execute("ExecuteScalar", CommandBehavior.Default, token));
         var result = reader.Read() ? reader.GetValue(0) : null;
@@ -173,6 +175,7 @@ public class SqliteCommand : DbCommand
 
     public override void Prepare()
     {
+        ThrowIfSynchronousBrowserOperation("PrepareAsync");
         EnsureExecutable("Prepare");
         if (Connection?.AhtolaConnection is { } ahtolaConnection)
         {
@@ -222,13 +225,22 @@ public class SqliteCommand : DbCommand
     protected override DbParameter CreateDbParameter() => new SqliteParameter();
 
     public new SqliteDataReader ExecuteReader()
-        => _cancellation.Run(token => Execute("ExecuteReader", CommandBehavior.Default, token));
+    {
+        ThrowIfSynchronousBrowserOperation("ExecuteReaderAsync");
+        return _cancellation.Run(token => Execute("ExecuteReader", CommandBehavior.Default, token));
+    }
 
     public new SqliteDataReader ExecuteReader(CommandBehavior behavior)
-        => _cancellation.Run(token => Execute("ExecuteReader", behavior, token));
+    {
+        ThrowIfSynchronousBrowserOperation("ExecuteReaderAsync");
+        return _cancellation.Run(token => Execute("ExecuteReader", behavior, token));
+    }
 
     protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
-        => _cancellation.Run<DbDataReader>(token => Execute("ExecuteReader", behavior, token));
+    {
+        ThrowIfSynchronousBrowserOperation("ExecuteReaderAsync");
+        return _cancellation.Run<DbDataReader>(token => Execute("ExecuteReader", behavior, token));
+    }
 
     public override Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
         => cancellationToken.IsCancellationRequested
@@ -447,6 +459,19 @@ public class SqliteCommand : DbCommand
         }
         _hasOpenReader = true;
         return new SqliteDataReader(this, recordsAffected, behavior, CloseReader);
+    }
+
+    internal bool RequiresAsyncExecution
+        => Connection?.RequiresAsyncExecution == true;
+
+    private void ThrowIfSynchronousBrowserOperation(string asyncAlternative)
+    {
+        if (RequiresAsyncExecution)
+        {
+            throw new PlatformNotSupportedException(
+                $"Synchronous command execution is not supported by the browser database source. "
+                + $"Use {asyncAlternative}.");
+        }
     }
 
     private async ValueTask<DbDataReader> ExecuteManagedLocalAsync(

--- a/src/Ahtola.Data.Sqlite/SqliteConnection.cs
+++ b/src/Ahtola.Data.Sqlite/SqliteConnection.cs
@@ -10,7 +10,10 @@ using Ahtola.Core.Storage;
 
 namespace Ahtola.Data.Sqlite;
 
-public partial class SqliteConnection : DbConnection, ILocalReaderConnection
+public partial class SqliteConnection :
+    DbConnection,
+    ILocalReaderConnection,
+    IManagedSchemaConnection
 {
     private const int SQLITE_ERROR = 1;
     private const int SQLITE_CANTOPEN = 14;
@@ -19,6 +22,7 @@ public partial class SqliteConnection : DbConnection, ILocalReaderConnection
 
     private AhtolaNativeDatabase? _database;
     private IManagedDatabaseAdapter? _managedDatabase;
+    private readonly IManagedDatabaseFactory? _managedDatabaseFactory;
     private AhtolaConnection? _ahtolaConnection;
     private bool _ahtolaConnectionWasOpen;
     private ManagedConnectionPoolLease? _managedPoolLease;
@@ -56,6 +60,15 @@ public partial class SqliteConnection : DbConnection, ILocalReaderConnection
     {
         _managedDatabase = managedDatabase ?? throw new ArgumentNullException(nameof(managedDatabase));
         _dataSource = ":memory:";
+    }
+
+    internal SqliteConnection(
+        string connectionString,
+        IManagedDatabaseFactory managedDatabaseFactory)
+        : this(connectionString)
+    {
+        _managedDatabaseFactory = managedDatabaseFactory
+            ?? throw new ArgumentNullException(nameof(managedDatabaseFactory));
     }
 
     [AllowNull]
@@ -189,6 +202,12 @@ public partial class SqliteConnection : DbConnection, ILocalReaderConnection
 
     public override void Open()
     {
+        if (_managedDatabaseFactory is not null)
+        {
+            throw new PlatformNotSupportedException(
+                "Synchronous Open is not supported by the browser database source. Use OpenAsync.");
+        }
+
         ObjectDisposedException.ThrowIf(_disposed, this);
         if (_database is not null || _managedDatabase is not null || _ahtolaConnection is not null)
             throw new InvalidOperationException("The connection is already open.");
@@ -340,6 +359,9 @@ public partial class SqliteConnection : DbConnection, ILocalReaderConnection
         if (cancellationToken.IsCancellationRequested)
             return Task.FromCanceled(cancellationToken);
 
+        if (_managedDatabaseFactory is not null)
+            return OpenManagedFactoryAsync(cancellationToken);
+
         if (IsRemoteDataSource)
             return OpenRemoteAsync(cancellationToken);
 
@@ -355,6 +377,49 @@ public partial class SqliteConnection : DbConnection, ILocalReaderConnection
                 cancellationToken.ThrowIfCancellationRequested();
             },
             CancellationToken.None);
+    }
+
+    private async Task OpenManagedFactoryAsync(CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (State != ConnectionState.Closed)
+            throw new InvalidOperationException("The connection is already open.");
+
+        var originalState = State;
+        IManagedDatabaseAdapter? database = null;
+        try
+        {
+            database = await _managedDatabaseFactory!
+                .OpenDatabaseAsync(cancellationToken)
+                .ConfigureAwait(false);
+            _ = await database.ConnectAsync(cancellationToken).ConfigureAwait(false);
+            _managedDatabase = database;
+            _dataSource = _managedDatabaseFactory.DataSource;
+            _readOnly = _managedDatabaseFactory.IsReadOnly;
+            if (IsManagedReadOnly)
+                await ExecuteNonQueryAsync("PRAGMA query_only = ON;", cancellationToken).ConfigureAwait(false);
+            ApplyExtensionSettings();
+            await ApplyConnectionOptionsAsync(cancellationToken).ConfigureAwait(false);
+            RegisterScalarFunctions();
+            RegisterAggregateFunctions();
+            RegisterCollations();
+            RegisterHooks();
+            LoadPendingExtensions();
+            OnStateChange(new StateChangeEventArgs(originalState, State));
+            database = null;
+        }
+        catch
+        {
+            _managedDatabase = null;
+            _dataSource = null;
+            _readOnly = false;
+            throw;
+        }
+        finally
+        {
+            if (database is not null)
+                await database.DisposeAsync().ConfigureAwait(false);
+        }
     }
 
     private async Task OpenRemoteAsync(CancellationToken cancellationToken)
@@ -498,6 +563,75 @@ public partial class SqliteConnection : DbConnection, ILocalReaderConnection
 
             OnStateChange(new StateChangeEventArgs(originalState, State));
         }
+    }
+
+    public override Task CloseAsync()
+        => _managedDatabaseFactory is null
+            ? base.CloseAsync()
+            : CloseManagedFactoryAsync();
+
+    private async Task CloseManagedFactoryAsync()
+    {
+        var database = _managedDatabase;
+        if (database is null)
+            return;
+
+        var originalState = State;
+        Exception? cleanupError = null;
+        try
+        {
+            if (Transaction is { IsCompleted: false } transaction)
+                await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+            if (Transaction is not null)
+                await Transaction.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            cleanupError = exception;
+        }
+        try
+        {
+            CloseOpenManagedBlobs();
+            CloseOpenReaders();
+            ResetOpenCommands();
+        }
+        catch (Exception exception)
+        {
+            cleanupError = cleanupError is null
+                ? exception
+                : new AggregateException(
+                    "Browser transaction rollback and connection cleanup both failed.",
+                    cleanupError,
+                    exception);
+        }
+        finally
+        {
+            _managedDatabase = null;
+            Transaction = null;
+            _dataSource = null;
+            _readOnly = false;
+            _recursiveTriggers = false;
+            _readUncommitted = false;
+            _managedSharedMemory = false;
+            try
+            {
+                await database.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                cleanupError = cleanupError is null
+                    ? exception
+                    : new AggregateException(
+                        "Browser connection cleanup and durable disposal both failed.",
+                        cleanupError,
+                        exception);
+            }
+
+            OnStateChange(new StateChangeEventArgs(originalState, State));
+        }
+
+        if (cleanupError is not null)
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(cleanupError).Throw();
     }
 
     public override void ChangeDatabase(string databaseName)
@@ -805,10 +939,44 @@ public partial class SqliteConnection : DbConnection, ILocalReaderConnection
         base.Dispose(disposing);
     }
 
-    public override ValueTask DisposeAsync()
+    public override async ValueTask DisposeAsync()
     {
-        Dispose();
-        return ValueTask.CompletedTask;
+        if (_managedDatabaseFactory is null)
+        {
+            Dispose();
+            return;
+        }
+        if (_disposed)
+            return;
+
+        Exception? disposalError = null;
+        try
+        {
+            await CloseAsync().ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            disposalError = exception;
+        }
+
+        _disposed = true;
+        _noOpenReaders.Dispose();
+        try
+        {
+            await base.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            disposalError = disposalError is null
+                ? exception
+                : new AggregateException(
+                    "Browser connection close and base disposal both failed.",
+                    disposalError,
+                    exception);
+        }
+
+        if (disposalError is not null)
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(disposalError).Throw();
     }
 
     internal AhtolaNativeDatabase NativeDatabase => _database ?? throw new InvalidOperationException("The connection is not open.");
@@ -816,7 +984,12 @@ public partial class SqliteConnection : DbConnection, ILocalReaderConnection
     internal IManagedConnectionAdapter ManagedConnection
         => _managedDatabase?.Connection ?? throw new InvalidOperationException("The connection is not open.");
 
+    IManagedConnectionAdapter IManagedSchemaConnection.ManagedSchemaConnection
+        => ManagedConnection;
+
     internal bool IsManagedConnection => _managedDatabase is not null;
+
+    internal bool RequiresAsyncExecution => _managedDatabaseFactory is not null;
 
     internal bool UsesManagedDatabase => IsManagedConnection;
 
@@ -947,6 +1120,14 @@ public partial class SqliteConnection : DbConnection, ILocalReaderConnection
         command.ExecuteNonQuery();
     }
 
+    internal async Task ExecuteNonQueryAsync(
+        string sql,
+        CancellationToken cancellationToken = default)
+    {
+        await using var command = new SqliteCommand(sql, this);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
     private List<string> GetSchemaSql()
     {
         var schema = new List<string>();
@@ -1001,6 +1182,28 @@ public partial class SqliteConnection : DbConnection, ILocalReaderConnection
             ExecuteNonQuery("PRAGMA foreign_keys = " + (_connectionOptions.ForeignKeys.Value ? "1" : "0") + ";");
         else if (IsManagedConnection)
             ExecuteNonQuery("PRAGMA foreign_keys = 1;");
+        if (_connectionOptions.RecursiveTriggers)
+            _recursiveTriggers = true;
+    }
+
+    private async Task ApplyConnectionOptionsAsync(CancellationToken cancellationToken)
+    {
+        if (_connectionOptions.ForeignKeys.HasValue)
+        {
+            await ExecuteNonQueryAsync(
+                    "PRAGMA foreign_keys = "
+                    + (_connectionOptions.ForeignKeys.Value ? "1" : "0")
+                    + ";",
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+        else if (IsManagedConnection)
+        {
+            await ExecuteNonQueryAsync(
+                    "PRAGMA foreign_keys = 1;",
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
         if (_connectionOptions.RecursiveTriggers)
             _recursiveTriggers = true;
     }

--- a/src/Ahtola.Data.Sqlite/SqliteConnection.cs
+++ b/src/Ahtola.Data.Sqlite/SqliteConnection.cs
@@ -1150,8 +1150,8 @@ public partial class SqliteConnection :
     internal IManagedConnectionAdapter ManagedConnection
         => _managedDatabase?.Connection ?? throw new InvalidOperationException("The connection is not open.");
 
-    IManagedConnectionAdapter IManagedSchemaConnection.ManagedSchemaConnection
-        => ManagedConnection;
+    IManagedConnectionAdapter? IManagedSchemaConnection.ManagedSchemaConnection
+        => IsManagedConnection ? ManagedConnection : null;
 
     internal bool IsManagedConnection => _managedDatabase is not null;
 

--- a/src/Ahtola.Data.Sqlite/SqliteConnection.cs
+++ b/src/Ahtola.Data.Sqlite/SqliteConnection.cs
@@ -578,31 +578,63 @@ public partial class SqliteConnection :
 
         var originalState = State;
         Exception? cleanupError = null;
+        if (Transaction is { IsCompleted: false } transaction)
+        {
+            try
+            {
+                await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                cleanupError = exception;
+            }
+        }
+        if (Transaction is not null)
+        {
+            try
+            {
+                await Transaction.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                cleanupError = CombineCleanupErrors(
+                    "Browser transaction rollback and disposal both failed.",
+                    cleanupError,
+                    exception);
+            }
+        }
         try
         {
-            if (Transaction is { IsCompleted: false } transaction)
-                await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
-            if (Transaction is not null)
-                await Transaction.DisposeAsync().ConfigureAwait(false);
+            await CloseOpenManagedBlobsAsync().ConfigureAwait(false);
         }
         catch (Exception exception)
         {
-            cleanupError = exception;
+            cleanupError = CombineCleanupErrors(
+                "Browser transaction and incremental blob cleanup both failed.",
+                cleanupError,
+                exception);
         }
         try
         {
-            CloseOpenManagedBlobs();
             CloseOpenReaders();
+        }
+        catch (Exception exception)
+        {
+            cleanupError = CombineCleanupErrors(
+                "Browser connection cleanup failed.",
+                cleanupError,
+                exception);
+        }
+        try
+        {
             ResetOpenCommands();
         }
         catch (Exception exception)
         {
-            cleanupError = cleanupError is null
-                ? exception
-                : new AggregateException(
-                    "Browser transaction rollback and connection cleanup both failed.",
-                    cleanupError,
-                    exception);
+            cleanupError = CombineCleanupErrors(
+                "Browser command cleanup failed.",
+                cleanupError,
+                exception);
         }
         finally
         {
@@ -619,12 +651,10 @@ public partial class SqliteConnection :
             }
             catch (Exception exception)
             {
-                cleanupError = cleanupError is null
-                    ? exception
-                    : new AggregateException(
-                        "Browser connection cleanup and durable disposal both failed.",
-                        cleanupError,
-                        exception);
+                cleanupError = CombineCleanupErrors(
+                    "Browser connection cleanup and durable disposal both failed.",
+                    cleanupError,
+                    exception);
             }
 
             OnStateChange(new StateChangeEventArgs(originalState, State));
@@ -861,6 +891,12 @@ public partial class SqliteConnection :
         if (State != ConnectionState.Open)
             throw new InvalidOperationException(Properties.Resources.CallRequiresOpenConnection("BackupDatabase"));
         ArgumentNullException.ThrowIfNull(destination);
+        if (RequiresAsyncExecution || destination.RequiresAsyncExecution)
+        {
+            throw new PlatformNotSupportedException(
+                "Synchronous backup is not supported by browser-managed databases. "
+                + "Use BackupDatabaseAsync.");
+        }
         if (!Capabilities.SupportsBackup || !destination.Capabilities.SupportsBackup)
             throw new NotSupportedException("Backup is supported only for local database connections.");
         if (IsManagedProvider != destination.IsManagedProvider)
@@ -883,6 +919,102 @@ public partial class SqliteConnection :
         foreach (var tableName in GetUserTableNames())
             CopyTableRows(destination, tableName);
     }
+
+    public virtual Task BackupDatabaseAsync(
+        SqliteConnection destination,
+        CancellationToken cancellationToken = default)
+        => BackupDatabaseAsync(destination, "main", "main", cancellationToken);
+
+    public virtual async Task BackupDatabaseAsync(
+        SqliteConnection destination,
+        string destinationName,
+        string sourceName,
+        CancellationToken cancellationToken = default)
+    {
+        if (State != ConnectionState.Open)
+            throw new InvalidOperationException(Properties.Resources.CallRequiresOpenConnection("BackupDatabase"));
+        ArgumentNullException.ThrowIfNull(destination);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (!Capabilities.SupportsBackup || !destination.Capabilities.SupportsBackup)
+            throw new NotSupportedException("Backup is supported only for local database connections.");
+        if (IsManagedProvider != destination.IsManagedProvider)
+            throw new NotSupportedException(Properties.Resources.ManagedBackupMixedProvidersNotSupported);
+        if (destination.State != ConnectionState.Open)
+            await destination.OpenAsync(cancellationToken).ConfigureAwait(false);
+        if (IsManagedProvider)
+        {
+            await SqliteManagedBackup
+                .CopyAsync(this, destination, destinationName, sourceName, cancellationToken)
+                .ConfigureAwait(false);
+            return;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        BackupDatabase(destination, destinationName, sourceName);
+    }
+
+    public virtual SqliteBlob OpenBlob(
+        string tableName,
+        string columnName,
+        long rowid,
+        bool readOnly = false)
+        => OpenBlob("main", tableName, columnName, rowid, readOnly);
+
+    public virtual SqliteBlob OpenBlob(
+        string databaseName,
+        string tableName,
+        string columnName,
+        long rowid,
+        bool readOnly = false)
+    {
+        if (RequiresAsyncExecution)
+        {
+            throw new PlatformNotSupportedException(
+                "Synchronous incremental blob opening is not supported by browser-managed databases. "
+                + "Use OpenBlobAsync.");
+        }
+
+        return new SqliteBlob(this, databaseName, tableName, columnName, rowid, readOnly);
+    }
+
+    public virtual ValueTask<SqliteBlob> OpenBlobAsync(
+        string tableName,
+        string columnName,
+        long rowid,
+        CancellationToken cancellationToken)
+        => OpenBlobAsync("main", tableName, columnName, rowid, readOnly: false, cancellationToken);
+
+    public virtual ValueTask<SqliteBlob> OpenBlobAsync(
+        string tableName,
+        string columnName,
+        long rowid,
+        bool readOnly = false,
+        CancellationToken cancellationToken = default)
+        => OpenBlobAsync("main", tableName, columnName, rowid, readOnly, cancellationToken);
+
+    public virtual ValueTask<SqliteBlob> OpenBlobAsync(
+        string databaseName,
+        string tableName,
+        string columnName,
+        long rowid,
+        CancellationToken cancellationToken)
+        => OpenBlobAsync(databaseName, tableName, columnName, rowid, readOnly: false, cancellationToken);
+
+    public virtual ValueTask<SqliteBlob> OpenBlobAsync(
+        string databaseName,
+        string tableName,
+        string columnName,
+        long rowid,
+        bool readOnly = false,
+        CancellationToken cancellationToken = default)
+        => SqliteBlob.OpenAsync(
+            this,
+            databaseName,
+            tableName,
+            columnName,
+            rowid,
+            readOnly,
+            cancellationToken);
 
     public new virtual SqliteCommand CreateCommand() => new(this) { Transaction = Transaction };
 
@@ -1393,20 +1525,89 @@ public partial class SqliteConnection :
         IConnectionOwnedReader[] readers;
         lock (_readerGate)
             readers = _openReaders.ToArray();
+        List<Exception>? failures = null;
         foreach (var reader in readers)
-            reader.CloseFromConnection();
+        {
+            try
+            {
+                reader.CloseFromConnection();
+            }
+            catch (Exception exception)
+            {
+                (failures ??= []).Add(exception);
+            }
+        }
+        ThrowCleanupFailures("One or more readers could not be closed.", failures);
     }
 
     private void CloseOpenManagedBlobs()
     {
+        List<Exception>? failures = null;
         foreach (var blob in _openManagedBlobs.ToArray())
-            blob.CloseFromConnection();
+        {
+            try
+            {
+                blob.CloseFromConnection();
+            }
+            catch (Exception exception)
+            {
+                (failures ??= []).Add(exception);
+            }
+        }
+        ThrowCleanupFailures("One or more incremental blobs could not be closed.", failures);
+    }
+
+    private async ValueTask CloseOpenManagedBlobsAsync()
+    {
+        List<Exception>? failures = null;
+        foreach (var blob in _openManagedBlobs.ToArray())
+        {
+            try
+            {
+                await blob.CloseFromConnectionAsync().ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                (failures ??= []).Add(exception);
+            }
+        }
+        ThrowCleanupFailures("One or more incremental blobs could not be closed.", failures);
     }
 
     private void ResetOpenCommands()
     {
+        List<Exception>? failures = null;
         foreach (var command in _openCommands.ToArray())
-            command.ResetFromConnection();
+        {
+            try
+            {
+                command.ResetFromConnection();
+            }
+            catch (Exception exception)
+            {
+                (failures ??= []).Add(exception);
+            }
+        }
+        ThrowCleanupFailures("One or more commands could not be reset.", failures);
+    }
+
+    private static Exception CombineCleanupErrors(
+        string message,
+        Exception? existing,
+        Exception current)
+        => existing is null
+            ? current
+            : new AggregateException(message, existing, current);
+
+    private static void ThrowCleanupFailures(
+        string message,
+        List<Exception>? failures)
+    {
+        if (failures is null)
+            return;
+        if (failures.Count == 1)
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(failures[0]).Throw();
+        throw new AggregateException(message, failures);
     }
 
     private static string NormalizeDataSource(

--- a/src/Ahtola.Data.Sqlite/SqliteConnection.cs
+++ b/src/Ahtola.Data.Sqlite/SqliteConnection.cs
@@ -13,7 +13,8 @@ namespace Ahtola.Data.Sqlite;
 public partial class SqliteConnection :
     DbConnection,
     ILocalReaderConnection,
-    IManagedSchemaConnection
+    IManagedSchemaConnection,
+    IAsyncExecutionConnection
 {
     private const int SQLITE_ERROR = 1;
     private const int SQLITE_CANTOPEN = 14;
@@ -493,6 +494,12 @@ public partial class SqliteConnection :
 
     public override void Close()
     {
+        if (_managedDatabaseFactory is not null && _managedDatabase is not null)
+        {
+            throw new PlatformNotSupportedException(
+                "Synchronous Close is not supported by the browser database source. Use CloseAsync.");
+        }
+
         if (_ahtolaConnection is not null)
         {
             var remoteCloseOriginalState = State;
@@ -616,7 +623,7 @@ public partial class SqliteConnection :
         }
         try
         {
-            CloseOpenReaders();
+            await CloseOpenReadersAsync().ConfigureAwait(false);
         }
         catch (Exception exception)
         {
@@ -751,6 +758,12 @@ public partial class SqliteConnection :
             throw new InvalidOperationException(Properties.Resources.CallRequiresOpenConnection(nameof(BeginTransaction)));
         if (Transaction is not null)
             throw new InvalidOperationException(Properties.Resources.ParallelTransactionsNotSupported);
+        if (RequiresAsyncExecution)
+        {
+            throw new PlatformNotSupportedException(
+                "Synchronous transaction creation is not supported by the browser database source. "
+                + "Use BeginTransactionAsync.");
+        }
 
         Transaction = new SqliteTransaction(this, isolationLevel, deferred);
         return Transaction;
@@ -1051,6 +1064,15 @@ public partial class SqliteConnection :
 
     protected override void Dispose(bool disposing)
     {
+        if (disposing
+            && !_disposed
+            && _managedDatabaseFactory is not null
+            && State != ConnectionState.Closed)
+        {
+            throw new PlatformNotSupportedException(
+                "Synchronous disposal is not supported by the browser database source. Use DisposeAsync.");
+        }
+
         if (disposing && !_disposed)
         {
             try
@@ -1122,6 +1144,8 @@ public partial class SqliteConnection :
     internal bool IsManagedConnection => _managedDatabase is not null;
 
     internal bool RequiresAsyncExecution => _managedDatabaseFactory is not null;
+
+    bool IAsyncExecutionConnection.RequiresAsyncExecution => RequiresAsyncExecution;
 
     internal bool UsesManagedDatabase => IsManagedConnection;
 
@@ -1531,6 +1555,26 @@ public partial class SqliteConnection :
             try
             {
                 reader.CloseFromConnection();
+            }
+            catch (Exception exception)
+            {
+                (failures ??= []).Add(exception);
+            }
+        }
+        ThrowCleanupFailures("One or more readers could not be closed.", failures);
+    }
+
+    private async ValueTask CloseOpenReadersAsync()
+    {
+        IConnectionOwnedReader[] readers;
+        lock (_readerGate)
+            readers = _openReaders.ToArray();
+        List<Exception>? failures = null;
+        foreach (var reader in readers)
+        {
+            try
+            {
+                await reader.CloseFromConnectionAsync().ConfigureAwait(false);
             }
             catch (Exception exception)
             {

--- a/src/Ahtola.Data.Sqlite/SqliteConnection.cs
+++ b/src/Ahtola.Data.Sqlite/SqliteConnection.cs
@@ -78,6 +78,11 @@ public partial class SqliteConnection :
         get => _connectionOptions.ConnectionString;
         set
         {
+            if (_managedDatabaseFactory is not null)
+            {
+                throw new InvalidOperationException(
+                    "Connections created by a browser data source cannot replace its connection string.");
+            }
             if (State == ConnectionState.Open)
                 throw new InvalidOperationException(Properties.Resources.ConnectionStringRequiresClosedConnection);
 
@@ -126,6 +131,11 @@ public partial class SqliteConnection :
         get => _pageCodec;
         set
         {
+            if (_managedDatabaseFactory is not null)
+            {
+                throw new InvalidOperationException(
+                    "Connections created by a browser data source cannot replace its page codec.");
+            }
             if (State == ConnectionState.Open)
                 throw new InvalidOperationException("PageCodec cannot be set while the connection is open.");
             if (value is not null && IsRemoteDataSource)

--- a/src/Ahtola.Data.Sqlite/SqliteConnection.cs
+++ b/src/Ahtola.Data.Sqlite/SqliteConnection.cs
@@ -51,6 +51,13 @@ public partial class SqliteConnection : DbConnection, ILocalReaderConnection
         ConnectionString = connectionString;
     }
 
+    internal SqliteConnection(IManagedDatabaseAdapter managedDatabase)
+        : this("Data Source=:memory:;Local Provider=Managed")
+    {
+        _managedDatabase = managedDatabase ?? throw new ArgumentNullException(nameof(managedDatabase));
+        _dataSource = ":memory:";
+    }
+
     [AllowNull]
     public override string ConnectionString
     {

--- a/src/Ahtola.Data.Sqlite/SqliteConnection.cs
+++ b/src/Ahtola.Data.Sqlite/SqliteConnection.cs
@@ -397,6 +397,7 @@ public partial class SqliteConnection :
             _managedDatabase = database;
             _dataSource = _managedDatabaseFactory.DataSource;
             _readOnly = _managedDatabaseFactory.IsReadOnly;
+            _managedSharedMemory = _managedDatabaseFactory.IsSharedMemory;
             if (IsManagedReadOnly)
                 await ExecuteNonQueryAsync("PRAGMA query_only = ON;", cancellationToken).ConfigureAwait(false);
             ApplyExtensionSettings();
@@ -414,6 +415,7 @@ public partial class SqliteConnection :
             _managedDatabase = null;
             _dataSource = null;
             _readOnly = false;
+            _managedSharedMemory = false;
             throw;
         }
         finally

--- a/src/Ahtola.Data.Sqlite/SqliteDataReader.cs
+++ b/src/Ahtola.Data.Sqlite/SqliteDataReader.cs
@@ -1274,19 +1274,60 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
     public override async Task CloseAsync()
         => await CloseCoreAsync().ConfigureAwait(false);
 
-    void IConnectionOwnedReader.CloseFromConnection()
+    void IConnectionOwnedReader.CloseFromConnection() => CloseFromConnection();
+
+    private void CloseFromConnection()
     {
         if (_isClosed)
             return;
 
-        _delegatedReader?.Dispose();
-        _delegatedReader = null;
-        _statement?.Dispose();
-        _statement = null;
+        Exception? error = null;
+        if (_delegatedReader is not null)
+        {
+            try
+            {
+                _delegatedReader.Dispose();
+            }
+            catch (Exception ex)
+            {
+                error = CombineCloseErrors(error, ex);
+            }
+            finally
+            {
+                _delegatedReader = null;
+            }
+        }
+        if (_statement is not null)
+        {
+            try
+            {
+                _statement.Dispose();
+            }
+            catch (Exception ex)
+            {
+                error = CombineCloseErrors(error, ex);
+            }
+            finally
+            {
+                _statement = null;
+            }
+        }
+
         _remainingSql.Clear();
         _hasPrefetchedRow = false;
         _hasCurrentRow = false;
-        FinishClose(closeConnection: false);
+        _currentStatementRowsAffectedCounted = false;
+        try
+        {
+            FinishClose(closeConnection: false);
+        }
+        catch (Exception ex)
+        {
+            error = CombineCloseErrors(error, ex);
+        }
+
+        if (error is not null)
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(error).Throw();
     }
 
     ValueTask IConnectionOwnedReader.CloseFromConnectionAsync()
@@ -1297,27 +1338,53 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
         if (_isClosed)
             return;
 
-        try
+        Exception? error = null;
+        if (_delegatedReader is not null)
         {
-            if (_delegatedReader is not null)
+            try
             {
                 await _delegatedReader.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                error = CombineCloseErrors(error, ex);
+            }
+            finally
+            {
                 _delegatedReader = null;
             }
-            if (_statement is not null)
+        }
+        if (_statement is not null)
+        {
+            try
             {
                 await _statement.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                error = CombineCloseErrors(error, ex);
+            }
+            finally
+            {
                 _statement = null;
             }
         }
-        finally
+
+        _remainingSql.Clear();
+        _hasPrefetchedRow = false;
+        _hasCurrentRow = false;
+        _currentStatementRowsAffectedCounted = false;
+        try
         {
-            _remainingSql.Clear();
-            _hasPrefetchedRow = false;
-            _hasCurrentRow = false;
-            _currentStatementRowsAffectedCounted = false;
             await FinishCloseAsync(closeConnection: false).ConfigureAwait(false);
         }
+        catch (Exception ex)
+        {
+            error = CombineCloseErrors(error, ex);
+        }
+
+        if (error is not null)
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(error).Throw();
     }
 
     private void CloseCore(bool throwOnError = true)
@@ -1325,6 +1392,8 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
         if (_isClosed)
             return;
 
+        Exception? primaryError = null;
+        Exception? cleanupError = null;
         try
         {
             if (_delegatedReader is not null)
@@ -1333,48 +1402,86 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
                 _hadRecordsAffectedStatement = true;
                 _delegatedReader.Dispose();
                 _delegatedReader = null;
-                FinishClose();
-                return;
             }
-
-            if (_statement is not null)
+            else
             {
-                while (GetStatement().Read())
+                if (_statement is not null)
                 {
+                    while (GetStatement().Read())
+                    {
+                    }
+
+                    CountCurrentStatementRowsAffected();
+
+                    _statement.Dispose();
+                    _statement = null;
+                    _hasPrefetchedRow = false;
+                    _currentStatementRowsAffectedCounted = false;
                 }
 
-                CountCurrentStatementRowsAffected();
-
-                _statement.Dispose();
-                _statement = null;
-                _hasPrefetchedRow = false;
-                _currentStatementRowsAffectedCounted = false;
+                DrainRemainingStatements();
             }
-
-            DrainRemainingStatements();
         }
-        catch (Exception ex) when (ex is AhtolaException or EmbeddedSqlException)
+        catch (Exception ex)
         {
-            _statement?.Dispose();
-            _statement = null;
-            _remainingSql.Clear();
-            FinishClose();
-            if (throwOnError)
-                throw SqliteCommand.ToSqliteException(ex);
-            return;
-        }
-        catch (SqliteException)
-        {
-            _statement?.Dispose();
-            _statement = null;
-            _remainingSql.Clear();
-            FinishClose();
-            if (throwOnError)
-                throw;
-            return;
+            primaryError = ex is AhtolaException or EmbeddedSqlException
+                ? SqliteCommand.ToSqliteException(ex)
+                : ex;
         }
 
-        FinishClose();
+        if (_delegatedReader is not null)
+        {
+            try
+            {
+                _delegatedReader.Dispose();
+            }
+            catch (Exception ex)
+            {
+                cleanupError = CombineCloseErrors(cleanupError, ex);
+            }
+            finally
+            {
+                _delegatedReader = null;
+            }
+        }
+        if (_statement is not null)
+        {
+            try
+            {
+                _statement.Dispose();
+            }
+            catch (Exception ex)
+            {
+                cleanupError = CombineCloseErrors(cleanupError, ex);
+            }
+            finally
+            {
+                _statement = null;
+            }
+        }
+
+        _remainingSql.Clear();
+        _hasPrefetchedRow = false;
+        _hasCurrentRow = false;
+        _currentStatementRowsAffectedCounted = false;
+        try
+        {
+            FinishClose();
+        }
+        catch (Exception ex)
+        {
+            cleanupError = CombineCloseErrors(cleanupError, ex);
+        }
+
+        if (cleanupError is not null)
+        {
+            var combined = primaryError is null
+                ? cleanupError
+                : CombineCloseErrors(primaryError, cleanupError);
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(combined).Throw();
+        }
+        if (primaryError is not null && throwOnError)
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(primaryError).Throw();
     }
 
     private async ValueTask FinishCloseAsync(bool closeConnection = true)

--- a/src/Ahtola.Data.Sqlite/SqliteDataReader.cs
+++ b/src/Ahtola.Data.Sqlite/SqliteDataReader.cs
@@ -1563,12 +1563,41 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
         if (_isClosed)
             return;
 
-        _closeCallback();
-        ((ILocalReaderConnection)_connection).ReaderClosed(this);
-        if (closeConnection && (_behavior & CommandBehavior.CloseConnection) == CommandBehavior.CloseConnection)
-            _connection.Close();
+        Exception? error = null;
+        try
+        {
+            _closeCallback();
+        }
+        catch (Exception ex)
+        {
+            error = ex;
+        }
+
+        try
+        {
+            ((ILocalReaderConnection)_connection).ReaderClosed(this);
+        }
+        catch (Exception ex)
+        {
+            error = CombineCloseErrors(error, ex);
+        }
 
         _isClosed = true;
+
+        if (closeConnection && (_behavior & CommandBehavior.CloseConnection) == CommandBehavior.CloseConnection)
+        {
+            try
+            {
+                _connection.Close();
+            }
+            catch (Exception ex)
+            {
+                error = CombineCloseErrors(error, ex);
+            }
+        }
+
+        if (error is not null)
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(error).Throw();
     }
 
     private void EnsureOpen([CallerMemberName] string operation = "")

--- a/src/Ahtola.Data.Sqlite/SqliteDataReader.cs
+++ b/src/Ahtola.Data.Sqlite/SqliteDataReader.cs
@@ -1382,11 +1382,46 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
         if (_isClosed)
             return;
 
-        _closeCallback();
-        ((ILocalReaderConnection)_connection).ReaderClosed(this);
+        // _closeCallback (command/batch bookkeeping) and ReaderClosed (connection
+        // deregistration) must not gate each other: if the callback throws, the reader still
+        // has to deregister and be marked closed, or it remains permanently "open" on its
+        // connection - and CommandBehavior.CloseConnection must still be honored asynchronously
+        // afterward. Every failure here is aggregated and rethrown rather than swallowed.
+        Exception? error = null;
+        try
+        {
+            _closeCallback();
+        }
+        catch (Exception ex)
+        {
+            error = ex;
+        }
+
+        try
+        {
+            ((ILocalReaderConnection)_connection).ReaderClosed(this);
+        }
+        catch (Exception ex)
+        {
+            error = CombineCloseErrors(error, ex);
+        }
+
         _isClosed = true;
+
         if (closeConnection && (_behavior & CommandBehavior.CloseConnection) == CommandBehavior.CloseConnection)
-            await _connection.CloseAsync().ConfigureAwait(false);
+        {
+            try
+            {
+                await _connection.CloseAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                error = CombineCloseErrors(error, ex);
+            }
+        }
+
+        if (error is not null)
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(error).Throw();
     }
 
     private async ValueTask CloseCoreAsync(

--- a/src/Ahtola.Data.Sqlite/SqliteDataReader.cs
+++ b/src/Ahtola.Data.Sqlite/SqliteDataReader.cs
@@ -414,15 +414,15 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
             return ApplyConfiguredDateTimeKind(ParseDateTime(GetDelegatedTextValue(ordinal)));
         EnsureOpen();
         var value = GetTypedValue(ordinal);
-            var dateTime = value.Kind switch
+        var dateTime = value.Kind switch
         {
             ReaderValueKind.Text => ParseDateTime(value.Text),
             ReaderValueKind.Real => DateTime.FromOADate(value.Real - 2415018.5),
             ReaderValueKind.Integer => DateTime.FromOADate(value.Integer - 2415018.5),
             _ => DateTime.Parse(GetString(ordinal), CultureInfo.InvariantCulture)
         };
-            return ApplyConfiguredDateTimeKind(dateTime);
-        }
+        return ApplyConfiguredDateTimeKind(dateTime);
+    }
 
     public virtual DateTimeOffset GetDateTimeOffset(int ordinal)
     {
@@ -993,6 +993,78 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
         return false;
     }
 
+    private async ValueTask<bool> NextResultCoreAsync(CancellationToken cancellationToken)
+    {
+        EnsureOpen();
+        if (_statement is null)
+            return false;
+        while (await GetStatement().ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+        }
+
+        CountCurrentStatementRowsAffected();
+
+        _hasCurrentRow = false;
+        _hasPrefetchedRow = false;
+        await _statement.DisposeAsync().ConfigureAwait(false);
+        _statement = null;
+        _currentStatementRowsAffectedCounted = false;
+
+        try
+        {
+            while (_remainingSql.Count > 0)
+            {
+                var sql = _remainingSql[0];
+                _remainingSql.RemoveAt(0);
+                if (_command.TryHandleFacadeStatement(sql, out var rewrittenSql))
+                    continue;
+
+                cancellationToken.ThrowIfCancellationRequested();
+                var statement = await _command
+                    .PrepareSingleStatementAsync(rewrittenSql, cancellationToken)
+                    .ConfigureAwait(false);
+                if (statement.ColumnCount > 0)
+                {
+                    _statement = statement;
+                    _currentSql = rewrittenSql;
+                    _hadResultSet = true;
+                    _currentStatementRowsAffectedCounted = false;
+                    _hasPrefetchedRow = await statement.ReadAsync(cancellationToken).ConfigureAwait(false);
+                    return true;
+                }
+
+                try
+                {
+                    while (await statement.ReadAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                    }
+
+                    if (SqliteCommand.CountsRowsAffected(sql))
+                    {
+                        _hadRecordsAffectedStatement = true;
+                        _recordsAffected += statement.RowsAffected;
+                    }
+                    _command.MarkTransactionCompletedExternally(sql);
+                }
+                finally
+                {
+                    await statement.DisposeAsync().ConfigureAwait(false);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is AhtolaException or EmbeddedSqlException)
+        {
+            if (_statement is not null)
+                await _statement.DisposeAsync().ConfigureAwait(false);
+            _statement = null;
+            _hasPrefetchedRow = false;
+            _remainingSql.Clear();
+            throw SqliteCommand.ToSqliteException(ex);
+        }
+
+        return false;
+    }
+
     public override bool Read()
     {
         if (_delegatedReader is null)
@@ -1033,10 +1105,39 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
         }
     }
 
+    private async ValueTask<bool> ReadCoreAsync(CancellationToken cancellationToken)
+    {
+        EnsureOpen();
+        if (_statement is null)
+            return false;
+        if (_hasPrefetchedRow)
+        {
+            _hasPrefetchedRow = false;
+            _hasCurrentRow = true;
+            return true;
+        }
+
+        try
+        {
+            _hasCurrentRow = await GetStatement().ReadAsync(cancellationToken).ConfigureAwait(false);
+            if (!_hasCurrentRow)
+                CountCurrentStatementRowsAffected();
+            return _hasCurrentRow;
+        }
+        catch (Exception ex) when (ex is AhtolaException or EmbeddedSqlException)
+        {
+            throw SqliteCommand.ToSqliteException(ex);
+        }
+    }
+
     public override async Task<bool> ReadAsync(CancellationToken cancellationToken)
     {
         if (_delegatedReader is null)
-            return await _command.RunOperationAsync(ReadCore, cancellationToken).ConfigureAwait(false);
+        {
+            return _statement?.UsesManagedResults == true
+                ? await _command.RunOperationAsync(ReadCoreAsync, cancellationToken).ConfigureAwait(false)
+                : await _command.RunOperationAsync(ReadCore, cancellationToken).ConfigureAwait(false);
+        }
 
         try
         {
@@ -1051,7 +1152,11 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
     public override async Task<bool> NextResultAsync(CancellationToken cancellationToken)
     {
         if (_delegatedReader is null)
-            return await _command.RunOperationAsync(NextResultCore, cancellationToken).ConfigureAwait(false);
+        {
+            return _statement?.UsesManagedResults == true
+                ? await _command.RunOperationAsync(NextResultCoreAsync, cancellationToken).ConfigureAwait(false)
+                : await _command.RunOperationAsync(NextResultCore, cancellationToken).ConfigureAwait(false);
+        }
 
         try
         {
@@ -1127,6 +1232,18 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
         base.Dispose(disposing);
     }
 
+    public override async ValueTask DisposeAsync()
+    {
+        if (_delegatedReader is null && _statement?.UsesManagedResults != true)
+        {
+            await base.DisposeAsync().ConfigureAwait(false);
+            return;
+        }
+
+        await CloseCoreAsync(throwOnError: false).ConfigureAwait(false);
+        await base.DisposeAsync().ConfigureAwait(false);
+    }
+
     public override void Close() => CloseCore();
 
     void IConnectionOwnedReader.CloseFromConnection()
@@ -1190,6 +1307,65 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
         catch (SqliteException)
         {
             _statement?.Dispose();
+            _statement = null;
+            _remainingSql.Clear();
+            FinishClose();
+            if (throwOnError)
+                throw;
+            return;
+        }
+
+        FinishClose();
+    }
+
+    private async ValueTask CloseCoreAsync(bool throwOnError = true)
+    {
+        if (_isClosed)
+            return;
+
+        try
+        {
+            if (_delegatedReader is not null)
+            {
+                _recordsAffected = _delegatedReader.RecordsAffected;
+                _hadRecordsAffectedStatement = true;
+                await _delegatedReader.DisposeAsync().ConfigureAwait(false);
+                _delegatedReader = null;
+                FinishClose();
+                return;
+            }
+
+            if (_statement is not null)
+            {
+                while (await GetStatement().ReadAsync().ConfigureAwait(false))
+                {
+                }
+
+                CountCurrentStatementRowsAffected();
+
+                await _statement.DisposeAsync().ConfigureAwait(false);
+                _statement = null;
+                _hasPrefetchedRow = false;
+                _currentStatementRowsAffectedCounted = false;
+            }
+
+            await DrainRemainingStatementsAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is AhtolaException or EmbeddedSqlException)
+        {
+            if (_statement is not null)
+                await _statement.DisposeAsync().ConfigureAwait(false);
+            _statement = null;
+            _remainingSql.Clear();
+            FinishClose();
+            if (throwOnError)
+                throw SqliteCommand.ToSqliteException(ex);
+            return;
+        }
+        catch (SqliteException)
+        {
+            if (_statement is not null)
+                await _statement.DisposeAsync().ConfigureAwait(false);
             _statement = null;
             _remainingSql.Clear();
             FinishClose();
@@ -1874,6 +2050,42 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
                     _recordsAffected += statement.RowsAffected;
                 }
                 _command.MarkTransactionCompletedExternally(sql);
+            }
+        }
+
+        finally
+        {
+            _remainingSql.Clear();
+        }
+    }
+
+    private async ValueTask DrainRemainingStatementsAsync()
+    {
+        try
+        {
+            foreach (var sql in _remainingSql)
+            {
+                if (_command.TryHandleFacadeStatement(sql, out var rewrittenSql))
+                    continue;
+
+                var statement = await _command.PrepareSingleStatementAsync(rewrittenSql).ConfigureAwait(false);
+                try
+                {
+                    while (await statement.ReadAsync().ConfigureAwait(false))
+                    {
+                    }
+
+                    if (SqliteCommand.CountsRowsAffected(rewrittenSql))
+                    {
+                        _hadRecordsAffectedStatement = true;
+                        _recordsAffected += statement.RowsAffected;
+                    }
+                    _command.MarkTransactionCompletedExternally(sql);
+                }
+                finally
+                {
+                    await statement.DisposeAsync().ConfigureAwait(false);
+                }
             }
         }
         finally

--- a/src/Ahtola.Data.Sqlite/SqliteDataReader.cs
+++ b/src/Ahtola.Data.Sqlite/SqliteDataReader.cs
@@ -1238,6 +1238,12 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
 
     protected override void Dispose(bool disposing)
     {
+        if (disposing && !_isClosed && _command.RequiresAsyncExecution)
+        {
+            throw new PlatformNotSupportedException(
+                "Synchronous reader disposal is not supported by the browser database source. Use DisposeAsync.");
+        }
+
         if (disposing)
             CloseCore(throwOnError: false);
 
@@ -1246,7 +1252,9 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
 
     public override async ValueTask DisposeAsync()
     {
-        if (_delegatedReader is null && _statement?.UsesManagedResults != true)
+        if (!_command.RequiresAsyncExecution
+            && _delegatedReader is null
+            && _statement?.UsesManagedResults != true)
         {
             await base.DisposeAsync().ConfigureAwait(false);
             return;
@@ -1256,7 +1264,15 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
         await base.DisposeAsync().ConfigureAwait(false);
     }
 
-    public override void Close() => CloseCore();
+    public override void Close()
+    {
+        if (!_isClosed)
+            ThrowIfSynchronousBrowserOperation();
+        CloseCore();
+    }
+
+    public override async Task CloseAsync()
+        => await CloseCoreAsync().ConfigureAwait(false);
 
     void IConnectionOwnedReader.CloseFromConnection()
     {
@@ -1271,6 +1287,37 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
         _hasPrefetchedRow = false;
         _hasCurrentRow = false;
         FinishClose(closeConnection: false);
+    }
+
+    ValueTask IConnectionOwnedReader.CloseFromConnectionAsync()
+        => CloseFromConnectionAsync();
+
+    private async ValueTask CloseFromConnectionAsync()
+    {
+        if (_isClosed)
+            return;
+
+        try
+        {
+            if (_delegatedReader is not null)
+            {
+                await _delegatedReader.DisposeAsync().ConfigureAwait(false);
+                _delegatedReader = null;
+            }
+            if (_statement is not null)
+            {
+                await _statement.DisposeAsync().ConfigureAwait(false);
+                _statement = null;
+            }
+        }
+        finally
+        {
+            _remainingSql.Clear();
+            _hasPrefetchedRow = false;
+            _hasCurrentRow = false;
+            _currentStatementRowsAffectedCounted = false;
+            await FinishCloseAsync(closeConnection: false).ConfigureAwait(false);
+        }
     }
 
     private void CloseCore(bool throwOnError = true)
@@ -1330,7 +1377,21 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
         FinishClose();
     }
 
-    private async ValueTask CloseCoreAsync(bool throwOnError = true)
+    private async ValueTask FinishCloseAsync(bool closeConnection = true)
+    {
+        if (_isClosed)
+            return;
+
+        _closeCallback();
+        ((ILocalReaderConnection)_connection).ReaderClosed(this);
+        _isClosed = true;
+        if (closeConnection && (_behavior & CommandBehavior.CloseConnection) == CommandBehavior.CloseConnection)
+            await _connection.CloseAsync().ConfigureAwait(false);
+    }
+
+    private async ValueTask CloseCoreAsync(
+        bool throwOnError = true,
+        bool closeConnection = true)
     {
         if (_isClosed)
             return;
@@ -1343,7 +1404,7 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
                 _hadRecordsAffectedStatement = true;
                 await _delegatedReader.DisposeAsync().ConfigureAwait(false);
                 _delegatedReader = null;
-                FinishClose();
+                await FinishCloseAsync(closeConnection).ConfigureAwait(false);
                 return;
             }
 
@@ -1369,7 +1430,7 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
                 await _statement.DisposeAsync().ConfigureAwait(false);
             _statement = null;
             _remainingSql.Clear();
-            FinishClose();
+            await FinishCloseAsync(closeConnection).ConfigureAwait(false);
             if (throwOnError)
                 throw SqliteCommand.ToSqliteException(ex);
             return;
@@ -1380,13 +1441,13 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
                 await _statement.DisposeAsync().ConfigureAwait(false);
             _statement = null;
             _remainingSql.Clear();
-            FinishClose();
+            await FinishCloseAsync(closeConnection).ConfigureAwait(false);
             if (throwOnError)
                 throw;
             return;
         }
 
-        FinishClose();
+        await FinishCloseAsync(closeConnection).ConfigureAwait(false);
     }
 
     private void FinishClose(bool closeConnection = true)

--- a/src/Ahtola.Data.Sqlite/SqliteDataReader.cs
+++ b/src/Ahtola.Data.Sqlite/SqliteDataReader.cs
@@ -902,6 +902,7 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
 
     public override bool NextResult()
     {
+        ThrowIfSynchronousBrowserOperation();
         if (_delegatedReader is null)
             return _command.RunOperation(NextResultCore);
 
@@ -1067,6 +1068,7 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
 
     public override bool Read()
     {
+        ThrowIfSynchronousBrowserOperation();
         if (_delegatedReader is null)
             return _command.RunOperation(ReadCore);
 
@@ -1183,6 +1185,16 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
 
     public override Task<bool> IsDBNullAsync(int ordinal, CancellationToken cancellationToken)
         => _delegatedReader?.IsDBNullAsync(ordinal, cancellationToken) ?? CompleteAsync(() => IsDBNull(ordinal), cancellationToken);
+
+    private void ThrowIfSynchronousBrowserOperation()
+    {
+        if (_command.RequiresAsyncExecution)
+        {
+            throw new PlatformNotSupportedException(
+                "Synchronous reader iteration is not supported by the browser database source. "
+                + "Use ReadAsync or NextResultAsync.");
+        }
+    }
 
     public override Task<T> GetFieldValueAsync<T>(int ordinal, CancellationToken cancellationToken)
         => CompleteAsync(() =>
@@ -1702,6 +1714,8 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
         var columns = new Dictionary<string, SchemaColumnInfo>(StringComparer.OrdinalIgnoreCase);
         if (_command.Connection is null)
             return columns;
+        if (_command.Connection.RequiresAsyncExecution)
+            return GetManagedTableColumns(_command.Connection.ManagedConnection, tableName);
 
         using var suspension = _command.Connection.SuspendHooks();
         using (var command = _command.Connection.CreateCommand())
@@ -1742,6 +1756,61 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
 
                 if (indexedColumns.Count == 1 && columns.TryGetValue(indexedColumns[0], out var column))
                     columns[indexedColumns[0]] = column with { IsUnique = true };
+            }
+        }
+
+        return columns;
+    }
+
+    private static Dictionary<string, SchemaColumnInfo> GetManagedTableColumns(
+        IManagedConnectionAdapter connection,
+        string tableName)
+    {
+        var columns = new Dictionary<string, SchemaColumnInfo>(StringComparer.OrdinalIgnoreCase);
+        using (var statement = connection.Prepare(
+                   $"PRAGMA table_info({QuoteIdentifier(tableName)});"))
+        {
+            while (statement.Step() == StatementStepResult.Row)
+            {
+                var name = statement.GetValue(1).AsText();
+                columns[name] = new SchemaColumnInfo(
+                    name,
+                    statement.GetValue(2).AsText(),
+                    statement.GetValue(3).AsInteger() == 0,
+                    statement.GetValue(5).AsInteger() != 0,
+                    false);
+            }
+        }
+
+        using var indexes = connection.Prepare(
+            $"PRAGMA index_list({QuoteIdentifier(tableName)});");
+        while (indexes.Step() == StatementStepResult.Row)
+        {
+            if (indexes.GetValue(2).AsInteger() == 0
+                || indexes.GetValue(4).AsInteger() != 0)
+            {
+                continue;
+            }
+
+            var indexName = indexes.GetValue(1).AsText();
+            using var info = connection.Prepare(
+                $"PRAGMA index_info({QuoteIdentifier(indexName)});");
+            string? indexedColumn = null;
+            var indexedColumnCount = 0;
+            while (info.Step() == StatementStepResult.Row)
+            {
+                if (info.GetValue(2).Kind != SqlValueKind.Null)
+                {
+                    indexedColumn = info.GetValue(2).AsText();
+                    indexedColumnCount++;
+                }
+            }
+
+            if (indexedColumnCount == 1
+                && indexedColumn is not null
+                && columns.TryGetValue(indexedColumn, out var column))
+            {
+                columns[indexedColumn] = column with { IsUnique = true };
             }
         }
 

--- a/src/Ahtola.Data.Sqlite/SqliteDataReader.cs
+++ b/src/Ahtola.Data.Sqlite/SqliteDataReader.cs
@@ -1447,6 +1447,28 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
 
     private string GetDeclaredTypeName(int ordinal)
     {
+        if (_command.Connection is { RequiresAsyncExecution: true } browserConnection)
+        {
+            var browserMatch = Regex.Match(
+                _command.CommandText,
+                @"^\s*SELECT\s+(?<column>[\w\[\]""`]+)\s+FROM\s+(?<table>[\w\[\]""`.]+)",
+                RegexOptions.IgnoreCase);
+            if (browserMatch.Success)
+            {
+                var columnName = UnquoteIdentifier(browserMatch.Groups["column"].Value);
+                var tableName = browserMatch.Groups["table"].Value
+                    .Split('.')
+                    .Select(UnquoteIdentifier)
+                    .ToArray();
+                var qualifiedTable = string.Join('.', tableName);
+                var columns = GetManagedTableColumns(
+                    browserConnection.ManagedConnection,
+                    qualifiedTable);
+                if (columns.TryGetValue(columnName, out var schemaColumn))
+                    return StripTypeLength(schemaColumn.TypeName);
+            }
+        }
+
         if (TryGetSelectSources(out var sources, out var selections))
         {
             var sourceColumns = GetSelectSourceColumns(sources);
@@ -1768,7 +1790,7 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
     {
         var columns = new Dictionary<string, SchemaColumnInfo>(StringComparer.OrdinalIgnoreCase);
         using (var statement = connection.Prepare(
-                   $"PRAGMA table_info({QuoteIdentifier(tableName)});"))
+                   BuildManagedPragma(tableName, "table_info")))
         {
             while (statement.Step() == StatementStepResult.Row)
             {
@@ -1783,7 +1805,7 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
         }
 
         using var indexes = connection.Prepare(
-            $"PRAGMA index_list({QuoteIdentifier(tableName)});");
+            BuildManagedPragma(tableName, "index_list"));
         while (indexes.Step() == StatementStepResult.Row)
         {
             if (indexes.GetValue(2).AsInteger() == 0
@@ -1794,7 +1816,9 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
 
             var indexName = indexes.GetValue(1).AsText();
             using var info = connection.Prepare(
-                $"PRAGMA index_info({QuoteIdentifier(indexName)});");
+                BuildManagedPragma(
+                    QualifyPragmaObject(tableName, indexName),
+                    "index_info"));
             string? indexedColumn = null;
             var indexedColumnCount = 0;
             while (info.Step() == StatementStepResult.Row)
@@ -1815,6 +1839,23 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
         }
 
         return columns;
+    }
+
+    private static string BuildManagedPragma(string objectName, string pragma)
+    {
+        var separator = objectName.IndexOf('.');
+        return separator < 0
+            ? $"PRAGMA {pragma}({QuoteIdentifier(objectName)});"
+            : $"PRAGMA {QuoteIdentifier(objectName[..separator])}.{pragma}"
+              + $"({QuoteIdentifier(objectName[(separator + 1)..])});";
+    }
+
+    private static string QualifyPragmaObject(string tableName, string objectName)
+    {
+        var separator = tableName.IndexOf('.');
+        return separator < 0
+            ? objectName
+            : tableName[..separator] + "." + objectName;
     }
 
     private static string GetDataTypeNameFromValueType(ReaderValueKind valueType, string selection)

--- a/src/Ahtola.Data.Sqlite/SqliteDataReader.cs
+++ b/src/Ahtola.Data.Sqlite/SqliteDataReader.cs
@@ -1396,6 +1396,22 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
         if (_isClosed)
             return;
 
+        // Every failure mode below (OPFS quota/I/O, Web Crypto, cancellation, or an
+        // AggregateException wrapping any of those, in addition to the engine's own
+        // AhtolaException/EmbeddedSqlException/SqliteException) must still release the
+        // statement/delegated reader, drop any remaining batched SQL, and deregister this
+        // reader from the connection. Catching only the engine exception types left every other
+        // failure to skip that cleanup entirely and leak the reader as permanently "open".
+        //
+        // Errors are tracked in two buckets: primaryError is the close/drain operation's own
+        // failure, which throwOnError lets callers (DisposeAsync) tolerate, matching the prior
+        // behavior for the engine exception types. cleanupError covers the best-effort recovery
+        // pass below (re-disposing a statement/delegated reader that never got released, and
+        // FinishCloseAsync deregistering the reader / honoring CommandBehavior.CloseConnection).
+        // A cleanup failure means the reader's bookkeeping with its connection may be
+        // inconsistent, so it is never swallowed, even when throwOnError is false.
+        Exception? primaryError = null;
+        Exception? cleanupError = null;
         try
         {
             if (_delegatedReader is not null)
@@ -1404,51 +1420,108 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
                 _hadRecordsAffectedStatement = true;
                 await _delegatedReader.DisposeAsync().ConfigureAwait(false);
                 _delegatedReader = null;
-                await FinishCloseAsync(closeConnection).ConfigureAwait(false);
-                return;
             }
-
-            if (_statement is not null)
+            else
             {
-                while (await GetStatement().ReadAsync().ConfigureAwait(false))
+                if (_statement is not null)
                 {
+                    while (await GetStatement().ReadAsync().ConfigureAwait(false))
+                    {
+                    }
+
+                    CountCurrentStatementRowsAffected();
+
+                    await _statement.DisposeAsync().ConfigureAwait(false);
+                    _statement = null;
+                    _hasPrefetchedRow = false;
+                    _currentStatementRowsAffectedCounted = false;
                 }
 
-                CountCurrentStatementRowsAffected();
-
-                await _statement.DisposeAsync().ConfigureAwait(false);
-                _statement = null;
-                _hasPrefetchedRow = false;
-                _currentStatementRowsAffectedCounted = false;
+                await DrainRemainingStatementsAsync().ConfigureAwait(false);
             }
-
-            await DrainRemainingStatementsAsync().ConfigureAwait(false);
         }
-        catch (Exception ex) when (ex is AhtolaException or EmbeddedSqlException)
+        catch (Exception ex)
         {
-            if (_statement is not null)
-                await _statement.DisposeAsync().ConfigureAwait(false);
-            _statement = null;
-            _remainingSql.Clear();
-            await FinishCloseAsync(closeConnection).ConfigureAwait(false);
-            if (throwOnError)
-                throw SqliteCommand.ToSqliteException(ex);
-            return;
-        }
-        catch (SqliteException)
-        {
-            if (_statement is not null)
-                await _statement.DisposeAsync().ConfigureAwait(false);
-            _statement = null;
-            _remainingSql.Clear();
-            await FinishCloseAsync(closeConnection).ConfigureAwait(false);
-            if (throwOnError)
-                throw;
-            return;
+            primaryError = ex is AhtolaException or EmbeddedSqlException
+                ? SqliteCommand.ToSqliteException(ex)
+                : ex;
         }
 
-        await FinishCloseAsync(closeConnection).ConfigureAwait(false);
+        // Best-effort cleanup: whatever failed above, a statement/delegated reader still
+        // referenced here was never disposed (or its own disposal is what failed), so retry it
+        // defensively before dropping the reference. SqliteStatementAdapter.DisposeAsync marks
+        // itself disposed before delegating, so a second attempt after a failed first one is a
+        // safe no-op rather than a duplicate disposal.
+        if (_delegatedReader is not null)
+        {
+            try
+            {
+                await _delegatedReader.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                cleanupError = CombineCloseErrors(cleanupError, ex);
+            }
+            finally
+            {
+                _delegatedReader = null;
+            }
+        }
+
+        if (_statement is not null)
+        {
+            try
+            {
+                await _statement.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                cleanupError = CombineCloseErrors(cleanupError, ex);
+            }
+            finally
+            {
+                _statement = null;
+            }
+        }
+
+        _remainingSql.Clear();
+        _hasPrefetchedRow = false;
+        _hasCurrentRow = false;
+        _currentStatementRowsAffectedCounted = false;
+
+        try
+        {
+            // Deregisters the reader from its connection and, when the behavior requires it,
+            // awaits the connection's own asynchronous close - this must run whether or not the
+            // primary operation above failed, or CommandBehavior.CloseConnection would silently
+            // stop being honored on any non-engine failure.
+            await FinishCloseAsync(closeConnection).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            cleanupError = CombineCloseErrors(cleanupError, ex);
+        }
+
+        // throwOnError only governs the primary operation failure (DisposeAsync tolerates it,
+        // matching prior behavior for the engine exception types); a cleanup failure indicates
+        // the reader's registration/connection-close bookkeeping may be inconsistent and is
+        // always surfaced, aggregated with the primary error when both occurred.
+        if (cleanupError is not null)
+        {
+            var combined = primaryError is null
+                ? cleanupError
+                : CombineCloseErrors(primaryError, cleanupError);
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(combined).Throw();
+        }
+
+        if (primaryError is not null && throwOnError)
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(primaryError).Throw();
     }
+
+    private static Exception CombineCloseErrors(Exception? existing, Exception next)
+        => existing is null
+            ? next
+            : new AggregateException("Data reader close encountered multiple failures.", existing, next);
 
     private void FinishClose(bool closeConnection = true)
     {
@@ -1510,23 +1583,33 @@ public class SqliteDataReader : DbDataReader, IConnectionOwnedReader
     {
         if (_command.Connection is { RequiresAsyncExecution: true } browserConnection)
         {
+            // Resolve against _currentSql (the statement the reader is positioned on), not
+            // _command.CommandText (the full, possibly multi-statement batch text). Matching
+            // against the whole batch always anchors on the FIRST statement's column/table, so a
+            // later result set would silently inherit its declared type (e.g. reporting a BLOB
+            // column as Guid because an earlier statement in the batch projected one). Validating
+            // the matched column against GetName(ordinal) further ensures the resolved metadata
+            // actually belongs to the column being asked about.
             var browserMatch = Regex.Match(
-                _command.CommandText,
+                _currentSql,
                 @"^\s*SELECT\s+(?<column>[\w\[\]""`]+)\s+FROM\s+(?<table>[\w\[\]""`.]+)",
                 RegexOptions.IgnoreCase);
             if (browserMatch.Success)
             {
                 var columnName = UnquoteIdentifier(browserMatch.Groups["column"].Value);
-                var tableName = browserMatch.Groups["table"].Value
-                    .Split('.')
-                    .Select(UnquoteIdentifier)
-                    .ToArray();
-                var qualifiedTable = string.Join('.', tableName);
-                var columns = GetManagedTableColumns(
-                    browserConnection.ManagedConnection,
-                    qualifiedTable);
-                if (columns.TryGetValue(columnName, out var schemaColumn))
-                    return StripTypeLength(schemaColumn.TypeName);
+                if (string.Equals(columnName, GetName(ordinal), StringComparison.OrdinalIgnoreCase))
+                {
+                    var tableName = browserMatch.Groups["table"].Value
+                        .Split('.')
+                        .Select(UnquoteIdentifier)
+                        .ToArray();
+                    var qualifiedTable = string.Join('.', tableName);
+                    var columns = GetManagedTableColumns(
+                        browserConnection.ManagedConnection,
+                        qualifiedTable);
+                    if (columns.TryGetValue(columnName, out var schemaColumn))
+                        return StripTypeLength(schemaColumn.TypeName);
+                }
             }
         }
 

--- a/src/Ahtola.Data.Sqlite/SqliteManagedBackup.cs
+++ b/src/Ahtola.Data.Sqlite/SqliteManagedBackup.cs
@@ -33,6 +33,47 @@ internal static class SqliteManagedBackup
         }
     }
 
+    internal static async ValueTask CopyAsync(
+        SqliteConnection source,
+        SqliteConnection destination,
+        string destinationName,
+        string sourceName,
+        CancellationToken cancellationToken = default)
+    {
+        if (!source.IsManagedConnection || !destination.IsManagedConnection)
+            throw new InvalidOperationException("Managed backup requires managed source and destination connections.");
+        ArgumentNullException.ThrowIfNull(destinationName);
+        ArgumentNullException.ThrowIfNull(sourceName);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (ReferenceEquals(source, destination)
+            && string.Equals(sourceName, destinationName, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new SqliteException(Properties.Resources.SqliteNativeError(1, "source and destination must be distinct"), 1);
+        }
+        if (destination.Transaction is not null || destination.HasOpenReader)
+        {
+            throw new SqliteException(Properties.Resources.SqliteNativeError(5, "database is locked"), 5);
+        }
+        try
+        {
+            await source.ManagedConnection
+                .CopySnapshotToAsync(
+                    destination.ManagedConnection,
+                    destinationName,
+                    sourceName,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (ManagedSnapshotException exception)
+        {
+            throw ToSqliteException(exception);
+        }
+        catch (EmbeddedSqlException exception)
+        {
+            throw SqliteCommand.ToSqliteException(exception);
+        }
+    }
+
     private static Exception ToSqliteException(ManagedSnapshotException exception)
     {
         return exception.Failure switch

--- a/src/Ahtola.Data.Sqlite/SqliteStatementAdapter.cs
+++ b/src/Ahtola.Data.Sqlite/SqliteStatementAdapter.cs
@@ -3,7 +3,7 @@ using Ahtola;
 
 namespace Ahtola.Data.Sqlite;
 
-internal sealed class SqliteStatementAdapter : IDisposable
+internal sealed class SqliteStatementAdapter : IDisposable, IAsyncDisposable
 {
     private readonly AhtolaNativeStatement? _nativeStatement;
     private readonly IManagedStatementAdapter? _managedStatement;
@@ -51,6 +51,12 @@ internal sealed class SqliteStatementAdapter : IDisposable
             ? ReadNative(cancellationToken)
             : _managedStatement.Step(cancellationToken) == StatementStepResult.Row;
 
+    public async ValueTask<bool> ReadAsync(CancellationToken cancellationToken = default)
+        => _managedStatement is null
+            ? ReadNative(cancellationToken)
+            : await _managedStatement.StepAsync(cancellationToken).ConfigureAwait(false)
+              == StatementStepResult.Row;
+
     public bool HasRows()
         => _managedStatement?.HasRows() ?? GetNativeStatement().HasRows;
 
@@ -80,6 +86,18 @@ internal sealed class SqliteStatementAdapter : IDisposable
             _nativeStatement?.Dispose();
         else
             _managedStatement.Dispose();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        if (_managedStatement is null)
+            _nativeStatement?.Dispose();
+        else
+            await _managedStatement.DisposeAsync().ConfigureAwait(false);
     }
 
     private AhtolaNativeStatement GetNativeStatement()

--- a/src/Ahtola.Data.Sqlite/SqliteTransaction.cs
+++ b/src/Ahtola.Data.Sqlite/SqliteTransaction.cs
@@ -138,6 +138,7 @@ public class SqliteTransaction : DbTransaction
 
     public override void Commit()
     {
+        ThrowIfSynchronousBrowserOperation("CommitAsync");
         ThrowIfCompleted();
         if (_externalRollback)
             throw new InvalidOperationException(Properties.Resources.TransactionCompleted);
@@ -187,6 +188,7 @@ public class SqliteTransaction : DbTransaction
 
     public override void Rollback()
     {
+        ThrowIfSynchronousBrowserOperation("RollbackAsync");
         ThrowIfCompleted();
         try
         {
@@ -222,6 +224,7 @@ public class SqliteTransaction : DbTransaction
 
     public override void Save(string savepointName)
     {
+        ThrowIfSynchronousBrowserOperation("SaveAsync");
         ArgumentNullException.ThrowIfNull(savepointName);
         ThrowIfCompleted();
         if (_ahtolaTransaction is not null)
@@ -246,6 +249,7 @@ public class SqliteTransaction : DbTransaction
 
     public override void Rollback(string savepointName)
     {
+        ThrowIfSynchronousBrowserOperation("RollbackAsync");
         ArgumentNullException.ThrowIfNull(savepointName);
         ThrowIfCompleted();
         if (_ahtolaTransaction is not null)
@@ -270,6 +274,7 @@ public class SqliteTransaction : DbTransaction
 
     public override void Release(string savepointName)
     {
+        ThrowIfSynchronousBrowserOperation("ReleaseAsync");
         ArgumentNullException.ThrowIfNull(savepointName);
         ThrowIfCompleted();
         if (_ahtolaTransaction is not null)
@@ -294,6 +299,13 @@ public class SqliteTransaction : DbTransaction
 
     protected override void Dispose(bool disposing)
     {
+        if (disposing && !_completed && _connection?.RequiresAsyncExecution == true)
+        {
+            throw new PlatformNotSupportedException(
+                "Synchronous transaction disposal is not supported by the browser database source. "
+                + "Use DisposeAsync or RollbackAsync.");
+        }
+
         if (disposing && !_completed && _ahtolaTransaction is not null)
             Complete();
         else if (disposing && !_completed && _connection is { State: ConnectionState.Open })
@@ -302,6 +314,25 @@ public class SqliteTransaction : DbTransaction
             _connection.Transaction = null;
 
         base.Dispose(disposing);
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        if (_connection?.RequiresAsyncExecution != true)
+        {
+            await base.DisposeAsync().ConfigureAwait(false);
+            return;
+        }
+
+        if (!_completed)
+        {
+            if (_connection is { State: ConnectionState.Open })
+                await RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+            else
+                Complete();
+        }
+
+        await base.DisposeAsync().ConfigureAwait(false);
     }
 
     internal void MarkCompletedExternally(bool rolledBack)
@@ -335,6 +366,16 @@ public class SqliteTransaction : DbTransaction
     {
         if (_completed || _connection is null || _connection.State != ConnectionState.Open)
             throw new InvalidOperationException(Properties.Resources.TransactionCompleted);
+    }
+
+    private void ThrowIfSynchronousBrowserOperation(string asyncAlternative)
+    {
+        if (_connection?.RequiresAsyncExecution == true)
+        {
+            throw new PlatformNotSupportedException(
+                "Synchronous transaction operations are not supported by the browser database source. "
+                + $"Use {asyncAlternative}.");
+        }
     }
 
     private static IsolationLevel NormalizeIsolationLevel(SqliteConnection connection, IsolationLevel isolationLevel, bool deferred)

--- a/src/Ahtola.Data/AhtolaCommand.cs
+++ b/src/Ahtola.Data/AhtolaCommand.cs
@@ -139,6 +139,7 @@ public class AhtolaCommand : DbCommand
 
     public override int ExecuteNonQuery()
     {
+        ThrowIfSynchronousBrowserOperation("ExecuteNonQueryAsync");
         if (_connection?.IsRemote == true)
         {
             return _cancellation
@@ -174,6 +175,7 @@ public class AhtolaCommand : DbCommand
 
     public override object? ExecuteScalar()
     {
+        ThrowIfSynchronousBrowserOperation("ExecuteScalarAsync");
         using var reader = _cancellation.Run(token => Execute(CommandBehavior.Default, token));
         var result = reader.Read()
             ? reader.GetValue(0)
@@ -192,8 +194,22 @@ public class AhtolaCommand : DbCommand
 
     public override void Prepare()
     {
+        ThrowIfSynchronousBrowserOperation("PrepareAsync");
         using var replicaOperation = _connection?.EnterManagedReplicaOperation(CancellationToken.None);
         PrepareCore();
+    }
+
+    internal bool RequiresAsyncExecution
+        => _connection?.RequiresAsyncExecution == true;
+
+    private void ThrowIfSynchronousBrowserOperation(string asyncAlternative)
+    {
+        if (RequiresAsyncExecution)
+        {
+            throw new PlatformNotSupportedException(
+                $"Synchronous command execution is not supported by the browser database source. "
+                + $"Use {asyncAlternative}.");
+        }
     }
 
     private void PrepareCore()
@@ -289,6 +305,7 @@ public class AhtolaCommand : DbCommand
 
     protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
     {
+        ThrowIfSynchronousBrowserOperation("ExecuteReaderAsync");
         return _cancellation.Run(token => Execute(behavior, token));
     }
 

--- a/src/Ahtola.Data/AhtolaCommand.cs
+++ b/src/Ahtola.Data/AhtolaCommand.cs
@@ -301,6 +301,13 @@ public class AhtolaCommand : DbCommand
                 cancellationToken);
         }
 
+        if (_connection?.IsManaged == true)
+        {
+            return _cancellation.RunAsync<DbDataReader>(
+                token => ExecuteManagedAsync(behavior, token),
+                cancellationToken);
+        }
+
         return _cancellation.RunAsync<DbDataReader>(
             token => Execute(behavior, token),
             cancellationToken);
@@ -434,6 +441,95 @@ public class AhtolaCommand : DbCommand
         }
     }
 
+    private async ValueTask<DbDataReader> ExecuteManagedAsync(
+        CommandBehavior behavior,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (_connection is null)
+            throw new InvalidOperationException("Connection must be set before executing a command.");
+
+        IDisposable? replicaOperation = null;
+        var beganManagedReplicaTransaction = false;
+        try
+        {
+            beganManagedReplicaTransaction =
+                _connection.BeginManagedReplicaSqlTransaction(CommandText, cancellationToken);
+            replicaOperation = _connection.EnterManagedReplicaOperation(cancellationToken);
+            await PrepareManagedCoreAsync(cancellationToken).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var managedStatement = _managedStatement
+                ?? throw new InvalidOperationException("Command was not prepared.");
+            _managedStatement = null;
+            var transactionCompletion = SqlTransactionControl.GetCompletion(CommandText);
+            _connection.ManagedReplicaStatementStarted(CommandText);
+            var reader = new AhtolaDataReader(
+                this,
+                nativeStatement: null,
+                managedStatement,
+                behavior,
+                () =>
+                {
+                    MarkTransactionCompletedExternally(transactionCompletion);
+                    _connection.ManagedReplicaStatementCompleted(CommandText);
+                },
+                _connection.ManagedReplicaStatementFailed,
+                _connection.ManagedReplicaStatementClosed,
+                replicaOperation);
+            replicaOperation = null;
+            return reader;
+        }
+        catch
+        {
+            replicaOperation?.Dispose();
+            if (beganManagedReplicaTransaction)
+                _connection.ManagedReplicaStatementFailed();
+            throw;
+        }
+    }
+
+    private async ValueTask PrepareManagedCoreAsync(CancellationToken cancellationToken)
+    {
+        if (_connection is null)
+            throw new InvalidOperationException("Connection must be set before preparing a command.");
+        if (string.IsNullOrWhiteSpace(CommandText))
+            throw new InvalidOperationException("CommandText must be set before preparing a command.");
+        ValidateTransaction();
+        _connection.ValidateCommandCapabilities(CommandText);
+        if (_connection.IsManagedReadOnly)
+            ManagedReadOnlySqlGuard.ThrowIfQueryOnlyIsDisabled(CommandText);
+
+        IManagedStatementAdapter? managedStatement = null;
+        try
+        {
+            var sql = RewriteFacadePragmas(CommandText, _connection);
+            _connection.ManagedConnection.BusyTimeout = CommandTimeout == 0
+                ? Timeout.InfiniteTimeSpan
+                : TimeSpan.FromSeconds(CommandTimeout);
+            managedStatement = await _connection.ManagedConnection
+                .PrepareAsync(sql, cancellationToken)
+                .ConfigureAwait(false);
+            BindManagedParameters(managedStatement, sql);
+            _ = managedStatement.ResultMetadata.ColumnCount;
+
+            _nativeStatement?.Dispose();
+            _nativeStatement = null;
+            if (_managedStatement is not null)
+                await _managedStatement.DisposeAsync().ConfigureAwait(false);
+            _managedStatement = managedStatement;
+            managedStatement = null;
+        }
+        catch (EmbeddedSqlException exception)
+        {
+            throw AhtolaException.FromCorePreparation(exception);
+        }
+        finally
+        {
+            if (managedStatement is not null)
+                await managedStatement.DisposeAsync().ConfigureAwait(false);
+        }
+    }
     internal T RunOperation<T>(
         Func<CancellationToken, T> operation,
         CancellationToken cancellationToken = default)
@@ -441,6 +537,11 @@ public class AhtolaCommand : DbCommand
 
     internal Task<T> RunOperationAsync<T>(
         Func<CancellationToken, T> operation,
+        CancellationToken cancellationToken = default)
+        => _cancellation.RunAsync(operation, cancellationToken);
+
+    internal Task<T> RunOperationAsync<T>(
+        Func<CancellationToken, ValueTask<T>> operation,
         CancellationToken cancellationToken = default)
         => _cancellation.RunAsync(operation, cancellationToken);
 

--- a/src/Ahtola.Data/AhtolaConnection.cs
+++ b/src/Ahtola.Data/AhtolaConnection.cs
@@ -198,6 +198,7 @@ public class AhtolaConnection :
             _managedDatabase = database;
             database = null;
             _managedReadOnly = _managedDatabaseFactory.IsReadOnly;
+            _managedSharedMemory = _managedDatabaseFactory.IsSharedMemory;
         }
         finally
         {

--- a/src/Ahtola.Data/AhtolaConnection.cs
+++ b/src/Ahtola.Data/AhtolaConnection.cs
@@ -6,7 +6,10 @@ using Ahtola.Core.Storage;
 
 namespace Ahtola;
 
-public class AhtolaConnection : DbConnection, ILocalReaderConnection
+public class AhtolaConnection :
+    DbConnection,
+    ILocalReaderConnection,
+    IManagedSchemaConnection
 {
     internal const int AutomaticSyncMaximumAttempts = 3;
     // Test-only transport seam. Production callers continue to use the default HttpClient transport.
@@ -16,6 +19,7 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
     private AhtolaReplicaDatabase? _replicaDatabase;
     private ManagedReplicaConnectionHost? _managedReplicaHost;
     private IManagedDatabaseAdapter? _managedDatabase;
+    private readonly IManagedDatabaseFactory? _managedDatabaseFactory;
     private ManagedConnectionPoolLease? _managedPoolLease;
     private ManagedConnectionPoolKey? _managedPoolKey;
     private AhtolaRemoteClient? _remoteClient;
@@ -106,6 +110,15 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
         _remoteClient = remoteClient ?? throw new ArgumentNullException(nameof(remoteClient));
     }
 
+    internal AhtolaConnection(
+        string connectionString,
+        IManagedDatabaseFactory managedDatabaseFactory)
+        : this(connectionString)
+    {
+        _managedDatabaseFactory = managedDatabaseFactory
+            ?? throw new ArgumentNullException(nameof(managedDatabaseFactory));
+    }
+
     internal AhtolaConnection(IManagedDatabaseAdapter managedDatabase)
         : this("")
     {
@@ -132,6 +145,11 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
 
     public override void Open()
     {
+        if (_managedDatabaseFactory is not null)
+        {
+            throw new PlatformNotSupportedException(
+                "Synchronous Open is not supported by the browser database source. Use OpenAsync.");
+        }
         ValidateCanOpen();
         OpenCore();
     }
@@ -140,6 +158,12 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
     {
         if (cancellationToken.IsCancellationRequested)
             return Task.FromCanceled(cancellationToken);
+
+        if (_managedDatabaseFactory is not null)
+        {
+            ValidateCanOpen();
+            return OpenManagedFactoryAsync(cancellationToken);
+        }
 
         if (_connectionOptions.IsRemote && _connectionOptions.IsReplica)
         {
@@ -159,6 +183,26 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
                 cancellationToken.ThrowIfCancellationRequested();
             },
             CancellationToken.None);
+    }
+
+    private async Task OpenManagedFactoryAsync(CancellationToken cancellationToken)
+    {
+        IManagedDatabaseAdapter? database = null;
+        try
+        {
+            database = await _managedDatabaseFactory!
+                .OpenDatabaseAsync(cancellationToken)
+                .ConfigureAwait(false);
+            _ = await database.ConnectAsync(cancellationToken).ConfigureAwait(false);
+            _managedDatabase = database;
+            database = null;
+            _managedReadOnly = _managedDatabaseFactory.IsReadOnly;
+        }
+        finally
+        {
+            if (database is not null)
+                await database.DisposeAsync().ConfigureAwait(false);
+        }
     }
 
     public static void ClearAllPools() => ManagedConnectionPool.ClearAll();
@@ -276,6 +320,58 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
             System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(cancellationError).Throw();
     }
 
+    public override Task CloseAsync()
+        => _managedDatabaseFactory is null
+            ? base.CloseAsync()
+            : CloseManagedFactoryAsync();
+
+    private async Task CloseManagedFactoryAsync()
+    {
+        var database = _managedDatabase;
+        if (database is null)
+            return;
+
+        Exception? cleanupError = null;
+        try
+        {
+            if (_transaction is { IsCompleted: false } transaction)
+                await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+            if (_transaction is not null)
+                await _transaction.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            cleanupError = exception;
+        }
+        try
+        {
+            CloseOpenReaders();
+            ResetOpenCommands();
+        }
+        catch (Exception exception)
+        {
+            cleanupError = CombineDisposalErrors(cleanupError, exception);
+        }
+        finally
+        {
+            _managedDatabase = null;
+            _transaction = null;
+            _readUncommitted = false;
+            _managedReadOnly = false;
+            try
+            {
+                await database.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                cleanupError = CombineDisposalErrors(cleanupError, exception);
+            }
+        }
+
+        if (cleanupError is not null)
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(cleanupError).Throw();
+    }
+
     protected override void Dispose(bool disposing)
     {
         if (!disposing || _disposed)
@@ -312,6 +408,40 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
         try
         {
             base.Dispose(disposing);
+        }
+        catch (Exception exception)
+        {
+            disposalError = CombineDisposalErrors(disposalError, exception);
+        }
+
+        if (disposalError is not null)
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(disposalError).Throw();
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        if (_managedDatabaseFactory is null)
+        {
+            await base.DisposeAsync().ConfigureAwait(false);
+            return;
+        }
+        if (_disposed)
+            return;
+
+        Exception? disposalError = null;
+        try
+        {
+            await CloseAsync().ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            disposalError = exception;
+        }
+
+        _disposed = true;
+        try
+        {
+            await base.DisposeAsync().ConfigureAwait(false);
         }
         catch (Exception exception)
         {
@@ -496,6 +626,8 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
 
     internal bool IsManaged => _managedReplicaHost is not null || _managedDatabase is not null;
 
+    internal bool RequiresAsyncExecution => _managedDatabaseFactory is not null;
+
     internal AhtolaTransaction? Transaction => _transaction;
 
     internal bool ReadUncommitted
@@ -523,6 +655,9 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
         => _managedReplicaHost?.Database.Connection
            ?? _managedDatabase?.Connection
            ?? throw new InvalidOperationException("Ahtola database is closed.");
+
+    IManagedConnectionAdapter IManagedSchemaConnection.ManagedSchemaConnection
+        => ManagedConnection;
 
     internal IDisposable? EnterManagedReplicaOperation(CancellationToken cancellationToken)
     {

--- a/src/Ahtola.Data/AhtolaConnection.cs
+++ b/src/Ahtola.Data/AhtolaConnection.cs
@@ -50,6 +50,11 @@ public class AhtolaConnection :
         get => _connectionOptions.GetConnectionString();
         set
         {
+            if (_managedDatabaseFactory is not null)
+            {
+                throw new InvalidOperationException(
+                    "Connections created by a browser data source cannot replace its connection string.");
+            }
             if (State == ConnectionState.Open)
                 throw new InvalidOperationException("ConnectionString cannot be set while the connection is open.");
 
@@ -86,6 +91,11 @@ public class AhtolaConnection :
         get => _pageCodec;
         set
         {
+            if (_managedDatabaseFactory is not null)
+            {
+                throw new InvalidOperationException(
+                    "Connections created by a browser data source cannot replace its page codec.");
+            }
             if (State == ConnectionState.Open)
                 throw new InvalidOperationException("PageCodec cannot be set while the connection is open.");
             if (value is not null)

--- a/src/Ahtola.Data/AhtolaConnection.cs
+++ b/src/Ahtola.Data/AhtolaConnection.cs
@@ -691,8 +691,8 @@ public class AhtolaConnection :
            ?? _managedDatabase?.Connection
            ?? throw new InvalidOperationException("Ahtola database is closed.");
 
-    IManagedConnectionAdapter IManagedSchemaConnection.ManagedSchemaConnection
-        => ManagedConnection;
+    IManagedConnectionAdapter? IManagedSchemaConnection.ManagedSchemaConnection
+        => IsManaged ? ManagedConnection : null;
 
     internal IDisposable? EnterManagedReplicaOperation(CancellationToken cancellationToken)
     {

--- a/src/Ahtola.Data/AhtolaConnection.cs
+++ b/src/Ahtola.Data/AhtolaConnection.cs
@@ -106,6 +106,12 @@ public class AhtolaConnection : DbConnection, ILocalReaderConnection
         _remoteClient = remoteClient ?? throw new ArgumentNullException(nameof(remoteClient));
     }
 
+    internal AhtolaConnection(IManagedDatabaseAdapter managedDatabase)
+        : this("")
+    {
+        _managedDatabase = managedDatabase ?? throw new ArgumentNullException(nameof(managedDatabase));
+    }
+
     /// <summary>
     /// Creates a connection configured as an embedded replica.
     /// </summary>

--- a/src/Ahtola.Data/AhtolaConnection.cs
+++ b/src/Ahtola.Data/AhtolaConnection.cs
@@ -9,7 +9,8 @@ namespace Ahtola;
 public class AhtolaConnection :
     DbConnection,
     ILocalReaderConnection,
-    IManagedSchemaConnection
+    IManagedSchemaConnection,
+    IAsyncExecutionConnection
 {
     internal const int AutomaticSyncMaximumAttempts = 3;
     // Test-only transport seam. Production callers continue to use the default HttpClient transport.
@@ -219,6 +220,12 @@ public class AhtolaConnection :
 
     public override void Close()
     {
+        if (_managedDatabaseFactory is not null && _managedDatabase is not null)
+        {
+            throw new PlatformNotSupportedException(
+                "Synchronous Close is not supported by the browser database source. Use CloseAsync.");
+        }
+
         _replicaOptions?.ThrowIfApplicationHttpReentrant(closing: true);
         var automaticSyncError = StopAutomaticManagedReplicaSync();
         if (_remoteClient is not null)
@@ -345,7 +352,7 @@ public class AhtolaConnection :
         }
         try
         {
-            CloseOpenReaders();
+            await CloseOpenReadersAsync().ConfigureAwait(false);
             ResetOpenCommands();
         }
         catch (Exception exception)
@@ -374,6 +381,15 @@ public class AhtolaConnection :
 
     protected override void Dispose(bool disposing)
     {
+        if (disposing
+            && !_disposed
+            && _managedDatabaseFactory is not null
+            && State != ConnectionState.Closed)
+        {
+            throw new PlatformNotSupportedException(
+                "Synchronous disposal is not supported by the browser database source. Use DisposeAsync.");
+        }
+
         if (!disposing || _disposed)
         {
             _disposed = true;
@@ -459,6 +475,12 @@ public class AhtolaConnection :
 
     protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
     {
+        if (RequiresAsyncExecution)
+        {
+            throw new PlatformNotSupportedException(
+                "Synchronous transaction creation is not supported by the browser database source. "
+                + "Use BeginTransactionAsync.");
+        }
         ValidateCanBeginTransaction();
 
         return _transaction = new AhtolaTransaction(this, isolationLevel);
@@ -627,6 +649,8 @@ public class AhtolaConnection :
     internal bool IsManaged => _managedReplicaHost is not null || _managedDatabase is not null;
 
     internal bool RequiresAsyncExecution => _managedDatabaseFactory is not null;
+
+    bool IAsyncExecutionConnection.RequiresAsyncExecution => RequiresAsyncExecution;
 
     internal AhtolaTransaction? Transaction => _transaction;
 
@@ -1657,6 +1681,30 @@ public class AhtolaConnection :
             readers = _openReaders.ToArray();
         foreach (var reader in readers)
             reader.CloseFromConnection();
+    }
+
+    private async ValueTask CloseOpenReadersAsync()
+    {
+        IConnectionOwnedReader[] readers;
+        lock (_readerLock)
+            readers = _openReaders.ToArray();
+        List<Exception>? failures = null;
+        foreach (var reader in readers)
+        {
+            try
+            {
+                await reader.CloseFromConnectionAsync().ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                (failures ??= []).Add(exception);
+            }
+        }
+
+        if (failures is { Count: 1 })
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(failures[0]).Throw();
+        if (failures is not null)
+            throw new AggregateException("One or more readers could not be closed.", failures);
     }
 
     private void ResetOpenCommands()

--- a/src/Ahtola.Data/AhtolaDataReader.cs
+++ b/src/Ahtola.Data/AhtolaDataReader.cs
@@ -367,7 +367,10 @@ public class AhtolaDataReader : DbDataReader, IConnectionOwnedReader
         || (_managedStatement is null && (_nativeStatement?.IsInvalid ?? true));
 
     public override bool NextResult()
-        => _command.RunOperation(NextResultCore);
+    {
+        ThrowIfSynchronousBrowserOperation();
+        return _command.RunOperation(NextResultCore);
+    }
 
     private bool NextResultCore(CancellationToken cancellationToken)
     {
@@ -439,7 +442,10 @@ public class AhtolaDataReader : DbDataReader, IConnectionOwnedReader
     void IConnectionOwnedReader.CloseFromConnection() => CloseCore(closeConnection: false);
 
     public override bool Read()
-        => _command.RunOperation(ReadCore);
+    {
+        ThrowIfSynchronousBrowserOperation();
+        return _command.RunOperation(ReadCore);
+    }
 
     private bool ReadCore(CancellationToken cancellationToken)
     {
@@ -689,6 +695,7 @@ public class AhtolaDataReader : DbDataReader, IConnectionOwnedReader
         {
             result = statement.Read();
         }
+
         catch (AhtolaException) when (cancellationToken.IsCancellationRequested)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -696,6 +703,16 @@ public class AhtolaDataReader : DbDataReader, IConnectionOwnedReader
         }
         cancellationToken.ThrowIfCancellationRequested();
         return result;
+    }
+
+    private void ThrowIfSynchronousBrowserOperation()
+    {
+        if (_command.RequiresAsyncExecution)
+        {
+            throw new PlatformNotSupportedException(
+                "Synchronous reader iteration is not supported by the browser database source. "
+                + "Use ReadAsync or NextResultAsync.");
+        }
     }
 
     private void ValidateOrdinal(int ordinal)

--- a/src/Ahtola.Data/AhtolaDataReader.cs
+++ b/src/Ahtola.Data/AhtolaDataReader.cs
@@ -421,6 +421,12 @@ public class AhtolaDataReader : DbDataReader, IConnectionOwnedReader
 
     protected override void Dispose(bool disposing)
     {
+        if (disposing && !_isClosed && _command.RequiresAsyncExecution)
+        {
+            throw new PlatformNotSupportedException(
+                "Synchronous reader disposal is not supported by the browser database source. Use DisposeAsync.");
+        }
+
         if (disposing)
             CloseCore(closeConnection: true);
 
@@ -429,7 +435,7 @@ public class AhtolaDataReader : DbDataReader, IConnectionOwnedReader
 
     public override async ValueTask DisposeAsync()
     {
-        if (_managedStatement is null)
+        if (!_command.RequiresAsyncExecution && _managedStatement is null)
         {
             await base.DisposeAsync().ConfigureAwait(false);
             return;
@@ -439,7 +445,28 @@ public class AhtolaDataReader : DbDataReader, IConnectionOwnedReader
         await base.DisposeAsync().ConfigureAwait(false);
     }
 
+    public override async Task CloseAsync()
+    {
+        if (_managedStatement is null)
+        {
+            CloseCore(closeConnection: true);
+            return;
+        }
+
+        await CloseCoreAsync(closeConnection: true).ConfigureAwait(false);
+    }
+
+    public override void Close()
+    {
+        if (!_isClosed)
+            ThrowIfSynchronousBrowserOperation();
+        CloseCore(closeConnection: true);
+    }
+
     void IConnectionOwnedReader.CloseFromConnection() => CloseCore(closeConnection: false);
+
+    ValueTask IConnectionOwnedReader.CloseFromConnectionAsync()
+        => CloseCoreAsync(closeConnection: false);
 
     public override bool Read()
     {
@@ -791,7 +818,7 @@ public class AhtolaDataReader : DbDataReader, IConnectionOwnedReader
             Interlocked.Exchange(ref _replicaOperation, null)?.Dispose();
             _closeCallback();
             if (closeConnection && (_behavior & CommandBehavior.CloseConnection) == CommandBehavior.CloseConnection)
-                _connection.Close();
+                await _connection.CloseAsync().ConfigureAwait(false);
         }
     }
 

--- a/src/Ahtola.Data/AhtolaDataReader.cs
+++ b/src/Ahtola.Data/AhtolaDataReader.cs
@@ -391,7 +391,29 @@ public class AhtolaDataReader : DbDataReader, IConnectionOwnedReader
 
     public override Task<bool> NextResultAsync(CancellationToken cancellationToken)
     {
-        return _command.RunOperationAsync(NextResultCore, cancellationToken);
+        return _managedStatement is null
+            ? _command.RunOperationAsync(NextResultCore, cancellationToken)
+            : _command.RunOperationAsync(NextResultCoreAsync, cancellationToken);
+    }
+
+    private async ValueTask<bool> NextResultCoreAsync(CancellationToken cancellationToken)
+    {
+        EnsureOpen();
+        try
+        {
+            while (await StepAsync(cancellationToken).ConfigureAwait(false))
+            {
+            }
+
+            _hasCurrentRow = false;
+            NotifyCompletion();
+            return false;
+        }
+        catch
+        {
+            NotifyFailure();
+            throw;
+        }
     }
 
     protected override void Dispose(bool disposing)
@@ -400,6 +422,18 @@ public class AhtolaDataReader : DbDataReader, IConnectionOwnedReader
             CloseCore(closeConnection: true);
 
         base.Dispose(disposing);
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        if (_managedStatement is null)
+        {
+            await base.DisposeAsync().ConfigureAwait(false);
+            return;
+        }
+
+        await CloseCoreAsync(closeConnection: true).ConfigureAwait(false);
+        await base.DisposeAsync().ConfigureAwait(false);
     }
 
     void IConnectionOwnedReader.CloseFromConnection() => CloseCore(closeConnection: false);
@@ -426,7 +460,26 @@ public class AhtolaDataReader : DbDataReader, IConnectionOwnedReader
 
     public override Task<bool> ReadAsync(CancellationToken cancellationToken)
     {
-        return _command.RunOperationAsync(ReadCore, cancellationToken);
+        return _managedStatement is null
+            ? _command.RunOperationAsync(ReadCore, cancellationToken)
+            : _command.RunOperationAsync(ReadCoreAsync, cancellationToken);
+    }
+
+    private async ValueTask<bool> ReadCoreAsync(CancellationToken cancellationToken)
+    {
+        EnsureOpen();
+        try
+        {
+            _hasCurrentRow = await StepAsync(cancellationToken).ConfigureAwait(false);
+            if (!_hasCurrentRow)
+                NotifyCompletion();
+            return _hasCurrentRow;
+        }
+        catch
+        {
+            NotifyFailure();
+            throw;
+        }
     }
 
     public override Task<bool> IsDBNullAsync(int ordinal, CancellationToken cancellationToken)
@@ -594,11 +647,29 @@ public class AhtolaDataReader : DbDataReader, IConnectionOwnedReader
             ? ReadNative(cancellationToken)
             : ExecuteManaged(statement => statement.Step(cancellationToken) == StatementStepResult.Row);
 
+    private ValueTask<bool> StepAsync(CancellationToken cancellationToken)
+        => ExecuteManagedAsync(
+            async statement =>
+                await statement.StepAsync(cancellationToken).ConfigureAwait(false) == StatementStepResult.Row);
+
     private T ExecuteManaged<T>(Func<IManagedStatementAdapter, T> operation)
     {
         try
         {
             return operation(_managedStatement!);
+        }
+        catch (EmbeddedSqlException exception)
+        {
+            throw AhtolaException.FromCore(exception);
+        }
+    }
+
+    private async ValueTask<T> ExecuteManagedAsync<T>(
+        Func<IManagedStatementAdapter, ValueTask<T>> operation)
+    {
+        try
+        {
+            return await operation(_managedStatement!).ConfigureAwait(false);
         }
         catch (EmbeddedSqlException exception)
         {
@@ -671,6 +742,29 @@ public class AhtolaDataReader : DbDataReader, IConnectionOwnedReader
             NotifyFailure();
             _nativeStatement?.Dispose();
             _managedStatement?.Dispose();
+        }
+        finally
+        {
+            _hasCurrentRow = false;
+            _isClosed = true;
+            ((ILocalReaderConnection)_connection).ReaderClosed(this);
+            Interlocked.Exchange(ref _replicaOperation, null)?.Dispose();
+            _closeCallback();
+            if (closeConnection && (_behavior & CommandBehavior.CloseConnection) == CommandBehavior.CloseConnection)
+                _connection.Close();
+        }
+    }
+
+    private async ValueTask CloseCoreAsync(bool closeConnection)
+    {
+        if (_isClosed)
+            return;
+
+        _command.Cancel();
+        try
+        {
+            NotifyFailure();
+            await _managedStatement!.DisposeAsync().ConfigureAwait(false);
         }
         finally
         {

--- a/src/Ahtola.Data/AhtolaSchemaCollections.cs
+++ b/src/Ahtola.Data/AhtolaSchemaCollections.cs
@@ -777,7 +777,7 @@ internal static class AhtolaSchemaCollections
     {
         var columns = new Dictionary<string, ReaderSchemaColumn>(StringComparer.OrdinalIgnoreCase);
         using (var statement = connection.Prepare(
-                   $"PRAGMA table_info({QuoteIdentifier(tableName)});"))
+                   BuildManagedPragma(tableName, "table_info")))
         {
             while (statement.Step() == StatementStepResult.Row)
             {
@@ -795,7 +795,7 @@ internal static class AhtolaSchemaCollections
             return columns;
 
         using var indexes = connection.Prepare(
-            $"PRAGMA index_list({QuoteIdentifier(tableName)});");
+            BuildManagedPragma(tableName, "index_list"));
         while (indexes.Step() == StatementStepResult.Row)
         {
             if (indexes.GetValue(2).AsInteger() == 0
@@ -806,7 +806,9 @@ internal static class AhtolaSchemaCollections
 
             var indexName = indexes.GetValue(1).AsText();
             using var info = connection.Prepare(
-                $"PRAGMA index_info({QuoteIdentifier(indexName)});");
+                BuildManagedPragma(
+                    QualifyPragmaObject(tableName, indexName),
+                    "index_info"));
             string? indexedColumn = null;
             var indexedColumnCount = 0;
             while (info.Step() == StatementStepResult.Row)
@@ -827,6 +829,23 @@ internal static class AhtolaSchemaCollections
         }
 
         return columns;
+    }
+
+    private static string BuildManagedPragma(string objectName, string pragma)
+    {
+        var separator = objectName.IndexOf('.');
+        return separator < 0
+            ? $"PRAGMA {pragma}({QuoteIdentifier(objectName)});"
+            : $"PRAGMA {QuoteIdentifier(objectName[..separator])}.{pragma}"
+              + $"({QuoteIdentifier(objectName[(separator + 1)..])});";
+    }
+
+    private static string QualifyPragmaObject(string tableName, string objectName)
+    {
+        var separator = tableName.IndexOf('.');
+        return separator < 0
+            ? objectName
+            : tableName[..separator] + "." + objectName;
     }
 
     private static List<string> GetUniqueSingleColumnIndexNames(DbConnection connection, string tableName)

--- a/src/Ahtola.Data/AhtolaSchemaCollections.cs
+++ b/src/Ahtola.Data/AhtolaSchemaCollections.cs
@@ -729,8 +729,14 @@ internal static class AhtolaSchemaCollections
 
     private static Dictionary<string, ReaderSchemaColumn> GetTableColumns(DbConnection connection, string tableName)
     {
-        if (connection is IManagedSchemaConnection managed)
-            return GetManagedTableColumns(managed.ManagedSchemaConnection, tableName);
+        // Only dispatch to the managed fast path when the connection is actually backed by a
+        // managed adapter. AhtolaConnection/SqliteConnection implement IManagedSchemaConnection
+        // unconditionally (native local and remote connections included), so checking the
+        // interface alone would route those connections into ManagedSchemaConnection, which has
+        // no adapter to return. Falling through to the PRAGMA-based path below keeps native and
+        // remote connections on their normal provider-neutral schema lookup.
+        if (connection is IManagedSchemaConnection { ManagedSchemaConnection: { } managedConnection })
+            return GetManagedTableColumns(managedConnection, tableName);
 
         var columns = new Dictionary<string, ReaderSchemaColumn>(StringComparer.OrdinalIgnoreCase);
         using (var command = connection.CreateCommand())

--- a/src/Ahtola.Data/AhtolaSchemaCollections.cs
+++ b/src/Ahtola.Data/AhtolaSchemaCollections.cs
@@ -3,6 +3,7 @@ using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.RegularExpressions;
+using Ahtola.Core;
 
 namespace Ahtola;
 
@@ -728,6 +729,9 @@ internal static class AhtolaSchemaCollections
 
     private static Dictionary<string, ReaderSchemaColumn> GetTableColumns(DbConnection connection, string tableName)
     {
+        if (connection is IManagedSchemaConnection managed)
+            return GetManagedTableColumns(managed.ManagedSchemaConnection, tableName);
+
         var columns = new Dictionary<string, ReaderSchemaColumn>(StringComparer.OrdinalIgnoreCase);
         using (var command = connection.CreateCommand())
         {
@@ -762,6 +766,64 @@ internal static class AhtolaSchemaCollections
 
             if (indexedColumns.Count == 1 && columns.TryGetValue(indexedColumns[0], out var column))
                 columns[indexedColumns[0]] = column with { IsUnique = true };
+        }
+
+        return columns;
+    }
+
+    private static Dictionary<string, ReaderSchemaColumn> GetManagedTableColumns(
+        IManagedConnectionAdapter connection,
+        string tableName)
+    {
+        var columns = new Dictionary<string, ReaderSchemaColumn>(StringComparer.OrdinalIgnoreCase);
+        using (var statement = connection.Prepare(
+                   $"PRAGMA table_info({QuoteIdentifier(tableName)});"))
+        {
+            while (statement.Step() == StatementStepResult.Row)
+            {
+                var name = statement.GetValue(1).AsText();
+                columns[name] = new ReaderSchemaColumn(
+                    name,
+                    statement.GetValue(2).AsText(),
+                    statement.GetValue(3).AsInteger() == 0,
+                    statement.GetValue(5).AsInteger() != 0,
+                    false);
+            }
+        }
+
+        if (columns.Count == 0)
+            return columns;
+
+        using var indexes = connection.Prepare(
+            $"PRAGMA index_list({QuoteIdentifier(tableName)});");
+        while (indexes.Step() == StatementStepResult.Row)
+        {
+            if (indexes.GetValue(2).AsInteger() == 0
+                || indexes.GetValue(4).AsInteger() != 0)
+            {
+                continue;
+            }
+
+            var indexName = indexes.GetValue(1).AsText();
+            using var info = connection.Prepare(
+                $"PRAGMA index_info({QuoteIdentifier(indexName)});");
+            string? indexedColumn = null;
+            var indexedColumnCount = 0;
+            while (info.Step() == StatementStepResult.Row)
+            {
+                if (info.GetValue(2).Kind != SqlValueKind.Null)
+                {
+                    indexedColumn = info.GetValue(2).AsText();
+                    indexedColumnCount++;
+                }
+            }
+
+            if (indexedColumnCount == 1
+                && indexedColumn is not null
+                && columns.TryGetValue(indexedColumn, out var column))
+            {
+                columns[indexedColumn] = column with { IsUnique = true };
+            }
         }
 
         return columns;

--- a/src/Ahtola.Data/AhtolaTransaction.cs
+++ b/src/Ahtola.Data/AhtolaTransaction.cs
@@ -28,6 +28,12 @@ public class AhtolaTransaction : DbTransaction
         _isolationLevel = NormalizeIsolationLevel(isolationLevel);
         _supportsSavepoints = connection.Capabilities.SupportsSavepoints;
         _isRemote = connection.IsRemote;
+        if (beginTransaction && connection.RequiresAsyncExecution)
+        {
+            throw new PlatformNotSupportedException(
+                "Synchronous transaction creation is not supported by the browser database source. "
+                + "Use BeginTransactionAsync.");
+        }
 
         if (_isolationLevel == IsolationLevel.ReadUncommitted)
             connection.ReadUncommitted = true;
@@ -88,6 +94,13 @@ public class AhtolaTransaction : DbTransaction
 
     protected override void Dispose(bool disposing)
     {
+        if (disposing && !_completed && _connection?.RequiresAsyncExecution == true)
+        {
+            throw new PlatformNotSupportedException(
+                "Synchronous transaction disposal is not supported by the browser database source. "
+                + "Use DisposeAsync or RollbackAsync.");
+        }
+
         if (!_completed)
         {
             if (_rootFailure is not null || _connection is null || _connection.State == System.Data.ConnectionState.Closed)
@@ -106,6 +119,31 @@ public class AhtolaTransaction : DbTransaction
         }
 
         base.Dispose(disposing);
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        if (_connection?.RequiresAsyncExecution != true)
+        {
+            await base.DisposeAsync().ConfigureAwait(false);
+            return;
+        }
+
+        if (!_completed)
+        {
+            if (_rootFailure is not null
+                || _connection is null
+                || _connection.State == System.Data.ConnectionState.Closed)
+            {
+                CompleteTransaction();
+            }
+            else
+            {
+                await RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+            }
+        }
+
+        await base.DisposeAsync().ConfigureAwait(false);
     }
 
     public override IsolationLevel IsolationLevel => _isolationLevel;
@@ -135,6 +173,7 @@ public class AhtolaTransaction : DbTransaction
 
     public override void Commit()
     {
+        ThrowIfSynchronousBrowserOperation("CommitAsync");
         ThrowIfCompleted();
         ThrowRootFailureIfPresent();
         var connection = GetConnection();
@@ -169,6 +208,7 @@ public class AhtolaTransaction : DbTransaction
 
     public override void Rollback()
     {
+        ThrowIfSynchronousBrowserOperation("RollbackAsync");
         ThrowIfCompleted();
         ThrowRootFailureIfPresent();
         var connection = GetConnection();
@@ -263,6 +303,7 @@ public class AhtolaTransaction : DbTransaction
 
     public override void Save(string savepointName)
     {
+        ThrowIfSynchronousBrowserOperation("SaveAsync");
         ArgumentNullException.ThrowIfNull(savepointName);
         ThrowIfCompleted();
         ThrowRootFailureIfPresent(completeTransaction: false);
@@ -281,6 +322,7 @@ public class AhtolaTransaction : DbTransaction
 
     public override void Rollback(string savepointName)
     {
+        ThrowIfSynchronousBrowserOperation("RollbackAsync");
         ArgumentNullException.ThrowIfNull(savepointName);
         ThrowIfCompleted();
         ThrowRootFailureIfPresent(completeTransaction: false);
@@ -299,6 +341,7 @@ public class AhtolaTransaction : DbTransaction
 
     public override void Release(string savepointName)
     {
+        ThrowIfSynchronousBrowserOperation("ReleaseAsync");
         ArgumentNullException.ThrowIfNull(savepointName);
         ThrowIfCompleted();
         ThrowRootFailureIfPresent(completeTransaction: false);
@@ -347,6 +390,16 @@ public class AhtolaTransaction : DbTransaction
 
     private AhtolaConnection GetConnection()
         => _connection ?? throw new InvalidOperationException("This transaction has already completed.");
+
+    private void ThrowIfSynchronousBrowserOperation(string asyncAlternative)
+    {
+        if (_connection?.RequiresAsyncExecution == true)
+        {
+            throw new PlatformNotSupportedException(
+                "Synchronous transaction operations are not supported by the browser database source. "
+                + $"Use {asyncAlternative}.");
+        }
+    }
 
     private async Task ExecuteNonQueryAsync(string sql, CancellationToken cancellationToken)
     {

--- a/src/Ahtola.Data/CommandCancellationController.cs
+++ b/src/Ahtola.Data/CommandCancellationController.cs
@@ -41,6 +41,17 @@ internal sealed class CommandCancellationController
         return RunTaskAsync(operation, cancellationToken);
     }
 
+    public Task<T> RunAsync<T>(
+        Func<CancellationToken, ValueTask<T>> operation,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        if (cancellationToken.IsCancellationRequested)
+            return Task.FromCanceled<T>(cancellationToken);
+
+        return RunValueTaskAsync(operation, cancellationToken);
+    }
+
     private async Task<T> RunTaskAsync<T>(
         Func<CancellationToken, Task<T>> operation,
         CancellationToken cancellationToken)
@@ -48,6 +59,23 @@ internal sealed class CommandCancellationController
         using var lease = Begin(cancellationToken);
         lease.Token.ThrowIfCancellationRequested();
         return await operation(lease.Token).ConfigureAwait(false);
+    }
+
+    private async Task<T> RunValueTaskAsync<T>(
+        Func<CancellationToken, ValueTask<T>> operation,
+        CancellationToken cancellationToken)
+    {
+        using var lease = Begin(cancellationToken);
+        lease.Token.ThrowIfCancellationRequested();
+        try
+        {
+            return await operation(lease.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            throw;
+        }
     }
 
     private async Task<T> RunSyncAsync<T>(

--- a/src/Ahtola.Data/IManagedSchemaConnection.cs
+++ b/src/Ahtola.Data/IManagedSchemaConnection.cs
@@ -4,5 +4,10 @@ namespace Ahtola;
 
 internal interface IManagedSchemaConnection
 {
-    IManagedConnectionAdapter ManagedSchemaConnection { get; }
+    /// <summary>
+    /// The managed connection adapter backing this connection, or <c>null</c> when the
+    /// connection is not actually backed by the managed engine (native local or remote
+    /// connections implement this interface too, but have no managed adapter to dispatch to).
+    /// </summary>
+    IManagedConnectionAdapter? ManagedSchemaConnection { get; }
 }

--- a/src/Ahtola.Data/IManagedSchemaConnection.cs
+++ b/src/Ahtola.Data/IManagedSchemaConnection.cs
@@ -1,0 +1,8 @@
+using Ahtola.Core;
+
+namespace Ahtola;
+
+internal interface IManagedSchemaConnection
+{
+    IManagedConnectionAdapter ManagedSchemaConnection { get; }
+}

--- a/src/Ahtola.Data/Properties/AssemblyInfo.cs
+++ b/src/Ahtola.Data/Properties/AssemblyInfo.cs
@@ -3,3 +3,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Devolutions.Ahtola.Data.Sqlite")]
 [assembly: InternalsVisibleTo("Devolutions.Ahtola.EntityFrameworkCore.Sqlite")]
 [assembly: InternalsVisibleTo("Ahtola.Tests")]
+[assembly: InternalsVisibleTo("Devolutions.Ahtola.Data.Sqlite.Browser")]

--- a/src/Ahtola.Data/SequentialBatchExecutor.cs
+++ b/src/Ahtola.Data/SequentialBatchExecutor.cs
@@ -7,6 +7,12 @@ namespace Ahtola;
 internal interface IConnectionOwnedReader
 {
     void CloseFromConnection();
+
+    ValueTask CloseFromConnectionAsync()
+    {
+        CloseFromConnection();
+        return ValueTask.CompletedTask;
+    }
 }
 
 internal interface ILocalReaderConnection
@@ -14,6 +20,11 @@ internal interface ILocalReaderConnection
     void ReaderOpened(IConnectionOwnedReader reader);
 
     void ReaderClosed(IConnectionOwnedReader reader);
+}
+
+internal interface IAsyncExecutionConnection
+{
+    bool RequiresAsyncExecution { get; }
 }
 
 internal sealed class BatchExecutionControl : IDisposable
@@ -82,7 +93,7 @@ internal sealed class BatchExecutionControl : IDisposable
     }
 }
 
-internal sealed class SequentialBatchCommand : IDisposable
+internal sealed class SequentialBatchCommand : IDisposable, IAsyncDisposable
 {
     private readonly Action<int> _setRecordsAffected;
     private readonly Func<DbTransaction?> _getTransaction;
@@ -123,6 +134,15 @@ internal sealed class SequentialBatchCommand : IDisposable
 
         _disposed = true;
         Command.Dispose();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        await Command.DisposeAsync().ConfigureAwait(false);
     }
 }
 
@@ -165,6 +185,7 @@ internal static class SequentialBatchExecutor
         BatchExecutionControl execution)
     {
         var total = 0;
+        Exception? failure = null;
         try
         {
             foreach (var entry in commands)
@@ -185,13 +206,16 @@ internal static class SequentialBatchExecutor
                     execution.ClearActiveCommand(entry.Command);
                 }
             }
-
-            return total;
         }
-        finally
+        catch (Exception exception)
         {
-            DisposeCommandsAndExecution(commands, execution);
+            failure = exception;
         }
+
+        failure = await DisposeCommandsAndExecutionAsync(commands, execution, failure)
+            .ConfigureAwait(false);
+        ThrowIfFailure(failure);
+        return total;
     }
 
     internal static DbDataReader ExecuteReader(
@@ -236,19 +260,33 @@ internal static class SequentialBatchExecutor
             reader = await first.Command
                 .ExecuteReaderAsync(WithoutCloseConnection(behavior), execution.Token)
                 .ConfigureAwait(false);
-            return new SequentialBatchDataReader(commands, execution, reader, behavior);
+            var ownedReader = reader;
+            reader = null;
+            return await SequentialBatchDataReader
+                .CreateAsync(commands, execution, ownedReader, behavior)
+                .ConfigureAwait(false);
         }
-        catch
+        catch (Exception operationFailure)
         {
-            try
+            Exception? failure = operationFailure;
+            if (reader is not null)
             {
-                if (reader is not null)
+                try
+                {
                     await reader.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (Exception cleanupFailure)
+                {
+                    failure = CombineFailure(
+                        "Batch execution and reader cleanup both failed.",
+                        failure,
+                        cleanupFailure);
+                }
             }
-            finally
-            {
-                DisposeCommandsAndExecution(commands, execution);
-            }
+
+            failure = await DisposeCommandsAndExecutionAsync(commands, execution, failure)
+                .ConfigureAwait(false);
+            ThrowIfFailure(failure);
             throw;
         }
     }
@@ -283,6 +321,54 @@ internal static class SequentialBatchExecutor
             execution.Dispose();
         }
     }
+
+    private static async ValueTask<Exception?> DisposeCommandsAndExecutionAsync(
+        IReadOnlyList<SequentialBatchCommand> commands,
+        BatchExecutionControl execution,
+        Exception? failure)
+    {
+        foreach (var command in commands)
+        {
+            try
+            {
+                await command.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception cleanupFailure)
+            {
+                failure = CombineFailure(
+                    "Batch execution and command cleanup both failed.",
+                    failure,
+                    cleanupFailure);
+            }
+        }
+        try
+        {
+            execution.Dispose();
+        }
+        catch (Exception cleanupFailure)
+        {
+            failure = CombineFailure(
+                "Batch execution and execution-context cleanup both failed.",
+                failure,
+                cleanupFailure);
+        }
+
+        return failure;
+    }
+
+    internal static Exception CombineFailure(
+        string message,
+        Exception? existing,
+        Exception current)
+        => existing is null
+            ? current
+            : new AggregateException(message, existing, current);
+
+    internal static void ThrowIfFailure(Exception? failure)
+    {
+        if (failure is not null)
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(failure).Throw();
+    }
 }
 
 internal sealed class SequentialBatchDataReader : DbDataReader, IConnectionOwnedReader
@@ -302,16 +388,61 @@ internal sealed class SequentialBatchDataReader : DbDataReader, IConnectionOwned
         IReadOnlyList<SequentialBatchCommand> commands,
         BatchExecutionControl execution,
         DbDataReader reader,
-        CommandBehavior behavior)
+        CommandBehavior behavior,
+        bool completeInitialResult = true)
     {
         _commands = commands;
         _execution = execution;
         _reader = reader;
         _behavior = behavior;
         _connection = commands[0].Command.Connection;
-        CompleteCurrentWithoutResultSet();
+        if (completeInitialResult)
+            CompleteCurrentWithoutResultSet();
         _readerConnection = _connection as ILocalReaderConnection;
         _readerConnection?.ReaderOpened(this);
+    }
+
+    internal static async ValueTask<SequentialBatchDataReader> CreateAsync(
+        IReadOnlyList<SequentialBatchCommand> commands,
+        BatchExecutionControl execution,
+        DbDataReader reader,
+        CommandBehavior behavior)
+    {
+        SequentialBatchDataReader? result = null;
+        try
+        {
+            result = new SequentialBatchDataReader(
+                commands,
+                execution,
+                reader,
+                behavior,
+                completeInitialResult: false);
+            await result
+                .CompleteCurrentWithoutResultSetAsync(execution.Token)
+                .ConfigureAwait(false);
+            return result;
+        }
+        catch (Exception operationFailure)
+        {
+            Exception? failure = operationFailure;
+            try
+            {
+                if (result is null)
+                    await reader.DisposeAsync().ConfigureAwait(false);
+                else
+                    await result.CloseCoreAsync(drain: false, closeConnection: false).ConfigureAwait(false);
+            }
+            catch (Exception cleanupFailure)
+            {
+                failure = SequentialBatchExecutor.CombineFailure(
+                    "Batch initialization and cleanup both failed.",
+                    failure,
+                    cleanupFailure);
+            }
+
+            SequentialBatchExecutor.ThrowIfFailure(failure);
+            throw;
+        }
     }
 
     public override int Depth => _finished ? 0 : Current.Depth;
@@ -463,11 +594,13 @@ internal sealed class SequentialBatchDataReader : DbDataReader, IConnectionOwned
             CompleteCurrent();
             if (_commandIndex + 1 == _commands.Count)
             {
-                Finish();
+                await FinishAsync().ConfigureAwait(false);
                 return false;
             }
 
-            DisposeCurrent();
+            var cleanupFailure = await DisposeCurrentAsync(closeFromConnection: false)
+                .ConfigureAwait(false);
+            SequentialBatchExecutor.ThrowIfFailure(cleanupFailure);
             _commandIndex++;
             var next = _commands[_commandIndex];
             next.PrepareForExecution();
@@ -476,12 +609,25 @@ internal sealed class SequentialBatchDataReader : DbDataReader, IConnectionOwned
             _reader = await next.Command
                 .ExecuteReaderAsync(WithoutCloseConnection(_behavior), transitionToken)
                 .ConfigureAwait(false);
-            CompleteCurrentWithoutResultSet();
+            await CompleteCurrentWithoutResultSetAsync(transitionToken).ConfigureAwait(false);
             return true;
         }
-        catch
+        catch (Exception operationFailure)
         {
-            CloseCore(drain: false);
+            Exception? failure = operationFailure;
+            try
+            {
+                await CloseCoreAsync(drain: false).ConfigureAwait(false);
+            }
+            catch (Exception cleanupFailure)
+            {
+                failure = SequentialBatchExecutor.CombineFailure(
+                    "Batch result transition and cleanup both failed.",
+                    failure,
+                    cleanupFailure);
+            }
+
+            SequentialBatchExecutor.ThrowIfFailure(failure);
             throw;
         }
     }
@@ -500,16 +646,35 @@ internal sealed class SequentialBatchDataReader : DbDataReader, IConnectionOwned
         return Current.GetFieldValueAsync<T>(ordinal, cancellationToken);
     }
 
-    public override void Close() => CloseCore(drain: true);
+    public override void Close()
+    {
+        if (!_isClosed)
+            ThrowIfSynchronousBrowserOperation();
+        CloseCore(drain: true);
+    }
+
+    public override async Task CloseAsync()
+        => await CloseCoreAsync(drain: true).ConfigureAwait(false);
 
     void IConnectionOwnedReader.CloseFromConnection() => CloseCore(drain: false, closeConnection: false);
 
+    ValueTask IConnectionOwnedReader.CloseFromConnectionAsync()
+        => CloseCoreAsync(drain: false, closeConnection: false);
+
     protected override void Dispose(bool disposing)
     {
+        if (disposing && !_isClosed)
+            ThrowIfSynchronousBrowserOperation();
         if (disposing)
             CloseCore(drain: true);
 
         base.Dispose(disposing);
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        await CloseCoreAsync(drain: true).ConfigureAwait(false);
+        await base.DisposeAsync().ConfigureAwait(false);
     }
 
     private DbDataReader Current
@@ -535,6 +700,19 @@ internal sealed class SequentialBatchDataReader : DbDataReader, IConnectionOwned
         CompleteCurrent();
     }
 
+    private async ValueTask CompleteCurrentWithoutResultSetAsync(
+        CancellationToken cancellationToken)
+    {
+        if (Current.FieldCount != 0)
+            return;
+
+        while (await Current.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+        }
+
+        CompleteCurrent();
+    }
+
     private void CompleteCurrent()
     {
         if (CurrentCommand.IsCompleted)
@@ -552,6 +730,25 @@ internal sealed class SequentialBatchDataReader : DbDataReader, IConnectionOwned
         _execution.Dispose();
     }
 
+    private async ValueTask FinishAsync()
+    {
+        var failure = await DisposeCurrentAsync(closeFromConnection: false)
+            .ConfigureAwait(false);
+        _finished = true;
+        try
+        {
+            _execution.Dispose();
+        }
+        catch (Exception cleanupFailure)
+        {
+            failure = SequentialBatchExecutor.CombineFailure(
+                "Batch reader and execution-context cleanup both failed.",
+                failure,
+                cleanupFailure);
+        }
+        SequentialBatchExecutor.ThrowIfFailure(failure);
+    }
+
     private void DisposeCurrent()
     {
         var reader = _reader;
@@ -566,6 +763,49 @@ internal sealed class SequentialBatchDataReader : DbDataReader, IConnectionOwned
             _execution.ClearActiveCommand(command.Command);
             command.Dispose();
         }
+    }
+
+    private async ValueTask<Exception?> DisposeCurrentAsync(
+        bool closeFromConnection,
+        Exception? failure = null)
+    {
+        var reader = _reader;
+        _reader = null;
+        try
+        {
+            if (reader is not null)
+            {
+                if (closeFromConnection && reader is IConnectionOwnedReader ownedReader)
+                    await ownedReader.CloseFromConnectionAsync().ConfigureAwait(false);
+                else
+                    await reader.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+        catch (Exception cleanupFailure)
+        {
+            failure = SequentialBatchExecutor.CombineFailure(
+                "Batch reader cleanup failed.",
+                failure,
+                cleanupFailure);
+        }
+        finally
+        {
+            var command = CurrentCommand;
+            _execution.ClearActiveCommand(command.Command);
+            try
+            {
+                await command.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception cleanupFailure)
+            {
+                failure = SequentialBatchExecutor.CombineFailure(
+                    "Batch reader and command cleanup both failed.",
+                    failure,
+                    cleanupFailure);
+            }
+        }
+
+        return failure;
     }
 
     private void CloseCore(bool drain, bool closeConnection = true)
@@ -608,10 +848,106 @@ internal sealed class SequentialBatchDataReader : DbDataReader, IConnectionOwned
         }
     }
 
+    private async ValueTask CloseCoreAsync(bool drain, bool closeConnection = true)
+    {
+        if (_isClosed)
+            return;
+
+        Exception? failure = null;
+        try
+        {
+            if (drain
+                && !_finished
+                && !_execution.Token.IsCancellationRequested
+                && !IsClosed)
+            {
+                while (await NextResultAsync(CancellationToken.None).ConfigureAwait(false))
+                {
+                }
+            }
+        }
+        catch (Exception operationFailure)
+        {
+            failure = operationFailure;
+        }
+
+        failure = await DisposeCurrentAsync(
+                closeFromConnection: !drain,
+                failure)
+            .ConfigureAwait(false);
+        for (var i = _commandIndex + 1; i < _commands.Count; i++)
+        {
+            try
+            {
+                await _commands[i].DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception cleanupFailure)
+            {
+                failure = SequentialBatchExecutor.CombineFailure(
+                    "Batch reader and command cleanup both failed.",
+                    failure,
+                    cleanupFailure);
+            }
+        }
+
+        _finished = true;
+        _isClosed = true;
+        try
+        {
+            _readerConnection?.ReaderClosed(this);
+        }
+        catch (Exception cleanupFailure)
+        {
+            failure = SequentialBatchExecutor.CombineFailure(
+                "Batch reader cleanup and connection notification both failed.",
+                failure,
+                cleanupFailure);
+        }
+        try
+        {
+            _execution.Dispose();
+        }
+        catch (Exception cleanupFailure)
+        {
+            failure = SequentialBatchExecutor.CombineFailure(
+                "Batch reader and execution-context cleanup both failed.",
+                failure,
+                cleanupFailure);
+        }
+        if (closeConnection
+            && (_behavior & CommandBehavior.CloseConnection) == CommandBehavior.CloseConnection
+            && _connection is not null)
+        {
+            try
+            {
+                await _connection.CloseAsync().ConfigureAwait(false);
+            }
+            catch (Exception cleanupFailure)
+            {
+                failure = SequentialBatchExecutor.CombineFailure(
+                    "Batch reader cleanup and connection close both failed.",
+                    failure,
+                    cleanupFailure);
+            }
+        }
+
+        SequentialBatchExecutor.ThrowIfFailure(failure);
+    }
+
     private void EnsureOpen()
     {
         if (IsClosed)
             throw new InvalidOperationException("The batch data reader is closed.");
+    }
+
+    private void ThrowIfSynchronousBrowserOperation()
+    {
+        if (_connection is IAsyncExecutionConnection { RequiresAsyncExecution: true })
+        {
+            throw new PlatformNotSupportedException(
+                "Synchronous batch reader operations are not supported by the browser database source. "
+                + "Use the corresponding asynchronous API.");
+        }
     }
 
     private static CommandBehavior WithoutCloseConnection(CommandBehavior behavior)

--- a/src/Ahtola.Tests/Ahtola.Tests.csproj
+++ b/src/Ahtola.Tests/Ahtola.Tests.csproj
@@ -36,6 +36,7 @@
     <ItemGroup>
         <ProjectReference Include="..\Ahtola.Data\Ahtola.Data.csproj" />
         <ProjectReference Include="..\Ahtola.Data.Sqlite\Ahtola.Data.Sqlite.csproj" />
+        <ProjectReference Include="..\Ahtola.Data.Sqlite.Browser\Ahtola.Data.Sqlite.Browser.csproj" />
         <ProjectReference Include="..\Ahtola.EntityFrameworkCore.Sqlite\Ahtola.EntityFrameworkCore.Sqlite.csproj" />
                 <ProjectReference Include="..\Devolutions.Ahtola.PowerShell\Devolutions.Ahtola.PowerShell.csproj" />
                 <ProjectReference Include="..\Ahtola.Core\Ahtola.Core.csproj" />

--- a/src/Ahtola.Tests/AhtolaBrowserCapabilitiesTests.cs
+++ b/src/Ahtola.Tests/AhtolaBrowserCapabilitiesTests.cs
@@ -1,0 +1,79 @@
+using AwesomeAssertions;
+using Ahtola.Data.Sqlite.Browser;
+
+namespace Ahtola.Tests;
+
+public sealed class AhtolaBrowserCapabilitiesTests
+{
+    [Test]
+    public void IsSupportedIsTrueOnlyWhenEveryCapabilityIsPresent()
+    {
+        var capabilities = new AhtolaBrowserCapabilities(
+            IsCrossOriginIsolated: true,
+            HasSharedArrayBuffer: true,
+            HasOriginPrivateFileSystem: true,
+            HasSynchronousAccessHandles: true,
+            HasWebLocks: true);
+
+        capabilities.IsSupported.Should().BeTrue();
+        capabilities.MissingCapabilities.Should().BeEmpty();
+    }
+
+    [Test]
+    public void IsSupportedIsFalseWhenOnlySynchronousAccessHandleCreationFails()
+    {
+        // Mirrors exactly what the real probe reports when
+        // createSyncAccessHandle fails (or the prerequisite checks pass but
+        // the browser still cannot actually create one): every other signal
+        // stays true, only this one flips to false.
+        var capabilities = new AhtolaBrowserCapabilities(
+            IsCrossOriginIsolated: true,
+            HasSharedArrayBuffer: true,
+            HasOriginPrivateFileSystem: true,
+            HasSynchronousAccessHandles: false,
+            HasWebLocks: true);
+
+        capabilities.IsSupported.Should().BeFalse();
+        capabilities.MissingCapabilities.Should().Equal(
+            "Origin Private File System synchronous access handles");
+    }
+
+    [Test]
+    public void MissingCapabilitiesListsEveryUnavailableFeatureInOrder()
+    {
+        var capabilities = new AhtolaBrowserCapabilities(
+            IsCrossOriginIsolated: false,
+            HasSharedArrayBuffer: false,
+            HasOriginPrivateFileSystem: false,
+            HasSynchronousAccessHandles: false,
+            HasWebLocks: false);
+
+        capabilities.IsSupported.Should().BeFalse();
+        capabilities.MissingCapabilities.Should().Equal(
+            "cross-origin isolation",
+            "SharedArrayBuffer",
+            "Origin Private File System",
+            "Origin Private File System synchronous access handles",
+            "Web Locks");
+    }
+
+    [Test]
+    public void MissingCapabilitiesReportsOnlyOriginPrivateFileSystemWhenOpfsItselfIsAbsent()
+    {
+        // This is the exact, structured signature the WebKit smoke-check
+        // script (scripts/Invoke-BrowserSmokeCheck.ps1) treats as the known,
+        // permanent Playwright-WebKit test-engine gap: OPFS itself is
+        // unavailable, which also makes the synchronous-handle probe
+        // unreachable, while every other capability is present.
+        var capabilities = new AhtolaBrowserCapabilities(
+            IsCrossOriginIsolated: true,
+            HasSharedArrayBuffer: true,
+            HasOriginPrivateFileSystem: false,
+            HasSynchronousAccessHandles: false,
+            HasWebLocks: true);
+
+        capabilities.MissingCapabilities.Should().Equal(
+            "Origin Private File System",
+            "Origin Private File System synchronous access handles");
+    }
+}

--- a/src/Ahtola.Tests/AhtolaBrowserCryptoKnownAnswerTests.cs
+++ b/src/Ahtola.Tests/AhtolaBrowserCryptoKnownAnswerTests.cs
@@ -1,0 +1,83 @@
+using System.Security.Cryptography;
+using System.Text;
+using AwesomeAssertions;
+using Ahtola.Core.Storage;
+using Ahtola.Data.Sqlite.Browser;
+
+namespace Ahtola.Tests;
+
+public sealed class AhtolaBrowserCryptoKnownAnswerTests
+{
+    [Test]
+    public void PasswordV1ParametersProduceTheExpectedPbkdf2Sha256Key()
+    {
+        AhtolaBrowserCryptoParameters.PasswordSchemeId
+            .Should().Be(AhtolaPasswordEncryption.SchemeIdV1);
+        AhtolaBrowserCryptoParameters.PasswordSalt
+            .Should().Be(AhtolaPasswordEncryption.DomainSaltV1);
+        AhtolaBrowserCryptoParameters.PasswordIterations
+            .Should().Be(AhtolaPasswordEncryption.Pbkdf2IterationsV1);
+        AhtolaBrowserCryptoParameters.PasswordKeySize.Should().Be(32);
+
+        var password = Encoding.UTF8.GetBytes(AhtolaBrowserCryptoKnownAnswers.Password);
+        var salt = Encoding.UTF8.GetBytes(AhtolaBrowserCryptoParameters.PasswordSalt);
+        var expected = AhtolaBrowserCryptoKnownAnswers.GetPasswordKey();
+        var actual = Rfc2898DeriveBytes.Pbkdf2(
+            password,
+            salt,
+            AhtolaBrowserCryptoParameters.PasswordIterations,
+            HashAlgorithmName.SHA256,
+            AhtolaBrowserCryptoParameters.PasswordKeySize);
+        try
+        {
+            actual.Should().Equal(expected);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(password);
+            CryptographicOperations.ZeroMemory(salt);
+            CryptographicOperations.ZeroMemory(expected);
+            CryptographicOperations.ZeroMemory(actual);
+        }
+    }
+
+    [TestCase(AhtolaEncryptionCipher.Aes128Gcm)]
+    [TestCase(AhtolaEncryptionCipher.Aes256Gcm)]
+    public void AhtolaAesGcmParametersMatchKnownAnswerVectors(AhtolaEncryptionCipher cipher)
+    {
+        using var vector = cipher == AhtolaEncryptionCipher.Aes128Gcm
+            ? AhtolaBrowserCryptoKnownAnswers.GetAes128()
+            : AhtolaBrowserCryptoKnownAnswers.GetAes256();
+        var ciphertext = new byte[vector.Plaintext.Length];
+        var tag = new byte[AhtolaBrowserCryptoParameters.AesGcmTagSize];
+        var decrypted = new byte[vector.Plaintext.Length];
+        try
+        {
+            using var aes = new AesGcm(vector.Key, AhtolaBrowserCryptoParameters.AesGcmTagSize);
+            aes.Encrypt(
+                vector.Nonce,
+                vector.Plaintext,
+                ciphertext,
+                tag,
+                vector.AssociatedData);
+
+            ciphertext.Should().Equal(vector.Ciphertext);
+            tag.Should().Equal(vector.Tag);
+
+            aes.Decrypt(
+                vector.Nonce,
+                ciphertext,
+                tag,
+                decrypted,
+                vector.AssociatedData);
+            decrypted.Should().Equal(vector.Plaintext);
+            vector.Nonce.Should().HaveCount(AhtolaBrowserCryptoParameters.AesGcmNonceSize);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(ciphertext);
+            CryptographicOperations.ZeroMemory(tag);
+            CryptographicOperations.ZeroMemory(decrypted);
+        }
+    }
+}

--- a/src/Ahtola.Tests/AhtolaBrowserDataSourceTests.cs
+++ b/src/Ahtola.Tests/AhtolaBrowserDataSourceTests.cs
@@ -1,0 +1,113 @@
+using System.Data;
+using System.Data.Common;
+using AwesomeAssertions;
+using Ahtola.Data.Sqlite;
+using Ahtola.Data.Sqlite.Browser;
+
+#pragma warning disable CA1416
+
+namespace Ahtola.Tests;
+
+public sealed class AhtolaBrowserDataSourceTests
+{
+    [Test]
+    public void OptionsNormalizePathsAndBuildManagedConnectionString()
+    {
+        var options = new AhtolaBrowserOptions(
+            @"applications\inventory\data.db",
+            @"applications\inventory",
+            sharedBufferSize: 128 * 1024,
+            readOnly: true);
+
+        options.DatabasePath.Should().Be("applications/inventory/data.db");
+        options.OwnedDirectory.Should().Be("applications/inventory");
+        options.SharedBufferSize.Should().Be(128 * 1024);
+        options.IsReadOnly.Should().BeTrue();
+
+        var connectionOptions = new SqliteConnectionStringBuilder(options.ConnectionString);
+        connectionOptions.DataSource.Should().Be(options.DatabasePath);
+        connectionOptions.Mode.Should().Be(SqliteOpenMode.ReadOnly);
+        connectionOptions.LocalProvider.Should().Be(AhtolaLocalProvider.Managed);
+        connectionOptions.Pooling.Should().BeFalse();
+    }
+
+    [TestCase("data.db", "owned")]
+    [TestCase("other/data.db", "owned")]
+    [TestCase("owned/../data.db", "owned")]
+    [TestCase("/owned/data.db", "owned")]
+    [TestCase("owned/data.db", "owned/")]
+    public void OptionsRejectPathsOutsideNormalizedOwnedDirectory(
+        string databasePath,
+        string ownedDirectory)
+    {
+        var action = () => new AhtolaBrowserOptions(databasePath, ownedDirectory);
+
+        action.Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void OptionsRequireWorkerBufferMinimum()
+    {
+        var action = () => new AhtolaBrowserOptions(
+            "owned/data.db",
+            "owned",
+            sharedBufferSize: 64 * 1024 - 1);
+
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public void OptionsEnforceWorkerBufferMaximum()
+    {
+        var action = () => new AhtolaBrowserOptions(
+        "owned/data.db",
+        "owned",
+        sharedBufferSize: 64 * 1024 * 1024 + 1);
+
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task FactoryCreatesTypedClosedConnectionsAndGuardsSyncOpen()
+    {
+        await using var source = new AhtolaBrowserDataSource(
+            new AhtolaBrowserOptions("owned/data.db", "owned"));
+        await using var sqliteConnection = source.CreateConnection();
+        await using var ahtolaConnection = source.CreateAhtolaConnection();
+
+        sqliteConnection.Should().BeOfType<SqliteConnection>();
+        sqliteConnection.State.Should().Be(ConnectionState.Closed);
+        sqliteConnection.DataSource.Should().Be("owned/data.db");
+        sqliteConnection.ConnectionString.Should().Be(source.ConnectionString);
+        ahtolaConnection.State.Should().Be(ConnectionState.Closed);
+        ahtolaConnection.DataSource.Should().Be("owned/data.db");
+        ahtolaConnection.ConnectionString.Should().Be(source.ConnectionString);
+
+        source.Invoking(static value => value.OpenConnection())
+            .Should().Throw<PlatformNotSupportedException>();
+        sqliteConnection.Invoking(static value => value.Open())
+            .Should().Throw<PlatformNotSupportedException>();
+        ahtolaConnection.Invoking(static value => value.Open())
+            .Should().Throw<PlatformNotSupportedException>();
+
+        sqliteConnection.CreateCommand()
+            .Invoking(static command => command.ExecuteNonQuery())
+            .Should().Throw<PlatformNotSupportedException>();
+        ahtolaConnection.CreateCommand()
+            .Invoking(static command => command.ExecuteNonQuery())
+            .Should().Throw<PlatformNotSupportedException>();
+    }
+
+    [Test]
+    public async Task FactorySyncDisposalFailsClearly()
+    {
+        var source = new AhtolaBrowserDataSource("owned/data.db");
+
+        ((DbDataSource)source).Invoking(static value => value.Dispose())
+            .Should().Throw<PlatformNotSupportedException>();
+
+        await source.DisposeAsync();
+    }
+}
+
+#pragma warning restore CA1416

--- a/src/Ahtola.Tests/AhtolaBrowserEncryptedStorageHardeningTests.cs
+++ b/src/Ahtola.Tests/AhtolaBrowserEncryptedStorageHardeningTests.cs
@@ -358,6 +358,31 @@ public sealed class AhtolaBrowserEncryptedStorageHardeningTests
             store.Read(path).AsSpan().IndexOf(Encoding.UTF8.GetBytes(Secret)).Should().Be(-1);
     }
 
+    [Test]
+    public async Task RejectedMvccEnableDoesNotBlockReopeningTheDatabase()
+    {
+        var store = new FakeBrowserPersistentStore();
+        const string DatabasePath = "app/data/main.db";
+
+        await using (var harness = await BrowserHarness.CreateAsync(store, Aes256Key))
+        {
+            using var database = EmbeddedDatabase.OpenFile(DatabasePath, harness.Mirror);
+            using var connection = database.Connect();
+            Execute(connection, "CREATE TABLE notes(body TEXT);");
+            Execute(connection, $"INSERT INTO notes VALUES ('{Secret}');");
+            Record(() => Execute(connection, "PRAGMA journal_mode=mvcc;")).Should().NotBeNull();
+
+            // Disposing flushes the orphaned create the rejected attempt queued, so
+            // an empty '-log' can reach OPFS even though no MVCC data ever did.
+        }
+
+        // That stray file must not brick the database on the next open.
+        await using var reopened = await BrowserHarness.CreateAsync(store, Aes256Key);
+        using var reopenedDatabase = EmbeddedDatabase.OpenFile(DatabasePath, reopened.Mirror);
+        using var reopenedConnection = reopenedDatabase.Connect();
+        ScalarText(reopenedConnection, "SELECT body FROM notes;").Should().Be(Secret);
+    }
+
     private static Exception? Record(Action action)
     {
         try

--- a/src/Ahtola.Tests/AhtolaBrowserEncryptedStorageHardeningTests.cs
+++ b/src/Ahtola.Tests/AhtolaBrowserEncryptedStorageHardeningTests.cs
@@ -1,0 +1,493 @@
+using System.Text;
+using AwesomeAssertions;
+using Ahtola.Core;
+using Ahtola.Core.Storage;
+using Ahtola.Data.Sqlite.Browser;
+using Ahtola.Data.Sqlite.Browser.Storage;
+
+#pragma warning disable CA1416
+
+namespace Ahtola.Tests;
+
+/// <summary>
+/// Regressions for the browser encryption hardening pass: role tracking that
+/// cannot be fooled by a database name, encrypted recovery that runs before page
+/// authentication, abandoned engine temporaries that must not block an open, and
+/// key material that is released on every path.
+/// </summary>
+[NonParallelizable]
+public sealed class AhtolaBrowserEncryptedStorageHardeningTests
+{
+    private const string OwnedDirectory = "app/data";
+    private const string Aes256Key = "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F";
+    private const string Secret = "hardening-plaintext-canary";
+
+    [TestCase("app/data/notes-shm")]
+    [TestCase("app/data/notes-wal")]
+    [TestCase("app/data/notes-journal")]
+    [TestCase("app/data/notes-log")]
+    public async Task DatabaseNamedLikeASidecarIsStillEncrypted(string databasePath)
+    {
+        var store = new FakeBrowserPersistentStore();
+        await using (var harness = await BrowserHarness.CreateAsync(store, Aes256Key))
+        {
+            using var database = EmbeddedDatabase.OpenFile(databasePath, harness.Mirror);
+            using var connection = database.Connect();
+            Execute(connection, "CREATE TABLE notes(body TEXT);");
+            Execute(connection, $"INSERT INTO notes VALUES ('{Secret}');");
+            await harness.Mirror.FlushPendingAsync();
+        }
+
+        store.Contains(databasePath).Should().BeTrue();
+        Encoding.ASCII.GetString(store.Read(databasePath), 0, 5).Should().Be(
+            "AHTLA",
+            "a database whose name resembles a sidecar must never be persisted in the clear");
+        foreach (var path in store.Paths)
+        {
+            store.Read(path).AsSpan().IndexOf(Encoding.UTF8.GetBytes(Secret)).Should().Be(-1);
+        }
+
+        await using var reopened = await BrowserHarness.CreateAsync(store, Aes256Key);
+        using var reopenedDatabase = EmbeddedDatabase.OpenFile(databasePath, reopened.Mirror);
+        using var reopenedConnection = reopenedDatabase.Connect();
+        ScalarText(reopenedConnection, "SELECT body FROM notes;").Should().Be(Secret);
+    }
+
+    [Test]
+    public async Task SidecarOfARealDatabaseIsStillRecognized()
+    {
+        var store = new FakeBrowserPersistentStore();
+        const string DatabasePath = "app/data/main.db";
+        await using var harness = await BrowserHarness.CreateAsync(store, Aes256Key);
+        using (var database = EmbeddedDatabase.OpenFile(DatabasePath, harness.Mirror))
+        {
+            using var connection = database.Connect();
+            Execute(connection, "PRAGMA journal_mode=DELETE;");
+            Execute(connection, "CREATE TABLE notes(body TEXT);");
+            Execute(connection, $"INSERT INTO notes VALUES ('{Secret}');");
+        }
+
+        await harness.Mirror.FlushPendingAsync();
+
+        var roles = new BrowserPersistedFileRoles();
+        roles.RegisterDatabase(DatabasePath);
+        roles.Resolve(DatabasePath + "-wal", []).Should().Be(BrowserPersistedFileRole.Wal);
+        roles.Resolve(DatabasePath + "-journal", []).Should().Be(BrowserPersistedFileRole.Journal);
+        roles.Resolve(DatabasePath + "-shm", []).Should().Be(BrowserPersistedFileRole.SharedMemory);
+        roles.Resolve(DatabasePath + "-log", []).Should().Be(BrowserPersistedFileRole.MvccLog);
+    }
+
+    [Test]
+    public void UnanchoredSidecarNamesAreTreatedAsDatabases()
+    {
+        var roles = new BrowserPersistedFileRoles();
+
+        roles.Resolve("app/data/notes-shm", []).Should().Be(BrowserPersistedFileRole.Database);
+        roles.Resolve("app/data/notes-log", []).Should().Be(BrowserPersistedFileRole.Database);
+    }
+
+    [Test]
+    public void DatabaseMagicVetoesASidecarClassification()
+    {
+        var roles = new BrowserPersistedFileRoles();
+        roles.RegisterDatabase("app/data/notes");
+
+        var encryptedHeader = new byte[16];
+        "AHTLA"u8.CopyTo(encryptedHeader);
+
+        roles.Resolve("app/data/notes-shm", encryptedHeader).Should().Be(
+            BrowserPersistedFileRole.Database,
+            "content that starts with the AHTLA magic is a database no matter how it is named");
+    }
+
+    [TestCase("app/data/main.db.vacuum-0123456789abcdef0123456789abcdef.tmp")]
+    [TestCase("app/data/main.db.vacuum-0123456789abcdef0123456789abcdef.tmp-wal")]
+    [TestCase("app/data/main.db.page-size-0123456789abcdef0123456789abcdef.tmp")]
+    [TestCase("app/data/main.db-log.v4-upgrade")]
+    public void EngineTemporariesAreRecognized(string path)
+        => BrowserPersistedFileRoles.IsTransientArtifact(path).Should().BeTrue();
+
+    [TestCase("app/data/main.db")]
+    [TestCase("app/data/main.db-wal")]
+    [TestCase("app/data/notes.tmp")]
+    [TestCase("app/data/main.db.vacuum-not-a-guid.tmp")]
+    [TestCase("app/data/main.db.vacuum-0123456789ABCDEF0123456789ABCDEF.tmp")]
+    public void RealDataIsNeverMistakenForAnEngineTemporary(string path)
+        => BrowserPersistedFileRoles.IsTransientArtifact(path).Should().BeFalse();
+
+    [Test]
+    public async Task AbandonedVacuumTemporaryDoesNotBlockOpeningAHealthyDatabase()
+    {
+        var store = new FakeBrowserPersistentStore();
+        const string DatabasePath = "app/data/main.db";
+        await using (var harness = await BrowserHarness.CreateAsync(store, Aes256Key))
+        {
+            using var database = EmbeddedDatabase.OpenFile(DatabasePath, harness.Mirror);
+            using var connection = database.Connect();
+            Execute(connection, "CREATE TABLE notes(body TEXT);");
+            Execute(connection, $"INSERT INTO notes VALUES ('{Secret}');");
+            await harness.Mirror.FlushPendingAsync();
+        }
+
+        // A crash during VACUUM leaves a preallocated, undecryptable temporary.
+        var abandoned = DatabasePath + ".vacuum-0123456789abcdef0123456789abcdef.tmp";
+        store.Seed(abandoned, new byte[8192]);
+        store.Seed(abandoned + "-journal", new byte[512]);
+
+        await using var reopened = await BrowserHarness.CreateAsync(store, Aes256Key);
+        using var reopenedDatabase = EmbeddedDatabase.OpenFile(DatabasePath, reopened.Mirror);
+        using var reopenedConnection = reopenedDatabase.Connect();
+        ScalarText(reopenedConnection, "SELECT body FROM notes;").Should().Be(Secret);
+
+        store.Contains(abandoned).Should().BeFalse("abandoned engine temporaries are cleaned at startup");
+        store.Contains(abandoned + "-journal").Should().BeFalse();
+    }
+
+    [Test]
+    public async Task HotRollbackJournalRecoversATornPageBeforeAuthentication()
+    {
+        var store = new FakeBrowserPersistentStore();
+        const string DatabasePath = "app/data/main.db";
+        await using (var harness = await BrowserHarness.CreateAsync(store, Aes256Key))
+        {
+            using var database = EmbeddedDatabase.OpenFile(DatabasePath, harness.Mirror);
+            using var connection = database.Connect();
+            Execute(connection, "PRAGMA journal_mode=DELETE;");
+            Execute(connection, "CREATE TABLE notes(id INTEGER PRIMARY KEY, body TEXT);");
+            for (var index = 0; index < 24; index++)
+                Execute(connection, $"INSERT INTO notes(body) VALUES ('{Secret}-{index}');");
+            await harness.Mirror.FlushPendingAsync();
+        }
+
+        var (journal, pageSize) = BuildHotJournalFrom(store, DatabasePath);
+        store.Seed(DatabasePath + "-journal", journal);
+
+        // Simulate a torn page: the process died mid-write, so the encrypted page
+        // no longer authenticates. The journal still holds its pre-image.
+        var torn = store.Read(DatabasePath);
+        torn.AsSpan(pageSize, 64).Fill(0xAB);
+        store.Seed(DatabasePath, torn);
+
+        await using var reopened = await BrowserHarness.CreateAsync(store, Aes256Key);
+        using var reopenedDatabase = EmbeddedDatabase.OpenFile(DatabasePath, reopened.Mirror);
+        using var reopenedConnection = reopenedDatabase.Connect();
+        Scalar(reopenedConnection, "SELECT COUNT(*) FROM notes;").Should().Be(
+            24,
+            "encrypted journal recovery must run before the torn page is authenticated");
+    }
+
+    [Test]
+    public async Task TornPageWithNoRecoverySourceStillFailsClosed()
+    {
+        var store = new FakeBrowserPersistentStore();
+        const string DatabasePath = "app/data/main.db";
+        await using (var harness = await BrowserHarness.CreateAsync(store, Aes256Key))
+        {
+            using var database = EmbeddedDatabase.OpenFile(DatabasePath, harness.Mirror);
+            using var connection = database.Connect();
+            Execute(connection, "CREATE TABLE notes(body TEXT);");
+            Execute(connection, $"INSERT INTO notes VALUES ('{Secret}');");
+            await harness.Mirror.FlushPendingAsync();
+        }
+
+        var torn = store.Read(DatabasePath);
+        torn.AsSpan(600, 32).Fill(0xCD);
+        store.Seed(DatabasePath, torn);
+
+        var failure = await Capture(() => BrowserHarness.CreateAsync(store, Aes256Key));
+        failure.Should().BeOfType<InvalidDataException>();
+        failure!.Message.Should().Contain("failed authentication");
+    }
+
+    [Test]
+    public async Task ConvenienceConstructorReleasesTheKeyItCreated()
+    {
+        using var encryption = AhtolaBrowserEncryptionOptions.FromHex(
+            AhtolaEncryptionCipher.Aes256Gcm,
+            Aes256Key);
+
+        var options = new AhtolaBrowserOptions("owned/data.db", "owned", encryption: encryption);
+        var retained = options.Encryption!;
+        var source = new AhtolaBrowserDataSource(options);
+
+        await source.DisposeAsync();
+
+        // Caller-supplied options stay the caller's to dispose, and the data source
+        // releases only the independent snapshot it took.
+        options.Encryption.Should().NotBeNull();
+        var callerCopyIsIntact = () => retained.CreateOwnedCopy();
+        callerCopyIsIntact.Should().NotThrow();
+        options.Dispose();
+    }
+
+    [Test]
+    public async Task ConvenienceConstructorDisposesOptionsItOwns()
+    {
+        using var encryption = AhtolaBrowserEncryptionOptions.FromHex(
+            AhtolaEncryptionCipher.Aes256Gcm,
+            Aes256Key);
+
+        var source = new AhtolaBrowserDataSource("owned/data.db", "owned", encryption: encryption);
+        var owned = source.Options.Encryption;
+        owned.Should().NotBeNull();
+
+        await source.DisposeAsync();
+
+        source.Options.Encryption.Should().BeNull(
+            "options created by the data source are disposed with it so their key copy is zeroed");
+        var released = () => owned!.CreateOwnedCopy();
+        released.Should().Throw<ObjectDisposedException>();
+    }
+
+    [Test]
+    public async Task DisposingAnUnusedDataSourceStillReleasesKeyMaterial()
+    {
+        using var encryption = AhtolaBrowserEncryptionOptions.FromHex(
+            AhtolaEncryptionCipher.Aes256Gcm,
+            Aes256Key);
+
+        var source = new AhtolaBrowserDataSource("owned/data.db", "owned", encryption: encryption);
+        var owned = source.Options.Encryption!;
+
+        await source.DisposeAsync();
+        await source.DisposeAsync();
+
+        var released = () => owned.CreateOwnedCopy();
+        released.Should().Throw<ObjectDisposedException>();
+    }
+
+    [Test]
+    public async Task VacuumIntoPublishesAnEncryptedDestination()
+    {
+        var store = new FakeBrowserPersistentStore();
+        const string DatabasePath = "app/data/main.db";
+        const string DestinationPath = "app/data/vacuumed.db";
+
+        await using (var harness = await BrowserHarness.CreateAsync(store, Aes256Key))
+        {
+            using (var database = EmbeddedDatabase.OpenFile(DatabasePath, harness.Mirror))
+            {
+                using var connection = database.Connect();
+                Execute(connection, "CREATE TABLE notes(id INTEGER PRIMARY KEY, body TEXT);");
+                for (var index = 0; index < 24; index++)
+                    Execute(connection, $"INSERT INTO notes(body) VALUES ('{Secret}-{index}');");
+
+                // The rebuilt image is written through the persisted mirror at a
+                // '.vacuum-<guid>.tmp' path and then published atomically, so it has
+                // to be encrypted exactly like any other database.
+                Execute(connection, $"VACUUM INTO '{DestinationPath}';");
+            }
+
+            await harness.Mirror.FlushPendingAsync();
+        }
+
+        store.Contains(DestinationPath).Should().BeTrue();
+        Encoding.ASCII.GetString(store.Read(DestinationPath), 0, 5).Should().Be(
+            "AHTLA",
+            "a published VACUUM INTO destination must be encrypted, not the plaintext temporary image");
+        foreach (var path in store.Paths)
+        {
+            store.Read(path).AsSpan().IndexOf(Encoding.UTF8.GetBytes(Secret)).Should().Be(
+                -1,
+                $"persisted file '{path}' must never contain plaintext row data");
+        }
+
+        await using var reopened = await BrowserHarness.CreateAsync(store, Aes256Key);
+        using var vacuumed = EmbeddedDatabase.OpenFile(DestinationPath, reopened.Mirror);
+        using var vacuumedConnection = vacuumed.Connect();
+        Scalar(vacuumedConnection, "SELECT COUNT(*) FROM notes;").Should().Be(24);
+    }
+
+    [Test]
+    public async Task LiveEngineTemporaryIsEncryptedWhileItIsBeingWritten()
+    {
+        var store = new FakeBrowserPersistentStore();
+        var temporaryPath = "app/data/main.db.vacuum-0123456789abcdef0123456789abcdef.tmp";
+
+        await using var harness = await BrowserHarness.CreateAsync(store, Aes256Key);
+        using (var database = EmbeddedDatabase.OpenFile(temporaryPath, harness.Mirror))
+        {
+            using var connection = database.Connect();
+            Execute(connection, "CREATE TABLE notes(body TEXT);");
+            Execute(connection, $"INSERT INTO notes VALUES ('{Secret}');");
+        }
+
+        await harness.Mirror.FlushPendingAsync();
+
+        // The transient-artifact shape is a load-time concept only: while the
+        // engine is writing one, it is a real database and must be encrypted.
+        Encoding.ASCII.GetString(store.Read(temporaryPath), 0, 5).Should().Be("AHTLA");
+        foreach (var path in store.Paths)
+            store.Read(path).AsSpan().IndexOf(Encoding.UTF8.GetBytes(Secret)).Should().Be(-1);
+    }
+
+    [Test]
+    public async Task MvccJournalModeFailsClosedInsteadOfWritingPlaintextRowData()
+    {
+        var store = new FakeBrowserPersistentStore();
+        const string DatabasePath = "app/data/main.db";
+        await using var harness = await BrowserHarness.CreateAsync(store, Aes256Key);
+        using var database = EmbeddedDatabase.OpenFile(DatabasePath, harness.Mirror);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE notes(body TEXT);");
+
+        // The engine writes the MVCC logical log outside the page codec, so it
+        // would land in OPFS unencrypted. That must fail loudly, not silently.
+        var failure = Record(() =>
+        {
+            Execute(connection, "PRAGMA journal_mode=mvcc;");
+            Execute(connection, $"INSERT INTO notes VALUES ('{Secret}');");
+        });
+
+        var chain = failure;
+        var mentionsMvcc = false;
+        while (chain is not null)
+        {
+            if (chain is NotSupportedException && chain.Message.Contains("MVCC logical log", StringComparison.Ordinal))
+            {
+                mentionsMvcc = true;
+                break;
+            }
+
+            chain = chain.InnerException;
+        }
+
+        mentionsMvcc.Should().BeTrue(
+            $"encrypted browser storage must reject the MVCC logical log explicitly, but saw: {failure}");
+        foreach (var path in store.Paths)
+            store.Read(path).AsSpan().IndexOf(Encoding.UTF8.GetBytes(Secret)).Should().Be(-1);
+    }
+
+    private static Exception? Record(Action action)
+    {
+        try
+        {
+            action();
+            return null;
+        }
+        catch (Exception exception)
+        {
+            return exception;
+        }
+    }
+
+    private static (byte[] Journal, int PageSize) BuildHotJournalFrom(
+        FakeBrowserPersistentStore store,
+        string databasePath)
+    {
+        var database = store.Read(databasePath);
+        var pageSize = (database[16] << 8) | database[17];
+        if (pageSize == 1)
+            pageSize = 65_536;
+
+        var pageCount = database.Length / pageSize;
+        const uint ChecksumNonce = 0x5A5A_1234;
+        var recordSize = pageSize + 8;
+        var journal = new byte[512 + recordSize];
+
+        // A one-record journal holding page 2's exact encrypted pre-image.
+        var magic = new byte[] { 0xd9, 0xd5, 0x05, 0xf9, 0x20, 0xa1, 0x63, 0xd7 };
+        magic.CopyTo(journal.AsSpan());
+        WriteUInt32BigEndian(journal.AsSpan(8), 1);
+        WriteUInt32BigEndian(journal.AsSpan(12), ChecksumNonce);
+        WriteUInt32BigEndian(journal.AsSpan(16), (uint)pageCount);
+        WriteUInt32BigEndian(journal.AsSpan(20), 512);
+        WriteUInt32BigEndian(journal.AsSpan(24), (uint)pageSize);
+
+        var page = database.AsSpan(pageSize, pageSize);
+        WriteUInt32BigEndian(journal.AsSpan(512), 2);
+        page.CopyTo(journal.AsSpan(512 + 4));
+        WriteUInt32BigEndian(
+            journal.AsSpan(512 + 4 + pageSize),
+            SqliteRollbackJournalFormat.ComputeChecksum(page, ChecksumNonce));
+        return (journal, pageSize);
+    }
+
+    private static void WriteUInt32BigEndian(Span<byte> destination, uint value)
+        => System.Buffers.Binary.BinaryPrimitives.WriteUInt32BigEndian(destination, value);
+
+    private static async Task<Exception?> Capture<T>(Func<ValueTask<T>> action)
+    {
+        try
+        {
+            await action();
+            return null;
+        }
+        catch (Exception exception)
+        {
+            return exception;
+        }
+    }
+
+    private static void Execute(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        while (statement.Step() == StatementStepResult.Row)
+        {
+        }
+    }
+
+    private static long Scalar(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        statement.Step().Should().Be(StatementStepResult.Row);
+        return statement.GetValue(0).AsInteger();
+    }
+
+    private static string ScalarText(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        statement.Step().Should().Be(StatementStepResult.Row);
+        return statement.GetValue(0).AsText();
+    }
+
+    private sealed class BrowserHarness : IAsyncDisposable
+    {
+        private readonly BrowserEncryptedPersistence _persistence;
+
+        private BrowserHarness(BrowserMirroredFileSystem mirror, BrowserEncryptedPersistence persistence)
+        {
+            Mirror = mirror;
+            _persistence = persistence;
+        }
+
+        public BrowserMirroredFileSystem Mirror { get; }
+
+        public static async ValueTask<BrowserHarness> CreateAsync(
+            FakeBrowserPersistentStore store,
+            string hexKey)
+        {
+            var persistence = new BrowserEncryptedPersistence(
+                new AhtolaAsyncPageTransformer(
+                    new DesktopAsyncPageCipher(
+                        Core.Storage.AhtolaEncryptionCipher.Aes256Gcm,
+                        Convert.FromHexString(hexKey))));
+            try
+            {
+                var mirror = await BrowserMirroredFileSystem.CreateAsync(
+                    store,
+                    OwnedDirectory,
+                    ownsPersistent: false,
+                    encryption: persistence);
+                return new BrowserHarness(mirror, persistence);
+            }
+            catch
+            {
+                await persistence.DisposeAsync();
+                throw;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            try
+            {
+                await Mirror.DisposeAsync();
+            }
+            finally
+            {
+                await _persistence.DisposeAsync();
+            }
+        }
+    }
+}

--- a/src/Ahtola.Tests/AhtolaBrowserEncryptedStorageTests.cs
+++ b/src/Ahtola.Tests/AhtolaBrowserEncryptedStorageTests.cs
@@ -1,0 +1,651 @@
+using System.Text;
+using AwesomeAssertions;
+using Ahtola.Core;
+using Ahtola.Core.Storage;
+using Ahtola.Data.Sqlite.Browser;
+using Ahtola.Data.Sqlite.Browser.Storage;
+
+#pragma warning disable CA1416
+
+namespace Ahtola.Tests;
+
+/// <summary>
+/// Proves that the browser package's asynchronous AHTLA encryption produces and
+/// consumes exactly the bytes the desktop engine writes, so an encrypted OPFS
+/// database is a plain Ahtola encrypted database rather than a browser container.
+/// </summary>
+[NonParallelizable]
+public sealed class AhtolaBrowserEncryptedStorageTests
+{
+    private const string OwnedDirectory = "app/data";
+    private const string DatabasePath = "app/data/browser.db";
+    private const string Aes256Key = "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F";
+    private const string Aes128Key = "000102030405060708090A0B0C0D0E0F";
+    private const string WrongAes256Key = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
+    private const string Secret = "browser-plaintext-canary";
+
+    [TestCase(Aes128Key, Core.Storage.AhtolaEncryptionCipher.Aes128Gcm)]
+    [TestCase(Aes256Key, Core.Storage.AhtolaEncryptionCipher.Aes256Gcm)]
+    public async Task AsyncPageTransformerRoundTripsThroughDesktopPageEncryption(
+        string hexKey,
+        Core.Storage.AhtolaEncryptionCipher cipher)
+    {
+        const int PageSize = 4096;
+        var key = Convert.FromHexString(hexKey);
+        await using var transformer = new AhtolaAsyncPageTransformer(new DesktopAsyncPageCipher(cipher, key));
+        using var options = new AhtolaEncryptionOptions(cipher, key);
+        using var desktop = options.CreatePageEncryption(PageSize);
+
+        foreach (var pageNumber in new uint[] { 1, 2, 37 })
+        {
+            var plaintext = CreatePlaintextPage(PageSize, pageNumber);
+
+            var browserEncrypted = await transformer.EncryptPageAsync(plaintext, pageNumber, default);
+            desktop.DecryptPage(browserEncrypted, pageNumber).Should().Equal(
+                plaintext,
+                "the desktop engine must be able to decrypt a page the browser wrote");
+
+            var desktopEncrypted = desktop.EncryptPage(plaintext, pageNumber);
+            (await transformer.DecryptPageAsync(desktopEncrypted, pageNumber, default)).Should().Equal(
+                plaintext,
+                "the browser must be able to decrypt a page the desktop engine wrote");
+
+            if (pageNumber == 1)
+            {
+                Encoding.ASCII.GetString(browserEncrypted, 0, 5).Should().Be("AHTLA");
+                browserEncrypted[5].Should().Be(0);
+                browserEncrypted[6].Should().Be((byte)cipher);
+                browserEncrypted.AsSpan(16, 84).ToArray().Should().Equal(
+                    plaintext.AsSpan(16, 84).ToArray(),
+                    "the visible SQLite header tail is copied verbatim and authenticated");
+            }
+        }
+    }
+
+    [Test]
+    public async Task BrowserWrittenDatabaseOpensWithDesktopEncryption()
+    {
+        var store = new FakeBrowserPersistentStore();
+        await using (var harness = await BrowserHarness.CreateAsync(store, Aes256Key))
+        {
+            using var database = EmbeddedDatabase.OpenFile(DatabasePath, harness.Mirror);
+            using var connection = database.Connect();
+            Execute(connection, "CREATE TABLE notes(id INTEGER PRIMARY KEY, body TEXT);");
+            Execute(connection, $"INSERT INTO notes(body) VALUES ('{Secret}');");
+            await harness.Mirror.FlushPendingAsync();
+        }
+
+        store.Contains(DatabasePath).Should().BeTrue();
+        AssertPersistedBytesAreEncrypted(store);
+
+        var desktop = new InMemoryFileSystem();
+        CopyInto(desktop, store);
+        using var encryptionOptions = AhtolaEncryptionOptions.FromHex(
+            Core.Storage.AhtolaEncryptionCipher.Aes256Gcm,
+            Aes256Key);
+        using var encrypted = new AhtolaEncryptionFileSystem(desktop, encryptionOptions);
+        using var reopened = EmbeddedDatabase.OpenFile(DatabasePath, encrypted);
+        using var desktopConnection = reopened.Connect();
+        ScalarText(desktopConnection, "SELECT body FROM notes;").Should().Be(Secret);
+    }
+
+    [Test]
+    public async Task DesktopWrittenDatabaseOpensInBrowser()
+    {
+        var desktop = new InMemoryFileSystem();
+        using (var encryptionOptions = AhtolaEncryptionOptions.FromHex(
+                   Core.Storage.AhtolaEncryptionCipher.Aes256Gcm,
+                   Aes256Key))
+        using (var encrypted = new AhtolaEncryptionFileSystem(desktop, encryptionOptions))
+        using (var database = EmbeddedDatabase.OpenFile(DatabasePath, encrypted))
+        using (var connection = database.Connect())
+        {
+            Execute(connection, "CREATE TABLE notes(id INTEGER PRIMARY KEY, body TEXT);");
+            Execute(connection, $"INSERT INTO notes(body) VALUES ('{Secret}');");
+        }
+
+        var store = new FakeBrowserPersistentStore();
+        CopyInto(store, desktop, DatabasePath, DatabasePath + "-wal", DatabasePath + "-journal");
+
+        await using var harness = await BrowserHarness.CreateAsync(store, Aes256Key);
+        using var browserDatabase = EmbeddedDatabase.OpenFile(DatabasePath, harness.Mirror);
+        using var browserConnection = browserDatabase.Connect();
+        ScalarText(browserConnection, "SELECT body FROM notes;").Should().Be(Secret);
+    }
+
+    [Test]
+    public async Task BrowserDatabaseSurvivesReopenAcrossSessions()
+    {
+        var store = new FakeBrowserPersistentStore();
+        await using (var harness = await BrowserHarness.CreateAsync(store, Aes256Key))
+        {
+            using var database = EmbeddedDatabase.OpenFile(DatabasePath, harness.Mirror);
+            using var connection = database.Connect();
+            Execute(connection, "CREATE TABLE notes(id INTEGER PRIMARY KEY, body TEXT);");
+            for (var index = 0; index < 64; index++)
+                Execute(connection, $"INSERT INTO notes(body) VALUES ('{Secret}-{index}');");
+            await harness.Mirror.FlushPendingAsync();
+        }
+
+        AssertPersistedBytesAreEncrypted(store);
+
+        await using var reopenedHarness = await BrowserHarness.CreateAsync(store, Aes256Key);
+        using var reopened = EmbeddedDatabase.OpenFile(DatabasePath, reopenedHarness.Mirror);
+        using var reopenedConnection = reopened.Connect();
+        Scalar(reopenedConnection, "SELECT COUNT(*) FROM notes;").Should().Be(64);
+        ScalarText(reopenedConnection, "SELECT body FROM notes WHERE id = 64;").Should().Be($"{Secret}-63");
+    }
+
+    [Test]
+    public async Task EncryptedBrowserDatabaseReservesTwentyEightBytesFromCreation()
+    {
+        var store = new FakeBrowserPersistentStore();
+        await using var harness = await BrowserHarness.CreateAsync(store, Aes256Key);
+        using (var database = EmbeddedDatabase.OpenFile(DatabasePath, harness.Mirror))
+        {
+            using var connection = database.Connect();
+            Execute(connection, "CREATE TABLE t(x INTEGER);");
+        }
+
+        await harness.Mirror.FlushPendingAsync();
+
+        var plaintextHeader = new byte[SqliteDatabaseHeader.Size];
+        using (var file = harness.Mirror.OpenFile(DatabasePath, FileOpenMode.OpenExisting, readOnly: true))
+            file.Read(0, plaintextHeader);
+        SqliteDatabaseHeader.Parse(plaintextHeader).ReservedSpace.Should().Be(28);
+
+        var persisted = store.Read(DatabasePath);
+        persisted[20].Should().Be(28, "the encrypted image keeps the reserved-space field visible");
+        Encoding.ASCII.GetString(persisted, 0, 5).Should().Be("AHTLA");
+    }
+
+    [Test]
+    public async Task WrongKeyFailsClosedWhenLoadingEncryptedBrowserStorage()
+    {
+        var store = new FakeBrowserPersistentStore();
+        await using (var harness = await BrowserHarness.CreateAsync(store, Aes256Key))
+        {
+            using var database = EmbeddedDatabase.OpenFile(DatabasePath, harness.Mirror);
+            using var connection = database.Connect();
+            Execute(connection, "CREATE TABLE t(x INTEGER);");
+            await harness.Mirror.FlushPendingAsync();
+        }
+
+        var failure = await ThrowsAsync(() => BrowserHarness.CreateAsync(store, WrongAes256Key));
+        failure.Should().BeOfType<InvalidDataException>();
+        failure!.Message.Should().Contain("failed authentication");
+    }
+
+    [Test]
+    public async Task CipherMismatchFailsClosedWithoutFallback()
+    {
+        var store = new FakeBrowserPersistentStore();
+        await using (var harness = await BrowserHarness.CreateAsync(store, Aes256Key))
+        {
+            using var database = EmbeddedDatabase.OpenFile(DatabasePath, harness.Mirror);
+            using var connection = database.Connect();
+            Execute(connection, "CREATE TABLE t(x INTEGER);");
+            await harness.Mirror.FlushPendingAsync();
+        }
+
+        var failure = await ThrowsAsync(() => BrowserHarness.CreateAsync(
+            store,
+            Aes128Key,
+            Core.Storage.AhtolaEncryptionCipher.Aes128Gcm));
+        failure.Should().BeOfType<InvalidDataException>();
+        failure!.Message.Should().Contain("cipher fallback is not permitted");
+    }
+
+    [Test]
+    public async Task TamperedEncryptedPageFailsClosed()
+    {
+        var store = new FakeBrowserPersistentStore();
+        await using (var harness = await BrowserHarness.CreateAsync(store, Aes256Key))
+        {
+            using var database = EmbeddedDatabase.OpenFile(DatabasePath, harness.Mirror);
+            using var connection = database.Connect();
+            Execute(connection, "CREATE TABLE t(x INTEGER);");
+            Execute(connection, "INSERT INTO t VALUES (5);");
+            await harness.Mirror.FlushPendingAsync();
+        }
+
+        var tampered = store.Read(DatabasePath);
+        tampered[600] ^= 0xFF;
+        store.Seed(DatabasePath, tampered);
+
+        var failure = await ThrowsAsync(() => BrowserHarness.CreateAsync(store, Aes256Key));
+        failure.Should().BeOfType<InvalidDataException>();
+        failure!.Message.Should().Contain("failed authentication");
+    }
+
+    [Test]
+    public async Task PlaintextDatabaseIsRejectedWhenEncryptionIsConfigured()
+    {
+        var store = new FakeBrowserPersistentStore();
+        var plaintext = new InMemoryFileSystem();
+        using (var database = EmbeddedDatabase.OpenFile(DatabasePath, plaintext))
+        using (var connection = database.Connect())
+        {
+            Execute(connection, "CREATE TABLE t(x INTEGER);");
+        }
+
+        CopyInto(store, plaintext, DatabasePath);
+
+        var failure = await ThrowsAsync(() => BrowserHarness.CreateAsync(store, Aes256Key));
+        failure.Should().BeOfType<InvalidDataException>();
+        failure!.Message.Should().Contain(AhtolaPasswordEncryption.EncryptedOrNotDatabaseMessage);
+    }
+
+    [Test]
+    public async Task RollbackJournalRecordsArePersistedEncryptedAndRecoverable()
+    {
+        var store = new FakeBrowserPersistentStore();
+        await using (var harness = await BrowserHarness.CreateAsync(store, Aes256Key))
+        {
+            using var database = EmbeddedDatabase.OpenFile(DatabasePath, harness.Mirror);
+            using var connection = database.Connect();
+            Execute(connection, "PRAGMA journal_mode=DELETE;");
+            Execute(connection, "CREATE TABLE notes(id INTEGER PRIMARY KEY, body TEXT);");
+            for (var index = 0; index < 40; index++)
+                Execute(connection, $"INSERT INTO notes(body) VALUES ('{Secret}-{index}');");
+            await harness.Mirror.FlushPendingAsync();
+        }
+
+        AssertPersistedBytesAreEncrypted(store);
+
+        var desktop = new InMemoryFileSystem();
+        CopyInto(desktop, store);
+        using var encryptionOptions = AhtolaEncryptionOptions.FromHex(
+            Core.Storage.AhtolaEncryptionCipher.Aes256Gcm,
+            Aes256Key);
+        using var encrypted = new AhtolaEncryptionFileSystem(desktop, encryptionOptions);
+        using var reopened = EmbeddedDatabase.OpenFile(DatabasePath, encrypted);
+        using var desktopConnection = reopened.Connect();
+        Scalar(desktopConnection, "SELECT COUNT(*) FROM notes;").Should().Be(40);
+    }
+
+    [Test]
+    public async Task AttachedEncryptedDatabaseRoundTripsThroughPersistentStore()
+    {
+        var store = new FakeBrowserPersistentStore();
+        const string AttachedPath = "app/data/attached.db";
+        await using (var harness = await BrowserHarness.CreateAsync(store, Aes256Key))
+        {
+            using var database = EmbeddedDatabase.OpenFile(DatabasePath, harness.Mirror);
+            using var connection = database.Connect();
+            Execute(connection, "CREATE TABLE main_notes(body TEXT);");
+            Execute(connection, $"INSERT INTO main_notes VALUES ('{Secret}-main');");
+            Execute(connection, $"ATTACH DATABASE '{AttachedPath}' AS side;");
+            Execute(connection, "CREATE TABLE side.side_notes(body TEXT);");
+            Execute(connection, $"INSERT INTO side.side_notes VALUES ('{Secret}-side');");
+            Execute(connection, "DETACH DATABASE side;");
+            await harness.Mirror.FlushPendingAsync();
+        }
+
+        store.Contains(AttachedPath).Should().BeTrue();
+        AssertPersistedBytesAreEncrypted(store);
+        Encoding.ASCII.GetString(store.Read(AttachedPath), 0, 5).Should().Be("AHTLA");
+
+        var desktop = new InMemoryFileSystem();
+        CopyInto(desktop, store);
+        using var encryptionOptions = AhtolaEncryptionOptions.FromHex(
+            Core.Storage.AhtolaEncryptionCipher.Aes256Gcm,
+            Aes256Key);
+        using var encrypted = new AhtolaEncryptionFileSystem(desktop, encryptionOptions);
+        using var reopened = EmbeddedDatabase.OpenFile(AttachedPath, encrypted);
+        using var desktopConnection = reopened.Connect();
+        ScalarText(desktopConnection, "SELECT body FROM side_notes;").Should().Be($"{Secret}-side");
+    }
+
+    [Test]
+    public async Task CommittedWalFramesArePersistedEncryptedAndReadableOnDesktop()
+    {
+        const int PageSize = 4096;
+        var walPath = DatabasePath + "-wal";
+        var store = new FakeBrowserPersistentStore();
+        var pages = new[]
+        {
+            CreatePlaintextPage(PageSize, 2),
+            CreatePlaintextPage(PageSize, 3),
+            CreatePlaintextPage(PageSize, 7),
+        };
+
+        await using (var harness = await BrowserHarness.CreateAsync(store, Aes256Key))
+        {
+            var header = SqliteWalHeader.Create(PageSize, salt1: 0x1234_5678, salt2: 0x9ABC_DEF0);
+            using (var wal = SqliteWalFile.Create(harness.Mirror, walPath, header))
+            {
+                wal.AppendFrame(2, pages[0]);
+                wal.AppendFrame(3, pages[1]);
+                wal.AppendFrame(7, pages[2], databaseSizeInPages: 7);
+            }
+
+            await harness.Mirror.FlushPendingAsync();
+        }
+
+        var persisted = store.Read(walPath);
+        persisted.Length.Should().Be(SqliteWalHeader.Size + (3 * (SqliteWalFrameHeader.Size + PageSize)));
+        AssertWalChainIsValid(persisted);
+        persisted.AsSpan(SqliteWalFrameHeader.Size + SqliteWalHeader.Size, PageSize).ToArray()
+            .Should().NotEqual(pages[0], "WAL frame bodies must be stored encrypted");
+
+        var desktop = new InMemoryFileSystem();
+        CopyInto(desktop, store);
+        using var encryptionOptions = AhtolaEncryptionOptions.FromHex(
+            Core.Storage.AhtolaEncryptionCipher.Aes256Gcm,
+            Aes256Key);
+        using var encryptedWal = SqliteWalFile.Open(
+            desktop,
+            walPath,
+            readOnly: true,
+            encryption: encryptionOptions);
+        encryptedWal.ReadFrame(1).PageData.Should().Equal(pages[0]);
+        encryptedWal.ReadFrame(2).PageData.Should().Equal(pages[1]);
+        encryptedWal.ReadFrame(3).PageData.Should().Equal(pages[2]);
+        encryptedWal.ReadFrame(3).Header.DatabaseSizeInPages.Should().Be(7);
+    }
+
+    [Test]
+    public async Task DesktopRetainedWalOpensInBrowser()
+    {
+        const int PageSize = 4096;
+        var walPath = DatabasePath + "-wal";
+        var desktop = new InMemoryFileSystem();
+        var pages = new[]
+        {
+            CreatePlaintextPage(PageSize, 2),
+            CreatePlaintextPage(PageSize, 5),
+        };
+
+        using (var encryptionOptions = AhtolaEncryptionOptions.FromHex(
+                   Core.Storage.AhtolaEncryptionCipher.Aes256Gcm,
+                   Aes256Key))
+        {
+            var header = SqliteWalHeader.Create(PageSize, salt1: 0x0BAD_F00D, salt2: 0x0000_1234, checkpointSequence: 3);
+            using var wal = SqliteWalFile.Create(desktop, walPath, header, encryption: encryptionOptions);
+            wal.AppendFrame(2, pages[0]);
+            wal.AppendFrame(5, pages[1], databaseSizeInPages: 5);
+        }
+
+        var store = new FakeBrowserPersistentStore();
+        CopyInto(store, desktop, walPath);
+
+        await using var harness = await BrowserHarness.CreateAsync(store, Aes256Key);
+        using var plaintextWal = SqliteWalFile.Open(harness.Mirror, walPath, readOnly: true);
+        plaintextWal.ReadFrame(1).PageData.Should().Equal(
+            pages[0],
+            "the browser must decrypt a desktop-written WAL into plaintext frames");
+        plaintextWal.ReadFrame(2).PageData.Should().Equal(pages[1]);
+        plaintextWal.ReadFrame(2).Header.DatabaseSizeInPages.Should().Be(5);
+    }
+
+    [Test]
+    public async Task BrowserAppendsToADesktopWrittenWalWithoutBreakingItsChain()
+    {
+        const int PageSize = 4096;
+        var walPath = DatabasePath + "-wal";
+        var desktop = new InMemoryFileSystem();
+        var first = CreatePlaintextPage(PageSize, 2);
+        var appended = CreatePlaintextPage(PageSize, 9);
+
+        using (var encryptionOptions = AhtolaEncryptionOptions.FromHex(
+                   Core.Storage.AhtolaEncryptionCipher.Aes256Gcm,
+                   Aes256Key))
+        {
+            var header = SqliteWalHeader.Create(PageSize, salt1: 7, salt2: 11, checkpointSequence: 1);
+            using var wal = SqliteWalFile.Create(desktop, walPath, header, encryption: encryptionOptions);
+            wal.AppendFrame(2, first, databaseSizeInPages: 2);
+        }
+
+        var store = new FakeBrowserPersistentStore();
+        CopyInto(store, desktop, walPath);
+
+        await using (var harness = await BrowserHarness.CreateAsync(store, Aes256Key))
+        {
+            using (var wal = SqliteWalFile.Open(harness.Mirror, walPath))
+                wal.AppendFrame(9, appended, databaseSizeInPages: 9);
+            await harness.Mirror.FlushPendingAsync();
+        }
+
+        AssertWalChainIsValid(store.Read(walPath));
+
+        var verification = new InMemoryFileSystem();
+        CopyInto(verification, store);
+        using var verifyOptions = AhtolaEncryptionOptions.FromHex(
+            Core.Storage.AhtolaEncryptionCipher.Aes256Gcm,
+            Aes256Key);
+        using var verified = SqliteWalFile.Open(
+            verification,
+            walPath,
+            readOnly: true,
+            encryption: verifyOptions);
+        verified.ReadFrame(1).PageData.Should().Equal(first);
+        verified.ReadFrame(2).PageData.Should().Equal(
+            appended,
+            "a frame the browser appended must extend the desktop chain byte-compatibly");
+    }
+
+    [Test]
+    public async Task PageCipherIsReleasedWhenPersistenceIsDisposed()
+    {
+        var cipher = new DesktopAsyncPageCipher(
+            Core.Storage.AhtolaEncryptionCipher.Aes256Gcm,
+            Convert.FromHexString(Aes256Key));
+        var persistence = new BrowserEncryptedPersistence(new AhtolaAsyncPageTransformer(cipher));
+
+        cipher.IsReleased.Should().BeFalse();
+        await persistence.DisposeAsync();
+        cipher.IsReleased.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task CancellingAFlushLeavesPendingMutationsReplayable()
+    {
+        var store = new FakeBrowserPersistentStore();
+        await using var harness = await BrowserHarness.CreateAsync(store, Aes256Key);
+        using var database = EmbeddedDatabase.OpenFile(DatabasePath, harness.Mirror);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE notes(body TEXT);");
+        Execute(connection, $"INSERT INTO notes VALUES ('{Secret}');");
+
+        using var cancelled = new CancellationTokenSource();
+        await cancelled.CancelAsync();
+        var failure = await ThrowsAsync(() => harness.Mirror.FlushPendingAsync(cancelled.Token));
+        failure.Should().BeAssignableTo<OperationCanceledException>();
+
+        harness.Mirror.HasPendingMutations.Should().BeTrue(
+            "a cancelled flush must keep the unreplayed mutations queued instead of losing them");
+
+        await harness.Mirror.FlushPendingAsync();
+        harness.Mirror.HasPendingMutations.Should().BeFalse();
+        AssertPersistedBytesAreEncrypted(store);
+    }
+
+    private static byte[] CreatePlaintextPage(int pageSize, uint pageNumber)
+    {
+        var page = new byte[pageSize];
+        if (pageNumber == 1)
+        {
+            "SQLite format 3\0"u8.CopyTo(page);
+            page[16] = (byte)(pageSize >> 8);
+            page[17] = (byte)pageSize;
+            page[18] = 2;
+            page[19] = 2;
+            page[20] = 28;
+        }
+
+        // Leave the trailing reserved bytes zero: the engine guarantees this and
+        // the encrypted layout stores its tag and nonce there.
+        for (var index = pageNumber == 1 ? 100 : 0; index < pageSize - 28; index++)
+            page[index] = (byte)((index * 31) + pageNumber);
+        return page;
+    }
+
+    private static void AssertWalChainIsValid(byte[] wal)
+    {
+        var header = SqliteWalHeader.Parse(wal.AsSpan(0, SqliteWalHeader.Size));
+        var frameSize = SqliteWalFrameHeader.Size + header.PageSize;
+        var running = (header.Checksum1, header.Checksum2);
+        var frames = 0;
+        for (var offset = SqliteWalHeader.Size; offset + frameSize <= wal.Length; offset += frameSize)
+        {
+            var frameHeader = SqliteWalFrameHeader.Parse(wal.AsSpan(offset, SqliteWalFrameHeader.Size));
+            var (First, Second) = SqliteWalChecksum.Calculate(
+                wal.AsSpan(offset, 8),
+                header.ChecksumByteOrder,
+                running.Item1,
+                running.Item2);
+            running = SqliteWalChecksum.Calculate(
+                wal.AsSpan(offset + SqliteWalFrameHeader.Size, header.PageSize),
+                header.ChecksumByteOrder,
+                First,
+                Second);
+            running.Should().Be(
+                (frameHeader.Checksum1, frameHeader.Checksum2),
+                "encrypted WAL frame checksums must be computed over the encrypted page image");
+            frames++;
+        }
+
+        frames.Should().BeGreaterThan(0);
+    }
+
+    private static void AssertPersistedBytesAreEncrypted(FakeBrowserPersistentStore store)
+    {
+        var needle = Encoding.UTF8.GetBytes(Secret);
+        foreach (var path in store.Paths)
+        {
+            if (path.EndsWith("-shm", StringComparison.Ordinal))
+                continue;
+            store.Read(path).AsSpan().IndexOf(needle).Should().Be(
+                -1,
+                $"persisted file '{path}' must never contain plaintext row data");
+        }
+    }
+
+    private static void CopyInto(InMemoryFileSystem destination, FakeBrowserPersistentStore source)
+    {
+        foreach (var path in source.Paths.ToArray())
+        {
+            var content = source.Read(path);
+            using var file = destination.OpenFile(path, FileOpenMode.OpenOrCreate);
+            file.SetLength(content.Length);
+            if (content.Length != 0)
+                file.Write(0, content);
+        }
+    }
+
+    private static void CopyInto(
+        FakeBrowserPersistentStore destination,
+        InMemoryFileSystem source,
+        params string[] paths)
+    {
+        foreach (var path in paths)
+        {
+            if (!source.FileExists(path))
+                continue;
+            using var file = source.OpenFile(path, FileOpenMode.OpenExisting, readOnly: true);
+            var content = new byte[file.Length];
+            if (content.Length != 0)
+                file.Read(0, content);
+            destination.Seed(path, content);
+        }
+    }
+
+    private static async Task<Exception?> ThrowsAsync(Func<ValueTask> action)
+    {
+        try
+        {
+            await action();
+            return null;
+        }
+        catch (Exception exception)
+        {
+            return exception;
+        }
+    }
+
+    private static async Task<Exception?> ThrowsAsync<T>(Func<ValueTask<T>> action)
+    {
+        try
+        {
+            await action();
+            return null;
+        }
+        catch (Exception exception)
+        {
+            return exception;
+        }
+    }
+
+    private static void Execute(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        while (statement.Step() == StatementStepResult.Row)
+        {
+        }
+    }
+
+    private static long Scalar(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        statement.Step().Should().Be(StatementStepResult.Row);
+        return statement.GetValue(0).AsInteger();
+    }
+
+    private static string ScalarText(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        statement.Step().Should().Be(StatementStepResult.Row);
+        return statement.GetValue(0).AsText();
+    }
+
+    private sealed class BrowserHarness : IAsyncDisposable
+    {
+        private readonly BrowserEncryptedPersistence _persistence;
+
+        private BrowserHarness(BrowserMirroredFileSystem mirror, BrowserEncryptedPersistence persistence)
+        {
+            Mirror = mirror;
+            _persistence = persistence;
+        }
+
+        public BrowserMirroredFileSystem Mirror { get; }
+
+        public static async ValueTask<BrowserHarness> CreateAsync(
+            FakeBrowserPersistentStore store,
+            string hexKey,
+            Core.Storage.AhtolaEncryptionCipher cipher = Core.Storage.AhtolaEncryptionCipher.Aes256Gcm)
+        {
+            var persistence = new BrowserEncryptedPersistence(
+                new AhtolaAsyncPageTransformer(
+                    new DesktopAsyncPageCipher(cipher, Convert.FromHexString(hexKey))));
+            try
+            {
+                var mirror = await BrowserMirroredFileSystem.CreateAsync(
+                    store,
+                    OwnedDirectory,
+                    ownsPersistent: false,
+                    encryption: persistence);
+                return new BrowserHarness(mirror, persistence);
+            }
+            catch
+            {
+                await persistence.DisposeAsync();
+                throw;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            try
+            {
+                await Mirror.DisposeAsync();
+            }
+            finally
+            {
+                await _persistence.DisposeAsync();
+            }
+        }
+    }
+}
+

--- a/src/Ahtola.Tests/AhtolaBrowserEncryptionOptionsTests.cs
+++ b/src/Ahtola.Tests/AhtolaBrowserEncryptionOptionsTests.cs
@@ -1,0 +1,169 @@
+using System.Text;
+using AwesomeAssertions;
+using Ahtola.Core.Storage;
+using Ahtola.Data.Sqlite;
+using Ahtola.Data.Sqlite.Browser;
+
+#pragma warning disable CA1416
+
+namespace Ahtola.Tests;
+
+/// <summary>
+/// Covers the public browser encryption option surface: key material shapes,
+/// defensive copying, disposal, and the guarantee that no secret ever reaches a
+/// connection string.
+/// </summary>
+public sealed class AhtolaBrowserEncryptionOptionsTests
+{
+    private const string Aes256Key = "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F";
+    private const string Aes128Key = "000102030405060708090A0B0C0D0E0F";
+    private const string Password = "correct horse battery staple";
+
+    [Test]
+    public void PasswordOptionsUseTheAhtolaPasswordV1Scheme()
+    {
+        using var options = AhtolaBrowserEncryptionOptions.FromPassword(Password);
+
+        options.IsPasswordDerived.Should().BeTrue();
+        options.Cipher.Should().Be(AhtolaEncryptionCipher.Aes256Gcm);
+        options.PasswordSchemeId.Should().Be(AhtolaPasswordEncryption.SchemeIdV1);
+        AhtolaBrowserCryptoParameters.PasswordIterations.Should().Be(AhtolaPasswordEncryption.Pbkdf2IterationsV1);
+        AhtolaBrowserCryptoParameters.PasswordSalt.Should().Be(AhtolaPasswordEncryption.DomainSaltV1);
+    }
+
+    [TestCase(Aes128Key, AhtolaEncryptionCipher.Aes128Gcm)]
+    [TestCase(Aes256Key, AhtolaEncryptionCipher.Aes256Gcm)]
+    public void HexAndRawKeysProduceEquivalentOptions(string hexKey, AhtolaEncryptionCipher cipher)
+    {
+        using var fromHex = AhtolaBrowserEncryptionOptions.FromHex(cipher, hexKey);
+        using var fromKey = AhtolaBrowserEncryptionOptions.FromKey(cipher, Convert.FromHexString(hexKey));
+
+        fromHex.Cipher.Should().Be(cipher);
+        fromKey.Cipher.Should().Be(cipher);
+        fromHex.IsPasswordDerived.Should().BeFalse();
+        fromHex.PasswordSchemeId.Should().BeNull();
+    }
+
+    [TestCase(AhtolaEncryptionCipher.Aes128Gcm, 15)]
+    [TestCase(AhtolaEncryptionCipher.Aes128Gcm, 32)]
+    [TestCase(AhtolaEncryptionCipher.Aes256Gcm, 16)]
+    public void ExactKeyLengthIsRequired(AhtolaEncryptionCipher cipher, int keyLength)
+    {
+        var action = () => AhtolaBrowserEncryptionOptions.FromKey(cipher, new byte[keyLength]);
+
+        action.Should().Throw<ArgumentException>();
+    }
+
+    [TestCase(AhtolaEncryptionCipher.Aegis256)]
+    [TestCase(AhtolaEncryptionCipher.Aegis128l)]
+    public void NonAesGcmCiphersAreRejected(AhtolaEncryptionCipher cipher)
+    {
+        var action = () => AhtolaBrowserEncryptionOptions.FromKey(cipher, new byte[32]);
+
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public void NonHexadecimalKeysAreRejected()
+    {
+        var action = () => AhtolaBrowserEncryptionOptions.FromHex(
+            AhtolaEncryptionCipher.Aes256Gcm,
+            "not-hexadecimal");
+
+        action.Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void ConnectionStringNeverCarriesKeyMaterial()
+    {
+        using var keyed = AhtolaBrowserEncryptionOptions.FromHex(AhtolaEncryptionCipher.Aes256Gcm, Aes256Key);
+        using var keyedOptions = new AhtolaBrowserOptions("owned/data.db", "owned", encryption: keyed);
+        using var passworded = AhtolaBrowserEncryptionOptions.FromPassword(Password);
+        using var passwordOptions = new AhtolaBrowserOptions("owned/data.db", "owned", encryption: passworded);
+
+        keyedOptions.IsEncrypted.Should().BeTrue();
+        passwordOptions.IsEncrypted.Should().BeTrue();
+        foreach (var connectionString in new[] { keyedOptions.ConnectionString, passwordOptions.ConnectionString })
+        {
+            connectionString.Should().NotContain(Aes256Key);
+            connectionString.Should().NotContain(Password);
+            connectionString.Should().NotContain("Password", "no password keyword may leak into the connection string");
+            connectionString.Should().NotContain("Key");
+        }
+
+        var builder = new SqliteConnectionStringBuilder(keyedOptions.ConnectionString);
+        builder.DataSource.Should().Be("owned/data.db");
+        builder.LocalProvider.Should().Be(AhtolaLocalProvider.Managed);
+    }
+
+    [Test]
+    public void OptionsWithoutEncryptionStayUnencrypted()
+    {
+        using var options = new AhtolaBrowserOptions("owned/data.db", "owned");
+
+        options.IsEncrypted.Should().BeFalse();
+        options.Encryption.Should().BeNull();
+    }
+
+    [Test]
+    public void OptionsCopyTheCallerSuppliedKeySoCallerDisposalIsSafe()
+    {
+        var caller = AhtolaBrowserEncryptionOptions.FromHex(AhtolaEncryptionCipher.Aes256Gcm, Aes256Key);
+        using var options = new AhtolaBrowserOptions("owned/data.db", "owned", encryption: caller);
+
+        caller.Dispose();
+
+        options.Encryption.Should().NotBeNull();
+        options.Encryption!.Cipher.Should().Be(AhtolaEncryptionCipher.Aes256Gcm);
+        var stillUsable = () => options.Encryption!.CreateOwnedCopy();
+        stillUsable.Should().NotThrow();
+    }
+
+    [Test]
+    public void DisposingOptionsReleasesTheEncryptionCopy()
+    {
+        using var caller = AhtolaBrowserEncryptionOptions.FromHex(AhtolaEncryptionCipher.Aes256Gcm, Aes256Key);
+        var options = new AhtolaBrowserOptions("owned/data.db", "owned", encryption: caller);
+        var copy = options.Encryption!;
+
+        options.Dispose();
+
+        options.Encryption.Should().BeNull();
+        var released = () => copy.CreateOwnedCopy();
+        released.Should().Throw<ObjectDisposedException>();
+    }
+
+    [Test]
+    public void DisposedEncryptionOptionsRejectFurtherUse()
+    {
+        var options = AhtolaBrowserEncryptionOptions.FromPassword(Password);
+        options.Dispose();
+        options.Dispose();
+
+        var action = () => options.CreateOwnedCopy();
+        action.Should().Throw<ObjectDisposedException>();
+    }
+
+    [Test]
+    public void EmptyPasswordsAndKeysAreRejected()
+    {
+        var emptyPassword = () => AhtolaBrowserEncryptionOptions.FromPassword(string.Empty);
+        var emptyHex = () => AhtolaBrowserEncryptionOptions.FromHex(AhtolaEncryptionCipher.Aes256Gcm, string.Empty);
+
+        emptyPassword.Should().Throw<ArgumentException>();
+        emptyHex.Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void BrowserPasswordDerivationMatchesTheDesktopScheme()
+    {
+        // The browser derives the same 32 bytes through Web Crypto PBKDF2; this
+        // asserts the shared parameters that make those two derivations agree.
+        using var desktop = AhtolaPasswordEncryption.FromPassword(Password);
+
+        desktop.Cipher.Should().Be(Core.Storage.AhtolaEncryptionCipher.Aes256Gcm);
+        AhtolaBrowserCryptoParameters.PasswordKeySize.Should().Be(32);
+        Encoding.UTF8.GetBytes(AhtolaBrowserCryptoParameters.PasswordSalt).Should().Equal(
+            Encoding.UTF8.GetBytes(AhtolaPasswordEncryption.DomainSaltV1));
+    }
+}

--- a/src/Ahtola.Tests/AhtolaBrowserInMemoryDataSourceTests.cs
+++ b/src/Ahtola.Tests/AhtolaBrowserInMemoryDataSourceTests.cs
@@ -1,0 +1,110 @@
+using Ahtola.Core.Storage;
+using Ahtola.Data.Sqlite;
+using Ahtola.Data.Sqlite.Browser;
+using AwesomeAssertions;
+
+#pragma warning disable CA1416
+
+namespace Ahtola.Tests;
+
+public sealed class AhtolaBrowserInMemoryDataSourceTests
+{
+    [Test]
+    public void MemoryOptionsUseSharedMemoryWithoutOpfs()
+    {
+        using var options = new AhtolaBrowserOptions(":memory:");
+        var connectionString = new SqliteConnectionStringBuilder(options.ConnectionString);
+
+        options.IsInMemory.Should().BeTrue();
+        options.IsEncrypted.Should().BeFalse();
+        options.DatabasePath.Should().Be(":memory:");
+        options.OwnedDirectory.Should().Be(":memory:");
+        connectionString.Mode.Should().Be(SqliteOpenMode.Memory);
+        connectionString.Cache.Should().Be(SqliteCacheMode.Shared);
+        connectionString.Pooling.Should().BeFalse();
+    }
+
+    [Test]
+    public void MemoryOptionsRejectStorageOnlySettings()
+    {
+        using var encryption = AhtolaBrowserEncryptionOptions.FromKey(
+            AhtolaEncryptionCipher.Aes128Gcm,
+            new byte[16]);
+
+        new Action(() => new AhtolaBrowserOptions(":memory:", readOnly: true))
+            .Should().Throw<ArgumentException>();
+        new Action(() => new AhtolaBrowserOptions(":memory:", encryption: encryption))
+            .Should().Throw<NotSupportedException>();
+        new Action(() => new AhtolaBrowserOptions(":memory:", "owned"))
+            .Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public async Task ConnectionsFromOneMemoryDataSourceShareState()
+    {
+        await using var dataSource = new AhtolaBrowserDataSource(":memory:");
+        await using var first = await dataSource.OpenConnectionAsync();
+        await using var second = await dataSource.OpenConnectionAsync();
+        await using (var create = first.CreateCommand())
+        {
+            create.CommandText = "CREATE TABLE probe(value INTEGER); INSERT INTO probe VALUES (42)";
+            await create.ExecuteNonQueryAsync();
+        }
+
+        await using var query = second.CreateCommand();
+        query.CommandText = "SELECT value FROM probe";
+
+        (await query.ExecuteScalarAsync()).Should().Be(42L);
+    }
+
+    [Test]
+    public async Task MemoryDataSourceSharesStateAcrossBothConnectionFacades()
+    {
+        await using var dataSource = new AhtolaBrowserDataSource(":memory:");
+        await using (var sqlite = await dataSource.OpenConnectionAsync())
+        {
+            await using var create = sqlite.CreateCommand();
+            create.CommandText = "CREATE TABLE probe(value INTEGER); INSERT INTO probe VALUES (84)";
+            await create.ExecuteNonQueryAsync();
+        }
+
+        await using var ahtola = dataSource.CreateAhtolaConnection();
+        await ahtola.OpenAsync();
+        await using var query = ahtola.CreateCommand();
+        query.CommandText = "SELECT value FROM probe";
+
+        (await query.ExecuteScalarAsync()).Should().Be(84L);
+    }
+
+    [Test]
+    public async Task MemoryDataSourceStillRejectsSynchronousExecution()
+    {
+        await using var dataSource = new AhtolaBrowserDataSource(":memory:");
+        await using var connection = await dataSource.OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 1";
+
+        command.Invoking(static value => value.ExecuteScalar())
+            .Should().Throw<PlatformNotSupportedException>()
+            .WithMessage("*ExecuteScalarAsync*");
+    }
+
+    [Test]
+    public async Task MemoryDataSourcePreservesSharedMemoryIsolationGuards()
+    {
+        await using var dataSource = new AhtolaBrowserDataSource(":memory:");
+        await using (var sqlite = await dataSource.OpenConnectionAsync())
+        {
+            sqlite.IsManagedSharedMemory.Should().BeTrue();
+            await sqlite.Invoking(static value =>
+                    value.BeginTransactionAsync(System.Data.IsolationLevel.ReadUncommitted).AsTask())
+                .Should().ThrowAsync<NotSupportedException>();
+        }
+
+        await using var ahtola = dataSource.CreateAhtolaConnection();
+        await ahtola.OpenAsync();
+        await ahtola.Invoking(static value =>
+                value.BeginTransactionAsync(System.Data.IsolationLevel.ReadUncommitted).AsTask())
+            .Should().ThrowAsync<NotSupportedException>();
+    }
+}

--- a/src/Ahtola.Tests/AhtolaBrowserOpfsPathReservationTests.cs
+++ b/src/Ahtola.Tests/AhtolaBrowserOpfsPathReservationTests.cs
@@ -1,0 +1,47 @@
+using AwesomeAssertions;
+using Ahtola.Data.Sqlite.Browser.Storage;
+
+#pragma warning disable CA1416
+
+namespace Ahtola.Tests;
+
+public sealed class AhtolaBrowserOpfsPathReservationTests
+{
+    [TestCase(".ahtola-replace-anything")]
+    [TestCase(".ahtola-replace-journal.0")]
+    [TestCase(".ahtola-replace-journal.1")]
+    [TestCase("app-data/.ahtola-replace-nested")]
+    [TestCase("a/b/.ahtola-replace-deep.tmp")]
+    public void CanonicalizeRejectsAnySegmentStartingWithTheReservedPrefix(string path)
+    {
+        var act = () => OpfsAsyncFileSystem.Canonicalize(path);
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [TestCase("not.ahtola-replace-mine.db")]
+    [TestCase("app-data/my.ahtola-replace-notes.db")]
+    [TestCase("plainfile.db")]
+    [TestCase("nested/dir/file.db")]
+    public void CanonicalizeAllowsNamesThatMerelyContainTheReservedPrefix(string path)
+    {
+        OpfsAsyncFileSystem.Canonicalize(path).Should().Be(path);
+    }
+
+    [TestCase("a/../b")]
+    [TestCase("a/./b")]
+    [TestCase("a//b")]
+    public void CanonicalizeStillRejectsEmptyCurrentAndParentSegments(string path)
+    {
+        var act = () => OpfsAsyncFileSystem.Canonicalize(path);
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void CanonicalizeRejectsRootedPaths()
+    {
+        var act = () => OpfsAsyncFileSystem.Canonicalize("/absolute/path");
+        act.Should().Throw<ArgumentException>();
+    }
+}
+
+#pragma warning restore CA1416

--- a/src/Ahtola.Tests/AhtolaBrowserStorageContractTests.cs
+++ b/src/Ahtola.Tests/AhtolaBrowserStorageContractTests.cs
@@ -1,0 +1,45 @@
+using AwesomeAssertions;
+using Ahtola.Data.Sqlite.Browser;
+using Ahtola.Data.Sqlite.Browser.Storage;
+
+namespace Ahtola.Tests;
+
+public sealed class AhtolaBrowserStorageContractTests
+{
+    [TestCase("NotFoundError: missing", typeof(FileNotFoundException))]
+    [TestCase("QuotaExceededError: full", typeof(IOException))]
+    [TestCase("NoModificationAllowedError: denied", typeof(UnauthorizedAccessException))]
+    [TestCase("InvalidModificationError: exists", typeof(IOException))]
+    [TestCase("InvalidStateError: closed", typeof(IOException))]
+    public void BrowserStorageErrorsUseStructuredNames(
+        string message,
+        Type expectedExceptionType)
+    {
+        var source = new InvalidOperationException(message);
+        var mapped = BrowserStorageExceptionMapper.Map(
+            source,
+            "data.db",
+            "open");
+
+        mapped.Should().BeOfType(expectedExceptionType);
+        mapped.InnerException.Should().BeSameAs(source);
+    }
+
+    [Test]
+    public void BrowserStorageDiagnosticSucceedsOnlyWhenEveryCheckPasses()
+    {
+        new AhtolaBrowserStorageDiagnosticResult(
+                CompetingContextRejected: true,
+                PositionalIoMatches: true,
+                AtomicReplaceMatches: true,
+                Details: "passed")
+            .Succeeded.Should().BeTrue();
+
+        new AhtolaBrowserStorageDiagnosticResult(
+                CompetingContextRejected: true,
+                PositionalIoMatches: false,
+                AtomicReplaceMatches: true,
+                Details: "failed")
+            .Succeeded.Should().BeFalse();
+    }
+}

--- a/src/Ahtola.Tests/AhtolaBrowserStorageContractTests.cs
+++ b/src/Ahtola.Tests/AhtolaBrowserStorageContractTests.cs
@@ -32,6 +32,7 @@ public sealed class AhtolaBrowserStorageContractTests
                 CompetingContextRejected: true,
                 PositionalIoMatches: true,
                 AtomicReplaceMatches: true,
+                ManagedPersistenceMatches: true,
                 Details: "passed")
             .Succeeded.Should().BeTrue();
 
@@ -39,6 +40,7 @@ public sealed class AhtolaBrowserStorageContractTests
                 CompetingContextRejected: true,
                 PositionalIoMatches: false,
                 AtomicReplaceMatches: true,
+                ManagedPersistenceMatches: true,
                 Details: "failed")
             .Succeeded.Should().BeFalse();
     }

--- a/src/Ahtola.Tests/AsyncFileSystemAdapterTests.cs
+++ b/src/Ahtola.Tests/AsyncFileSystemAdapterTests.cs
@@ -1,0 +1,746 @@
+using System.Runtime.ExceptionServices;
+using AwesomeAssertions;
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Tests;
+
+public sealed class AsyncFileSystemAdapterTests
+{
+    [Test]
+    public async Task AdapterCompletesInlineAndPreservesFileSemantics()
+    {
+        var faults = new DeterministicFaultInjector();
+        var synchronous = new InMemoryFileSystem(faults);
+        var fileSystem = AsyncFileSystemAdapter.Create(synchronous);
+
+        var exists = fileSystem.FileExistsAsync("inline.db");
+        exists.IsCompletedSuccessfully.Should().BeTrue();
+        (await exists).Should().BeFalse();
+
+        var open = fileSystem.OpenFileAsync("inline.db", FileOpenMode.CreateNew);
+        open.IsCompletedSuccessfully.Should().BeTrue();
+        await using var file = await open;
+
+        var write = file.WriteAsync(0, new byte[] { 1, 2, 3, 4, 5 });
+        write.IsCompletedSuccessfully.Should().BeTrue();
+        await write;
+
+        var flush = file.FlushToDiskAsync();
+        flush.IsCompletedSuccessfully.Should().BeTrue();
+        await flush;
+
+        var length = file.GetLengthAsync();
+        length.IsCompletedSuccessfully.Should().BeTrue();
+        (await length).Should().Be(5);
+
+        var destination = Enumerable.Repeat((byte)0xCC, 8).ToArray();
+        var read = file.ReadAsync(0, destination);
+        read.IsCompletedSuccessfully.Should().BeTrue();
+        (await read).Should().Be(5);
+        destination.Should().Equal(1, 2, 3, 4, 5, 0xCC, 0xCC, 0xCC);
+
+        var truncate = file.SetLengthAsync(2);
+        truncate.IsCompletedSuccessfully.Should().BeTrue();
+        await truncate;
+        (await file.GetLengthAsync()).Should().Be(2);
+
+        faults.GetOperationCount(FileSystemOperation.Write).Should().Be(1);
+        faults.GetOperationCount(FileSystemOperation.Read).Should().Be(1);
+        faults.GetOperationCount(FileSystemOperation.FlushToDisk).Should().Be(1);
+        faults.GetOperationCount(FileSystemOperation.SetLength).Should().Be(1);
+
+        var delete = fileSystem.DeleteFileAsync("inline.db");
+        delete.IsCompletedSuccessfully.Should().BeTrue();
+        await delete;
+        synchronous.FileExists("inline.db").Should().BeFalse();
+    }
+
+    [Test]
+    public async Task AdapterPreservesAtomicReplacementCapabilityAndSemantics()
+    {
+        var synchronous = new InMemoryFileSystem();
+        using (var source = synchronous.OpenFile("source.db", FileOpenMode.CreateNew))
+        {
+            source.Write(0, new byte[] { 4, 2 });
+        }
+
+        using (synchronous.OpenFile("destination.db", FileOpenMode.CreateNew))
+        {
+        }
+
+        var fileSystem = AsyncFileSystemAdapter.Create(synchronous);
+        var atomic = fileSystem.Should().BeAssignableTo<IAsyncAtomicFileSystem>().Subject;
+        var replace = atomic.ReplaceFileAtomicallyAsync(
+            "source.db",
+            "destination.db",
+            replaceEmptyDestination: true);
+
+        replace.IsCompletedSuccessfully.Should().BeTrue();
+        await replace;
+        synchronous.FileExists("source.db").Should().BeFalse();
+
+        await using var destination = await fileSystem.OpenFileAsync(
+            "destination.db",
+            FileOpenMode.OpenExisting);
+        var bytes = new byte[2];
+        (await destination.ReadAsync(0, bytes)).Should().Be(2);
+        bytes.Should().Equal(4, 2);
+    }
+
+    [Test]
+    public async Task AdapterPreservesTemporaryFileDeleteOnCloseWhereSupported()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"ahtola-async-{Guid.NewGuid():N}.tmp");
+        var fileSystem = AsyncFileSystemAdapter.Create(PhysicalFileSystem.Instance);
+        var temporary = fileSystem.Should().BeAssignableTo<IAsyncTemporaryFileSystem>().Subject;
+
+        try
+        {
+            var open = temporary.OpenTemporaryFileAsync(path);
+            open.IsCompletedSuccessfully.Should().BeTrue();
+            var file = await open;
+            await file.WriteAsync(0, new byte[] { 9 });
+            var dispose = file.DisposeAsync();
+            dispose.IsCompletedSuccessfully.Should().BeTrue();
+            await dispose;
+
+            File.Exists(path).Should().BeFalse();
+        }
+        finally
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task AdapterPreservesPageMaterializationCapability()
+    {
+        var synchronous = new MaterializingFile();
+        var file = AsyncFileAdapter.Create(synchronous);
+        var materializing = file.Should().BeAssignableTo<IAsyncPageMaterializingFile>().Subject;
+
+        var operation = materializing.EnsureMaterializedAsync(4096, 1024);
+
+        operation.IsCompletedSuccessfully.Should().BeTrue();
+        await operation;
+        synchronous.MaterializedRange.Should().Be((4096L, 1024));
+    }
+
+    [Test]
+    public void AdapterHonorsCancellationBeforeCallingSynchronousStorage()
+    {
+        var faults = new DeterministicFaultInjector();
+        var fileSystem = AsyncFileSystemAdapter.Create(new InMemoryFileSystem(faults));
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        var exception = Assert.Throws<OperationCanceledException>(
+            () => fileSystem.OpenFileAsync(
+                "cancelled.db",
+                FileOpenMode.OpenOrCreate,
+                cancellationToken: cancellation.Token));
+
+        exception.CancellationToken.Should().Be(cancellation.Token);
+        faults.GetOperationCount(FileSystemOperation.Open).Should().Be(0);
+    }
+
+    [Test]
+    public void AdapterPropagatesExactExceptionsWithoutWrapping()
+    {
+        var expectedDelete = new IOException("delete failed");
+        var fileSystem = AsyncFileSystemAdapter.Create(new ThrowingFileSystem(expectedDelete));
+        fileSystem.Should().NotBeAssignableTo<IStoragePathResolver>();
+        fileSystem.Should().NotBeAssignableTo<IAsyncAtomicFileSystem>();
+        fileSystem.Should().NotBeAssignableTo<IAsyncTemporaryFileSystem>();
+
+        var delete = Assert.Throws<IOException>(() => fileSystem.DeleteFileAsync("fault.db"));
+        delete.Should().BeSameAs(expectedDelete);
+
+        var expectedWrite = new InvalidDataException("write failed");
+        var file = AsyncFileAdapter.Create(new ThrowingFile(expectedWrite, disposeException: null));
+        var write = Assert.Throws<InvalidDataException>(
+            () => file.WriteAsync(0, new byte[] { 1 }));
+        write.Should().BeSameAs(expectedWrite);
+
+        var expectedDispose = new IOException("dispose failed");
+        var disposable = AsyncFileAdapter.Create(new ThrowingFile(writeException: null, expectedDispose));
+        var dispose = Assert.Throws<IOException>(() => disposable.DisposeAsync());
+        dispose.Should().BeSameAs(expectedDispose);
+    }
+
+    [Test]
+    public void AdapterPreservesCanonicalPathCapability()
+    {
+        var logical = AsyncFileSystemAdapter.Create(new InMemoryFileSystem())
+            .Should().BeAssignableTo<IStoragePathResolver>().Subject;
+        logical.GetCanonicalPath("folder/database.db").Should().Be("folder/database.db");
+        logical.PathComparer.Should().BeSameAs(StringComparer.Ordinal);
+
+        var physical = AsyncFileSystemAdapter.Create(PhysicalFileSystem.Instance)
+            .Should().BeAssignableTo<IStoragePathResolver>().Subject;
+        physical.GetCanonicalPath("database.db").Should().Be(Path.GetFullPath("database.db"));
+        physical.PathComparer.Equals("A", "a").Should().Be(
+            OperatingSystem.IsWindows() || OperatingSystem.IsMacOS());
+    }
+
+    private sealed class ThrowingFileSystem(Exception deleteException) : IFileSystem
+    {
+        public bool FileExists(string path) => false;
+
+        public IFile OpenFile(string path, FileOpenMode mode, bool readOnly = false)
+            => throw new NotSupportedException();
+
+        public void DeleteFile(string path) => ExceptionDispatchInfo.Capture(deleteException).Throw();
+    }
+
+    private sealed class ThrowingFile(
+        Exception? writeException,
+        Exception? disposeException) : IFile
+    {
+        public long Length => 0;
+
+        public bool IsReadOnly => false;
+
+        public int Read(long position, Span<byte> destination) => 0;
+
+        public void Write(long position, ReadOnlySpan<byte> source)
+        {
+            if (writeException is not null)
+                ExceptionDispatchInfo.Capture(writeException).Throw();
+        }
+
+        public void SetLength(long length)
+        {
+        }
+
+        public void FlushToDisk()
+        {
+        }
+
+        public void Dispose()
+        {
+            if (disposeException is not null)
+                ExceptionDispatchInfo.Capture(disposeException).Throw();
+        }
+    }
+
+    internal sealed class MaterializingFile : IFile, IPageMaterializingFile
+    {
+        internal (long Position, int Length)? MaterializedRange { get; private set; }
+
+        public long Length => 0;
+
+        public bool IsReadOnly => false;
+
+        public int Read(long position, Span<byte> destination) => 0;
+
+        public void Write(long position, ReadOnlySpan<byte> source)
+        {
+        }
+
+        public void SetLength(long length)
+        {
+        }
+
+        public void FlushToDisk()
+        {
+        }
+
+        public void EnsureMaterialized(long position, int length)
+            => MaterializedRange = (position, length);
+
+        public void Dispose()
+        {
+        }
+    }
+}
+
+public sealed class DeterministicAsyncFileSystemTests
+{
+    [Test]
+    public async Task ForcedCompletionsSuspendEveryCoreFileOperation()
+    {
+        var controller = new DeterministicAsyncIoController(forceYield: true);
+        var fileSystem = DeterministicAsyncFileSystem.Create(
+            AsyncFileSystemAdapter.Create(new InMemoryFileSystem()),
+            controller);
+
+        (await CompleteYieldAsync(
+            fileSystem.FileExistsAsync("yield.db"),
+            controller)).Should().BeFalse();
+        (await CompleteYieldAsync(
+            fileSystem.GetWriteStampAsync("yield.db"),
+            controller)).Should().BeNull();
+
+        var file = await CompleteYieldAsync(
+            fileSystem.OpenFileAsync("yield.db", FileOpenMode.CreateNew),
+            controller);
+        fileSystem.Should().NotBeAssignableTo<IAsyncTemporaryFileSystem>();
+        file.Should().NotBeAssignableTo<IAsyncPageMaterializingFile>();
+        await CompleteYieldAsync(file.WriteAsync(0, new byte[] { 1, 2, 3 }), controller);
+        (await CompleteYieldAsync(file.GetLengthAsync(), controller)).Should().Be(3);
+
+        var bytes = new byte[4];
+        (await CompleteYieldAsync(file.ReadAsync(0, bytes), controller)).Should().Be(3);
+        await CompleteYieldAsync(file.SetLengthAsync(1), controller);
+        await CompleteYieldAsync(file.FlushToDiskAsync(), controller);
+        await CompleteYieldAsync(file.DisposeAsync(), controller);
+        await CompleteYieldAsync(fileSystem.DeleteFileAsync("yield.db"), controller);
+
+        controller.GetOperationCount(FileSystemOperation.FileExists).Should().Be(1);
+        controller.GetOperationCount(FileSystemOperation.GetWriteStamp).Should().Be(1);
+        controller.GetOperationCount(FileSystemOperation.Open).Should().Be(1);
+        controller.GetOperationCount(FileSystemOperation.Write).Should().Be(1);
+        controller.GetOperationCount(FileSystemOperation.GetLength).Should().Be(1);
+        controller.GetOperationCount(FileSystemOperation.Read).Should().Be(1);
+        controller.GetOperationCount(FileSystemOperation.SetLength).Should().Be(1);
+        controller.GetOperationCount(FileSystemOperation.FlushToDisk).Should().Be(1);
+        controller.GetOperationCount(FileSystemOperation.Dispose).Should().Be(1);
+        controller.GetOperationCount(FileSystemOperation.Delete).Should().Be(1);
+    }
+
+    [Test]
+    public async Task ForcedCompletionHonorsCancellationWhileSuspended()
+    {
+        var controller = new DeterministicAsyncIoController(forceYield: true);
+        var fileSystem = DeterministicAsyncFileSystem.Create(
+            AsyncFileSystemAdapter.Create(new InMemoryFileSystem()),
+            controller);
+        using var cancellation = new CancellationTokenSource();
+
+        var pending = fileSystem.FileExistsAsync("cancel.db", cancellation.Token);
+        pending.IsCompleted.Should().BeFalse();
+        controller.PendingYieldCount.Should().Be(1);
+        cancellation.Cancel();
+
+        var exception = Assert.CatchAsync<OperationCanceledException>(
+            async () => await pending);
+        exception.CancellationToken.Should().Be(cancellation.Token);
+        controller.ReleaseNext();
+    }
+
+    [Test]
+    public async Task TargetedFailureIsRaisedAfterYieldAndPreservesExactException()
+    {
+        var expected = new IOException("targeted write failure");
+        var controller = new DeterministicAsyncIoController(forceYield: true);
+        controller.FailNext(FileSystemOperation.Write, expected);
+        var fileSystem = DeterministicAsyncFileSystem.Create(
+            AsyncFileSystemAdapter.Create(new InMemoryFileSystem()),
+            controller);
+        var file = await CompleteYieldAsync(
+            fileSystem.OpenFileAsync("fault.db", FileOpenMode.CreateNew),
+            controller);
+
+        var pending = file.WriteAsync(0, new byte[] { 7 });
+        pending.IsCompleted.Should().BeFalse();
+        controller.ReleaseNext();
+
+        var exception = Assert.ThrowsAsync<IOException>(async () => await pending);
+        exception.Should().BeSameAs(expected);
+        (await CompleteYieldAsync(file.GetLengthAsync(), controller)).Should().Be(0);
+    }
+
+    [Test]
+    public async Task ForcedCompletionsCoverAtomicTemporaryAndMaterializationCapabilities()
+    {
+        var memoryController = new DeterministicAsyncIoController(forceYield: true);
+        var memory = new InMemoryFileSystem();
+        using (memory.OpenFile("source.db", FileOpenMode.CreateNew))
+        {
+        }
+
+        var memoryAsync = DeterministicAsyncFileSystem.Create(
+            AsyncFileSystemAdapter.Create(memory),
+            memoryController);
+        var atomic = memoryAsync.Should().BeAssignableTo<IAsyncAtomicFileSystem>().Subject;
+        await CompleteYieldAsync(
+            atomic.ReplaceFileAtomicallyAsync(
+                "source.db",
+                "destination.db",
+                replaceEmptyDestination: false),
+            memoryController);
+        memory.FileExists("destination.db").Should().BeTrue();
+
+        var materializationController = new DeterministicAsyncIoController(forceYield: true);
+        var materializingFile = DeterministicAsyncFile.Create(
+            AsyncFileAdapter.Create(new AsyncFileSystemAdapterTests.MaterializingFile()),
+            materializationController);
+        var materializing = materializingFile
+            .Should().BeAssignableTo<IAsyncPageMaterializingFile>().Subject;
+        await CompleteYieldAsync(
+            materializing.EnsureMaterializedAsync(0, 4096),
+            materializationController);
+
+        var path = Path.Combine(Path.GetTempPath(), $"ahtola-async-yield-{Guid.NewGuid():N}.tmp");
+        var physicalController = new DeterministicAsyncIoController(forceYield: true);
+        var physical = DeterministicAsyncFileSystem.Create(
+            AsyncFileSystemAdapter.Create(PhysicalFileSystem.Instance),
+            physicalController);
+        var temporaryFileSystem = physical
+            .Should().BeAssignableTo<IAsyncTemporaryFileSystem>().Subject;
+        try
+        {
+            var temporary = await CompleteYieldAsync(
+                temporaryFileSystem.OpenTemporaryFileAsync(path),
+                physicalController);
+            await CompleteYieldAsync(temporary.DisposeAsync(), physicalController);
+            File.Exists(path).Should().BeFalse();
+        }
+        finally
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+
+        memoryController.GetOperationCount(FileSystemOperation.AtomicReplace).Should().Be(1);
+        materializationController.GetOperationCount(FileSystemOperation.EnsureMaterialized).Should().Be(1);
+        physicalController.GetOperationCount(FileSystemOperation.OpenTemporary).Should().Be(1);
+    }
+
+    private static async Task CompleteYieldAsync(
+        ValueTask operation,
+        DeterministicAsyncIoController controller)
+    {
+        operation.IsCompleted.Should().BeFalse();
+        controller.PendingYieldCount.Should().Be(1);
+        controller.ReleaseNext();
+        await operation;
+    }
+
+    private static async Task<T> CompleteYieldAsync<T>(
+        ValueTask<T> operation,
+        DeterministicAsyncIoController controller)
+    {
+        operation.IsCompleted.Should().BeFalse();
+        controller.PendingYieldCount.Should().Be(1);
+        controller.ReleaseNext();
+        return await operation;
+    }
+}
+
+internal sealed class DeterministicAsyncIoController(bool forceYield)
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<FileSystemOperation, long> _counts = new();
+    private readonly Dictionary<(FileSystemOperation Operation, long Occurrence), Exception> _faults = new();
+    private readonly Queue<TaskCompletionSource> _pendingYields = new();
+
+    internal int PendingYieldCount
+    {
+        get
+        {
+            lock (_gate)
+                return _pendingYields.Count;
+        }
+    }
+
+    internal void FailNext(FileSystemOperation operation, Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        lock (_gate)
+        {
+            var occurrence = _counts.GetValueOrDefault(operation) + 1;
+            _faults[(operation, occurrence)] = exception;
+        }
+    }
+
+    internal long GetOperationCount(FileSystemOperation operation)
+    {
+        lock (_gate)
+            return _counts.GetValueOrDefault(operation);
+    }
+
+    internal void ReleaseNext()
+    {
+        TaskCompletionSource completion;
+        lock (_gate)
+            completion = _pendingYields.Dequeue();
+        completion.SetResult();
+    }
+
+    internal async ValueTask BeforeOperationAsync(
+        FileSystemOperation operation,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        TaskCompletionSource? completion = null;
+        Exception? fault;
+        lock (_gate)
+        {
+            var occurrence = _counts.GetValueOrDefault(operation) + 1;
+            _counts[operation] = occurrence;
+            _faults.Remove((operation, occurrence), out fault);
+            if (forceYield)
+            {
+                completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                _pendingYields.Enqueue(completion);
+            }
+        }
+
+        if (completion is not null)
+            await completion.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        cancellationToken.ThrowIfCancellationRequested();
+        if (fault is not null)
+            ExceptionDispatchInfo.Capture(fault).Throw();
+    }
+}
+
+internal class DeterministicAsyncFileSystem : IAsyncFileSystem
+{
+    protected DeterministicAsyncFileSystem(
+        IAsyncFileSystem inner,
+        DeterministicAsyncIoController controller)
+    {
+        Inner = inner;
+        Controller = controller;
+    }
+
+    protected IAsyncFileSystem Inner { get; }
+
+    protected DeterministicAsyncIoController Controller { get; }
+
+    internal static IAsyncFileSystem Create(
+        IAsyncFileSystem inner,
+        DeterministicAsyncIoController controller)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        ArgumentNullException.ThrowIfNull(controller);
+        return (inner is IAsyncAtomicFileSystem, inner is IAsyncTemporaryFileSystem) switch
+        {
+            (true, true) => new AtomicTemporaryFileSystem(inner, controller),
+            (true, false) => new AtomicFileSystem(inner, controller),
+            (false, true) => new TemporaryFileSystem(inner, controller),
+            _ => new DeterministicAsyncFileSystem(inner, controller),
+        };
+    }
+
+    public async ValueTask<bool> FileExistsAsync(
+        string path,
+        CancellationToken cancellationToken = default)
+    {
+        await Controller.BeforeOperationAsync(
+            FileSystemOperation.FileExists,
+            cancellationToken).ConfigureAwait(false);
+        return await Inner.FileExistsAsync(path, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask<IAsyncFile> OpenFileAsync(
+        string path,
+        FileOpenMode mode,
+        bool readOnly = false,
+        CancellationToken cancellationToken = default)
+    {
+        await Controller.BeforeOperationAsync(
+            FileSystemOperation.Open,
+            cancellationToken).ConfigureAwait(false);
+        var file = await Inner.OpenFileAsync(path, mode, readOnly, cancellationToken).ConfigureAwait(false);
+        return DeterministicAsyncFile.Create(file, Controller);
+    }
+
+    public async ValueTask DeleteFileAsync(
+        string path,
+        CancellationToken cancellationToken = default)
+    {
+        await Controller.BeforeOperationAsync(
+            FileSystemOperation.Delete,
+            cancellationToken).ConfigureAwait(false);
+        await Inner.DeleteFileAsync(path, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask<FileWriteStamp?> GetWriteStampAsync(
+        string path,
+        CancellationToken cancellationToken = default)
+    {
+        await Controller.BeforeOperationAsync(
+            FileSystemOperation.GetWriteStamp,
+            cancellationToken).ConfigureAwait(false);
+        return await Inner.GetWriteStampAsync(path, cancellationToken).ConfigureAwait(false);
+    }
+
+    private sealed class AtomicFileSystem(
+        IAsyncFileSystem inner,
+        DeterministicAsyncIoController controller) :
+        DeterministicAsyncFileSystem(inner, controller),
+        IAsyncAtomicFileSystem
+    {
+        public async ValueTask ReplaceFileAtomicallyAsync(
+            string sourcePath,
+            string destinationPath,
+            bool replaceEmptyDestination,
+            CancellationToken cancellationToken = default)
+        {
+            await Controller.BeforeOperationAsync(
+                FileSystemOperation.AtomicReplace,
+                cancellationToken).ConfigureAwait(false);
+            await ((IAsyncAtomicFileSystem)Inner).ReplaceFileAtomicallyAsync(
+                sourcePath,
+                destinationPath,
+                replaceEmptyDestination,
+                cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private sealed class TemporaryFileSystem(
+        IAsyncFileSystem inner,
+        DeterministicAsyncIoController controller) :
+        DeterministicAsyncFileSystem(inner, controller),
+        IAsyncTemporaryFileSystem
+    {
+        public async ValueTask<IAsyncFile> OpenTemporaryFileAsync(
+            string path,
+            CancellationToken cancellationToken = default)
+        {
+            await Controller.BeforeOperationAsync(
+                FileSystemOperation.OpenTemporary,
+                cancellationToken).ConfigureAwait(false);
+            var file = await ((IAsyncTemporaryFileSystem)Inner)
+                .OpenTemporaryFileAsync(path, cancellationToken).ConfigureAwait(false);
+            return DeterministicAsyncFile.Create(file, Controller);
+        }
+    }
+
+    private sealed class AtomicTemporaryFileSystem(
+        IAsyncFileSystem inner,
+        DeterministicAsyncIoController controller) :
+        DeterministicAsyncFileSystem(inner, controller),
+        IAsyncAtomicFileSystem,
+        IAsyncTemporaryFileSystem
+    {
+        public async ValueTask ReplaceFileAtomicallyAsync(
+            string sourcePath,
+            string destinationPath,
+            bool replaceEmptyDestination,
+            CancellationToken cancellationToken = default)
+        {
+            await Controller.BeforeOperationAsync(
+                FileSystemOperation.AtomicReplace,
+                cancellationToken).ConfigureAwait(false);
+            await ((IAsyncAtomicFileSystem)Inner).ReplaceFileAtomicallyAsync(
+                sourcePath,
+                destinationPath,
+                replaceEmptyDestination,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        public async ValueTask<IAsyncFile> OpenTemporaryFileAsync(
+            string path,
+            CancellationToken cancellationToken = default)
+        {
+            await Controller.BeforeOperationAsync(
+                FileSystemOperation.OpenTemporary,
+                cancellationToken).ConfigureAwait(false);
+            var file = await ((IAsyncTemporaryFileSystem)Inner)
+                .OpenTemporaryFileAsync(path, cancellationToken).ConfigureAwait(false);
+            return DeterministicAsyncFile.Create(file, Controller);
+        }
+    }
+}
+
+internal class DeterministicAsyncFile : IAsyncFile
+{
+    protected DeterministicAsyncFile(
+        IAsyncFile inner,
+        DeterministicAsyncIoController controller)
+    {
+        Inner = inner;
+        Controller = controller;
+    }
+
+    protected IAsyncFile Inner { get; }
+
+    protected DeterministicAsyncIoController Controller { get; }
+
+    internal static IAsyncFile Create(
+        IAsyncFile inner,
+        DeterministicAsyncIoController controller)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        ArgumentNullException.ThrowIfNull(controller);
+        return inner is IAsyncPageMaterializingFile
+            ? new MaterializingFile(inner, controller)
+            : new DeterministicAsyncFile(inner, controller);
+    }
+
+    public bool IsReadOnly => Inner.IsReadOnly;
+
+    public async ValueTask<long> GetLengthAsync(CancellationToken cancellationToken = default)
+    {
+        await Controller.BeforeOperationAsync(
+            FileSystemOperation.GetLength,
+            cancellationToken).ConfigureAwait(false);
+        return await Inner.GetLengthAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask<int> ReadAsync(
+        long position,
+        Memory<byte> destination,
+        CancellationToken cancellationToken = default)
+    {
+        await Controller.BeforeOperationAsync(
+            FileSystemOperation.Read,
+            cancellationToken).ConfigureAwait(false);
+        return await Inner.ReadAsync(position, destination, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask WriteAsync(
+        long position,
+        ReadOnlyMemory<byte> source,
+        CancellationToken cancellationToken = default)
+    {
+        await Controller.BeforeOperationAsync(
+            FileSystemOperation.Write,
+            cancellationToken).ConfigureAwait(false);
+        await Inner.WriteAsync(position, source, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask SetLengthAsync(
+        long length,
+        CancellationToken cancellationToken = default)
+    {
+        await Controller.BeforeOperationAsync(
+            FileSystemOperation.SetLength,
+            cancellationToken).ConfigureAwait(false);
+        await Inner.SetLengthAsync(length, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask FlushToDiskAsync(CancellationToken cancellationToken = default)
+    {
+        await Controller.BeforeOperationAsync(
+            FileSystemOperation.FlushToDisk,
+            cancellationToken).ConfigureAwait(false);
+        await Inner.FlushToDiskAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await Controller.BeforeOperationAsync(
+            FileSystemOperation.Dispose,
+            CancellationToken.None).ConfigureAwait(false);
+        await Inner.DisposeAsync().ConfigureAwait(false);
+    }
+
+    private sealed class MaterializingFile(
+        IAsyncFile inner,
+        DeterministicAsyncIoController controller) :
+        DeterministicAsyncFile(inner, controller),
+        IAsyncPageMaterializingFile
+    {
+        public async ValueTask EnsureMaterializedAsync(
+            long position,
+            int length,
+            CancellationToken cancellationToken = default)
+        {
+            await Controller.BeforeOperationAsync(
+                FileSystemOperation.EnsureMaterialized,
+                cancellationToken).ConfigureAwait(false);
+            await ((IAsyncPageMaterializingFile)Inner).EnsureMaterializedAsync(
+                position,
+                length,
+                cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Ahtola.Tests/AsyncPagerConcurrencyRegressionTests.cs
+++ b/src/Ahtola.Tests/AsyncPagerConcurrencyRegressionTests.cs
@@ -434,6 +434,141 @@ public sealed class AsyncPagerConcurrencyRegressionTests
         ExecuteAll(owner, "COMMIT;");
     }
 
+    [Test]
+    public async Task DurableWalCommitSurvivesAPostFlushBookkeepingFailure()
+    {
+        var storage = new InMemoryFileSystem();
+        var writerFileSystem = new FlushInterceptingAsyncFileSystem(storage, WalPath);
+        var first = CreatePage(0xF1);
+        var second = CreatePage(0xF2);
+
+        await using (var writer = await AsyncSqlitePager.CreateAsync(
+                         writerFileSystem,
+                         DatabasePath,
+                         WalPath,
+                         CreateWalHeader()))
+        {
+            await CommitPageAsync(writer, first);
+
+            // The commit frame reaches durable storage and only the bookkeeping that
+            // records it fails, so the transaction is committed and must stay so.
+            writerFileSystem.PostFlushReadFailure =
+                new IOException("injected post-flush SQLite WAL read failure");
+            await using var failing = await writer.BeginTransactionAsync(2);
+            await failing.WritePageAsync(2, second);
+            Func<Task> commit = async () => await failing.CommitAsync();
+            await commit.Should().ThrowAsync<IOException>();
+        }
+
+        await AssertDurableCommitSurvivesAsync(storage, second, expectedFrameCount: 2);
+    }
+
+    [Test]
+    public async Task DurableWalCommitSurvivesCancellationRaisedAfterItsFlush()
+    {
+        var storage = new InMemoryFileSystem();
+        var writerFileSystem = new FlushInterceptingAsyncFileSystem(storage, WalPath);
+        var first = CreatePage(0xF3);
+        var second = CreatePage(0xF4);
+
+        await using (var writer = await AsyncSqlitePager.CreateAsync(
+                         writerFileSystem,
+                         DatabasePath,
+                         WalPath,
+                         CreateWalHeader()))
+        {
+            await CommitPageAsync(writer, first);
+
+            using var cancellation = new CancellationTokenSource();
+            writerFileSystem.AfterFlush = () =>
+            {
+                cancellation.Cancel();
+                return ValueTask.CompletedTask;
+            };
+
+            await using var committing = await writer.BeginTransactionAsync(2);
+            await committing.WritePageAsync(2, second);
+
+            // Cancelling cannot un-commit a durable transaction, so the commit runs
+            // to completion rather than abandoning the record of it.
+            await committing.CommitAsync(cancellation.Token);
+            committing.State.Should().Be(SqlitePagerTransactionState.Committed);
+            writer.CommittedFrameCount.Should().Be(2);
+        }
+
+        await AssertDurableCommitSurvivesAsync(storage, second, expectedFrameCount: 2);
+    }
+
+    [Test]
+    public async Task FailedCreateKeepsAnAbandonedWalTailHidden()
+    {
+        var storage = new InMemoryFileSystem();
+        var writerFileSystem = new FlushInterceptingAsyncFileSystem(storage, WalPath);
+        var committed = CreatePage(0xC7);
+        var abandoned = CreatePage(0xC8);
+
+        await using var writer = await AsyncSqlitePager.CreateAsync(
+            writerFileSystem,
+            DatabasePath,
+            WalPath,
+            CreateWalHeader());
+        await CommitPageAsync(writer, committed);
+
+        await using var readerPager = await AsyncSqlitePager.OpenAsync(
+            AsyncFileSystemAdapter.Create(storage),
+            DatabasePath,
+            WalPath);
+        (await readerPager.ReadPageAsync(2)).Should().Equal(committed);
+
+        // Both the flush and the rollback truncation fail, so the abandoned tail is
+        // still physically present and only the boundary is hiding it.
+        writerFileSystem.FlushFailure = new IOException("injected SQLite WAL flush failure");
+        writerFileSystem.SetLengthFailure = new IOException("injected SQLite WAL truncation failure");
+        await using (var failing = await writer.BeginTransactionAsync(2))
+        {
+            await failing.WritePageAsync(2, abandoned);
+            Func<Task> commit = async () => await failing.CommitAsync();
+            await commit.Should().ThrowAsync<IOException>();
+        }
+
+        (await readerPager.ReadPageAsync(2)).Should().Equal(committed);
+
+        // Creating over the existing database fails, and a create that never
+        // produced fresh storage must not publish the tail it was hiding.
+        Func<Task> create = async () => await AsyncSqlitePager.CreateAsync(
+            AsyncFileSystemAdapter.Create(storage),
+            DatabasePath,
+            WalPath,
+            CreateWalHeader());
+        await create.Should().ThrowAsync<IOException>();
+
+        (await readerPager.ReadPageAsync(2)).Should().Equal(committed);
+        readerPager.CommittedFrameCount.Should().Be(1);
+    }
+
+    private static async Task AssertDurableCommitSurvivesAsync(
+        IFileSystem storage,
+        byte[] expectedPage,
+        long expectedFrameCount)
+    {
+        // A writable reopen repairs whatever the boundary still hides, so a commit
+        // wrongly left hidden would be truncated away here rather than retained.
+        await using (var reopened = await AsyncSqlitePager.OpenAsync(
+                         AsyncFileSystemAdapter.Create(storage),
+                         DatabasePath,
+                         WalPath))
+        {
+            (await reopened.ReadPageAsync(2)).Should().Equal(expectedPage);
+            reopened.CommittedFrameCount.Should().Be(expectedFrameCount);
+        }
+
+        await using var rawWal = await SqliteWalFile.OpenAsync(
+            AsyncFileSystemAdapter.Create(storage),
+            WalPath,
+            readOnly: true);
+        (await rawWal.ScanRecoveryAsync()).LastCommittedFrameNumber.Should().Be(expectedFrameCount);
+    }
+
     private static async Task CommitPageAsync(AsyncSqlitePager pager, byte[] replacement)
     {
         await using var transaction = await pager.BeginTransactionAsync(2);
@@ -523,6 +658,12 @@ internal sealed class FlushInterceptingAsyncFileSystem :
 
     internal Exception? FlushFailure { get; set; }
 
+    internal Exception? SetLengthFailure { get; set; }
+
+    internal Exception? PostFlushReadFailure { get; set; }
+
+    private Exception? ArmedReadFailure { get; set; }
+
     public IFileSystem BackingFileSystem => _backing;
 
     public StringComparer PathComparer => ((IStoragePathResolver)_inner).PathComparer;
@@ -563,7 +704,16 @@ internal sealed class FlushInterceptingAsyncFileSystem :
             long position,
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
-            => inner.ReadAsync(position, destination, cancellationToken);
+        {
+            var armed = owner.ArmedReadFailure;
+            if (armed is not null)
+            {
+                owner.ArmedReadFailure = null;
+                throw armed;
+            }
+
+            return inner.ReadAsync(position, destination, cancellationToken);
+        }
 
         public ValueTask WriteAsync(
             long position,
@@ -572,7 +722,16 @@ internal sealed class FlushInterceptingAsyncFileSystem :
             => inner.WriteAsync(position, source, cancellationToken);
 
         public ValueTask SetLengthAsync(long length, CancellationToken cancellationToken = default)
-            => inner.SetLengthAsync(length, cancellationToken);
+        {
+            var failure = owner.SetLengthFailure;
+            if (failure is not null)
+            {
+                owner.SetLengthFailure = null;
+                throw failure;
+            }
+
+            return inner.SetLengthAsync(length, cancellationToken);
+        }
 
         public async ValueTask FlushToDiskAsync(CancellationToken cancellationToken = default)
         {
@@ -592,6 +751,8 @@ internal sealed class FlushInterceptingAsyncFileSystem :
 
             await inner.FlushToDiskAsync(cancellationToken).ConfigureAwait(false);
 
+            owner.ArmedReadFailure = owner.PostFlushReadFailure;
+            owner.PostFlushReadFailure = null;
             var after = owner.AfterFlush;
             if (after is not null)
             {

--- a/src/Ahtola.Tests/AsyncPagerConcurrencyRegressionTests.cs
+++ b/src/Ahtola.Tests/AsyncPagerConcurrencyRegressionTests.cs
@@ -1,0 +1,503 @@
+using System.Diagnostics;
+using AwesomeAssertions;
+using Ahtola.Core;
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Tests;
+
+/// <summary>
+/// Concurrency regressions for the asynchronous pager and the asynchronous
+/// statement seam. Every case pairs two participants on one physical database so
+/// a lost lock, an early publication, or a blocking wait is observable rather
+/// than merely theoretical.
+/// </summary>
+public sealed class AsyncPagerConcurrencyRegressionTests
+{
+    private const string DatabasePath = "main.db";
+    private const string WalPath = "main.db-wal";
+
+    [Test]
+    public async Task DeleteModeCommitReportsBusyWhileAReadSnapshotIsOpen()
+    {
+        var storage = new InMemoryFileSystem();
+        var original = CreatePage(0xA1);
+        var replacement = CreatePage(0xB2);
+
+        await using var writer = await AsyncSqlitePager.CreateRollbackJournalAsync(
+            AsyncFileSystemAdapter.Create(storage),
+            DatabasePath,
+            WalPath,
+            CreateLegacyHeader());
+        await CommitPageAsync(writer, replacement: original);
+
+        await using var readerPager = await AsyncSqlitePager.OpenAsync(
+            AsyncFileSystemAdapter.Create(storage),
+            DatabasePath,
+            WalPath);
+        var snapshot = await readerPager.BeginReadAsync();
+        try
+        {
+            (await snapshot.ReadPageAsync(2)).Should().Equal(original);
+
+            await using (var contended = await writer.BeginTransactionAsync(2, TimeSpan.Zero))
+            {
+                await contended.WritePageAsync(2, replacement);
+                Func<Task> commit = async () => await contended.CommitAsync();
+                await commit.Should().ThrowAsync<SqlitePagerBusyException>();
+                await contended.RollbackAsync();
+            }
+
+            (await snapshot.ReadPageAsync(2)).Should().Equal(original);
+        }
+        finally
+        {
+            await snapshot.DisposeAsync();
+        }
+
+        await CommitPageAsync(writer, replacement);
+        (await readerPager.ReadPageAsync(2)).Should().Equal(replacement);
+    }
+
+    [Test]
+    public async Task DeleteModeCommitWaitsForTheReadSnapshotItWouldOverwrite()
+    {
+        var storage = new InMemoryFileSystem();
+        var lockManager = new SqlitePagerLockManager();
+        var original = CreatePage(0xA3);
+        var replacement = CreatePage(0xB4);
+
+        await using var writer = await AsyncSqlitePager.CreateRollbackJournalAsync(
+            AsyncFileSystemAdapter.Create(storage),
+            DatabasePath,
+            WalPath,
+            CreateLegacyHeader(),
+            lockManager: lockManager);
+        await CommitPageAsync(writer, original);
+
+        await using var readerPager = await AsyncSqlitePager.OpenAsync(
+            AsyncFileSystemAdapter.Create(storage),
+            DatabasePath,
+            WalPath,
+            lockManager: lockManager);
+        var snapshot = await readerPager.BeginReadAsync();
+        var snapshotReleased = false;
+        try
+        {
+            await using var contended = await writer.BeginTransactionAsync(
+                2,
+                Timeout.InfiniteTimeSpan);
+            await contended.WritePageAsync(2, replacement);
+            var commit = contended.CommitAsync().AsTask();
+
+            // The commit registers its EXCLUSIVE intent before waiting, which is
+            // exactly what shuts new readers out; poll for that instead of sleeping.
+            await WaitUntilAsync(() => ExcludesNewReaders(lockManager));
+            commit.IsCompleted.Should().BeFalse();
+            (await snapshot.ReadPageAsync(2)).Should().Equal(original);
+
+            await snapshot.DisposeAsync();
+            snapshotReleased = true;
+            await commit.WaitAsync(TimeSpan.FromSeconds(30));
+        }
+        finally
+        {
+            if (!snapshotReleased)
+                await snapshot.DisposeAsync();
+        }
+
+        (await readerPager.ReadPageAsync(2)).Should().Equal(replacement);
+    }
+
+    [Test]
+    public async Task WalCommitStaysInvisibleToConcurrentReadersUntilItsFlushSucceeds()
+    {
+        var storage = new InMemoryFileSystem();
+        var writerFileSystem = new FlushInterceptingAsyncFileSystem(storage, WalPath);
+        var first = CreatePage(0xC1);
+        var second = CreatePage(0xC2);
+
+        await using var writer = await AsyncSqlitePager.CreateAsync(
+            writerFileSystem,
+            DatabasePath,
+            WalPath,
+            CreateWalHeader());
+        await CommitPageAsync(writer, first);
+
+        await using var readerPager = await AsyncSqlitePager.OpenAsync(
+            AsyncFileSystemAdapter.Create(storage),
+            DatabasePath,
+            WalPath);
+        (await readerPager.ReadPageAsync(2)).Should().Equal(first);
+
+        byte[]? pageDuringFlush = null;
+        var frameCountDuringFlush = -1L;
+        writerFileSystem.BeforeFlush = async () =>
+        {
+            pageDuringFlush = await readerPager.ReadPageAsync(2);
+            frameCountDuringFlush = readerPager.CommittedFrameCount;
+        };
+
+        await CommitPageAsync(writer, second);
+
+        pageDuringFlush.Should().Equal(first);
+        frameCountDuringFlush.Should().Be(1);
+        (await readerPager.ReadPageAsync(2)).Should().Equal(second);
+        readerPager.CommittedFrameCount.Should().Be(2);
+    }
+
+    [Test]
+    public async Task WalCommitWhoseFlushFailsNeverBecomesVisibleToConcurrentReaders()
+    {
+        var storage = new InMemoryFileSystem();
+        var writerFileSystem = new FlushInterceptingAsyncFileSystem(storage, WalPath);
+        var committed = CreatePage(0xD1);
+        var abandoned = CreatePage(0xD2);
+
+        await using var writer = await AsyncSqlitePager.CreateAsync(
+            writerFileSystem,
+            DatabasePath,
+            WalPath,
+            CreateWalHeader());
+        await CommitPageAsync(writer, committed);
+
+        await using var readerPager = await AsyncSqlitePager.OpenAsync(
+            AsyncFileSystemAdapter.Create(storage),
+            DatabasePath,
+            WalPath);
+        (await readerPager.ReadPageAsync(2)).Should().Equal(committed);
+
+        writerFileSystem.FlushFailure = new IOException("injected SQLite WAL flush failure");
+        await using (var failing = await writer.BeginTransactionAsync(2))
+        {
+            await failing.WritePageAsync(2, abandoned);
+            Func<Task> commit = async () => await failing.CommitAsync();
+            await commit.Should().ThrowAsync<IOException>();
+        }
+
+        // The commit-bearing frame is physically present and checksum-valid, so a
+        // reader that trusted the raw WAL would adopt a transaction that failed.
+        await using (var rawWal = await SqliteWalFile.OpenAsync(
+                         AsyncFileSystemAdapter.Create(storage),
+                         WalPath,
+                         readOnly: true))
+        {
+            (await rawWal.ScanRecoveryAsync()).LastCommittedFrameNumber.Should().Be(2);
+        }
+
+        (await readerPager.ReadPageAsync(2)).Should().Equal(committed);
+        readerPager.CommittedFrameCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task SeparateAsyncAdaptersOverOneBackendShareTheWriterLock()
+    {
+        var storage = new InMemoryFileSystem();
+        await using var owner = await AsyncSqlitePager.CreateAsync(
+            AsyncFileSystemAdapter.Create(storage),
+            DatabasePath,
+            WalPath,
+            CreateWalHeader());
+        await using var peer = await AsyncSqlitePager.OpenAsync(
+            AsyncFileSystemAdapter.Create(storage),
+            DatabasePath,
+            WalPath);
+
+        await using var held = await owner.BeginTransactionAsync(2, TimeSpan.Zero);
+        Func<Task> contend = async () => await peer.BeginTransactionAsync(2, TimeSpan.Zero);
+        await contend.Should().ThrowAsync<SqlitePagerBusyException>();
+    }
+
+    [Test]
+    public async Task CaseAliasedPathsOnACaseInsensitiveBackendShareTheWriterLock()
+    {
+        var storage = new CaseInsensitiveFileSystem();
+        await using var owner = await AsyncSqlitePager.CreateAsync(
+            AsyncFileSystemAdapter.Create(storage),
+            DatabasePath,
+            WalPath,
+            CreateWalHeader());
+        await using var alias = await AsyncSqlitePager.OpenAsync(
+            AsyncFileSystemAdapter.Create(storage),
+            DatabasePath.ToUpperInvariant(),
+            WalPath.ToUpperInvariant());
+
+        await using var held = await owner.BeginTransactionAsync(2, TimeSpan.Zero);
+        Func<Task> contend = async () => await alias.BeginTransactionAsync(2, TimeSpan.Zero);
+        await contend.Should().ThrowAsync<SqlitePagerBusyException>();
+    }
+
+    [Test]
+    public async Task StepAsyncSuspendsInsteadOfBlockingWhileAPeerHoldsTheWriteReservation()
+    {
+        using var database = new EmbeddedDatabase();
+        using var owner = database.Connect();
+        using var contender = database.Connect();
+        ExecuteAll(owner, "CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);", "BEGIN IMMEDIATE;");
+
+        var adapter = ManagedConnectionAdapter.Wrap(contender);
+        adapter.BusyTimeout = TimeSpan.FromSeconds(30);
+        using var statement = adapter.Prepare("INSERT INTO t(v) VALUES (1);");
+
+        var callDuration = Stopwatch.StartNew();
+        var step = statement.StepAsync().AsTask();
+        callDuration.Stop();
+
+        // The synchronous engine would have parked this thread for the whole busy
+        // timeout; the seam has to return a pending task instead.
+        callDuration.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(5));
+        step.IsCompleted.Should().BeFalse();
+
+        ExecuteAll(owner, "COMMIT;");
+        (await step.WaitAsync(TimeSpan.FromSeconds(30))).Should().Be(StatementStepResult.Done);
+
+        using var count = adapter.Prepare("SELECT count(*) FROM t;");
+        count.Step().Should().Be(StatementStepResult.Row);
+        count.GetValue(0).AsInteger().Should().Be(1);
+    }
+
+    [Test]
+    public async Task StepAsyncCancellationIsObservedWithoutSpendingTheBusyTimeout()
+    {
+        using var database = new EmbeddedDatabase();
+        using var owner = database.Connect();
+        using var contender = database.Connect();
+        ExecuteAll(owner, "CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);", "BEGIN IMMEDIATE;");
+
+        var adapter = ManagedConnectionAdapter.Wrap(contender);
+        adapter.BusyTimeout = Timeout.InfiniteTimeSpan;
+        using var statement = adapter.Prepare("INSERT INTO t(v) VALUES (1);");
+        using var cancellation = new CancellationTokenSource();
+
+        var step = statement.StepAsync(cancellation.Token).AsTask();
+        step.IsCompleted.Should().BeFalse();
+
+        cancellation.Cancel();
+        Func<Task> awaitCanceled = async () => await step;
+        var canceled = await awaitCanceled.Should().ThrowAsync<OperationCanceledException>();
+        canceled.Which.CancellationToken.Should().Be(cancellation.Token);
+
+        ExecuteAll(owner, "COMMIT;");
+    }
+
+    [Test]
+    public async Task StepAsyncPreservesBusyReportingWhenTheTimeoutIsExhausted()
+    {
+        using var database = new EmbeddedDatabase();
+        using var owner = database.Connect();
+        using var contender = database.Connect();
+        ExecuteAll(owner, "CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);", "BEGIN IMMEDIATE;");
+
+        var adapter = ManagedConnectionAdapter.Wrap(contender);
+        adapter.BusyTimeout = TimeSpan.FromMilliseconds(50);
+        using var statement = adapter.Prepare("INSERT INTO t(v) VALUES (1);");
+
+        Func<Task> step = async () => await statement.StepAsync();
+        await step.Should().ThrowAsync<EmbeddedBusyException>();
+        adapter.BusyTimeout.Should().Be(TimeSpan.FromMilliseconds(50));
+
+        ExecuteAll(owner, "COMMIT;");
+    }
+
+    private static async Task CommitPageAsync(AsyncSqlitePager pager, byte[] replacement)
+    {
+        await using var transaction = await pager.BeginTransactionAsync(2);
+        await transaction.WritePageAsync(2, replacement);
+        await transaction.CommitAsync();
+    }
+
+    private static void ExecuteAll(EmbeddedConnection connection, params string[] statements)
+    {
+        foreach (var sql in statements)
+        {
+            using var statement = connection.Prepare(sql);
+            statement.Step();
+        }
+    }
+
+    private static bool ExcludesNewReaders(SqlitePagerLockManager lockManager)
+    {
+        try
+        {
+            lockManager.EnterReader(TimeSpan.Zero).Dispose();
+            return false;
+        }
+        catch (SqlitePagerBusyException)
+        {
+            return true;
+        }
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        var deadline = Stopwatch.StartNew();
+        while (!condition())
+        {
+            if (deadline.Elapsed > TimeSpan.FromSeconds(30))
+                throw new TimeoutException("The awaited pager lock state never arrived.");
+            await Task.Yield();
+        }
+    }
+
+    private static SqliteWalHeader CreateWalHeader()
+        => SqliteWalHeader.Create(
+            SqlitePageSize.Default,
+            salt1: 0x0F1E_2D3C,
+            salt2: 0x4B5A_6978,
+            checkpointSequence: 3);
+
+    private static SqliteDatabaseHeader CreateLegacyHeader()
+        => SqliteDatabaseHeader.CreateDefault() with
+        {
+            ReadVersion = SqliteFileFormatVersion.Legacy,
+            WriteVersion = SqliteFileFormatVersion.Legacy,
+        };
+
+    private static byte[] CreatePage(byte fill)
+    {
+        var page = new byte[SqlitePageSize.Default];
+        Array.Fill(page, fill);
+        return page;
+    }
+}
+
+/// <summary>
+/// Wraps a synchronous backend and lets a test observe or fail the durable flush
+/// of one specific file. It reports the same backing store as a plain adapter so
+/// pagers built on either facade still resolve to one pager lock scope.
+/// </summary>
+internal sealed class FlushInterceptingAsyncFileSystem :
+    IAsyncFileSystem,
+    IStoragePathResolver,
+    IAsyncFileSystemBacking
+{
+    private readonly IFileSystem _backing;
+    private readonly IAsyncFileSystem _inner;
+    private readonly string _interceptedPath;
+
+    internal FlushInterceptingAsyncFileSystem(IFileSystem backing, string interceptedPath)
+    {
+        _backing = backing;
+        _inner = AsyncFileSystemAdapter.Create(backing);
+        _interceptedPath = interceptedPath;
+    }
+
+    internal Func<ValueTask>? BeforeFlush { get; set; }
+
+    internal Exception? FlushFailure { get; set; }
+
+    public IFileSystem BackingFileSystem => _backing;
+
+    public StringComparer PathComparer => ((IStoragePathResolver)_inner).PathComparer;
+
+    public string GetCanonicalPath(string path) => ((IStoragePathResolver)_inner).GetCanonicalPath(path);
+
+    public ValueTask<bool> FileExistsAsync(string path, CancellationToken cancellationToken = default)
+        => _inner.FileExistsAsync(path, cancellationToken);
+
+    public async ValueTask<IAsyncFile> OpenFileAsync(
+        string path,
+        FileOpenMode mode,
+        bool readOnly = false,
+        CancellationToken cancellationToken = default)
+    {
+        var file = await _inner.OpenFileAsync(path, mode, readOnly, cancellationToken).ConfigureAwait(false);
+        return string.Equals(path, _interceptedPath, StringComparison.Ordinal)
+            ? new InterceptedFile(file, this)
+            : file;
+    }
+
+    public ValueTask DeleteFileAsync(string path, CancellationToken cancellationToken = default)
+        => _inner.DeleteFileAsync(path, cancellationToken);
+
+    public ValueTask<FileWriteStamp?> GetWriteStampAsync(
+        string path,
+        CancellationToken cancellationToken = default)
+        => _inner.GetWriteStampAsync(path, cancellationToken);
+
+    private sealed class InterceptedFile(IAsyncFile inner, FlushInterceptingAsyncFileSystem owner) : IAsyncFile
+    {
+        public bool IsReadOnly => inner.IsReadOnly;
+
+        public ValueTask<long> GetLengthAsync(CancellationToken cancellationToken = default)
+            => inner.GetLengthAsync(cancellationToken);
+
+        public ValueTask<int> ReadAsync(
+            long position,
+            Memory<byte> destination,
+            CancellationToken cancellationToken = default)
+            => inner.ReadAsync(position, destination, cancellationToken);
+
+        public ValueTask WriteAsync(
+            long position,
+            ReadOnlyMemory<byte> source,
+            CancellationToken cancellationToken = default)
+            => inner.WriteAsync(position, source, cancellationToken);
+
+        public ValueTask SetLengthAsync(long length, CancellationToken cancellationToken = default)
+            => inner.SetLengthAsync(length, cancellationToken);
+
+        public async ValueTask FlushToDiskAsync(CancellationToken cancellationToken = default)
+        {
+            var observe = owner.BeforeFlush;
+            if (observe is not null)
+            {
+                owner.BeforeFlush = null;
+                await observe().ConfigureAwait(false);
+            }
+
+            var failure = owner.FlushFailure;
+            if (failure is not null)
+            {
+                owner.FlushFailure = null;
+                throw failure;
+            }
+
+            await inner.FlushToDiskAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        public ValueTask DisposeAsync() => inner.DisposeAsync();
+    }
+}
+
+/// <summary>
+/// Models a case-insensitive volume: canonical paths keep their original casing,
+/// exactly like <c>Path.GetFullPath</c> on Windows, while lookups and comparison
+/// ignore case.
+/// </summary>
+internal sealed class CaseInsensitiveFileSystem : IFileSystem, IStoragePathResolver
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<string, string> _storedSpellings = new(StringComparer.OrdinalIgnoreCase);
+    private readonly InMemoryFileSystem _inner = new();
+
+    public StringComparer PathComparer => StringComparer.OrdinalIgnoreCase;
+
+    public string GetCanonicalPath(string path)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        return path;
+    }
+
+    public bool FileExists(string path) => _inner.FileExists(Resolve(path));
+
+    public IFile OpenFile(string path, FileOpenMode mode, bool readOnly = false)
+        => _inner.OpenFile(Resolve(path), mode, readOnly);
+
+    public void DeleteFile(string path) => _inner.DeleteFile(Resolve(path));
+
+    public FileWriteStamp? GetWriteStamp(string path)
+        => ((IFileSystem)_inner).GetWriteStamp(Resolve(path));
+
+
+    private string Resolve(string path)
+    {
+        lock (_gate)
+        {
+            if (_storedSpellings.TryGetValue(path, out var stored))
+                return stored;
+
+            _storedSpellings[path] = path;
+            return path;
+        }
+    }
+}

--- a/src/Ahtola.Tests/AsyncPagerConcurrencyRegressionTests.cs
+++ b/src/Ahtola.Tests/AsyncPagerConcurrencyRegressionTests.cs
@@ -174,18 +174,83 @@ public sealed class AsyncPagerConcurrencyRegressionTests
             await commit.Should().ThrowAsync<IOException>();
         }
 
-        // The commit-bearing frame is physically present and checksum-valid, so a
-        // reader that trusted the raw WAL would adopt a transaction that failed.
+        // The abandoned commit is rolled out of the WAL durably rather than merely
+        // hidden, so no reader — in this process or another — can adopt it.
         await using (var rawWal = await SqliteWalFile.OpenAsync(
                          AsyncFileSystemAdapter.Create(storage),
                          WalPath,
                          readOnly: true))
         {
-            (await rawWal.ScanRecoveryAsync()).LastCommittedFrameNumber.Should().Be(2);
+            var recovery = await rawWal.ScanRecoveryAsync();
+            recovery.LastCommittedFrameNumber.Should().Be(1);
+            recovery.LastValidFrameNumber.Should().Be(1);
         }
 
         (await readerPager.ReadPageAsync(2)).Should().Equal(committed);
         readerPager.CommittedFrameCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task WalCommitWhoseFlushFailsStaysInvisibleToLaterOpensAndReadOnlyReaders()
+    {
+        var storage = new InMemoryFileSystem();
+        var writerFileSystem = new FlushInterceptingAsyncFileSystem(storage, WalPath);
+        var committed = CreatePage(0xE1);
+        var abandoned = CreatePage(0xE2);
+
+        await using (var writer = await AsyncSqlitePager.CreateAsync(
+                         writerFileSystem,
+                         DatabasePath,
+                         WalPath,
+                         CreateWalHeader()))
+        {
+            await CommitPageAsync(writer, committed);
+
+            writerFileSystem.FlushFailure = new IOException("injected SQLite WAL flush failure");
+            await using var failing = await writer.BeginTransactionAsync(2);
+            await failing.WritePageAsync(2, abandoned);
+            Func<Task> commit = async () => await failing.CommitAsync();
+            await commit.Should().ThrowAsync<IOException>();
+        }
+
+        // A read-only open cannot repair the WAL, so it must keep honoring the
+        // boundary rather than adopting the abandoned commit.
+        await using (var readOnly = await AsyncSqlitePager.OpenAsync(
+                         AsyncFileSystemAdapter.Create(storage),
+                         DatabasePath,
+                         WalPath,
+                         readOnly: true))
+        {
+            (await readOnly.ReadPageAsync(2)).Should().Equal(committed);
+        }
+
+        // A writable open owns the file, so it durably drops the hidden tail before
+        // republishing; the abandoned commit can never come back afterwards.
+        await using (var reopened = await AsyncSqlitePager.OpenAsync(
+                         AsyncFileSystemAdapter.Create(storage),
+                         DatabasePath,
+                         WalPath))
+        {
+            (await reopened.ReadPageAsync(2)).Should().Equal(committed);
+            reopened.CommittedFrameCount.Should().Be(1);
+        }
+
+        await using (var rawWal = await SqliteWalFile.OpenAsync(
+                         AsyncFileSystemAdapter.Create(storage),
+                         WalPath,
+                         readOnly: true))
+        {
+            var recovery = await rawWal.ScanRecoveryAsync();
+            recovery.LastCommittedFrameNumber.Should().Be(1);
+            recovery.LastValidFrameNumber.Should().Be(1);
+        }
+
+        await using var final = await AsyncSqlitePager.OpenAsync(
+            AsyncFileSystemAdapter.Create(storage),
+            DatabasePath,
+            WalPath,
+            readOnly: true);
+        (await final.ReadPageAsync(2)).Should().Equal(committed);
     }
 
     [Test]

--- a/src/Ahtola.Tests/AsyncPagerConcurrencyRegressionTests.cs
+++ b/src/Ahtola.Tests/AsyncPagerConcurrencyRegressionTests.cs
@@ -254,6 +254,77 @@ public sealed class AsyncPagerConcurrencyRegressionTests
     }
 
     [Test]
+    public async Task WalCommitIgnoresCancellationRequestedAfterItsFlushBecomesDurable()
+    {
+        var storage = new InMemoryFileSystem();
+        var writerFileSystem = new FlushInterceptingAsyncFileSystem(storage, WalPath);
+        var committed = CreatePage(0xE3);
+        await using var writer = await AsyncSqlitePager.CreateAsync(
+            writerFileSystem,
+            DatabasePath,
+            WalPath,
+            CreateWalHeader());
+        using var cancellation = new CancellationTokenSource();
+        writerFileSystem.AfterFlush = () =>
+        {
+            cancellation.Cancel();
+            return ValueTask.CompletedTask;
+        };
+
+        await using (var transaction = await writer.BeginTransactionAsync(2))
+        {
+            await transaction.WritePageAsync(2, committed);
+            await transaction.CommitAsync(cancellation.Token);
+        }
+
+        cancellation.IsCancellationRequested.Should().BeTrue();
+        await using var reopened = await AsyncSqlitePager.OpenAsync(
+            AsyncFileSystemAdapter.Create(storage),
+            DatabasePath,
+            WalPath,
+            readOnly: true);
+        (await reopened.ReadPageAsync(2)).Should().Equal(committed);
+        reopened.CommittedFrameCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task FailedCreateDoesNotPublishAnExistingHiddenWalTail()
+    {
+        var storage = new InMemoryFileSystem();
+        var lockManager = new SqlitePagerLockManager();
+        await using (var existing = await AsyncSqlitePager.CreateAsync(
+                         AsyncFileSystemAdapter.Create(storage),
+                         DatabasePath,
+                         WalPath,
+                         CreateWalHeader(),
+                         lockManager: lockManager))
+        {
+            await CommitPageAsync(existing, CreatePage(0xE4));
+        }
+
+        using (var writer = lockManager.EnterWriter(TimeSpan.Zero))
+            writer.BeginWalPublication(lastPublishedFrameNumber: 0);
+        lockManager.WalPublicationBoundary.Should().Be(0);
+
+        Func<Task> create = async () => await AsyncSqlitePager.CreateAsync(
+            AsyncFileSystemAdapter.Create(storage),
+            DatabasePath,
+            WalPath,
+            CreateWalHeader(),
+            lockManager: lockManager);
+        await create.Should().ThrowAsync<IOException>();
+        lockManager.WalPublicationBoundary.Should().Be(0);
+
+        await using var readOnly = await AsyncSqlitePager.OpenAsync(
+            AsyncFileSystemAdapter.Create(storage),
+            DatabasePath,
+            WalPath,
+            readOnly: true,
+            lockManager: lockManager);
+        readOnly.CommittedFrameCount.Should().Be(0);
+    }
+
+    [Test]
     public async Task SeparateAsyncAdaptersOverOneBackendShareTheWriterLock()
     {
         var storage = new InMemoryFileSystem();
@@ -448,6 +519,8 @@ internal sealed class FlushInterceptingAsyncFileSystem :
 
     internal Func<ValueTask>? BeforeFlush { get; set; }
 
+    internal Func<ValueTask>? AfterFlush { get; set; }
+
     internal Exception? FlushFailure { get; set; }
 
     public IFileSystem BackingFileSystem => _backing;
@@ -518,6 +591,13 @@ internal sealed class FlushInterceptingAsyncFileSystem :
             }
 
             await inner.FlushToDiskAsync(cancellationToken).ConfigureAwait(false);
+
+            var after = owner.AfterFlush;
+            if (after is not null)
+            {
+                owner.AfterFlush = null;
+                await after().ConfigureAwait(false);
+            }
         }
 
         public ValueTask DisposeAsync() => inner.DisposeAsync();

--- a/src/Ahtola.Tests/AsyncSqlitePageStoreTests.cs
+++ b/src/Ahtola.Tests/AsyncSqlitePageStoreTests.cs
@@ -1,0 +1,446 @@
+using AwesomeAssertions;
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Tests;
+
+public sealed class AsyncSqlitePageStoreTests
+{
+    [Test]
+    public async Task CreateWriteReadAndReopenMatchSynchronousStoreBytes()
+    {
+        var synchronousFileSystem = new InMemoryFileSystem();
+        var asynchronousBacking = new InMemoryFileSystem();
+        var asynchronousFileSystem = AsyncFileSystemAdapter.Create(asynchronousBacking);
+        var page2 = CreatePage(SqlitePageSize.Default, 0xA5);
+
+        using (var synchronous = SqlitePageStore.Create(synchronousFileSystem, "main.db"))
+        {
+            synchronous.WritePage(2, page2);
+            synchronous.Flush();
+        }
+
+        await using (var asynchronous = await AsyncSqlitePageStore.CreateAsync(
+            asynchronousFileSystem,
+            "main.db"))
+        {
+            asynchronous.Path.Should().Be("main.db");
+            asynchronous.PageSize.Should().Be(SqlitePageSize.Default);
+            asynchronous.IsReadOnly.Should().BeFalse();
+            (await asynchronous.GetPageCountAsync()).Should().Be(1);
+
+            await asynchronous.WritePageAsync(2, page2);
+            asynchronous.Header.DatabaseSizeInPages.Should().Be(2);
+            (await asynchronous.GetPageCountAsync()).Should().Be(2);
+
+            var destination = new byte[asynchronous.PageSize];
+            await asynchronous.ReadPageAsync(2, destination);
+            destination.Should().Equal(page2);
+            (await asynchronous.ReadPageAsync(2)).Should().Equal(page2);
+            await asynchronous.FlushAsync();
+        }
+
+        Snapshot(synchronousFileSystem, "main.db")
+            .Should().Equal(Snapshot(asynchronousBacking, "main.db"));
+
+        await using var reopened = await AsyncSqlitePageStore.OpenAsync(
+            asynchronousFileSystem,
+            "main.db",
+            readOnly: true);
+        reopened.IsReadOnly.Should().BeTrue();
+        reopened.Header.DatabaseSizeInPages.Should().Be(2);
+        (await reopened.GetPageCountAsync()).Should().Be(2);
+        (await reopened.ReadRawPageAsync(2)).Should().Equal(page2);
+    }
+
+    [Test]
+    public async Task ForcedYieldAppendRestoresLengthWhenHeaderWriteFails()
+    {
+        var faults = new DeterministicFaultInjector();
+        var backing = new InMemoryFileSystem(faults);
+        var controller = new DeterministicAsyncIoController(forceYield: true);
+        var fileSystem = DeterministicAsyncFileSystem.Create(
+            AsyncFileSystemAdapter.Create(backing),
+            controller);
+        var store = await CompleteAsync(
+            AsyncSqlitePageStore.CreateAsync(fileSystem, "main.db"),
+            controller);
+        faults.FailOnOccurrence(FileSystemOperation.Write, 3);
+
+        Assert.ThrowsAsync<IOException>(async () => await CompleteAsync(
+            store.WritePageAsync(2, CreatePage(store.PageSize, 0xD1)),
+            controller));
+
+        (await CompleteAsync(store.GetPageCountAsync(), controller)).Should().Be(1);
+        using (var reopened = SqlitePageStore.Open(backing, "main.db"))
+            reopened.PageCount.Should().Be(1);
+
+        await CompleteAsync(store.DisposeAsync(), controller);
+    }
+
+    [Test]
+    public async Task ReadRejectsAnExactShortPage()
+    {
+        var backing = new InMemoryFileSystem();
+        var controlled = new ControlledAsyncFileSystem(
+            AsyncFileSystemAdapter.Create(backing));
+        await using var store = await AsyncSqlitePageStore.CreateAsync(
+            controlled,
+            "main.db");
+        controlled.ShortReads = true;
+
+        var exception = Assert.ThrowsAsync<InvalidDataException>(
+            async () => await store.ReadPageAsync(1));
+
+        exception.Message.Should().Contain("Short read on page 1");
+        exception.Message.Should().Contain($"expected {store.PageSize} bytes");
+    }
+
+    [Test]
+    public async Task CancellationWhileBackendIsSuspendedPropagatesTheToken()
+    {
+        var controller = new DeterministicAsyncIoController(forceYield: true);
+        var fileSystem = DeterministicAsyncFileSystem.Create(
+            AsyncFileSystemAdapter.Create(new InMemoryFileSystem()),
+            controller);
+        var store = await CompleteAsync(
+            AsyncSqlitePageStore.CreateAsync(fileSystem, "main.db"),
+            controller);
+        using var cancellation = new CancellationTokenSource();
+
+        var pending = store.ReadPageAsync(1, cancellation.Token);
+        pending.IsCompleted.Should().BeFalse();
+        controller.PendingYieldCount.Should().Be(1);
+        cancellation.Cancel();
+
+        var exception = Assert.CatchAsync<OperationCanceledException>(
+            async () => await pending);
+        exception.CancellationToken.Should().Be(cancellation.Token);
+        controller.ReleaseNext();
+        await CompleteAsync(store.DisposeAsync(), controller);
+    }
+
+    [Test]
+    public async Task ShrinkPageOneThenTruncateMatchesSynchronousStore()
+    {
+        var synchronousFileSystem = new InMemoryFileSystem();
+        var asynchronousBacking = new InMemoryFileSystem();
+        using var synchronous = SqlitePageStore.Create(synchronousFileSystem, "main.db");
+        await using var asynchronous = await AsyncSqlitePageStore.CreateAsync(
+            AsyncFileSystemAdapter.Create(asynchronousBacking),
+            "main.db");
+        var page2 = CreatePage(synchronous.PageSize, 0x22);
+        var page3 = CreatePage(synchronous.PageSize, 0x33);
+
+        synchronous.WritePage(2, page2);
+        synchronous.WritePage(3, page3);
+        await asynchronous.WritePageAsync(2, page2);
+        await asynchronous.WritePageAsync(3, page3);
+
+        var synchronousPageOne = synchronous.ReadPage(1);
+        (synchronous.Header with { DatabaseSizeInPages = 1 }).WriteTo(synchronousPageOne);
+        synchronous.WriteShrinkCheckpointPageOne(synchronousPageOne);
+        synchronous.TruncateToPageCount(1);
+
+        var asynchronousPageOne = await asynchronous.ReadPageAsync(1);
+        (asynchronous.Header with { DatabaseSizeInPages = 1 }).WriteTo(asynchronousPageOne);
+        await asynchronous.WriteShrinkCheckpointPageOneAsync(asynchronousPageOne);
+        await asynchronous.TruncateToPageCountAsync(1);
+
+        (await asynchronous.GetPageCountAsync()).Should().Be(1);
+        asynchronous.Header.DatabaseSizeInPages.Should().Be(1);
+        Snapshot(synchronousFileSystem, "main.db")
+            .Should().Equal(Snapshot(asynchronousBacking, "main.db"));
+    }
+
+    [Test]
+    public async Task UnpublishedImageAcceptsAsynchronousPageCallbacks()
+    {
+        var backing = new InMemoryFileSystem();
+        await using var store = await AsyncSqlitePageStore.CreateAsync(
+            AsyncFileSystemAdapter.Create(backing),
+            "vacuum.db",
+            flushOnCreate: false);
+        var pageOne = await store.ReadPageAsync(1);
+        (store.Header with { DatabaseSizeInPages = 2 }).WriteTo(pageOne);
+        var pageTwo = CreatePage(store.PageSize, 0x74);
+        var callbackCalls = new List<uint>();
+
+        await store.WriteUnpublishedImageAsync(
+            2,
+            async (pageNumber, cancellationToken) =>
+            {
+                await Task.Yield();
+                cancellationToken.ThrowIfCancellationRequested();
+                callbackCalls.Add(pageNumber);
+                return pageNumber == 1 ? pageOne : pageTwo;
+            });
+
+        callbackCalls.Should().Equal(1U, 2U);
+        (await store.GetPageCountAsync()).Should().Be(2);
+        (await store.ReadPageAsync(2)).Should().Equal(pageTwo);
+    }
+
+    [Test]
+    public async Task RawReplacementCanRefreshTheHeader()
+    {
+        var backing = new InMemoryFileSystem();
+        using (var source = SqlitePageStore.Create(backing, "source.db"))
+        {
+            var pageOne = source.ReadPage(1);
+            (source.Header with { UserVersion = 42 }).WriteTo(pageOne);
+            source.WritePage(1, pageOne);
+        }
+
+        var fileSystem = AsyncFileSystemAdapter.Create(backing);
+        await using var destination = await AsyncSqlitePageStore.CreateAsync(
+            fileSystem,
+            "destination.db");
+        await using var sourceFile = await fileSystem.OpenFileAsync(
+            "source.db",
+            FileOpenMode.OpenExisting,
+            readOnly: true);
+
+        await destination.ReplaceRawContentAsync(sourceFile);
+        await destination.RefreshHeaderAsync();
+
+        destination.Header.UserVersion.Should().Be(42);
+        Snapshot(backing, "destination.db").Should().Equal(Snapshot(backing, "source.db"));
+    }
+
+    [Test]
+    public async Task ExternalSynchronousCodecRunsAcrossForcedAsyncIo()
+    {
+        var controller = new DeterministicAsyncIoController(forceYield: true);
+        var fileSystem = DeterministicAsyncFileSystem.Create(
+            AsyncFileSystemAdapter.Create(new InMemoryFileSystem()),
+            controller);
+        var codec = new RecordingPageCodec();
+        var store = await CompleteAsync(
+            AsyncSqlitePageStore.CreateAsync(fileSystem, "coded.db", pageCodec: codec),
+            controller);
+        var pageTwo = CreatePage(store.PageSize, 0x6C);
+
+        await CompleteAsync(store.WritePageAsync(2, pageTwo), controller);
+        (await CompleteAsync(store.ReadPageAsync(2), controller)).Should().Equal(pageTwo);
+        codec.EncodeCount.Should().BeGreaterThanOrEqualTo(3);
+        codec.DecodeCount.Should().BeGreaterThanOrEqualTo(2);
+        await CompleteAsync(store.DisposeAsync(), controller);
+
+        var reopened = await CompleteAsync(
+            AsyncSqlitePageStore.OpenAsync(fileSystem, "coded.db", pageCodec: codec),
+            controller);
+        (await CompleteAsync(reopened.ReadPageAsync(2), controller)).Should().Equal(pageTwo);
+        await CompleteAsync(reopened.DisposeAsync(), controller);
+    }
+
+    [Test]
+    public async Task InvalidOpenAndFailedCreateCleanUpOwnedHandlesAndArtifacts()
+    {
+        var malformedBacking = new InMemoryFileSystem();
+        using (var store = SqlitePageStore.Create(malformedBacking, "malformed.db"))
+        {
+        }
+
+        using (var file = malformedBacking.OpenFile("malformed.db", FileOpenMode.OpenExisting))
+            file.SetLength(file.Length + 1);
+
+        var controlled = new ControlledAsyncFileSystem(
+            AsyncFileSystemAdapter.Create(malformedBacking));
+        Assert.ThrowsAsync<InvalidDataException>(
+            async () => await AsyncSqlitePageStore.OpenAsync(controlled, "malformed.db"));
+        controlled.DisposeCount.Should().Be(1);
+
+        var faults = new DeterministicFaultInjector();
+        var failedBacking = new InMemoryFileSystem(faults);
+        faults.FailNext(FileSystemOperation.Write);
+        Assert.ThrowsAsync<IOException>(async () => await AsyncSqlitePageStore.CreateAsync(
+            AsyncFileSystemAdapter.Create(failedBacking),
+            "failed.db"));
+        failedBacking.FileExists("failed.db").Should().BeFalse();
+
+        var existingBacking = new InMemoryFileSystem();
+        using (SqlitePageStore.Create(existingBacking, "existing.db"))
+        {
+        }
+
+        var original = Snapshot(existingBacking, "existing.db");
+        Assert.ThrowsAsync<IOException>(async () => await AsyncSqlitePageStore.CreateAsync(
+            AsyncFileSystemAdapter.Create(existingBacking),
+            "existing.db"));
+        Snapshot(existingBacking, "existing.db").Should().Equal(original);
+    }
+
+    [Test]
+    public async Task DisposeIsAsynchronousIdempotentAndGuardsState()
+    {
+        var controlled = new ControlledAsyncFileSystem(
+            AsyncFileSystemAdapter.Create(new InMemoryFileSystem()));
+        var store = await AsyncSqlitePageStore.CreateAsync(controlled, "main.db");
+
+        await store.DisposeAsync();
+        await store.DisposeAsync();
+
+        controlled.DisposeCount.Should().Be(1);
+        Assert.Throws<ObjectDisposedException>(() => _ = store.Header);
+        Assert.ThrowsAsync<ObjectDisposedException>(
+            async () => await store.GetPageCountAsync());
+    }
+
+    private static byte[] CreatePage(int pageSize, byte fill)
+    {
+        var page = new byte[pageSize];
+        Array.Fill(page, fill);
+        return page;
+    }
+
+    private static byte[] Snapshot(InMemoryFileSystem fileSystem, string path)
+    {
+        using var file = fileSystem.OpenFile(path, FileOpenMode.OpenExisting, readOnly: true);
+        var bytes = new byte[checked((int)file.Length)];
+        file.Read(0, bytes).Should().Be(bytes.Length);
+        return bytes;
+    }
+
+    private static async Task CompleteAsync(
+        ValueTask operation,
+        DeterministicAsyncIoController controller)
+    {
+        var task = operation.AsTask();
+        await DrainAsync(task, controller);
+    }
+
+    private static async Task<T> CompleteAsync<T>(
+        ValueTask<T> operation,
+        DeterministicAsyncIoController controller)
+    {
+        var task = operation.AsTask();
+        await DrainAsync(task, controller);
+        return await task;
+    }
+
+    private static async Task DrainAsync(
+        Task task,
+        DeterministicAsyncIoController controller)
+    {
+        while (!task.IsCompleted)
+        {
+            if (controller.PendingYieldCount > 0)
+                controller.ReleaseNext();
+            else
+                await Task.Yield();
+        }
+
+        await task;
+    }
+
+    private sealed class ControlledAsyncFileSystem(IAsyncFileSystem inner) : IAsyncFileSystem
+    {
+        internal bool ShortReads { get; set; }
+
+        internal int DisposeCount { get; private set; }
+
+        public ValueTask<bool> FileExistsAsync(
+            string path,
+            CancellationToken cancellationToken = default)
+            => inner.FileExistsAsync(path, cancellationToken);
+
+        public async ValueTask<IAsyncFile> OpenFileAsync(
+            string path,
+            FileOpenMode mode,
+            bool readOnly = false,
+            CancellationToken cancellationToken = default)
+        {
+            var file = await inner.OpenFileAsync(
+                path,
+                mode,
+                readOnly,
+                cancellationToken);
+            return new ControlledAsyncFile(this, file);
+        }
+
+        public ValueTask DeleteFileAsync(
+            string path,
+            CancellationToken cancellationToken = default)
+            => inner.DeleteFileAsync(path, cancellationToken);
+
+        public ValueTask<FileWriteStamp?> GetWriteStampAsync(
+            string path,
+            CancellationToken cancellationToken = default)
+            => inner.GetWriteStampAsync(path, cancellationToken);
+
+        private sealed class ControlledAsyncFile(
+            ControlledAsyncFileSystem owner,
+            IAsyncFile innerFile) : IAsyncFile
+        {
+            public bool IsReadOnly => innerFile.IsReadOnly;
+
+            public ValueTask<long> GetLengthAsync(CancellationToken cancellationToken = default)
+                => innerFile.GetLengthAsync(cancellationToken);
+
+            public ValueTask<int> ReadAsync(
+                long position,
+                Memory<byte> destination,
+                CancellationToken cancellationToken = default)
+                => innerFile.ReadAsync(
+                    position,
+                    owner.ShortReads && destination.Length > 0
+                        ? destination[..^1]
+                        : destination,
+                    cancellationToken);
+
+            public ValueTask WriteAsync(
+                long position,
+                ReadOnlyMemory<byte> source,
+                CancellationToken cancellationToken = default)
+                => innerFile.WriteAsync(position, source, cancellationToken);
+
+            public ValueTask SetLengthAsync(
+                long length,
+                CancellationToken cancellationToken = default)
+                => innerFile.SetLengthAsync(length, cancellationToken);
+
+            public ValueTask FlushToDiskAsync(CancellationToken cancellationToken = default)
+                => innerFile.FlushToDiskAsync(cancellationToken);
+
+            public async ValueTask DisposeAsync()
+            {
+                owner.DisposeCount++;
+                await innerFile.DisposeAsync();
+            }
+        }
+    }
+
+    private sealed class RecordingPageCodec : IPageCodec
+    {
+        private static readonly PageCodecId Id = new(
+            new byte[] { 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 });
+
+        internal int EncodeCount { get; private set; }
+
+        internal int DecodeCount { get; private set; }
+
+        public PageCodecId CodecId => Id;
+
+        public byte RequiredReservedBytes => 0;
+
+        public void EncodePage(
+            PageCodecContext context,
+            ReadOnlySpan<byte> input,
+            Span<byte> output)
+        {
+            context.Location.Should().Be(PageLocation.Database);
+            EncodeCount++;
+            input.CopyTo(output);
+        }
+
+        public void DecodePage(
+            PageCodecContext context,
+            ReadOnlySpan<byte> input,
+            Span<byte> output)
+        {
+            context.Location.Should().Be(PageLocation.Database);
+            DecodeCount++;
+            input.CopyTo(output);
+        }
+    }
+}

--- a/src/Ahtola.Tests/AsyncSqlitePagerTests.cs
+++ b/src/Ahtola.Tests/AsyncSqlitePagerTests.cs
@@ -1,0 +1,361 @@
+using AwesomeAssertions;
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Tests;
+
+public sealed class AsyncSqlitePagerTests
+{
+    private const string DatabasePath = "main.db";
+    private const string WalPath = "main.db-wal";
+
+    [Test]
+    public async Task AsyncWalCommitMatchesSynchronousDatabaseAndWalBytes()
+    {
+        var syncStorage = new InMemoryFileSystem();
+        var asyncStorage = new InMemoryFileSystem();
+        var header = CreateWalHeader();
+        var page2 = CreatePage(SqlitePageSize.Default, 0xA1);
+
+        using (var pager = SqlitePager.Create(
+                   syncStorage,
+                   DatabasePath,
+                   WalPath,
+                   header))
+        {
+            using var transaction = pager.BeginTransaction(2);
+            transaction.WritePage(2, page2);
+            transaction.Commit();
+        }
+
+        await using (var pager = await AsyncSqlitePager.CreateAsync(
+                         AsyncFileSystemAdapter.Create(asyncStorage),
+                         DatabasePath,
+                         WalPath,
+                         header))
+        {
+            await using var transaction = await pager.BeginTransactionAsync(2);
+            await transaction.WritePageAsync(2, page2);
+            await transaction.CommitAsync();
+            pager.CommittedPageCount.Should().Be(2);
+            pager.CommittedFrameCount.Should().Be(1);
+        }
+
+        ReadAll(asyncStorage, DatabasePath).Should().Equal(ReadAll(syncStorage, DatabasePath));
+        ReadAll(asyncStorage, WalPath).Should().Equal(ReadAll(syncStorage, WalPath));
+    }
+
+    [Test]
+    public async Task ReadSnapshotRemainsStableAcrossCommitAndRollback()
+    {
+        var storage = new InMemoryFileSystem();
+        var fileSystem = AsyncFileSystemAdapter.Create(storage);
+        await using var pager = await AsyncSqlitePager.CreateAsync(
+            fileSystem,
+            DatabasePath,
+            WalPath,
+            CreateWalHeader());
+        await using var snapshot = await pager.BeginReadAsync();
+        var originalPageOne = await snapshot.ReadPageAsync(1);
+        var committedPage = CreatePage(pager.PageSize, 0xB2);
+
+        await using (var transaction = await pager.BeginTransactionAsync(2))
+        {
+            await transaction.WritePageAsync(2, committedPage);
+            (await transaction.ReadPageAsync(2)).Should().Equal(committedPage);
+            await transaction.CommitAsync();
+        }
+
+        snapshot.PageCount.Should().Be(1);
+        (await snapshot.ReadPageAsync(1)).Should().Equal(originalPageOne);
+        (await pager.ReadPageAsync(2)).Should().Equal(committedPage);
+
+        await using (var transaction = await pager.BeginTransactionAsync(2))
+        {
+            await transaction.WritePageAsync(2, CreatePage(pager.PageSize, 0xB3));
+            await transaction.RollbackAsync();
+        }
+        (await pager.ReadPageAsync(2)).Should().Equal(committedPage);
+    }
+
+    [Test]
+    public async Task WritableOpenRecoversUncommittedWalTailAndPreservesCommittedView()
+    {
+        var storage = new InMemoryFileSystem();
+        var fileSystem = AsyncFileSystemAdapter.Create(storage);
+        var committedPage = CreatePage(SqlitePageSize.Default, 0xC1);
+        await using (var pager = await AsyncSqlitePager.CreateAsync(
+                         fileSystem,
+                         DatabasePath,
+                         WalPath,
+                         CreateWalHeader()))
+        {
+            await using var transaction = await pager.BeginTransactionAsync(2);
+            await transaction.WritePageAsync(2, committedPage);
+            await transaction.CommitAsync();
+        }
+
+        await using (var wal = await SqliteWalFile.OpenAsync(fileSystem, WalPath))
+        {
+            await wal.AppendFrameAsync(2, CreatePage(SqlitePageSize.Default, 0xC2));
+            await wal.FlushAsync();
+        }
+
+        await using (var recovered = await AsyncSqlitePager.OpenAsync(
+                         fileSystem,
+                         DatabasePath,
+                         WalPath))
+        {
+            recovered.RecoveryInfo.LastValidFrameNumber.Should().Be(2);
+            recovered.RecoveryInfo.LastCommittedFrameNumber.Should().Be(1);
+            recovered.CommittedFrameCount.Should().Be(1);
+            (await recovered.ReadPageAsync(2)).Should().Equal(committedPage);
+        }
+
+        await using var repairedWal = await SqliteWalFile.OpenAsync(
+            fileSystem,
+            WalPath,
+            readOnly: true);
+        var recovery = await repairedWal.ScanRecoveryAsync();
+        recovery.LastValidFrameNumber.Should().Be(1);
+        recovery.LastCommittedFrameNumber.Should().Be(1);
+        recovery.StopReason.Should().Be(SqliteWalRecoveryStopReason.EndOfFile);
+    }
+
+    [Test]
+    public async Task CheckpointFlushesMainBeforeResetAndReopensFromCheckpointedView()
+    {
+        var storage = new InMemoryFileSystem();
+        var fileSystem = AsyncFileSystemAdapter.Create(storage);
+        var page2 = CreatePage(SqlitePageSize.Default, 0xD1);
+        await using (var pager = await AsyncSqlitePager.CreateAsync(
+                         fileSystem,
+                         DatabasePath,
+                         WalPath,
+                         CreateWalHeader()))
+        {
+            await using (var transaction = await pager.BeginTransactionAsync(2))
+            {
+                await transaction.WritePageAsync(2, page2);
+                await transaction.CommitAsync();
+            }
+
+            var retained = await pager.CheckpointToMainStoreAsync();
+            retained.Should().Be(new SqliteCheckpointResult(2, 1, 1));
+            var reset = await pager.CheckpointToMainStoreAndResetWalAsync();
+            reset.Should().Be(new SqliteCheckpointResult(2, 1, 0));
+            pager.CommittedFrameCount.Should().Be(0);
+        }
+
+        await using var store = await AsyncSqlitePageStore.OpenAsync(
+            fileSystem,
+            DatabasePath,
+            readOnly: true);
+        (await store.ReadPageAsync(2)).Should().Equal(page2);
+
+        await using var reopened = await AsyncSqlitePager.OpenAsync(
+            fileSystem,
+            DatabasePath,
+            WalPath,
+            readOnly: true);
+        reopened.CommittedPageCount.Should().Be(2);
+        (await reopened.ReadPageAsync(2)).Should().Equal(page2);
+    }
+
+    [Test]
+    public async Task DeleteModeCommitMatchesSynchronousPagerAndLeavesNoHotJournal()
+    {
+        var syncStorage = new InMemoryFileSystem();
+        var asyncStorage = new InMemoryFileSystem();
+        var legacyHeader = SqliteDatabaseHeader.CreateDefault() with
+        {
+            ReadVersion = SqliteFileFormatVersion.Legacy,
+            WriteVersion = SqliteFileFormatVersion.Legacy,
+        };
+        var page2 = CreatePage(SqlitePageSize.Default, 0xE1);
+
+        using (var pager = SqlitePager.CreateRollbackJournal(
+                   syncStorage,
+                   DatabasePath,
+                   WalPath,
+                   legacyHeader))
+        {
+            using var transaction = pager.BeginTransaction(2);
+            transaction.WritePage(2, page2);
+            transaction.Commit();
+        }
+
+        var asyncFileSystem = AsyncFileSystemAdapter.Create(asyncStorage);
+        await using (var pager = await AsyncSqlitePager.CreateRollbackJournalAsync(
+                         asyncFileSystem,
+                         DatabasePath,
+                         WalPath,
+                         legacyHeader))
+        {
+            await using var transaction = await pager.BeginTransactionAsync(2);
+            await transaction.WritePageAsync(2, page2);
+            await transaction.CommitAsync();
+        }
+
+        ReadAll(asyncStorage, DatabasePath).Should().Equal(ReadAll(syncStorage, DatabasePath));
+        asyncStorage.FileExists(DatabasePath + "-journal").Should().BeFalse();
+        await using var reopened = await AsyncSqlitePager.OpenAsync(
+            asyncFileSystem,
+            DatabasePath,
+            WalPath);
+        reopened.JournalMode.Should().Be(SqliteJournalMode.Delete);
+        (await reopened.ReadPageAsync(2)).Should().Equal(page2);
+    }
+
+    [Test]
+    public async Task OpenRecoversHotRollbackJournalBeforePublishingDeleteModeView()
+    {
+        var storage = new InMemoryFileSystem();
+        var legacyHeader = SqliteDatabaseHeader.CreateDefault() with
+        {
+            ReadVersion = SqliteFileFormatVersion.Legacy,
+            WriteVersion = SqliteFileFormatVersion.Legacy,
+        };
+        using (var pager = SqlitePager.CreateRollbackJournal(
+                   storage,
+                   DatabasePath,
+                   WalPath,
+                   legacyHeader))
+        {
+        }
+
+        byte[] originalPage;
+        using (var store = SqlitePageStore.Open(storage, DatabasePath))
+        {
+            originalPage = store.ReadPage(1);
+            var changedPage = originalPage.ToArray();
+            changedPage[200] ^= 0x5A;
+            Assert.Throws<IOException>(() => SqliteRollbackJournal.Commit(
+                storage,
+                DatabasePath + "-journal",
+                store,
+                [1],
+                () =>
+                {
+                    store.WritePage(1, changedPage);
+                    store.Flush();
+                    throw new IOException("simulate a crash before journal deletion");
+                }));
+        }
+
+        await using var recovered = await AsyncSqlitePager.OpenAsync(
+            AsyncFileSystemAdapter.Create(storage),
+            DatabasePath,
+            WalPath);
+        recovered.JournalMode.Should().Be(SqliteJournalMode.Delete);
+        (await recovered.ReadPageAsync(1)).Should().Equal(originalPage);
+        storage.FileExists(DatabasePath + "-journal").Should().BeFalse();
+    }
+
+    [Test]
+    public async Task CancellationLeavesPagerReadableAndCommitFaultRequiresRecovery()
+    {
+        var storage = new InMemoryFileSystem();
+        var controller = new DeterministicAsyncIoController(forceYield: true);
+        var fileSystem = DeterministicAsyncFileSystem.Create(
+            AsyncFileSystemAdapter.Create(storage),
+            controller);
+        var pager = await CompleteAsync(
+            AsyncSqlitePager.CreateAsync(
+                fileSystem,
+                DatabasePath,
+                WalPath,
+                CreateWalHeader()),
+            controller);
+        using var cancellation = new CancellationTokenSource();
+
+        var canceledRead = pager.ReadPageAsync(1, cancellation.Token).AsTask();
+        await WaitForPendingYieldAsync(canceledRead, controller);
+        cancellation.Cancel();
+        var canceled = Assert.CatchAsync<OperationCanceledException>(async () => await canceledRead);
+        canceled!.CancellationToken.Should().Be(cancellation.Token);
+        controller.ReleaseNext();
+        pager.State.Should().Be(SqlitePagerState.Ready);
+
+        var transaction = await CompleteAsync(pager.BeginTransactionAsync(2), controller);
+        await CompleteAsync(
+            transaction.WritePageAsync(2, CreatePage(pager.PageSize, 0xF1)),
+            controller);
+        var expected = new IOException("injected async pager WAL failure");
+        controller.FailNext(FileSystemOperation.Write, expected);
+        var commit = transaction.CommitAsync().AsTask();
+        await ReleaseUntilCompleteAsync(commit, controller);
+        var failure = Assert.ThrowsAsync<IOException>(async () => await commit);
+        failure.Should().BeSameAs(expected);
+        transaction.State.Should().Be(SqlitePagerTransactionState.Faulted);
+        pager.State.Should().Be(SqlitePagerState.Faulted);
+        await CompleteAsync(transaction.DisposeAsync(), controller);
+        await CompleteAsync(pager.DisposeAsync(), controller);
+
+        await using var recovered = await AsyncSqlitePager.OpenAsync(
+            AsyncFileSystemAdapter.Create(storage),
+            DatabasePath,
+            WalPath);
+        recovered.CommittedPageCount.Should().Be(1);
+    }
+
+    private static SqliteWalHeader CreateWalHeader()
+        => SqliteWalHeader.Create(
+            SqlitePageSize.Default,
+            salt1: 0x1122_3344,
+            salt2: 0x5566_7788,
+            checkpointSequence: 9);
+
+    private static byte[] CreatePage(int pageSize, byte fill)
+    {
+        var page = new byte[pageSize];
+        Array.Fill(page, fill);
+        return page;
+    }
+
+    private static byte[] ReadAll(IFileSystem fileSystem, string path)
+    {
+        using var file = fileSystem.OpenFile(path, FileOpenMode.OpenExisting, readOnly: true);
+        var bytes = new byte[checked((int)file.Length)];
+        file.Read(0, bytes).Should().Be(bytes.Length);
+        return bytes;
+    }
+
+    private static async Task CompleteAsync(
+        ValueTask operation,
+        DeterministicAsyncIoController controller)
+    {
+        var task = operation.AsTask();
+        await ReleaseUntilCompleteAsync(task, controller);
+        await task;
+    }
+
+    private static async Task<T> CompleteAsync<T>(
+        ValueTask<T> operation,
+        DeterministicAsyncIoController controller)
+    {
+        var task = operation.AsTask();
+        await ReleaseUntilCompleteAsync(task, controller);
+        return await task;
+    }
+
+    private static async Task ReleaseUntilCompleteAsync(
+        Task task,
+        DeterministicAsyncIoController controller)
+    {
+        while (!task.IsCompleted)
+        {
+            if (controller.PendingYieldCount > 0)
+                controller.ReleaseNext();
+            else
+                await Task.Yield();
+        }
+    }
+
+    private static async Task WaitForPendingYieldAsync(
+        Task task,
+        DeterministicAsyncIoController controller)
+    {
+        while (!task.IsCompleted && controller.PendingYieldCount == 0)
+            await Task.Yield();
+    }
+}

--- a/src/Ahtola.Tests/AsyncSqliteRollbackJournalTests.cs
+++ b/src/Ahtola.Tests/AsyncSqliteRollbackJournalTests.cs
@@ -1,0 +1,308 @@
+using System.Buffers.Binary;
+using AwesomeAssertions;
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Tests;
+
+public sealed class AsyncSqliteRollbackJournalTests
+{
+    [Test]
+    public async Task AsyncWriterMatchesSynchronousJournalBytesAcrossForcedYields()
+    {
+        var expected = CreateSynchronousHotJournal();
+        var backing = new InMemoryFileSystem();
+        var controller = new DeterministicAsyncIoController(forceYield: true);
+        var fileSystem = DeterministicAsyncFileSystem.Create(
+            AsyncFileSystemAdapter.Create(backing),
+            controller);
+
+        var writer = await CompleteAsync(
+            SqliteRollbackJournal.BeginAsync(
+                fileSystem,
+                "async.db-journal",
+                recordCount: 1,
+                expected.ChecksumNonce,
+                initialDatabasePageCount: 1,
+                expected.PageSize),
+            controller);
+        try
+        {
+            await CompleteAsync(
+                writer.WritePageRecordAsync(1, expected.OriginalPage),
+                controller);
+            await CompleteAsync(writer.FinalizeAsync(), controller);
+        }
+        finally
+        {
+            await CompleteAsync(writer.DisposeAsync(), controller);
+        }
+
+        ReadAll(backing, "async.db-journal").Should().Equal(expected.JournalBytes);
+        controller.GetOperationCount(FileSystemOperation.Open).Should().Be(1);
+        controller.GetOperationCount(FileSystemOperation.Write).Should().Be(5);
+        controller.GetOperationCount(FileSystemOperation.SetLength).Should().Be(1);
+        controller.GetOperationCount(FileSystemOperation.FlushToDisk).Should().Be(2);
+        controller.GetOperationCount(FileSystemOperation.Dispose).Should().Be(1);
+    }
+
+    [Test]
+    public async Task AsyncRecoveryRestoresHotJournalAndDeletesItAfterDurableDatabaseFlush()
+    {
+        var expected = CreateSynchronousHotJournal();
+        var backing = new InMemoryFileSystem();
+        WriteAll(backing, "recover.db", Enumerable.Repeat((byte)0xCC, expected.PageSize).ToArray());
+        WriteAll(backing, "recover.db-journal", expected.JournalBytes);
+        var controller = new DeterministicAsyncIoController(forceYield: true);
+        var fileSystem = DeterministicAsyncFileSystem.Create(
+            AsyncFileSystemAdapter.Create(backing),
+            controller);
+
+        await CompleteAsync(
+            SqliteRollbackJournal.RecoverIfPresentAsync(
+                fileSystem,
+                "recover.db",
+                "recover.db-journal",
+                readOnly: false),
+            controller);
+
+        ReadAll(backing, "recover.db").Should().Equal(expected.OriginalPage);
+        backing.FileExists("recover.db-journal").Should().BeFalse();
+        controller.GetOperationCount(FileSystemOperation.FileExists).Should().Be(2);
+        controller.GetOperationCount(FileSystemOperation.Write).Should().Be(2);
+        controller.GetOperationCount(FileSystemOperation.SetLength).Should().Be(1);
+        controller.GetOperationCount(FileSystemOperation.FlushToDisk).Should().Be(2);
+        controller.GetOperationCount(FileSystemOperation.Delete).Should().Be(1);
+    }
+
+    [Test]
+    public async Task AsyncRecoveryRejectsHotJournalForReadOnlyOpenWithoutMutation()
+    {
+        var expected = CreateSynchronousHotJournal();
+        var backing = new InMemoryFileSystem();
+        var changedPage = Enumerable.Repeat((byte)0xA7, expected.PageSize).ToArray();
+        WriteAll(backing, "readonly.db", changedPage);
+        WriteAll(backing, "readonly.db-journal", expected.JournalBytes);
+        var controller = new DeterministicAsyncIoController(forceYield: true);
+        var fileSystem = DeterministicAsyncFileSystem.Create(
+            AsyncFileSystemAdapter.Create(backing),
+            controller);
+
+        var exception = Assert.ThrowsAsync<InvalidDataException>(
+            async () => await CompleteAsync(
+                SqliteRollbackJournal.RecoverIfPresentAsync(
+                    fileSystem,
+                    "readonly.db",
+                    "readonly.db-journal",
+                    readOnly: true),
+                controller));
+
+        exception.Message.Should().Contain("hot rollback journal");
+        ReadAll(backing, "readonly.db").Should().Equal(changedPage);
+        ReadAll(backing, "readonly.db-journal").Should().Equal(expected.JournalBytes);
+        controller.GetOperationCount(FileSystemOperation.Delete).Should().Be(0);
+    }
+
+    [Test]
+    public async Task AsyncHotDetectionReportsShortReadAfterObservedLengthChanges()
+    {
+        var backing = new InMemoryFileSystem();
+        var bytes = new byte[9];
+        new byte[] { 0xd9, 0xd5, 0x05, 0xf9, 0x20, 0xa1, 0x63, 0xd7 }.CopyTo(bytes, 0);
+        WriteAll(backing, "short.db-journal", bytes);
+        var controller = new DeterministicAsyncIoController(forceYield: true);
+        var fileSystem = DeterministicAsyncFileSystem.Create(
+            AsyncFileSystemAdapter.Create(backing),
+            controller);
+
+        var operation = SqliteRollbackJournal
+            .IsHotAsync(fileSystem, "short.db-journal")
+            .AsTask();
+        await ReleaseNextAsync(operation, controller);
+        await ReleaseNextAsync(operation, controller);
+        await ReleaseNextAsync(operation, controller);
+        await WaitForPendingYieldAsync(operation, controller);
+        using (var journal = backing.OpenFile("short.db-journal", FileOpenMode.OpenExisting))
+            journal.SetLength(4);
+        controller.ReleaseNext();
+
+        await ReleaseRemainingAsync(operation, controller);
+        var exception = Assert.ThrowsAsync<InvalidDataException>(async () => await operation);
+        exception.Message.Should().Be("SQLite rollback journal magic is truncated.");
+    }
+
+    [Test]
+    public async Task AsyncHotDetectionPreservesCancellationTokenWhileSuspended()
+    {
+        var backing = new InMemoryFileSystem();
+        var controller = new DeterministicAsyncIoController(forceYield: true);
+        var fileSystem = DeterministicAsyncFileSystem.Create(
+            AsyncFileSystemAdapter.Create(backing),
+            controller);
+        using var cancellation = new CancellationTokenSource();
+
+        var operation = SqliteRollbackJournal
+            .IsHotAsync(fileSystem, "cancel.db-journal", cancellation.Token)
+            .AsTask();
+        await WaitForPendingYieldAsync(operation, controller);
+        cancellation.Cancel();
+
+        var exception = Assert.CatchAsync<OperationCanceledException>(
+            async () => await operation);
+        exception.CancellationToken.Should().Be(cancellation.Token);
+        controller.ReleaseNext();
+        backing.FileExists("cancel.db-journal").Should().BeFalse();
+    }
+
+    [Test]
+    public async Task AsyncFinalizePropagatesSecondFlushFaultAfterPublishingMagic()
+    {
+        var expected = CreateSynchronousHotJournal();
+        var backing = new InMemoryFileSystem();
+        var controller = new DeterministicAsyncIoController(forceYield: true);
+        var fileSystem = DeterministicAsyncFileSystem.Create(
+            AsyncFileSystemAdapter.Create(backing),
+            controller);
+        var writer = await CompleteAsync(
+            SqliteRollbackJournal.BeginAsync(
+                fileSystem,
+                "fault.db-journal",
+                recordCount: 1,
+                expected.ChecksumNonce,
+                initialDatabasePageCount: 1,
+                expected.PageSize),
+            controller);
+        await CompleteAsync(writer.WritePageRecordAsync(1, expected.OriginalPage), controller);
+
+        var finalize = writer.FinalizeAsync().AsTask();
+        await ReleaseNextAsync(finalize, controller);
+        await ReleaseNextAsync(finalize, controller);
+        await WaitForPendingYieldAsync(finalize, controller);
+        var expectedException = new IOException("second journal flush failed");
+        controller.FailNext(FileSystemOperation.FlushToDisk, expectedException);
+        controller.ReleaseNext();
+        await ReleaseNextAsync(finalize, controller);
+
+        var exception = Assert.ThrowsAsync<IOException>(async () => await finalize);
+        exception.Should().BeSameAs(expectedException);
+        SqliteRollbackJournal.IsHot(backing, "fault.db-journal").Should().BeTrue();
+        await CompleteAsync(writer.DisposeAsync(), controller);
+    }
+
+    [Test]
+    public async Task AsyncWriterRejectsDuplicatePagesBeforePublishingHotJournal()
+    {
+        var expected = CreateSynchronousHotJournal();
+        var backing = new InMemoryFileSystem();
+        var controller = new DeterministicAsyncIoController(forceYield: true);
+        var fileSystem = DeterministicAsyncFileSystem.Create(
+            AsyncFileSystemAdapter.Create(backing),
+            controller);
+        var writer = await CompleteAsync(
+            SqliteRollbackJournal.BeginAsync(
+                fileSystem,
+                "duplicate.db-journal",
+                recordCount: 2,
+                expected.ChecksumNonce,
+                initialDatabasePageCount: 1,
+                expected.PageSize),
+            controller);
+        await CompleteAsync(writer.WritePageRecordAsync(1, expected.OriginalPage), controller);
+
+        var exception = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await writer.WritePageRecordAsync(1, expected.OriginalPage));
+
+        exception.Message.Should().Contain("already contains page 1");
+        controller.GetOperationCount(FileSystemOperation.Write).Should().Be(4);
+        SqliteRollbackJournal.IsHot(backing, "duplicate.db-journal").Should().BeFalse();
+        await CompleteAsync(writer.DisposeAsync(), controller);
+    }
+
+    private static HotJournalFixture CreateSynchronousHotJournal()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        const string databasePath = "sync.db";
+        const string journalPath = "sync.db-journal";
+        using var pageStore = SqlitePageStore.Create(fileSystem, databasePath);
+        var originalPage = pageStore.ReadRawPage(1);
+
+        Assert.Throws<InvalidOperationException>(
+            () => SqliteRollbackJournal.Commit(
+                fileSystem,
+                journalPath,
+                pageStore,
+                [1],
+                () => throw new InvalidOperationException("retain hot journal")));
+
+        var journalBytes = ReadAll(fileSystem, journalPath);
+        var checksumNonce = BinaryPrimitives.ReadUInt32BigEndian(journalBytes.AsSpan(12));
+        return new HotJournalFixture(
+            journalBytes,
+            originalPage,
+            checksumNonce,
+            pageStore.PageSize);
+    }
+
+    private static byte[] ReadAll(IFileSystem fileSystem, string path)
+    {
+        using var file = fileSystem.OpenFile(path, FileOpenMode.OpenExisting, readOnly: true);
+        var bytes = new byte[checked((int)file.Length)];
+        file.Read(0, bytes).Should().Be(bytes.Length);
+        return bytes;
+    }
+
+    private static void WriteAll(IFileSystem fileSystem, string path, ReadOnlySpan<byte> bytes)
+    {
+        using var file = fileSystem.OpenFile(path, FileOpenMode.CreateNew);
+        file.Write(0, bytes);
+        file.SetLength(bytes.Length);
+    }
+
+    private static async Task CompleteAsync(
+        ValueTask operation,
+        DeterministicAsyncIoController controller)
+    {
+        var task = operation.AsTask();
+        await ReleaseRemainingAsync(task, controller);
+        await task;
+    }
+
+    private static async Task<T> CompleteAsync<T>(
+        ValueTask<T> operation,
+        DeterministicAsyncIoController controller)
+    {
+        var task = operation.AsTask();
+        await ReleaseRemainingAsync(task, controller);
+        return await task;
+    }
+
+    private static async Task ReleaseRemainingAsync(
+        Task operation,
+        DeterministicAsyncIoController controller)
+    {
+        while (!operation.IsCompleted)
+            await ReleaseNextAsync(operation, controller);
+    }
+
+    private static async Task ReleaseNextAsync(
+        Task operation,
+        DeterministicAsyncIoController controller)
+    {
+        await WaitForPendingYieldAsync(operation, controller);
+        if (!operation.IsCompleted)
+            controller.ReleaseNext();
+    }
+
+    private static async Task WaitForPendingYieldAsync(
+        Task operation,
+        DeterministicAsyncIoController controller)
+    {
+        while (!operation.IsCompleted && controller.PendingYieldCount == 0)
+            await Task.Yield();
+    }
+
+    private sealed record HotJournalFixture(
+        byte[] JournalBytes,
+        byte[] OriginalPage,
+        uint ChecksumNonce,
+        int PageSize);
+}

--- a/src/Ahtola.Tests/AsyncSqliteWalTests.cs
+++ b/src/Ahtola.Tests/AsyncSqliteWalTests.cs
@@ -1,0 +1,333 @@
+using AwesomeAssertions;
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Tests;
+
+public sealed class AsyncSqliteWalTests
+{
+    private const int PageSize = 512;
+
+    [Test]
+    public async Task AsyncWalMatchesSyncBytesAndSuspendsAtEveryIoBoundary()
+    {
+        var header = CreateHeader();
+        var pages = CreatePages(4);
+        var syncFileSystem = new InMemoryFileSystem();
+        var asyncStorage = new InMemoryFileSystem();
+        var controller = new DeterministicAsyncIoController(forceYield: true);
+        var asyncFileSystem = DeterministicAsyncFileSystem.Create(
+            AsyncFileSystemAdapter.Create(asyncStorage),
+            controller);
+
+        using (var syncWal = SqliteWalFile.Create(syncFileSystem, "sync.db-wal", header))
+        {
+            syncWal.AppendFrames(new FrameSource(pages), commitDatabaseSizeInPages: 4);
+            syncWal.Flush();
+        }
+
+        var asyncWal = await CompleteAsync(
+            SqliteWalFile.CreateAsync(asyncFileSystem, "async.db-wal", header),
+            controller);
+        (await CompleteAsync(
+            asyncWal.AppendFramesAsync(new FrameSource(pages), commitDatabaseSizeInPages: 4),
+            controller)).Should().Be(4);
+        await CompleteAsync(asyncWal.FlushAsync(), controller);
+        (await CompleteAsync(asyncWal.GetLengthAsync(), controller))
+            .Should().Be(SqliteWalHeader.Size + 4L * (SqliteWalFrameHeader.Size + PageSize));
+        (await CompleteAsync(asyncWal.ReadDurableHeaderAsync(), controller))
+            .Should().BeEquivalentTo(header);
+
+        var frames = await CompleteAsync(asyncWal.ReadFrameRangeAsync(1, 4), controller);
+        frames.Should().HaveCount(4);
+        frames.Select(static frame => frame.Header.PageNumber).Should().Equal(1U, 2U, 3U, 4U);
+        frames[^1].Header.DatabaseSizeInPages.Should().Be(4);
+        (await CompleteAsync(asyncWal.ScanRecoveryAsync(), controller))
+            .LastCommittedFrameNumber.Should().Be(4);
+        await CompleteAsync(asyncWal.DisposeAsync(), controller);
+
+        ReadAllBytes(asyncStorage, "async.db-wal")
+            .Should().Equal(ReadAllBytes(syncFileSystem, "sync.db-wal"));
+        controller.GetOperationCount(FileSystemOperation.Open).Should().BeGreaterThan(0);
+        controller.GetOperationCount(FileSystemOperation.Read).Should().BeGreaterThan(0);
+        controller.GetOperationCount(FileSystemOperation.Write).Should().BeGreaterThan(0);
+        controller.GetOperationCount(FileSystemOperation.GetLength).Should().BeGreaterThan(0);
+        controller.GetOperationCount(FileSystemOperation.FlushToDisk).Should().BeGreaterThan(0);
+        controller.GetOperationCount(FileSystemOperation.Dispose).Should().Be(1);
+    }
+
+    [Test]
+    public async Task AsyncWalTreatsShortFrameReadsAsTruncation()
+    {
+        var storage = new InMemoryFileSystem();
+        var shortReads = new ShortReadController();
+        var fileSystem = new ShortReadAsyncFileSystem(
+            AsyncFileSystemAdapter.Create(storage),
+            shortReads);
+        await using var wal = await SqliteWalFile.CreateAsync(fileSystem, "short.db-wal", CreateHeader());
+        await wal.AppendFrameAsync(1, CreatePage(0x51), databaseSizeInPages: 1);
+
+        shortReads.ShortenNextRead();
+        var readException = Assert.ThrowsAsync<InvalidDataException>(
+            async () => await wal.ReadFrameAsync(1));
+        readException!.Message.Should().Contain("Short read on SQLite WAL frame");
+
+        shortReads.ShortenNextRead();
+        var recovery = await wal.ScanRecoveryAsync();
+        recovery.LastValidFrameNumber.Should().Be(0);
+        recovery.StopReason.Should().Be(SqliteWalRecoveryStopReason.PartialFrame);
+    }
+
+    [Test]
+    public async Task AsyncAppendFaultRestoresFrameAlignmentAndPreservesException()
+    {
+        var storage = new InMemoryFileSystem();
+        var controller = new DeterministicAsyncIoController(forceYield: false);
+        var fileSystem = DeterministicAsyncFileSystem.Create(
+            AsyncFileSystemAdapter.Create(storage),
+            controller);
+        await using var wal = await SqliteWalFile.CreateAsync(fileSystem, "fault.db-wal", CreateHeader());
+        var expected = new IOException("injected async WAL write failure");
+        controller.FailNext(FileSystemOperation.Write, expected);
+
+        var exception = Assert.ThrowsAsync<IOException>(
+            async () => await wal.AppendFrameAsync(1, CreatePage(0x61), databaseSizeInPages: 1));
+        exception.Should().BeSameAs(expected);
+        (await wal.GetLengthAsync()).Should().Be(SqliteWalHeader.Size);
+        (await wal.ScanRecoveryAsync()).StopReason.Should().Be(SqliteWalRecoveryStopReason.EndOfFile);
+
+        (await wal.AppendFrameAsync(1, CreatePage(0x62), databaseSizeInPages: 1)).Should().Be(1);
+        (await wal.ScanRecoveryAsync()).LastCommittedFrameNumber.Should().Be(1);
+    }
+
+    [Test]
+    public async Task AsyncWalCancellationPropagatesTheOriginalTokenWhileSuspended()
+    {
+        var storage = new InMemoryFileSystem();
+        var controller = new DeterministicAsyncIoController(forceYield: true);
+        var fileSystem = DeterministicAsyncFileSystem.Create(
+            AsyncFileSystemAdapter.Create(storage),
+            controller);
+        var wal = await CompleteAsync(
+            SqliteWalFile.CreateAsync(fileSystem, "cancel.db-wal", CreateHeader()),
+            controller);
+        using var cancellation = new CancellationTokenSource();
+
+        var pending = wal.ScanRecoveryAsync(cancellation.Token);
+        pending.IsCompleted.Should().BeFalse();
+        controller.PendingYieldCount.Should().Be(1);
+        cancellation.Cancel();
+
+        var exception = Assert.CatchAsync<OperationCanceledException>(
+            async () => await pending);
+        exception!.CancellationToken.Should().Be(cancellation.Token);
+        controller.ReleaseNext();
+        await CompleteAsync(wal.DisposeAsync(), controller);
+    }
+
+    [Test]
+    public async Task AsyncRecoveryTruncatesPartialAndUncommittedTailsAtLastCommit()
+    {
+        var storage = new InMemoryFileSystem();
+        var fileSystem = AsyncFileSystemAdapter.Create(storage);
+        await using var wal = await SqliteWalFile.CreateAsync(fileSystem, "recover.db-wal", CreateHeader());
+        await wal.AppendFrameAsync(1, CreatePage(0x71), databaseSizeInPages: 1);
+        await wal.AppendFrameAsync(2, CreatePage(0x72));
+        var committedLength = SqliteWalHeader.Size + wal.FrameSize;
+
+        await using (var raw = await fileSystem.OpenFileAsync(
+            "recover.db-wal",
+            FileOpenMode.OpenExisting))
+        {
+            await raw.WriteAsync(await raw.GetLengthAsync(), new byte[] { 0xAA, 0xBB, 0xCC });
+        }
+
+        var scan = await wal.ScanRecoveryAsync();
+        scan.LastValidFrameNumber.Should().Be(2);
+        scan.LastCommittedFrameNumber.Should().Be(1);
+        scan.StopReason.Should().Be(SqliteWalRecoveryStopReason.PartialFrame);
+
+        (await wal.RecoverToLastCommittedFrameAsync()).Should().Be(scan);
+        (await wal.GetLengthAsync()).Should().Be(committedLength);
+        (await wal.ScanRecoveryAsync()).StopReason.Should().Be(SqliteWalRecoveryStopReason.EndOfFile);
+        Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await wal.ReadFrameAsync(2));
+    }
+
+    [Test]
+    public async Task AsyncReadOnlyResetAndTruncatePreserveWalLifecycleSemantics()
+    {
+        var storage = new InMemoryFileSystem();
+        var fileSystem = AsyncFileSystemAdapter.Create(storage);
+        var wal = await SqliteWalFile.CreateAsync(fileSystem, "lifecycle.db-wal", CreateHeader());
+        await wal.AppendFrameAsync(1, CreatePage(0x81), databaseSizeInPages: 1);
+        var originalSalt = wal.Header.Salt1;
+
+        await wal.ResetAfterDurableCheckpointAsync(publishCheckpointedRecoveryMarker: true);
+        (await wal.GetLengthAsync()).Should().Be(SqliteWalHeader.Size);
+        wal.Header.Salt1.Should().Be(unchecked(originalSalt + 1));
+        wal.HasCheckpointedRecoveryMarker.Should().BeTrue();
+
+        await wal.AppendFrameAsync(2, CreatePage(0x82), databaseSizeInPages: 2);
+        await wal.TruncateAfterDurableCheckpointAsync();
+        (await wal.GetLengthAsync()).Should().Be(0);
+        await wal.AppendFrameAsync(3, CreatePage(0x83), databaseSizeInPages: 3);
+        (await wal.ScanRecoveryAsync()).LastCommittedDatabaseSizeInPages.Should().Be(3);
+        Assert.Throws<InvalidOperationException>(() => wal.ScanRecovery());
+        await wal.DisposeAsync();
+
+        await using var readOnly = await SqliteWalFile.OpenAsync(
+            fileSystem,
+            "lifecycle.db-wal",
+            readOnly: true);
+        readOnly.IsReadOnly.Should().BeTrue();
+        (await readOnly.ReadFrameAsync(1)).PageData.Should().Equal(CreatePage(0x83));
+        Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await readOnly.AppendFrameAsync(4, CreatePage(0x84), databaseSizeInPages: 4));
+        await readOnly.FlushAsync();
+    }
+
+    private static SqliteWalHeader CreateHeader()
+        => SqliteWalHeader.Create(
+            PageSize,
+            salt1: 0x1234_5678,
+            salt2: 0x9ABC_DEF0,
+            checkpointSequence: 7,
+            checksumByteOrder: SqliteWalChecksumByteOrder.BigEndian);
+
+    private static byte[] CreatePage(byte fill)
+    {
+        var page = new byte[PageSize];
+        Array.Fill(page, fill);
+        return page;
+    }
+
+    private static List<WalPage> CreatePages(int count)
+    {
+        var pages = new List<WalPage>(count);
+        for (var index = 0; index < count; index++)
+            pages.Add(new WalPage((uint)(index + 1), CreatePage(unchecked((byte)(0x20 + index)))));
+        return pages;
+    }
+
+    private static byte[] ReadAllBytes(IFileSystem fileSystem, string path)
+    {
+        using var file = fileSystem.OpenFile(path, FileOpenMode.OpenExisting, readOnly: true);
+        var contents = new byte[checked((int)file.Length)];
+        file.Read(0, contents).Should().Be(contents.Length);
+        return contents;
+    }
+
+    private static async Task CompleteAsync(
+        ValueTask operation,
+        DeterministicAsyncIoController controller)
+    {
+        var task = operation.AsTask();
+        await ReleaseUntilCompleteAsync(task, controller);
+        await task;
+    }
+
+    private static async Task<T> CompleteAsync<T>(
+        ValueTask<T> operation,
+        DeterministicAsyncIoController controller)
+    {
+        var task = operation.AsTask();
+        await ReleaseUntilCompleteAsync(task, controller);
+        return await task;
+    }
+
+    private static async Task ReleaseUntilCompleteAsync(
+        Task task,
+        DeterministicAsyncIoController controller)
+    {
+        while (!task.IsCompleted)
+        {
+            if (controller.PendingYieldCount > 0)
+                controller.ReleaseNext();
+            else
+                await Task.Yield();
+        }
+    }
+
+    private sealed record WalPage(uint PageNumber, byte[] Image);
+
+    private sealed class FrameSource(IReadOnlyList<WalPage> pages) : ISqliteWalFrameSource
+    {
+        public int Count => pages.Count;
+
+        public uint GetPageNumber(int index) => pages[index].PageNumber;
+
+        public ReadOnlySpan<byte> GetPageImage(int index) => pages[index].Image;
+    }
+
+    private sealed class ShortReadController
+    {
+        private int _remaining;
+
+        internal void ShortenNextRead() => Interlocked.Exchange(ref _remaining, 1);
+
+        internal bool Consume() => Interlocked.Exchange(ref _remaining, 0) != 0;
+    }
+
+    private sealed class ShortReadAsyncFileSystem(
+        IAsyncFileSystem inner,
+        ShortReadController controller) : IAsyncFileSystem
+    {
+        public ValueTask<bool> FileExistsAsync(
+            string path,
+            CancellationToken cancellationToken = default)
+            => inner.FileExistsAsync(path, cancellationToken);
+
+        public async ValueTask<IAsyncFile> OpenFileAsync(
+            string path,
+            FileOpenMode mode,
+            bool readOnly = false,
+            CancellationToken cancellationToken = default)
+            => new ShortReadAsyncFile(
+                await inner.OpenFileAsync(path, mode, readOnly, cancellationToken),
+                controller);
+
+        public ValueTask DeleteFileAsync(
+            string path,
+            CancellationToken cancellationToken = default)
+            => inner.DeleteFileAsync(path, cancellationToken);
+
+        public ValueTask<FileWriteStamp?> GetWriteStampAsync(
+            string path,
+            CancellationToken cancellationToken = default)
+            => inner.GetWriteStampAsync(path, cancellationToken);
+    }
+
+    private sealed class ShortReadAsyncFile(
+        IAsyncFile inner,
+        ShortReadController controller) : IAsyncFile
+    {
+        public bool IsReadOnly => inner.IsReadOnly;
+
+        public ValueTask<long> GetLengthAsync(CancellationToken cancellationToken = default)
+            => inner.GetLengthAsync(cancellationToken);
+
+        public ValueTask<int> ReadAsync(
+            long position,
+            Memory<byte> destination,
+            CancellationToken cancellationToken = default)
+            => inner.ReadAsync(
+                position,
+                controller.Consume() && destination.Length > 0 ? destination[..^1] : destination,
+                cancellationToken);
+
+        public ValueTask WriteAsync(
+            long position,
+            ReadOnlyMemory<byte> source,
+            CancellationToken cancellationToken = default)
+            => inner.WriteAsync(position, source, cancellationToken);
+
+        public ValueTask SetLengthAsync(
+            long length,
+            CancellationToken cancellationToken = default)
+            => inner.SetLengthAsync(length, cancellationToken);
+
+        public ValueTask FlushToDiskAsync(CancellationToken cancellationToken = default)
+            => inner.FlushToDiskAsync(cancellationToken);
+
+        public ValueTask DisposeAsync() => inner.DisposeAsync();
+    }
+}

--- a/src/Ahtola.Tests/AsyncStorageSynchronizationTests.cs
+++ b/src/Ahtola.Tests/AsyncStorageSynchronizationTests.cs
@@ -1,0 +1,305 @@
+using AwesomeAssertions;
+using Ahtola.Core;
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Tests;
+
+public class AsyncStorageSynchronizationTests
+{
+    [Test]
+    public async Task FifoGateServesAsyncWaitersInArrivalOrder()
+    {
+        using var gate = new AsyncFifoGate();
+        using var first = gate.Enter(Timeout.InfiniteTimeSpan);
+        var secondTask = gate.EnterAsync(Timeout.InfiniteTimeSpan).AsTask();
+        var thirdTask = gate.EnterAsync(Timeout.InfiniteTimeSpan).AsTask();
+
+        first.Dispose();
+        using var second = await secondTask.WaitAsync(TimeSpan.FromSeconds(5));
+        thirdTask.IsCompleted.Should().BeFalse();
+
+        second.Dispose();
+        using var third = await thirdTask.WaitAsync(TimeSpan.FromSeconds(5));
+        third.IsActive.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task FifoGateCancellationDoesNotLeakOrSkipTheNextWaiter()
+    {
+        using var gate = new AsyncFifoGate();
+        using var first = gate.Enter(Timeout.InfiniteTimeSpan);
+        using var cancellation = new CancellationTokenSource();
+        var canceledTask = gate
+            .EnterAsync(Timeout.InfiniteTimeSpan, cancellation.Token)
+            .AsTask();
+        var nextTask = gate.EnterAsync(Timeout.InfiniteTimeSpan).AsTask();
+
+        cancellation.Cancel();
+        Func<Task> awaitCanceled = async () => await canceledTask;
+        await awaitCanceled.Should().ThrowAsync<OperationCanceledException>();
+
+        first.Dispose();
+        using var next = await nextTask.WaitAsync(TimeSpan.FromSeconds(5));
+        next.IsActive.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task FifoGateTimeoutAndDisposalReleaseEveryWaiter()
+    {
+        using var gate = new AsyncFifoGate();
+        using var first = gate.Enter(Timeout.InfiniteTimeSpan);
+        var timedOutTask = gate.EnterAsync(TimeSpan.FromMilliseconds(20)).AsTask();
+        Func<Task> awaitTimeout = async () => await timedOutTask;
+        await awaitTimeout.Should().ThrowAsync<TimeoutException>();
+
+        var disposedTask = gate.EnterAsync(Timeout.InfiniteTimeSpan).AsTask();
+        gate.Dispose();
+        Func<Task> awaitDisposed = async () => await disposedTask;
+        await awaitDisposed.Should().ThrowAsync<ObjectDisposedException>();
+
+        first.Dispose();
+        Action enterAgain = () => gate.Enter();
+        enterAgain.Should().Throw<ObjectDisposedException>();
+    }
+
+    [Test]
+    public async Task TransactionLockAsyncWaitersPreserveFifoHandoff()
+    {
+        var transactionLock = new EmbeddedTransactionLock();
+        var first = new object();
+        var second = new object();
+        var third = new object();
+        transactionLock.Enter(first, excludeReaders: false, Timeout.InfiniteTimeSpan);
+        var secondTask = transactionLock
+            .EnterAsync(second, excludeReaders: false, Timeout.InfiniteTimeSpan)
+            .AsTask();
+        var thirdTask = transactionLock
+            .EnterAsync(third, excludeReaders: false, Timeout.InfiniteTimeSpan)
+            .AsTask();
+
+        transactionLock.Exit(first);
+        await secondTask.WaitAsync(TimeSpan.FromSeconds(5));
+        transactionLock.IsHeldBy(second).Should().BeTrue();
+        thirdTask.IsCompleted.Should().BeFalse();
+
+        transactionLock.Exit(second);
+        await thirdTask.WaitAsync(TimeSpan.FromSeconds(5));
+        transactionLock.IsHeldBy(third).Should().BeTrue();
+        transactionLock.Exit(third);
+    }
+
+    [Test]
+    public async Task TransactionLockCanceledHeadDoesNotStrandOwnership()
+    {
+        var transactionLock = new EmbeddedTransactionLock();
+        var first = new object();
+        var canceled = new object();
+        var next = new object();
+        transactionLock.Enter(first, excludeReaders: false, Timeout.InfiniteTimeSpan);
+        using var cancellation = new CancellationTokenSource();
+        var canceledTask = transactionLock
+            .EnterAsync(canceled, excludeReaders: false, Timeout.InfiniteTimeSpan, cancellation.Token)
+            .AsTask();
+        var nextTask = transactionLock
+            .EnterAsync(next, excludeReaders: false, Timeout.InfiniteTimeSpan)
+            .AsTask();
+
+        cancellation.Cancel();
+        Func<Task> awaitCanceled = async () => await canceledTask;
+        await awaitCanceled.Should().ThrowAsync<OperationCanceledException>();
+
+        transactionLock.Exit(first);
+        await nextTask.WaitAsync(TimeSpan.FromSeconds(5));
+        transactionLock.IsHeldBy(next).Should().BeTrue();
+        transactionLock.IsHeldBy(canceled).Should().BeFalse();
+        transactionLock.Exit(next);
+    }
+
+    [Test]
+    public async Task TransactionLockTimeoutLeavesNoOwnershipBehind()
+    {
+        var transactionLock = new EmbeddedTransactionLock();
+        var first = new object();
+        var timedOut = new object();
+        var next = new object();
+        transactionLock.Enter(first, excludeReaders: false, Timeout.InfiniteTimeSpan);
+
+        var timedOutTask = transactionLock
+            .EnterAsync(timedOut, excludeReaders: false, TimeSpan.FromMilliseconds(20))
+            .AsTask();
+        Func<Task> awaitTimeout = async () => await timedOutTask;
+        await awaitTimeout.Should().ThrowAsync<EmbeddedBusyException>()
+            .WithMessage("database is locked");
+
+        transactionLock.Exit(first);
+        await transactionLock.EnterAsync(
+            next,
+            excludeReaders: false,
+            TimeSpan.FromSeconds(1));
+        transactionLock.IsHeldBy(next).Should().BeTrue();
+        transactionLock.Exit(next);
+    }
+
+    [Test]
+    public async Task TransactionLockExclusiveHandoffNeverAdmitsACompetingReader()
+    {
+        var transactionLock = new EmbeddedTransactionLock();
+        var first = new object();
+        var second = new object();
+        var reader = new object();
+        transactionLock.Enter(first, excludeReaders: true, Timeout.InfiniteTimeSpan);
+        var secondTask = transactionLock
+            .EnterAsync(second, excludeReaders: true, Timeout.InfiniteTimeSpan)
+            .AsTask();
+        var readerTask = transactionLock
+            .ThrowIfReadBlockedAsync(reader, Timeout.InfiniteTimeSpan)
+            .AsTask();
+
+        transactionLock.Exit(first);
+        await secondTask.WaitAsync(TimeSpan.FromSeconds(5));
+        readerTask.IsCompleted.Should().BeFalse();
+
+        transactionLock.Exit(second);
+        await readerTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task PagerCheckpointKeepsPriorityAcrossAsyncWakeups()
+    {
+        var locks = new SqlitePagerLockManager();
+        using var firstReader = locks.EnterReader();
+        var checkpointTask = locks
+            .EnterCheckpointAsync(TimeSpan.FromSeconds(5))
+            .AsTask();
+        SpinWait.SpinUntil(
+                () => locks.WaitingCheckpointCount == 1,
+                TimeSpan.FromSeconds(2))
+            .Should()
+            .BeTrue();
+        var laterReaderTask = locks
+            .EnterReaderAsync(TimeSpan.FromSeconds(5))
+            .AsTask();
+
+        firstReader.Dispose();
+        using var checkpoint = await checkpointTask.WaitAsync(TimeSpan.FromSeconds(5));
+        locks.State.Should().Be(SqlitePagerLockState.Checkpoint);
+        laterReaderTask.IsCompleted.Should().BeFalse();
+
+        checkpoint.Dispose();
+        using var laterReader = await laterReaderTask.WaitAsync(TimeSpan.FromSeconds(5));
+        locks.State.Should().Be(SqlitePagerLockState.Readers);
+    }
+
+    [Test]
+    public async Task PagerAsyncCancellationAndTimeoutDoNotLeakWriterOwnership()
+    {
+        var locks = new SqlitePagerLockManager();
+        using var first = locks.EnterWriter();
+        using var cancellation = new CancellationTokenSource();
+        var canceledTask = locks
+            .EnterWriterAsync(Timeout.InfiniteTimeSpan, cancellation.Token)
+            .AsTask();
+        cancellation.Cancel();
+        Func<Task> awaitCanceled = async () => await canceledTask;
+        await awaitCanceled.Should().ThrowAsync<OperationCanceledException>();
+
+        var timedOutTask = locks
+            .EnterWriterAsync(TimeSpan.FromMilliseconds(20))
+            .AsTask();
+        Func<Task> awaitTimeout = async () => await timedOutTask;
+        await awaitTimeout.Should().ThrowAsync<SqlitePagerBusyException>();
+
+        first.Dispose();
+        using var next = await locks.EnterWriterAsync(TimeSpan.FromSeconds(1));
+        locks.State.Should().Be(SqlitePagerLockState.Writer);
+    }
+
+    [Test]
+    public async Task PagerExternalAsyncCancellationAndDisposalReleaseExactlyOnce()
+    {
+        var coordinator = new TestAsyncPagerCoordinator { BlockAcquisition = true };
+        var locks = new SqlitePagerLockManager(coordinator);
+        using var cancellation = new CancellationTokenSource();
+        var canceledTask = locks
+            .EnterWriterAsync(Timeout.InfiniteTimeSpan, cancellation.Token)
+            .AsTask();
+        SpinWait.SpinUntil(
+                () => coordinator.AsyncAcquireCount == 1,
+                TimeSpan.FromSeconds(2))
+            .Should()
+            .BeTrue();
+
+        cancellation.Cancel();
+        Func<Task> awaitCanceled = async () => await canceledTask;
+        await awaitCanceled.Should().ThrowAsync<OperationCanceledException>();
+        locks.State.Should().Be(SqlitePagerLockState.Unlocked);
+
+        coordinator.BlockAcquisition = false;
+        var lease = await locks.EnterWriterAsync(TimeSpan.FromSeconds(1));
+        lease.Dispose();
+        lease.Dispose();
+
+        coordinator.LeaseDisposeCount.Should().Be(1);
+        locks.State.Should().Be(SqlitePagerLockState.Unlocked);
+    }
+
+    [Test]
+    public async Task AsyncBusyBackoffObservesCancellationWithoutBlocking()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        Func<Task> wait = async () => await SqliteBusyBackoff.WaitAsync(
+            attempt: 0,
+            Timeout.InfiniteTimeSpan,
+            stopwatch: null,
+            cancellation.Token);
+
+        await wait.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    private sealed class TestAsyncPagerCoordinator :
+        ISqlitePagerLockCoordinator,
+        IAsyncSqlitePagerLockCoordinator
+    {
+        private volatile bool _blockAcquisition;
+        private int _asyncAcquireCount;
+        private int _leaseDisposeCount;
+
+        internal bool BlockAcquisition
+        {
+            get => _blockAcquisition;
+            set => _blockAcquisition = value;
+        }
+
+        internal int AsyncAcquireCount => Volatile.Read(ref _asyncAcquireCount);
+
+        internal int LeaseDisposeCount => Volatile.Read(ref _leaseDisposeCount);
+
+        public IDisposable Acquire(SqlitePagerLockOperation operation, TimeSpan timeout)
+            => throw new AssertionException("Synchronous coordinator acquisition was not expected.");
+
+        public IDisposable AcquireRecovery(TimeSpan timeout)
+            => throw new AssertionException("Synchronous coordinator acquisition was not expected.");
+
+        public async ValueTask<IDisposable> AcquireAsync(
+            SqlitePagerLockOperation operation,
+            TimeSpan timeout,
+            CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref _asyncAcquireCount);
+            if (_blockAcquisition)
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return new CountingLease(this);
+        }
+
+        public ValueTask<IDisposable> AcquireRecoveryAsync(
+            TimeSpan timeout,
+            CancellationToken cancellationToken = default)
+            => ValueTask.FromResult<IDisposable>(new CountingLease(this));
+
+        private sealed class CountingLease(TestAsyncPagerCoordinator owner) : IDisposable
+        {
+            public void Dispose() => Interlocked.Increment(ref owner._leaseDisposeCount);
+        }
+    }
+}

--- a/src/Ahtola.Tests/BrowserAsyncOnlyLifecycleTests.cs
+++ b/src/Ahtola.Tests/BrowserAsyncOnlyLifecycleTests.cs
@@ -1,0 +1,278 @@
+using System.Data;
+using Ahtola.Core;
+using Ahtola.Data.Sqlite;
+using AwesomeAssertions;
+
+namespace Ahtola.Tests;
+
+public sealed class BrowserAsyncOnlyLifecycleTests
+{
+    [Test]
+    public async Task SqliteConnectionSyncCloseAndDisposeRemainRecoverable()
+    {
+        var connection = CreateSqliteConnection();
+        await connection.OpenAsync();
+
+        connection.Invoking(static value => value.Close())
+            .Should().Throw<PlatformNotSupportedException>()
+            .WithMessage("*CloseAsync*");
+        connection.State.Should().Be(ConnectionState.Open);
+        connection.Invoking(static value => value.Dispose())
+            .Should().Throw<PlatformNotSupportedException>()
+            .WithMessage("*DisposeAsync*");
+        connection.State.Should().Be(ConnectionState.Open);
+
+        await connection.DisposeAsync();
+
+        connection.State.Should().Be(ConnectionState.Closed);
+    }
+
+    [Test]
+    public async Task AhtolaConnectionSyncCloseAndDisposeRemainRecoverable()
+    {
+        var connection = CreateAhtolaConnection();
+        await connection.OpenAsync();
+
+        connection.Invoking(static value => value.Close())
+            .Should().Throw<PlatformNotSupportedException>()
+            .WithMessage("*CloseAsync*");
+        connection.State.Should().Be(ConnectionState.Open);
+        connection.Invoking(static value => value.Dispose())
+            .Should().Throw<PlatformNotSupportedException>()
+            .WithMessage("*DisposeAsync*");
+        connection.State.Should().Be(ConnectionState.Open);
+
+        await connection.DisposeAsync();
+
+        connection.State.Should().Be(ConnectionState.Closed);
+    }
+
+    [Test]
+    public async Task SqliteTransactionSyncOperationsDoNotTerminalizeBrowserTransaction()
+    {
+        await using var connection = CreateSqliteConnection();
+        await connection.OpenAsync();
+        connection.Invoking(static value => value.BeginTransaction())
+            .Should().Throw<PlatformNotSupportedException>()
+            .WithMessage("*BeginTransactionAsync*");
+
+        var transaction = (SqliteTransaction)await connection.BeginTransactionAsync();
+        transaction.Invoking(static value => value.Rollback())
+            .Should().Throw<PlatformNotSupportedException>()
+            .WithMessage("*RollbackAsync*");
+        transaction.IsCompleted.Should().BeFalse();
+        connection.Transaction.Should().BeSameAs(transaction);
+        transaction.Invoking(static value => value.Dispose())
+            .Should().Throw<PlatformNotSupportedException>()
+            .WithMessage("*DisposeAsync*");
+        transaction.IsCompleted.Should().BeFalse();
+
+        await transaction.DisposeAsync();
+
+        transaction.IsCompleted.Should().BeTrue();
+        connection.Transaction.Should().BeNull();
+    }
+
+    [Test]
+    public async Task AhtolaTransactionSyncOperationsDoNotTerminalizeBrowserTransaction()
+    {
+        await using var connection = CreateAhtolaConnection();
+        await connection.OpenAsync();
+        connection.Invoking(static value => value.BeginTransaction())
+            .Should().Throw<PlatformNotSupportedException>()
+            .WithMessage("*BeginTransactionAsync*");
+
+        var transaction = (global::Ahtola.AhtolaTransaction)await connection.BeginTransactionAsync();
+        transaction.Invoking(static value => value.Rollback())
+            .Should().Throw<PlatformNotSupportedException>()
+            .WithMessage("*RollbackAsync*");
+        transaction.IsCompleted.Should().BeFalse();
+        connection.Transaction.Should().BeSameAs(transaction);
+        transaction.Invoking(static value => value.Dispose())
+            .Should().Throw<PlatformNotSupportedException>()
+            .WithMessage("*DisposeAsync*");
+        transaction.IsCompleted.Should().BeFalse();
+
+        await transaction.DisposeAsync();
+
+        transaction.IsCompleted.Should().BeTrue();
+        connection.Transaction.Should().BeNull();
+    }
+
+    [Test]
+    public async Task SqliteReaderAsyncDisposalHonorsCloseConnection()
+    {
+        var connection = CreateSqliteConnection();
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 1";
+        var explicitlyClosed = await command.ExecuteReaderAsync();
+
+        await explicitlyClosed.CloseAsync();
+
+        explicitlyClosed.IsClosed.Should().BeTrue();
+        connection.State.Should().Be(ConnectionState.Open);
+        var reader = await command.ExecuteReaderAsync(CommandBehavior.CloseConnection);
+
+        reader.Invoking(static value => value.Dispose())
+            .Should().Throw<PlatformNotSupportedException>()
+            .WithMessage("*DisposeAsync*");
+        reader.IsClosed.Should().BeFalse();
+        connection.State.Should().Be(ConnectionState.Open);
+
+        await reader.DisposeAsync();
+
+        reader.IsClosed.Should().BeTrue();
+        connection.State.Should().Be(ConnectionState.Closed);
+        await connection.DisposeAsync();
+    }
+
+    [Test]
+    public async Task AhtolaReaderAsyncDisposalHonorsCloseConnection()
+    {
+        var connection = CreateAhtolaConnection();
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 1";
+        var explicitlyClosed = await command.ExecuteReaderAsync();
+
+        await explicitlyClosed.CloseAsync();
+
+        explicitlyClosed.IsClosed.Should().BeTrue();
+        connection.State.Should().Be(ConnectionState.Open);
+        var reader = await command.ExecuteReaderAsync(CommandBehavior.CloseConnection);
+
+        reader.Invoking(static value => value.Dispose())
+            .Should().Throw<PlatformNotSupportedException>()
+            .WithMessage("*DisposeAsync*");
+        reader.IsClosed.Should().BeFalse();
+        connection.State.Should().Be(ConnectionState.Open);
+
+        await reader.DisposeAsync();
+
+        reader.IsClosed.Should().BeTrue();
+        connection.State.Should().Be(ConnectionState.Closed);
+        await connection.DisposeAsync();
+    }
+
+    [Test]
+    public async Task ConnectionOwnedReaderCloseDoesNotExecuteTrailingSql()
+    {
+        await using var connection = CreateSqliteConnection();
+        await connection.OpenAsync();
+        await using (var create = connection.CreateCommand())
+        {
+            create.CommandText = "CREATE TABLE data(value INTEGER)";
+            await create.ExecuteNonQueryAsync();
+        }
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 1; INSERT INTO data VALUES (42)";
+        var reader = await command.ExecuteReaderAsync();
+        (await reader.ReadAsync()).Should().BeTrue();
+
+        await ((IConnectionOwnedReader)reader).CloseFromConnectionAsync();
+
+        await using var count = connection.CreateCommand();
+        count.CommandText = "SELECT COUNT(*) FROM data";
+        (await count.ExecuteScalarAsync()).Should().Be(0L);
+    }
+
+    [Test]
+    public async Task SqliteBatchReaderUsesAsyncTransitionsAndCloseConnection()
+    {
+        var connection = CreateSqliteConnection();
+        await connection.OpenAsync();
+        await using var batch = new SqliteBatch(connection);
+        batch.BatchCommands.Add(new SqliteBatchCommand("SELECT 1"));
+        batch.BatchCommands.Add(new SqliteBatchCommand("SELECT 2"));
+        var reader = await batch.ExecuteReaderAsync(
+            CommandBehavior.CloseConnection,
+            CancellationToken.None);
+
+        (await reader.ReadAsync()).Should().BeTrue();
+        reader.GetInt64(0).Should().Be(1);
+        (await reader.NextResultAsync()).Should().BeTrue();
+        (await reader.ReadAsync()).Should().BeTrue();
+        reader.GetInt64(0).Should().Be(2);
+        await reader.DisposeAsync();
+
+        reader.IsClosed.Should().BeTrue();
+        connection.State.Should().Be(ConnectionState.Closed);
+        await connection.DisposeAsync();
+    }
+
+    [Test]
+    public async Task ConnectionOwnedBatchReaderCloseDoesNotExecuteTrailingSql()
+    {
+        await using var connection = CreateSqliteConnection();
+        await connection.OpenAsync();
+        await using (var create = connection.CreateCommand())
+        {
+            create.CommandText = "CREATE TABLE data(value INTEGER)";
+            await create.ExecuteNonQueryAsync();
+        }
+
+        await using var batch = new SqliteBatch(connection);
+        batch.BatchCommands.Add(new SqliteBatchCommand(
+            "SELECT 1; INSERT INTO data VALUES (42)"));
+        var reader = await batch.ExecuteReaderAsync();
+        (await reader.ReadAsync()).Should().BeTrue();
+
+        await ((IConnectionOwnedReader)reader).CloseFromConnectionAsync();
+
+        await using var count = connection.CreateCommand();
+        count.CommandText = "SELECT COUNT(*) FROM data";
+        (await count.ExecuteScalarAsync()).Should().Be(0L);
+        await reader.DisposeAsync();
+    }
+
+    [Test]
+    public async Task AhtolaBatchReaderUsesAsyncTransitionsAndCloseConnection()
+    {
+        var connection = CreateAhtolaConnection();
+        await connection.OpenAsync();
+        await using var batch = new global::Ahtola.AhtolaBatch(connection);
+        batch.BatchCommands.Add(new global::Ahtola.AhtolaBatchCommand("SELECT 1"));
+        batch.BatchCommands.Add(new global::Ahtola.AhtolaBatchCommand("SELECT 2"));
+        var reader = await batch.ExecuteReaderAsync(
+            CommandBehavior.CloseConnection,
+            CancellationToken.None);
+
+        (await reader.ReadAsync()).Should().BeTrue();
+        reader.GetInt64(0).Should().Be(1);
+        (await reader.NextResultAsync()).Should().BeTrue();
+        (await reader.ReadAsync()).Should().BeTrue();
+        reader.GetInt64(0).Should().Be(2);
+        await reader.DisposeAsync();
+
+        reader.IsClosed.Should().BeTrue();
+        connection.State.Should().Be(ConnectionState.Closed);
+        await connection.DisposeAsync();
+    }
+
+    private static SqliteConnection CreateSqliteConnection()
+        => new(
+            "Data Source=:memory:;Local Provider=Managed;Pooling=False",
+            new AsyncOnlyManagedDatabaseFactory());
+
+    private static global::Ahtola.AhtolaConnection CreateAhtolaConnection()
+        => new(
+            "Data Source=:memory:;Local Provider=Managed",
+            new AsyncOnlyManagedDatabaseFactory());
+
+    private sealed class AsyncOnlyManagedDatabaseFactory : IManagedDatabaseFactory
+    {
+        public string DataSource => ":memory:";
+
+        public bool IsReadOnly => false;
+
+        public ValueTask<IManagedDatabaseAdapter> OpenDatabaseAsync(
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult<IManagedDatabaseAdapter>(
+                ManagedDatabaseAdapter.Open(":memory:"));
+        }
+    }
+}

--- a/src/Ahtola.Tests/BrowserAsyncOnlyLifecycleTests.cs
+++ b/src/Ahtola.Tests/BrowserAsyncOnlyLifecycleTests.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using Ahtola.Core;
+using Ahtola.Core.Storage;
 using Ahtola.Data.Sqlite;
 using AwesomeAssertions;
 
@@ -156,6 +157,23 @@ public sealed class BrowserAsyncOnlyLifecycleTests
     }
 
     [Test]
+    public void BrowserDataSourceConnectionsCannotOverrideStorageConfiguration()
+    {
+        using var sqlite = CreateSqliteConnection();
+        using var ahtola = CreateAhtolaConnection();
+        var codec = new IdentityPageCodec();
+
+        sqlite.Invoking(static value => value.ConnectionString = "Data Source=other.db")
+            .Should().Throw<InvalidOperationException>();
+        sqlite.Invoking(value => value.PageCodec = codec)
+            .Should().Throw<InvalidOperationException>();
+        ahtola.Invoking(static value => value.ConnectionString = "Data Source=other.db")
+            .Should().Throw<InvalidOperationException>();
+        ahtola.Invoking(value => value.PageCodec = codec)
+            .Should().Throw<InvalidOperationException>();
+    }
+
+    [Test]
     public async Task ConnectionOwnedReaderCloseDoesNotExecuteTrailingSql()
     {
         await using var connection = CreateSqliteConnection();
@@ -274,5 +292,20 @@ public sealed class BrowserAsyncOnlyLifecycleTests
             return ValueTask.FromResult<IManagedDatabaseAdapter>(
                 ManagedDatabaseAdapter.Open(":memory:"));
         }
+    }
+
+    private sealed class IdentityPageCodec : IPageCodec
+    {
+        private static readonly PageCodecId Id = new("browser-config"u8.ToArray().Concat(new byte[2]).ToArray());
+
+        public PageCodecId CodecId => Id;
+
+        public byte RequiredReservedBytes => 0;
+
+        public void EncodePage(PageCodecContext context, ReadOnlySpan<byte> input, Span<byte> output)
+            => input.CopyTo(output);
+
+        public void DecodePage(PageCodecContext context, ReadOnlySpan<byte> input, Span<byte> output)
+            => input.CopyTo(output);
     }
 }

--- a/src/Ahtola.Tests/BrowserEncryptedStorageTestDoubles.cs
+++ b/src/Ahtola.Tests/BrowserEncryptedStorageTestDoubles.cs
@@ -1,0 +1,184 @@
+using System.Security.Cryptography;
+using Ahtola.Core.Storage;
+using Ahtola.Data.Sqlite.Browser;
+using Ahtola.Data.Sqlite.Browser.Storage;
+
+#pragma warning disable CA1416
+
+namespace Ahtola.Tests;
+
+/// <summary>
+/// A desktop AES-GCM implementation of the browser's asynchronous page cipher.
+/// Web Crypto is unavailable off-browser, so this stands in for it and lets the
+/// suite prove that the browser transforms produce byte-identical AHTLA output.
+/// </summary>
+internal sealed class DesktopAsyncPageCipher(Core.Storage.AhtolaEncryptionCipher cipher, byte[] key)
+    : IAhtolaAsyncPageCipher
+{
+    private byte[]? _key = key.AsSpan().ToArray();
+
+    public Core.Storage.AhtolaEncryptionCipher Cipher { get; } = cipher;
+
+    public int EncryptCount { get; private set; }
+
+    public int DecryptCount { get; private set; }
+
+    public bool IsReleased => _key is null;
+
+    public ValueTask<AhtolaBrowserAesGcmResult> EncryptAsync(
+        ReadOnlyMemory<byte> plaintext,
+        ReadOnlyMemory<byte> nonce,
+        ReadOnlyMemory<byte> associatedData,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        EncryptCount++;
+        using var aes = new AesGcm(RequireKey(), 16);
+        var ciphertext = new byte[plaintext.Length];
+        var tag = new byte[16];
+        aes.Encrypt(nonce.Span, plaintext.Span, ciphertext, tag, associatedData.Span);
+        return ValueTask.FromResult(new AhtolaBrowserAesGcmResult(ciphertext, tag));
+    }
+
+    public ValueTask<byte[]> DecryptAsync(
+        ReadOnlyMemory<byte> ciphertext,
+        ReadOnlyMemory<byte> tag,
+        ReadOnlyMemory<byte> nonce,
+        ReadOnlyMemory<byte> associatedData,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        DecryptCount++;
+        using var aes = new AesGcm(RequireKey(), 16);
+        var plaintext = new byte[ciphertext.Length];
+        aes.Decrypt(nonce.Span, ciphertext.Span, tag.Span, plaintext, associatedData.Span);
+        return ValueTask.FromResult(plaintext);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        var released = Interlocked.Exchange(ref _key, null);
+        if (released is not null)
+            CryptographicOperations.ZeroMemory(released);
+        return ValueTask.CompletedTask;
+    }
+
+    private byte[] RequireKey()
+        => _key ?? throw new ObjectDisposedException(nameof(DesktopAsyncPageCipher));
+}
+
+/// <summary>An in-memory stand-in for the browser's OPFS-backed persistent store.</summary>
+internal sealed class FakeBrowserPersistentStore : IBrowserPersistentStore
+{
+    private readonly Dictionary<string, byte[]> _files = new(StringComparer.Ordinal);
+
+    public int Disposals { get; private set; }
+
+    public IReadOnlyCollection<string> Paths => _files.Keys;
+
+    public byte[] Read(string path) => _files[path].AsSpan().ToArray();
+
+    public bool Contains(string path) => _files.ContainsKey(path);
+
+    public void Seed(string path, byte[] content) => _files[path] = content.AsSpan().ToArray();
+
+    public ValueTask<IReadOnlyList<string>> ListFilesAsync(
+        string directory,
+        CancellationToken cancellationToken = default)
+    {
+        var prefix = directory.TrimEnd('/') + "/";
+        IReadOnlyList<string> matches = _files.Keys
+            .Where(path => path.StartsWith(prefix, StringComparison.Ordinal))
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+        return ValueTask.FromResult(matches);
+    }
+
+    public ValueTask<IAsyncFile> OpenFileAsync(
+        string path,
+        FileOpenMode mode,
+        bool readOnly = false,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_files.ContainsKey(path))
+        {
+            if (mode == FileOpenMode.OpenExisting)
+                throw new FileNotFoundException($"Persisted file '{path}' does not exist.", path);
+            _files[path] = [];
+        }
+
+        return ValueTask.FromResult<IAsyncFile>(new FakeFile(this, path, readOnly));
+    }
+
+    public ValueTask DeleteFileAsync(string path, CancellationToken cancellationToken = default)
+    {
+        _files.Remove(path);
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask ReplaceFileAtomicallyAsync(
+        string sourcePath,
+        string destinationPath,
+        bool replaceEmptyDestination,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_files.Remove(sourcePath, out var content))
+            throw new FileNotFoundException($"Persisted file '{sourcePath}' does not exist.", sourcePath);
+        _files[destinationPath] = content;
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Disposals++;
+        return ValueTask.CompletedTask;
+    }
+
+    private sealed class FakeFile(FakeBrowserPersistentStore owner, string path, bool readOnly) : IAsyncFile
+    {
+        public bool IsReadOnly => readOnly;
+
+        public ValueTask<long> GetLengthAsync(CancellationToken cancellationToken = default)
+            => ValueTask.FromResult((long)owner._files[path].Length);
+
+        public ValueTask<int> ReadAsync(
+            long position,
+            Memory<byte> destination,
+            CancellationToken cancellationToken = default)
+        {
+            var content = owner._files[path];
+            if (position >= content.Length)
+                return ValueTask.FromResult(0);
+            var count = (int)Math.Min(destination.Length, content.Length - position);
+            content.AsSpan((int)position, count).CopyTo(destination.Span);
+            return ValueTask.FromResult(count);
+        }
+
+        public ValueTask WriteAsync(
+            long position,
+            ReadOnlyMemory<byte> source,
+            CancellationToken cancellationToken = default)
+        {
+            var content = owner._files[path];
+            var required = (int)position + source.Length;
+            if (content.Length < required)
+                Array.Resize(ref content, required);
+            source.Span.CopyTo(content.AsSpan((int)position));
+            owner._files[path] = content;
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask SetLengthAsync(long length, CancellationToken cancellationToken = default)
+        {
+            var content = owner._files[path];
+            Array.Resize(ref content, (int)length);
+            owner._files[path] = content;
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask FlushToDiskAsync(CancellationToken cancellationToken = default)
+            => ValueTask.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/src/Ahtola.Tests/CoreManagedLocalAdapterLifecycleTests.cs
+++ b/src/Ahtola.Tests/CoreManagedLocalAdapterLifecycleTests.cs
@@ -33,4 +33,26 @@ public class CoreManagedLocalAdapterLifecycleTests
         statement.Step().Should().Be(StatementStepResult.Row);
         statement.GetValue(0).AsInteger().Should().Be(9);
     }
+
+    [Test]
+    public async Task CoreManagedAdapterAsyncDefaultsCompleteInline()
+    {
+        await using var database = ManagedDatabaseAdapter.Open(":memory:");
+        var connect = database.ConnectAsync();
+        connect.IsCompletedSuccessfully.Should().BeTrue();
+        var connection = await connect;
+
+        var prepare = connection.PrepareAsync("SELECT 31;");
+        prepare.IsCompletedSuccessfully.Should().BeTrue();
+        await using var statement = await prepare;
+
+        var step = statement.StepAsync();
+        step.IsCompletedSuccessfully.Should().BeTrue();
+        (await step).Should().Be(StatementStepResult.Row);
+
+        var reset = statement.ResetAsync();
+        reset.IsCompletedSuccessfully.Should().BeTrue();
+        await reset;
+        statement.Step().Should().Be(StatementStepResult.Row);
+    }
 }

--- a/src/Ahtola.Tests/ManagedAsyncBlobAndBackupTests.cs
+++ b/src/Ahtola.Tests/ManagedAsyncBlobAndBackupTests.cs
@@ -1,0 +1,337 @@
+using AwesomeAssertions;
+using Ahtola.Core;
+using Ahtola.Data.Sqlite;
+
+namespace Ahtola.Tests;
+
+public sealed class ManagedAsyncBlobAndBackupTests
+{
+    [Test]
+    public async Task IncrementalBlobAdapterAsyncDefaultsPreserveSyncParityAndCancellation()
+    {
+        IManagedIncrementalBlobAdapter adapter = new InlineBlobAdapter([1, 2, 3]);
+        var buffer = new byte[2];
+
+        (await adapter.ReadAsync(1, buffer)).Should().Be(2);
+        buffer.Should().Equal(2, 3);
+        await adapter.WriteAsync(0, new byte[] { 9, 8 });
+
+        var updated = new byte[3];
+        adapter.Read(0, updated).Should().Be(3);
+        updated.Should().Equal(9, 8, 3);
+
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        Assert.CatchAsync<OperationCanceledException>(
+            async () => await adapter.ReadAsync(0, buffer, cancellation.Token));
+        Assert.CatchAsync<OperationCanceledException>(
+            async () => await adapter.WriteAsync(0, buffer, cancellation.Token));
+
+        await adapter.DisposeAsync();
+        ((InlineBlobAdapter)adapter).IsDisposed.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task SqliteBlobAsyncReadWriteTracksPositionAndPersistsBytes()
+    {
+        await using var connection = new SqliteConnection(
+            "Data Source=:memory:;Local Provider=Managed;Pooling=False");
+        await connection.OpenAsync();
+        await ExecuteAsync(
+            connection,
+            "CREATE TABLE data(value BLOB); INSERT INTO data(rowid, value) VALUES (1, X'01020304');");
+
+        var blob = await connection.OpenBlobAsync("data", "value", 1);
+        var read = new byte[2];
+        (await blob.ReadAsync(read)).Should().Be(2);
+        read.Should().Equal(1, 2);
+        blob.Position.Should().Be(2);
+
+        await blob.WriteAsync(new byte[] { 9, 8 });
+        blob.Position.Should().Be(4);
+        await blob.FlushAsync();
+        await blob.DisposeAsync();
+
+        blob.CanRead.Should().BeFalse();
+        Assert.Throws<ObjectDisposedException>(() => _ = blob.Length);
+        (await ScalarAsync<byte[]>(connection, "SELECT value FROM data WHERE rowid = 1;"))
+            .Should().Equal(1, 2, 9, 8);
+    }
+
+    [Test]
+    public async Task SqliteBlobAsyncCancellationLeavesPositionAndValueUnchanged()
+    {
+        await using var connection = new SqliteConnection(
+            "Data Source=:memory:;Local Provider=Managed;Pooling=False");
+        await connection.OpenAsync();
+        await ExecuteAsync(
+            connection,
+            "CREATE TABLE data(value BLOB); INSERT INTO data(rowid, value) VALUES (1, X'0102');");
+        await using var blob = await connection.OpenBlobAsync("data", "value", 1);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        Assert.CatchAsync<OperationCanceledException>(
+            async () => await blob.ReadExactlyAsync(new byte[1], cancellation.Token));
+        blob.Position.Should().Be(0);
+        Assert.CatchAsync<OperationCanceledException>(
+            async () => await blob.WriteAsync(new byte[] { 9 }, cancellation.Token));
+        blob.Position.Should().Be(0);
+        (await ScalarAsync<byte[]>(connection, "SELECT value FROM data WHERE rowid = 1;"))
+            .Should().Equal(1, 2);
+    }
+
+    [Test]
+    public async Task BackupDatabaseAsyncAutoOpensDestinationAndPreservesDataAndHeader()
+    {
+        await using var source = new SqliteConnection(
+            "Data Source=:memory:;Local Provider=Managed;Pooling=False");
+        await using var destination = new SqliteConnection(
+            "Data Source=:memory:;Local Provider=Managed;Pooling=False");
+        await source.OpenAsync();
+        await ExecuteAsync(
+            source,
+            "CREATE TABLE data(id INTEGER PRIMARY KEY, value BLOB);"
+            + "INSERT INTO data VALUES (7, X'0001FEFF');"
+            + "PRAGMA user_version = 123;"
+            + "PRAGMA application_id = 456;");
+
+        await source.BackupDatabaseAsync(destination);
+
+        destination.State.Should().Be(System.Data.ConnectionState.Open);
+        (await ScalarAsync<byte[]>(destination, "SELECT value FROM data WHERE id = 7;"))
+            .Should().Equal(0, 1, 254, 255);
+        (await ScalarAsync<long>(destination, "PRAGMA user_version;")).Should().Be(123);
+        (await ScalarAsync<long>(destination, "PRAGMA application_id;")).Should().Be(456);
+    }
+
+    [Test]
+    public async Task ManagedSnapshotAsyncDefaultsHonorCancellationBeforeMutation()
+    {
+        using var sourceDatabase = ManagedDatabaseAdapter.Open(":memory:");
+        using var destinationDatabase = ManagedDatabaseAdapter.Open(":memory:");
+        var source = sourceDatabase.Connect();
+        var destination = destinationDatabase.Connect();
+        Execute(source, "CREATE TABLE data(value TEXT);");
+        Execute(source, "INSERT INTO data VALUES ('source');");
+        Execute(destination, "PRAGMA user_version = 8;");
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        Assert.CatchAsync<OperationCanceledException>(
+            async () => await source.CopySnapshotToAsync(destination, cancellation.Token));
+        Assert.CatchAsync<OperationCanceledException>(
+            async () => await destination.ApplySnapshotPragmaHeaderAsync(1, 2, 3, cancellation.Token));
+
+        Scalar(destination, "PRAGMA user_version;").Should().Be(8);
+        Scalar(destination, "SELECT count(*) FROM sqlite_master WHERE name = 'data';").Should().Be(0);
+    }
+
+    [Test]
+    public async Task ManagedSnapshotAsyncSynchronizesDurableDestinationBeforeReturning()
+    {
+        var copied = false;
+        IManagedConnectionAdapter source = new SnapshotSourceAdapter(() => copied = true);
+        var destination = new DurableDestinationAdapter(() => copied.Should().BeTrue());
+
+        await source.CopySnapshotToAsync(destination);
+
+        destination.SynchronizationCount.Should().Be(1);
+    }
+
+    [Test]
+    public void ManagedSnapshotRejectsConnectionDecoratorCycles()
+    {
+        using var database = ManagedDatabaseAdapter.Open(":memory:");
+        using var source = database.Connect();
+        var first = new DecoratorAdapter();
+        var second = new DecoratorAdapter();
+        first.Inner = second;
+        second.Inner = first;
+
+        source.Invoking(adapter => adapter.CopySnapshotTo(first))
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("*cannot form a cycle*");
+    }
+
+    [Test]
+    public async Task BrowserStyleConnectionsGuardSyncBlobAndBackupSurfaces()
+    {
+        await using var source = CreateBrowserStyleConnection();
+        await using var destination = CreateBrowserStyleConnection();
+        await source.OpenAsync();
+        await destination.OpenAsync();
+        await ExecuteAsync(
+            source,
+            "CREATE TABLE data(value BLOB); INSERT INTO data(rowid, value) VALUES (1, X'0102');");
+
+        source.Invoking(connection => connection.OpenBlob("data", "value", 1))
+            .Should().Throw<PlatformNotSupportedException>()
+            .WithMessage("*OpenBlobAsync*");
+        source.Invoking(connection => new SqliteBlob(connection, "data", "value", 1))
+            .Should().Throw<PlatformNotSupportedException>()
+            .WithMessage("*OpenBlobAsync*");
+        source.Invoking(connection => connection.BackupDatabase(destination))
+            .Should().Throw<PlatformNotSupportedException>()
+            .WithMessage("*BackupDatabaseAsync*");
+
+        await using var blob = await source.OpenBlobAsync("data", "value", 1);
+        blob.Invoking(value => value.Read(new byte[1], 0, 1))
+            .Should().Throw<PlatformNotSupportedException>();
+        blob.Invoking(value => value.Write([], 0, 0))
+            .Should().Throw<PlatformNotSupportedException>();
+        blob.Invoking(value => value.Flush())
+            .Should().Throw<PlatformNotSupportedException>();
+
+        blob.Position = 0;
+        var bytes = new byte[2];
+        (await blob.ReadAsync(bytes, 0, bytes.Length)).Should().Be(2);
+        bytes.Should().Equal(1, 2);
+        blob.Position = 0;
+        await blob.WriteAsync(new byte[] { 3, 4 }, 0, 2);
+        blob.Invoking(value => value.Dispose())
+            .Should().Throw<PlatformNotSupportedException>()
+            .WithMessage("*asynchronous Stream API*");
+        blob.CanRead.Should().BeTrue();
+        await blob.DisposeAsync();
+        blob.CanRead.Should().BeFalse();
+
+        await source.BackupDatabaseAsync(destination);
+        (await ScalarAsync<byte[]>(destination, "SELECT value FROM data WHERE rowid = 1;"))
+            .Should().Equal(3, 4);
+    }
+
+    private static SqliteConnection CreateBrowserStyleConnection()
+        => new(
+            "Data Source=:memory:;Local Provider=Managed;Pooling=False",
+            new AsyncOnlyManagedDatabaseFactory());
+
+    private static async Task ExecuteAsync(SqliteConnection connection, string sql)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private static async Task<T> ScalarAsync<T>(SqliteConnection connection, string sql)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        return (T)(await command.ExecuteScalarAsync()
+            ?? throw new InvalidOperationException("The scalar query returned null."));
+    }
+
+    private static void Execute(IManagedConnectionAdapter connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        while (statement.Step() == StatementStepResult.Row)
+        {
+        }
+    }
+
+    private static long Scalar(IManagedConnectionAdapter connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        statement.Step().Should().Be(StatementStepResult.Row);
+        return statement.GetValue(0).AsInteger();
+    }
+
+    private sealed class InlineBlobAdapter(byte[] value) : IManagedIncrementalBlobAdapter
+    {
+        private readonly byte[] _value = value;
+
+        public bool IsDisposed { get; private set; }
+
+        public long Length => _value.Length;
+
+        public int Read(long offset, Span<byte> destination)
+        {
+            var count = Math.Min(destination.Length, _value.Length - checked((int)offset));
+            _value.AsSpan((int)offset, count).CopyTo(destination);
+            return count;
+        }
+
+        public void Write(long offset, ReadOnlySpan<byte> source)
+            => source.CopyTo(_value.AsSpan(checked((int)offset)));
+
+        public void Dispose() => IsDisposed = true;
+    }
+
+    private sealed class AsyncOnlyManagedDatabaseFactory : IManagedDatabaseFactory
+    {
+        public string DataSource => ":memory:";
+
+        public bool IsReadOnly => false;
+
+        public ValueTask<IManagedDatabaseAdapter> OpenDatabaseAsync(
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult<IManagedDatabaseAdapter>(
+                ManagedDatabaseAdapter.Open(":memory:"));
+        }
+    }
+
+    private abstract class ConnectionAdapterStub : IManagedConnectionAdapter
+    {
+        public IManagedStatementAdapter Prepare(string sql) => throw new NotSupportedException();
+
+        public virtual void CopySnapshotTo(IManagedConnectionAdapter destination)
+            => throw new NotSupportedException();
+
+        public void RegisterScalarFunction(
+            string name,
+            int arity,
+            Func<IReadOnlyList<SqlValue>, SqlValue> function)
+            => throw new NotSupportedException();
+
+        public int UnregisterScalarFunctions(string name) => throw new NotSupportedException();
+
+        public void RegisterAggregateFunction(
+            string name,
+            int arity,
+            SqlValue seed,
+            Func<SqlValue, IReadOnlyList<SqlValue>, SqlValue> step,
+            Func<SqlValue, SqlValue> finalize)
+            => throw new NotSupportedException();
+
+        public int UnregisterAggregateFunctions(string name) => throw new NotSupportedException();
+
+        public void RegisterCollation(string name, Func<string, string, int> compare)
+            => throw new NotSupportedException();
+
+        public bool UnregisterCollation(string name) => throw new NotSupportedException();
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class SnapshotSourceAdapter(Action copy) : ConnectionAdapterStub
+    {
+        public override void CopySnapshotTo(IManagedConnectionAdapter destination) => copy();
+    }
+
+    private sealed class DurableDestinationAdapter(Action synchronized) :
+        ConnectionAdapterStub,
+        IManagedConnectionDurabilityBoundary
+    {
+        public int SynchronizationCount { get; private set; }
+
+        public ValueTask SynchronizeAsync()
+        {
+            synchronized();
+            SynchronizationCount++;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class DecoratorAdapter :
+        ConnectionAdapterStub,
+        IManagedConnectionAdapterDecorator
+    {
+        public IManagedConnectionAdapter Inner { get; set; } = null!;
+
+        public IManagedConnectionAdapter InnerConnectionAdapter => Inner;
+    }
+}

--- a/src/Ahtola.Tests/ManagedBackupCoreSnapshotAdapterBoundaryTests.cs
+++ b/src/Ahtola.Tests/ManagedBackupCoreSnapshotAdapterBoundaryTests.cs
@@ -276,6 +276,22 @@ public sealed class ManagedBackupCoreSnapshotAdapterBoundaryTests
         Scalar(destination, "SELECT COUNT(*) FROM sqlite_master WHERE name = 'source_data';").Should().Be(0);
     }
 
+    [Test]
+    public void CoreSnapshotAcceptsFileSystemThatProvesFilesAreDistinct()
+    {
+        var fileSystem = new KnownIdentityFileSystem(new InMemoryFileSystem());
+        using var sourceDatabase = ManagedDatabaseAdapter.OpenFile("source.db", fileSystem);
+        using var destinationDatabase = ManagedDatabaseAdapter.OpenFile("destination.db", fileSystem);
+        using var source = sourceDatabase.Connect();
+        using var destination = destinationDatabase.Connect();
+        PrepareReplacementPair(source, destination);
+
+        source.CopySnapshotTo(destination);
+
+        Scalar(destination, "SELECT COUNT(*) FROM source_data;").Should().Be(1);
+        Scalar(destination, "SELECT COUNT(*) FROM sqlite_master WHERE name = 'preserved';").Should().Be(0);
+    }
+
     private static SqliteConnection OpenManagedConnection()
     {
         var connection = new SqliteConnection("Data Source=:memory:;Local Provider=Managed");
@@ -323,5 +339,24 @@ public sealed class ManagedBackupCoreSnapshotAdapterBoundaryTests
             => inner.OpenFile(path, mode, readOnly);
 
         public void DeleteFile(string path) => inner.DeleteFile(path);
+    }
+
+    private sealed class KnownIdentityFileSystem(IFileSystem inner) :
+        IFileSystem,
+        ISnapshotFileIdentity
+    {
+        public bool FileExists(string path) => inner.FileExists(path);
+
+        public IFile OpenFile(string path, FileOpenMode mode, bool readOnly = false)
+            => inner.OpenFile(path, mode, readOnly);
+
+        public void DeleteFile(string path) => inner.DeleteFile(path);
+
+        public bool CanProveDistinctFile(
+            string path,
+            IFileSystem otherFileSystem,
+            string otherPath)
+            => ReferenceEquals(this, otherFileSystem)
+               && !StringComparer.Ordinal.Equals(path, otherPath);
     }
 }

--- a/src/Ahtola.Tests/ManagedProviderAsyncParity.cs
+++ b/src/Ahtola.Tests/ManagedProviderAsyncParity.cs
@@ -125,23 +125,12 @@ public sealed class ManagedProviderAsyncParityTests
     }
 
     [Test]
-    public async Task ManagedSqliteAsyncExecutionObservesMidOperationCancellation()
+    public async Task ManagedSqliteAsyncExecutionDoesNotHopToTheThreadPool()
     {
         using var connection = new SqliteConnection("Data Source=:memory:;Local Provider=Managed");
         connection.Open();
-        using var entered = new ManualResetEventSlim();
-        using var cancellation = new CancellationTokenSource();
-        connection.CreateFunction<long>(
-            "wait_for_cancellation",
-            () =>
-            {
-                entered.Set();
-                cancellation.Token.WaitHandle.WaitOne();
-                return 1;
-            });
 
         using var command = connection.CreateCommand();
-        command.CommandText = "SELECT wait_for_cancellation();";
         var callerThread = Environment.CurrentManagedThreadId;
         var executionThread = callerThread;
         connection.CreateFunction<long>(
@@ -151,18 +140,12 @@ public sealed class ManagedProviderAsyncParityTests
                 executionThread = Environment.CurrentManagedThreadId;
                 return 1;
             });
-        command.CommandText = "SELECT execution_thread(), wait_for_cancellation();";
+        command.CommandText = "SELECT execution_thread();";
 
-        var execution = command.ExecuteScalarAsync(cancellation.Token);
-        entered.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
-        execution.IsCompleted.Should().BeFalse();
-        executionThread.Should().NotBe(callerThread);
-
-        cancellation.Cancel();
-        await AssertCanceledAsync(execution);
-
-        command.CommandText = "SELECT 2;";
-        (await command.ExecuteScalarAsync()).Should().Be(2L);
+        var execution = command.ExecuteScalarAsync();
+        execution.IsCompletedSuccessfully.Should().BeTrue();
+        (await execution).Should().Be(1L);
+        executionThread.Should().Be(callerThread);
     }
 
     [Test]
@@ -183,12 +166,16 @@ public sealed class ManagedProviderAsyncParityTests
 
         using var command = connection.CreateCommand();
         command.CommandText = "SELECT wait_for_command_cancel();";
+        var cancelThread = new Thread(() =>
+        {
+            entered.Wait();
+            command.Cancel();
+            release.Set();
+        });
+        cancelThread.Start();
         var execution = command.ExecuteScalarAsync();
-        entered.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
-
-        command.Cancel();
-        release.Set();
         await AssertCanceledAsync(execution);
+        cancelThread.Join(TimeSpan.FromSeconds(5)).Should().BeTrue();
 
         command.CommandText = "SELECT 3;";
         (await command.ExecuteScalarAsync()).Should().Be(3L);
@@ -226,9 +213,9 @@ public sealed class ManagedProviderAsyncParityTests
 
         using var command = connection.CreateCommand();
         command.CommandText = "UPDATE items SET value = cancel_during_update(value);";
+        cancellation.CancelAfter(TimeSpan.FromMilliseconds(50));
         var execution = command.ExecuteNonQueryAsync(cancellation.Token);
-        entered.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
-        cancellation.Cancel();
+        entered.IsSet.Should().BeTrue();
         await AssertCanceledAsync(execution);
 
         command.CommandText = "SELECT group_concat(value, ',') FROM items ORDER BY rowid;";
@@ -254,11 +241,9 @@ public sealed class ManagedProviderAsyncParityTests
         using var cancellation = new CancellationTokenSource();
 
         Task<int>? execution = null;
+        cancellation.CancelAfter(TimeSpan.FromMilliseconds(50));
         Assert.DoesNotThrow(() => execution = writer.ExecuteNonQueryAsync(cancellation.Token));
-        await Task.Delay(50);
-        execution!.IsCompleted.Should().BeFalse();
-        cancellation.Cancel();
-        await AssertCanceledAsync(execution);
+        await AssertCanceledAsync(execution!);
     }
 
     [Test]
@@ -272,11 +257,15 @@ public sealed class ManagedProviderAsyncParityTests
             "SELECT 1 UNION ALL SELECT value + 1 FROM counter WHERE value < 100000000" +
             ") SELECT max(value) FROM counter;";
 
+        var cancelThread = new Thread(() =>
+        {
+            Thread.Sleep(50);
+            command.Cancel();
+        });
+        cancelThread.Start();
         var execution = command.ExecuteScalarAsync();
-        await Task.Delay(50);
-        execution.IsCompleted.Should().BeFalse();
-        command.Cancel();
         await AssertCanceledAsync(execution);
+        cancelThread.Join(TimeSpan.FromSeconds(5)).Should().BeTrue();
 
         command.CommandText = "SELECT 4;";
         (await command.ExecuteScalarAsync()).Should().Be(4L);

--- a/src/Ahtola.Tests/ManagedProviderTrueAsyncTests.cs
+++ b/src/Ahtola.Tests/ManagedProviderTrueAsyncTests.cs
@@ -1,0 +1,360 @@
+using System.Data;
+using System.Data.Common;
+using AwesomeAssertions;
+using Ahtola.Core;
+using Ahtola.Data.Sqlite;
+
+namespace Ahtola.Tests;
+
+public sealed class ManagedProviderTrueAsyncTests
+{
+    [Test]
+    public async Task ManagedAhtolaAsyncExecutionAwaitsAdapterPrepareAndStep()
+    {
+        await using var adapter = new GatedDatabaseAdapter();
+        using var connection = new AhtolaConnection(adapter);
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 7;";
+
+        var execution = command.ExecuteReaderAsync();
+        adapter.PrepareStarted.Task.IsCompleted.Should().BeTrue();
+        execution.IsCompleted.Should().BeFalse();
+
+        adapter.ReleasePrepare();
+        await using var reader = await execution;
+        var read = reader.ReadAsync();
+        adapter.StepStarted.Task.IsCompleted.Should().BeTrue();
+        read.IsCompleted.Should().BeFalse();
+
+        adapter.ReleaseStep();
+        (await read).Should().BeTrue();
+        reader.GetInt64(0).Should().Be(7);
+    }
+
+    [Test]
+    public async Task ManagedSqliteAsyncExecutionAwaitsAdapterPrepareAndStep()
+    {
+        await using var adapter = new GatedDatabaseAdapter();
+        using var connection = new SqliteConnection(adapter);
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 11;";
+
+        var execution = command.ExecuteReaderAsync();
+        adapter.PrepareStarted.Task.IsCompleted.Should().BeTrue();
+        execution.IsCompleted.Should().BeFalse();
+
+        adapter.ReleasePrepare();
+        await using var reader = await execution;
+        var read = reader.ReadAsync();
+        adapter.StepStarted.Task.IsCompleted.Should().BeTrue();
+        read.IsCompleted.Should().BeFalse();
+
+        adapter.ReleaseStep();
+        (await read).Should().BeTrue();
+        reader.GetInt64(0).Should().Be(11);
+    }
+
+    [Test]
+    public async Task ManagedLocalAsyncExecutionCompletesInlineWithoutThreadPoolHop()
+    {
+        await using var adapter = new GatedDatabaseAdapter(released: true);
+        using var connection = new AhtolaConnection(adapter);
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 13;";
+        var callerThread = Environment.CurrentManagedThreadId;
+
+        var execution = command.ExecuteReaderAsync();
+        execution.IsCompletedSuccessfully.Should().BeTrue();
+        await using var reader = await execution;
+        var read = reader.ReadAsync();
+        read.IsCompletedSuccessfully.Should().BeTrue();
+        (await read).Should().BeTrue();
+
+        adapter.PrepareThreadId.Should().Be(callerThread);
+        adapter.StepThreadId.Should().Be(callerThread);
+    }
+
+    [Test]
+    public async Task ManagedLocalAsyncCancellationPreservesTheExactToken()
+    {
+        await using var adapter = new GatedDatabaseAdapter(prepareReleased: true);
+        using var connection = new AhtolaConnection(adapter);
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 17;";
+        await using var reader = await command.ExecuteReaderAsync();
+        using var cancellation = new CancellationTokenSource();
+
+        var read = reader.ReadAsync(cancellation.Token);
+        read.IsCompleted.Should().BeFalse();
+        cancellation.Cancel();
+
+        var exception = Assert.CatchAsync<OperationCanceledException>(async () => await read);
+        exception.Should().NotBeNull();
+        exception!.CancellationToken.Should().Be(cancellation.Token);
+        read.IsCanceled.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task ManagedLocalAsyncStepErrorsKeepProviderMapping()
+    {
+        await using var ahtolaAdapter = new GatedDatabaseAdapter(
+            released: true,
+            stepError: new EmbeddedSqlException("async-step-failure"));
+        using var ahtolaConnection = new AhtolaConnection(ahtolaAdapter);
+        using var ahtolaCommand = ahtolaConnection.CreateCommand();
+        ahtolaCommand.CommandText = "SELECT 19;";
+        await using var ahtolaReader = await ahtolaCommand.ExecuteReaderAsync();
+
+        var ahtolaError = Assert.CatchAsync<AhtolaException>(async () => await ahtolaReader.ReadAsync());
+        ahtolaError.Should().NotBeNull();
+        ahtolaError!.Message.Should().Contain("async-step-failure");
+
+        await using var sqliteAdapter = new GatedDatabaseAdapter(
+            released: true,
+            stepError: new EmbeddedSqlException("async-step-failure"));
+        using var sqliteConnection = new SqliteConnection(sqliteAdapter);
+        using var sqliteCommand = sqliteConnection.CreateCommand();
+        sqliteCommand.CommandText = "SELECT 23;";
+        await using var sqliteReader = await sqliteCommand.ExecuteReaderAsync();
+
+        var sqliteError = Assert.CatchAsync<SqliteException>(async () => await sqliteReader.ReadAsync());
+        sqliteError.Should().NotBeNull();
+        sqliteError!.SqliteErrorCode.Should().Be(1);
+        sqliteError.Message.Should().Contain("async-step-failure");
+    }
+
+    [Test]
+    public async Task ManagedLocalSynchronousExecutionStillUsesSynchronousAdapterMethods()
+    {
+        await using var adapter = new GatedDatabaseAdapter();
+        using var ahtolaConnection = new AhtolaConnection(adapter);
+        using var command = ahtolaConnection.CreateCommand();
+        command.CommandText = "SELECT 29;";
+
+        command.ExecuteScalar().Should().Be(29L);
+        adapter.SynchronousPrepareCount.Should().Be(1);
+        adapter.SynchronousStepCount.Should().BeGreaterThan(0);
+        adapter.PrepareStarted.Task.IsCompleted.Should().BeFalse();
+        adapter.StepStarted.Task.IsCompleted.Should().BeFalse();
+    }
+
+    private sealed class GatedDatabaseAdapter : IManagedDatabaseAdapter
+    {
+        private readonly ManagedDatabaseAdapter _inner = ManagedDatabaseAdapter.Open(":memory:");
+        private readonly GatedConnectionAdapter _connection;
+
+        public GatedDatabaseAdapter(
+            bool released = false,
+            bool prepareReleased = false,
+            Exception? stepError = null)
+        {
+            _connection = new GatedConnectionAdapter(
+                _inner.Connect(),
+                prepareReleased || released,
+                released,
+                stepError);
+        }
+
+        public TaskCompletionSource<bool> PrepareStarted => _connection.PrepareStarted;
+
+        public TaskCompletionSource<bool> StepStarted => _connection.StepStarted;
+
+        public int PrepareThreadId => _connection.PrepareThreadId;
+
+        public int StepThreadId => _connection.StepThreadId;
+
+        public int SynchronousPrepareCount => _connection.SynchronousPrepareCount;
+
+        public int SynchronousStepCount => _connection.SynchronousStepCount;
+
+        public IManagedConnectionAdapter Connect() => _connection;
+
+        public IManagedConnectionAdapter Connection => _connection;
+
+        public void ReleasePrepare() => _connection.ReleasePrepare();
+
+        public void ReleaseStep() => _connection.ReleaseStep();
+
+        public void Dispose() => _inner.Dispose();
+
+        public ValueTask DisposeAsync() => _inner.DisposeAsync();
+    }
+
+    private sealed class GatedConnectionAdapter(
+        IManagedConnectionAdapter inner,
+        bool prepareReleased,
+        bool stepReleased,
+        Exception? stepError) : IManagedConnectionAdapter
+    {
+        private readonly TaskCompletionSource<bool> _prepareRelease = CreateGate(prepareReleased);
+        private readonly TaskCompletionSource<bool> _stepRelease = CreateGate(stepReleased);
+
+        public TaskCompletionSource<bool> PrepareStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource<bool> StepStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int PrepareThreadId { get; private set; }
+
+        public int StepThreadId { get; private set; }
+
+        public int SynchronousPrepareCount { get; private set; }
+
+        public int SynchronousStepCount { get; private set; }
+
+        public bool HasAttachedDatabases => inner.HasAttachedDatabases;
+
+        public TimeSpan BusyTimeout
+        {
+            get => inner.BusyTimeout;
+            set => inner.BusyTimeout = value;
+        }
+
+        public ManagedConnectionHooks Hooks => inner.Hooks;
+
+        public IManagedStatementAdapter Prepare(string sql)
+        {
+            SynchronousPrepareCount++;
+            return new GatedStatementAdapter(inner.Prepare(sql), this, stepError);
+        }
+
+        public async ValueTask<IManagedStatementAdapter> PrepareAsync(
+            string sql,
+            CancellationToken cancellationToken = default)
+        {
+            PrepareThreadId = Environment.CurrentManagedThreadId;
+            PrepareStarted.TrySetResult(true);
+            await _prepareRelease.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            var statement = await inner.PrepareAsync(sql, cancellationToken).ConfigureAwait(false);
+            return new GatedStatementAdapter(statement, this, stepError);
+        }
+
+        public void ReleasePrepare() => _prepareRelease.TrySetResult(true);
+
+        public void ReleaseStep() => _stepRelease.TrySetResult(true);
+
+        public void ResetForPooling() => inner.ResetForPooling();
+
+        public IManagedIncrementalBlobAdapter OpenBlob(
+            string databaseName,
+            string tableName,
+            string columnName,
+            long rowId,
+            bool readOnly = false)
+            => inner.OpenBlob(databaseName, tableName, columnName, rowId, readOnly);
+
+        public void RegisterScalarFunction(
+            string name,
+            int arity,
+            Func<IReadOnlyList<SqlValue>, SqlValue> function)
+            => inner.RegisterScalarFunction(name, arity, function);
+
+        public int UnregisterScalarFunctions(string name) => inner.UnregisterScalarFunctions(name);
+
+        public void RegisterAggregateFunction(
+            string name,
+            int arity,
+            SqlValue seed,
+            Func<SqlValue, IReadOnlyList<SqlValue>, SqlValue> step,
+            Func<SqlValue, SqlValue> finalize)
+            => inner.RegisterAggregateFunction(name, arity, seed, step, finalize);
+
+        public int UnregisterAggregateFunctions(string name) => inner.UnregisterAggregateFunctions(name);
+
+        public void RegisterCollation(string name, Func<string, string, int> compare)
+            => inner.RegisterCollation(name, compare);
+
+        public bool UnregisterCollation(string name) => inner.UnregisterCollation(name);
+
+        public void CopySnapshotTo(IManagedConnectionAdapter destination)
+            => inner.CopySnapshotTo(destination);
+
+        public void CopySnapshotTo(
+            IManagedConnectionAdapter destination,
+            string destinationName,
+            string sourceName)
+            => inner.CopySnapshotTo(destination, destinationName, sourceName);
+
+        public void ApplySnapshotPragmaHeader(int schemaVersion, int userVersion, int applicationId)
+            => inner.ApplySnapshotPragmaHeader(schemaVersion, userVersion, applicationId);
+
+        public void Dispose()
+        {
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        private static TaskCompletionSource<bool> CreateGate(bool released)
+        {
+            var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            if (released)
+                gate.SetResult(true);
+            return gate;
+        }
+
+        private sealed class GatedStatementAdapter(
+            IManagedStatementAdapter statement,
+            GatedConnectionAdapter owner,
+            Exception? stepError) : IManagedStatementAdapter
+        {
+            public int ParameterCount => statement.ParameterCount;
+
+            public int RowsAffected => statement.RowsAffected;
+
+            public void Bind(int index, SqlValue value) => statement.Bind(index, value);
+
+            public int GetParameterIndex(string name) => statement.GetParameterIndex(name);
+
+            public StatementStepResult Step()
+            {
+                owner.SynchronousStepCount++;
+                return statement.Step();
+            }
+
+            public StatementStepResult Step(CancellationToken cancellationToken)
+            {
+                owner.SynchronousStepCount++;
+                return statement.Step(cancellationToken);
+            }
+
+            public async ValueTask<StatementStepResult> StepAsync(
+                CancellationToken cancellationToken = default)
+            {
+                owner.StepThreadId = Environment.CurrentManagedThreadId;
+                owner.StepStarted.TrySetResult(true);
+                await owner._stepRelease.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+                if (stepError is not null)
+                    throw stepError;
+                return await statement.StepAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            public bool HasRows() => statement.HasRows();
+
+            public void Reset() => statement.Reset();
+
+            public ValueTask ResetAsync(CancellationToken cancellationToken = default)
+                => statement.ResetAsync(cancellationToken);
+
+            public void ClearBindings() => statement.ClearBindings();
+
+            public SqlValue GetValue(int ordinal) => statement.GetValue(ordinal);
+
+            public string GetColumnName(int ordinal) => statement.GetColumnName(ordinal);
+
+            public int GetColumnCount() => statement.GetColumnCount();
+
+            public ManagedResultValue GetResultValue(int ordinal) => statement.GetResultValue(ordinal);
+
+            public ManagedResultColumn GetResultColumn(int ordinal) => statement.GetResultColumn(ordinal);
+
+            public int GetResultColumnCount() => statement.GetResultColumnCount();
+
+            public string? GetParameterName(int index) => statement.GetParameterName(index);
+
+            public void Dispose() => statement.Dispose();
+
+            public ValueTask DisposeAsync() => statement.DisposeAsync();
+        }
+    }
+}

--- a/src/Ahtola.Tests/ManagedSchemaAndReaderCorrectnessTests.cs
+++ b/src/Ahtola.Tests/ManagedSchemaAndReaderCorrectnessTests.cs
@@ -202,6 +202,30 @@ public sealed class ManagedSchemaAndReaderCorrectnessTests
     }
 
     [Test]
+    public void ThrowingCloseCallback_SynchronousCloseStillDeregistersReader()
+    {
+        using var connection = new SqliteConnection("Data Source=:memory:;Pooling=False");
+        connection.Open();
+
+        using var command = connection.CreateCommand();
+        var thrown = new InvalidOperationException("Simulated synchronous close-callback failure.");
+        var reader = new SqliteDataReader(
+            command,
+            recordsAffected: 0,
+            CommandBehavior.Default,
+            closeCallback: () => throw thrown);
+
+        Action close = reader.Close;
+        close.Should().Throw<InvalidOperationException>().Which.Should().BeSameAs(thrown);
+        reader.IsClosed.Should().BeTrue();
+        connection.HasOpenReader.Should().BeFalse();
+
+        using var verify = connection.CreateCommand();
+        verify.CommandText = "SELECT 1";
+        verify.ExecuteScalar().Should().Be(1L);
+    }
+
+    [Test]
     public async Task BrowserReaderDisposalFailure_DisposeAsyncSwallowsOperationFailure_ButStillCleansUp()
     {
         var factory = new FaultInjectingManagedDatabaseFactory();

--- a/src/Ahtola.Tests/ManagedSchemaAndReaderCorrectnessTests.cs
+++ b/src/Ahtola.Tests/ManagedSchemaAndReaderCorrectnessTests.cs
@@ -226,6 +226,71 @@ public sealed class ManagedSchemaAndReaderCorrectnessTests
     }
 
     [Test]
+    public async Task ConnectionOwnedAsyncCloseAggregatesDisposalAndCallbackFailures()
+    {
+        var factory = new FaultInjectingManagedDatabaseFactory();
+        await using var connection = new SqliteConnection(
+            "Data Source=:memory:;Local Provider=Managed;Pooling=False",
+            factory);
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 1";
+        var statement = SqliteStatementAdapter.FromManaged(
+            await connection.ManagedConnection.PrepareAsync(command.CommandText));
+        var callbackFailure = new InvalidOperationException("Simulated async close-callback failure.");
+        var reader = new SqliteDataReader(
+            command,
+            statement,
+            command.CommandText,
+            [],
+            recordsAffected: 0,
+            CommandBehavior.Default,
+            closeCallback: () => throw callbackFailure);
+        var disposalFailure = new SimulatedBrowserDisposalException(
+            "Simulated async connection-owned disposal failure.");
+        factory.PendingStatementDisposeFault = disposalFailure;
+
+        var aggregate = Assert.ThrowsAsync<AggregateException>(
+            async () => await ((IConnectionOwnedReader)reader).CloseFromConnectionAsync());
+
+        aggregate!.Flatten().InnerExceptions.Should().Contain(disposalFailure).And.Contain(callbackFailure);
+        reader.IsClosed.Should().BeTrue();
+        connection.HasOpenReader.Should().BeFalse();
+    }
+
+    [Test]
+    public void SynchronousCloseAggregatesDisposalAndCallbackFailures()
+    {
+        var factory = new FaultInjectingManagedDatabaseFactory();
+        var database = new FaultInjectingDatabaseAdapter(
+            ManagedDatabaseAdapter.Open(":memory:"),
+            factory);
+        using var connection = new SqliteConnection(database);
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 1";
+        var statement = SqliteStatementAdapter.FromManaged(
+            connection.ManagedConnection.Prepare(command.CommandText));
+        var callbackFailure = new InvalidOperationException("Simulated sync close-callback failure.");
+        var reader = new SqliteDataReader(
+            command,
+            statement,
+            command.CommandText,
+            [],
+            recordsAffected: 0,
+            CommandBehavior.Default,
+            closeCallback: () => throw callbackFailure);
+        var disposalFailure = new SimulatedBrowserDisposalException(
+            "Simulated synchronous statement disposal failure.");
+        factory.PendingStatementSyncDisposeFault = disposalFailure;
+
+        var aggregate = Assert.Throws<AggregateException>(reader.Close);
+
+        aggregate!.Flatten().InnerExceptions.Should().Contain(disposalFailure).And.Contain(callbackFailure);
+        reader.IsClosed.Should().BeTrue();
+        connection.HasOpenReader.Should().BeFalse();
+    }
+
+    [Test]
     public async Task BrowserReaderDisposalFailure_DisposeAsyncSwallowsOperationFailure_ButStillCleansUp()
     {
         var factory = new FaultInjectingManagedDatabaseFactory();
@@ -478,6 +543,8 @@ public sealed class ManagedSchemaAndReaderCorrectnessTests
 
         public Exception? PendingStatementDisposeFault { get; set; }
 
+        public Exception? PendingStatementSyncDisposeFault { get; set; }
+
         public ValueTask<IManagedDatabaseAdapter> OpenDatabaseAsync(
             CancellationToken cancellationToken = default)
         {
@@ -592,7 +659,14 @@ public sealed class ManagedSchemaAndReaderCorrectnessTests
 
         public string? GetParameterName(int index) => inner.GetParameterName(index);
 
-        public void Dispose() => inner.Dispose();
+        public void Dispose()
+        {
+            var fault = faults.PendingStatementSyncDisposeFault;
+            faults.PendingStatementSyncDisposeFault = null;
+            inner.Dispose();
+            if (fault is not null)
+                throw fault;
+        }
 
         public ValueTask DisposeAsync()
         {

--- a/src/Ahtola.Tests/ManagedSchemaAndReaderCorrectnessTests.cs
+++ b/src/Ahtola.Tests/ManagedSchemaAndReaderCorrectnessTests.cs
@@ -168,6 +168,40 @@ public sealed class ManagedSchemaAndReaderCorrectnessTests
     }
 
     [Test]
+    public async Task ThrowingCloseCallback_StillDeregistersReader_AndConnectionRecovers()
+    {
+        // FinishCloseAsync used to call _closeCallback() (command/batch bookkeeping) before
+        // ReaderClosed/_isClosed, with nothing to catch a callback failure: if it threw, the
+        // reader was never deregistered or marked closed. Constructing the reader directly (with
+        // a throwing callback) reaches FinishCloseAsync without needing a real command-level
+        // failure to trigger it.
+        await using var connection = new SqliteConnection("Data Source=:memory:;Pooling=False");
+        await connection.OpenAsync();
+
+        var command = connection.CreateCommand();
+        var thrown = new InvalidOperationException("Simulated close-callback failure.");
+        var reader = new SqliteDataReader(
+            command,
+            recordsAffected: 0,
+            CommandBehavior.Default,
+            closeCallback: () => throw thrown);
+
+        Func<Task> close = async () => await reader.CloseAsync();
+        (await close.Should().ThrowAsync<InvalidOperationException>()).Which.Should().BeSameAs(thrown);
+
+        reader.IsClosed.Should().BeTrue();
+        connection.HasOpenReader.Should().BeFalse();
+
+        // The connection recovers and can still run further commands after the failed close.
+        await using var verify = connection.CreateCommand();
+        verify.CommandText = "SELECT 1";
+        (await verify.ExecuteScalarAsync()).Should().Be(1L);
+
+        await connection.CloseAsync();
+        connection.State.Should().Be(ConnectionState.Closed);
+    }
+
+    [Test]
     public async Task BrowserReaderDisposalFailure_DisposeAsyncSwallowsOperationFailure_ButStillCleansUp()
     {
         var factory = new FaultInjectingManagedDatabaseFactory();

--- a/src/Ahtola.Tests/ManagedSchemaAndReaderCorrectnessTests.cs
+++ b/src/Ahtola.Tests/ManagedSchemaAndReaderCorrectnessTests.cs
@@ -1,0 +1,556 @@
+using System.Data;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using Ahtola.Core;
+using Ahtola.Data.Sqlite;
+using AwesomeAssertions;
+
+namespace Ahtola.Tests;
+
+/// <summary>
+/// Regressions for a full-branch review of the managed schema dispatch and async reader close
+/// paths:
+/// 1) AhtolaSchemaCollections must only take the managed fast path when the connection is
+///    actually backed by a managed adapter; native local and remote connections implement
+///    IManagedSchemaConnection too, but must fall back to the provider-neutral PRAGMA path.
+/// 2) SqliteDataReader.CloseCoreAsync must stay exception-safe for any failure (not just the
+///    engine's own exception types), always releasing the statement/delegated reader and
+///    deregistering from the connection.
+/// 3) SqliteDataReader's browser declared-type shortcut must resolve against the current
+///    statement (_currentSql), not the whole (possibly multi-statement) command text.
+/// </summary>
+public sealed class ManagedSchemaAndReaderCorrectnessTests
+{
+    [Test]
+    public void NativeConnection_GetValue_ResolvesDeclaredType_WithoutReachingManagedConnection()
+    {
+        AhtolaNativeProvider.Register(new FakeNativeProviderFactory());
+
+        using var connection = new AhtolaConnection("Data Source=:memory:;Local Provider=Native");
+        connection.Open();
+        connection.IsManaged.Should().BeFalse("a native connection has no managed adapter to dispatch schema lookups to");
+
+        using (var create = connection.CreateCommand())
+        {
+            create.CommandText = "CREATE TABLE widgets (id GUID, payload BLOB)";
+            create.ExecuteNonQuery();
+        }
+
+        using (var insert = connection.CreateCommand())
+        {
+            insert.CommandText = "INSERT INTO widgets (id, payload) VALUES (X'0102030405060708090A0B0C0D0E0F10', X'AABBCCDD')";
+            insert.ExecuteNonQuery();
+        }
+
+        using var select = connection.CreateCommand();
+        select.CommandText = "SELECT id FROM widgets";
+        using var reader = select.ExecuteReader();
+        reader.Read().Should().BeTrue();
+
+        // Before the fix, GetValue's declared-type lookup unconditionally preferred the managed
+        // fast path (AhtolaSchemaCollections.GetTableColumns), which threw InvalidOperationException
+        // ("Ahtola database is closed.") for this native (non-managed) connection.
+        Action getValue = () => reader.GetValue(0);
+        getValue.Should().NotThrow();
+        reader.GetValue(0).Should().BeOfType<Guid>();
+    }
+
+    [Test]
+    public void RemoteAhtolaConnection_GetSchemaTable_FallsBackToPragma_InsteadOfThrowing()
+    {
+        using var handler = new MinimalRemoteSchemaHandler();
+        var priorFactory = global::Ahtola.AhtolaConnection.RemoteMessageHandlerFactory;
+        global::Ahtola.AhtolaConnection.RemoteMessageHandlerFactory = () => handler;
+        try
+        {
+            using var connection = new global::Ahtola.AhtolaConnection(
+                "Data Source=https://example.test/db;Auth Token=token");
+            connection.Open();
+            connection.IsRemote.Should().BeTrue();
+            connection.IsManaged.Should().BeFalse("a plain remote connection has no managed adapter either");
+
+            using var command = connection.CreateCommand();
+            command.CommandText = "SELECT value FROM widgets";
+            using var reader = command.ExecuteReader();
+            reader.Read().Should().BeTrue();
+
+            // Before the fix, BuildReaderSchemaTable's call into GetTableColumns unconditionally
+            // preferred the managed fast path and threw for this remote (non-managed) connection.
+            Action getSchemaTable = () => reader.GetSchemaTable();
+            getSchemaTable.Should().NotThrow();
+            var schema = reader.GetSchemaTable();
+            schema.Rows.Count.Should().Be(1);
+            schema.Rows[0][System.Data.Common.SchemaTableColumn.ColumnName].Should().Be("value");
+        }
+        finally
+        {
+            global::Ahtola.AhtolaConnection.RemoteMessageHandlerFactory = priorFactory;
+        }
+    }
+
+    [Test]
+    public void RemoteSqliteConnection_GetSchemaTable_FallsBackToPragma_ViaDelegatedAhtolaReader()
+    {
+        using var handler = new MinimalRemoteSchemaHandler();
+        var priorFactory = SqliteConnection.RemoteMessageHandlerFactory;
+        SqliteConnection.RemoteMessageHandlerFactory = () => handler;
+        try
+        {
+            using var connection = new SqliteConnection(
+                "Data Source=https://example.test/db;Auth Token=token");
+            connection.Open();
+            connection.IsRemoteConnection.Should().BeTrue();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = "SELECT value FROM widgets";
+            using var reader = command.ExecuteReader();
+            reader.Read().Should().BeTrue();
+
+            // SqliteDataReader delegates GetSchemaTable to the inner AhtolaRemoteDataReader for
+            // remote connections, so this exercises the exact same AhtolaSchemaCollections
+            // dispatch fix through the Sqlite facade.
+            Action getSchemaTable = () => reader.GetSchemaTable();
+            getSchemaTable.Should().NotThrow();
+        }
+        finally
+        {
+            SqliteConnection.RemoteMessageHandlerFactory = priorFactory;
+        }
+    }
+
+    [Test]
+    public async Task BrowserReaderDisposalFailure_StillClosesReader_AndConnectionRecovers()
+    {
+        var factory = new FaultInjectingManagedDatabaseFactory();
+        await using var connection = new SqliteConnection(
+            "Data Source=:memory:;Local Provider=Managed;Pooling=False",
+            factory);
+        await connection.OpenAsync();
+
+        await using (var create = connection.CreateCommand())
+        {
+            create.CommandText = "CREATE TABLE t (value INTEGER)";
+            await create.ExecuteNonQueryAsync();
+        }
+
+        await using (var insert = connection.CreateCommand())
+        {
+            insert.CommandText = "INSERT INTO t VALUES (1)";
+            await insert.ExecuteNonQueryAsync();
+        }
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT value FROM t";
+        var reader = await command.ExecuteReaderAsync();
+        (await reader.ReadAsync()).Should().BeTrue();
+
+        factory.PendingStatementDisposeFault = new SimulatedBrowserDisposalException(
+            "Simulated OPFS statement disposal failure.");
+
+        // CloseAsync (throwOnError: true) must still surface the injected, non-engine failure...
+        Func<Task> close = async () => await reader.CloseAsync();
+        await close.Should().ThrowAsync<SimulatedBrowserDisposalException>();
+
+        // ...but cleanup must have happened regardless: the reader is closed and deregistered.
+        reader.IsClosed.Should().BeTrue();
+        connection.HasOpenReader.Should().BeFalse();
+
+        // The connection recovers and can run further commands after the failed close.
+        await using var verify = connection.CreateCommand();
+        verify.CommandText = "SELECT COUNT(*) FROM t";
+        (await verify.ExecuteScalarAsync()).Should().Be(1L);
+
+        await connection.CloseAsync();
+        connection.State.Should().Be(ConnectionState.Closed);
+    }
+
+    [Test]
+    public async Task BrowserReaderDisposalFailure_DisposeAsyncSwallowsOperationFailure_ButStillCleansUp()
+    {
+        var factory = new FaultInjectingManagedDatabaseFactory();
+        await using var connection = new SqliteConnection(
+            "Data Source=:memory:;Local Provider=Managed;Pooling=False",
+            factory);
+        await connection.OpenAsync();
+
+        await using (var create = connection.CreateCommand())
+        {
+            create.CommandText = "CREATE TABLE t (value INTEGER)";
+            await create.ExecuteNonQueryAsync();
+        }
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT value FROM t";
+        var reader = await command.ExecuteReaderAsync();
+
+        factory.PendingStatementDisposeFault = new SimulatedBrowserDisposalException(
+            "Simulated OPFS statement disposal failure.");
+
+        // DisposeAsync (throwOnError: false) tolerates the operation failure, matching prior
+        // behavior for the engine's own exception types, but must still deregister the reader.
+        Func<Task> dispose = async () => await reader.DisposeAsync();
+        await dispose.Should().NotThrowAsync();
+
+        reader.IsClosed.Should().BeTrue();
+        connection.HasOpenReader.Should().BeFalse();
+
+        await using var verify = connection.CreateCommand();
+        verify.CommandText = "SELECT COUNT(*) FROM t";
+        (await verify.ExecuteScalarAsync()).Should().Be(0L);
+    }
+
+    [Test]
+    public async Task MultiResultSelect_SecondBlobRemainsBlob_DespiteFirstGuidDeclaredType()
+    {
+        await using var connection = new SqliteConnection(
+            "Data Source=:memory:;Local Provider=Managed;Pooling=False",
+            new AsyncOnlyManagedDatabaseFactory());
+        await connection.OpenAsync();
+
+        await using (var create = connection.CreateCommand())
+        {
+            create.CommandText = "CREATE TABLE ids (id GUID); CREATE TABLE blobs (payload BLOB);";
+            await create.ExecuteNonQueryAsync();
+        }
+
+        await using (var insert = connection.CreateCommand())
+        {
+            insert.CommandText =
+                "INSERT INTO ids VALUES (X'0102030405060708090A0B0C0D0E0F10'); "
+                + "INSERT INTO blobs VALUES (X'AABBCCDD');";
+            await insert.ExecuteNonQueryAsync();
+        }
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT id FROM ids; SELECT payload FROM blobs;";
+        var reader = await command.ExecuteReaderAsync();
+
+        (await reader.ReadAsync()).Should().BeTrue();
+        reader.GetValue(0).Should().BeOfType<Guid>();
+
+        (await reader.NextResultAsync()).Should().BeTrue();
+        (await reader.ReadAsync()).Should().BeTrue();
+
+        // Before the fix, the browser metadata shortcut re-parsed _command.CommandText (the
+        // whole batch), which always anchored on the FIRST statement ("SELECT id FROM ids"), so
+        // this second result set's "payload" BLOB column inherited the "id" column's GUID
+        // declared type and was incorrectly converted (or failed to convert) to a Guid.
+        Action getValue = () => reader.GetValue(0);
+        getValue.Should().NotThrow();
+        reader.GetValue(0).Should().BeOfType<byte[]>();
+        ((byte[])reader.GetValue(0)).Should().Equal(0xAA, 0xBB, 0xCC, 0xDD);
+
+        await reader.DisposeAsync();
+    }
+
+    private sealed class SimulatedBrowserDisposalException(string message) : Exception(message);
+
+    #region Fake native provider (non-managed connection with real SQL execution)
+
+    private sealed class FakeNativeProviderFactory : AhtolaNativeProviderFactory
+    {
+        public override AhtolaNativeDatabase OpenDatabase(
+            string path,
+            AhtolaEncryptionCipher? cipher,
+            string? encryptionKey)
+            => new FakeNativeDatabase(path);
+    }
+
+    private sealed class FakeNativeDatabase : AhtolaNativeDatabase
+    {
+        private readonly ManagedDatabaseAdapter _database;
+        private readonly IManagedConnectionAdapter _connection;
+        private bool _disposed;
+
+        public FakeNativeDatabase(string path)
+        {
+            _database = ManagedDatabaseAdapter.Open(path);
+            _connection = _database.Connect();
+        }
+
+        public override bool IsInvalid => _disposed;
+
+        public override AhtolaNativeStatement PrepareStatement(string sql)
+            => new FakeNativeStatement(_connection.Prepare(sql));
+
+        public override void SetBusyTimeout(TimeSpan timeout) => _connection.BusyTimeout = timeout;
+
+        public override void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            _database.Dispose();
+        }
+    }
+
+    private sealed class FakeNativeStatement(IManagedStatementAdapter statement) : AhtolaNativeStatement
+    {
+        private bool _disposed;
+
+        public override bool IsInvalid => _disposed;
+
+        public override int ParameterCount => statement.ParameterCount;
+
+        public override void BindParameter(int index, AhtolaValue value)
+            => statement.Bind(index - 1, ToSqlValue(value));
+
+        public override int BindNamedParameter(string name, AhtolaValue value)
+        {
+            var index = statement.GetParameterIndex(name);
+            statement.Bind(index, ToSqlValue(value));
+            return index + 1;
+        }
+
+        public override string? GetParameterName(int index) => statement.GetParameterName(index - 1);
+
+        public override bool Read() => statement.Step() == StatementStepResult.Row;
+
+        public override void Interrupt()
+        {
+        }
+
+        public override AhtolaValue GetValue(int ordinal) => ToAhtolaValue(statement.GetValue(ordinal));
+
+        public override string GetName(int ordinal) => statement.GetColumnName(ordinal);
+
+        public override int FieldCount => statement.GetColumnCount();
+
+        public override int RowsAffected => statement.RowsAffected;
+
+        public override bool HasRows => statement.HasRows();
+
+        public override void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            statement.Dispose();
+        }
+
+        private static SqlValue ToSqlValue(AhtolaValue value) => value.ValueType switch
+        {
+            AhtolaValueType.Empty or AhtolaValueType.Null => SqlValue.Null,
+            AhtolaValueType.Integer => SqlValue.Integer(value.IntValue),
+            AhtolaValueType.Real => SqlValue.Real(value.RealValue),
+            AhtolaValueType.Text => SqlValue.Text(value.StringValue),
+            AhtolaValueType.Blob => SqlValue.Blob(value.BlobValue),
+            _ => throw new ArgumentOutOfRangeException(nameof(value)),
+        };
+
+        private static AhtolaValue ToAhtolaValue(SqlValue value) => value.Kind switch
+        {
+            SqlValueKind.Null => AhtolaValue.Null(),
+            SqlValueKind.Integer => AhtolaValue.Int(value.AsInteger()),
+            SqlValueKind.Real => AhtolaValue.Real(value.AsReal()),
+            SqlValueKind.Text => AhtolaValue.String(value.AsText()),
+            SqlValueKind.Blob => AhtolaValue.Blob(value.AsBlob().ToArray()),
+            _ => throw new ArgumentOutOfRangeException(nameof(value)),
+        };
+    }
+
+    #endregion
+
+    #region Fake remote (Hrana) handler
+
+    /// <summary>
+    /// Responds to any "SELECT ..." statement with a single "value"/INTEGER 42 row (enough for
+    /// TryGetSelectSource to resolve a FROM-clause table), and to anything else (in particular
+    /// the PRAGMA table_info fallback) with an empty, successful result.
+    /// </summary>
+    private sealed class MinimalRemoteSchemaHandler : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            using var document = JsonDocument.Parse(
+                await request.Content!.ReadAsStringAsync(cancellationToken));
+            var sql = document.RootElement
+                .GetProperty("requests")[0]
+                .GetProperty("stmt")
+                .GetProperty("sql")
+                .GetString();
+
+            var response = sql!.StartsWith("SELECT", StringComparison.OrdinalIgnoreCase)
+                ? """{"results":[{"type":"ok","response":{"type":"execute","result":{"cols":[{"name":"value","decltype":"INTEGER"}],"rows":[[{"type":"integer","value":"42"}]],"affected_row_count":0}}}]}"""
+                : """{"results":[{"type":"ok","response":{"type":"execute","result":{"cols":[],"rows":[],"affected_row_count":0}}}]}""";
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(response, Encoding.UTF8, "application/json"),
+            };
+        }
+    }
+
+    #endregion
+
+    #region Browser-mode (async-only) managed database factories
+
+    private sealed class AsyncOnlyManagedDatabaseFactory : IManagedDatabaseFactory
+    {
+        public string DataSource => ":memory:";
+
+        public bool IsReadOnly => false;
+
+        public ValueTask<IManagedDatabaseAdapter> OpenDatabaseAsync(
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult<IManagedDatabaseAdapter>(
+                ManagedDatabaseAdapter.Open(":memory:"));
+        }
+    }
+
+    /// <summary>
+    /// An async-only (browser-shaped) managed database factory whose statements can be armed to
+    /// throw an arbitrary, non-engine exception the next time one is disposed asynchronously -
+    /// simulating an OPFS/Web Crypto failure surfacing through statement teardown.
+    /// </summary>
+    private sealed class FaultInjectingManagedDatabaseFactory : IManagedDatabaseFactory
+    {
+        public string DataSource => ":memory:";
+
+        public bool IsReadOnly => false;
+
+        public Exception? PendingStatementDisposeFault { get; set; }
+
+        public ValueTask<IManagedDatabaseAdapter> OpenDatabaseAsync(
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult<IManagedDatabaseAdapter>(
+                new FaultInjectingDatabaseAdapter(ManagedDatabaseAdapter.Open(DataSource), this));
+        }
+    }
+
+    private sealed class FaultInjectingDatabaseAdapter : IManagedDatabaseAdapter
+    {
+        private readonly ManagedDatabaseAdapter _inner;
+        private readonly FaultInjectingConnectionAdapter _connection;
+
+        public FaultInjectingDatabaseAdapter(ManagedDatabaseAdapter inner, FaultInjectingManagedDatabaseFactory faults)
+        {
+            _inner = inner;
+            _connection = new FaultInjectingConnectionAdapter(inner.Connect(), faults);
+        }
+
+        public IManagedConnectionAdapter Connect() => _connection;
+
+        public IManagedConnectionAdapter Connection => _connection;
+
+        public void Dispose() => _inner.Dispose();
+
+        public ValueTask DisposeAsync() => _inner.DisposeAsync();
+    }
+
+    private sealed class FaultInjectingConnectionAdapter(
+        IManagedConnectionAdapter inner,
+        FaultInjectingManagedDatabaseFactory faults) : IManagedConnectionAdapter
+    {
+        public bool HasAttachedDatabases => inner.HasAttachedDatabases;
+
+        public TimeSpan BusyTimeout
+        {
+            get => inner.BusyTimeout;
+            set => inner.BusyTimeout = value;
+        }
+
+        public ManagedConnectionHooks Hooks => inner.Hooks;
+
+        public IManagedStatementAdapter Prepare(string sql)
+            => new FaultInjectingStatementAdapter(inner.Prepare(sql), faults);
+
+        public async ValueTask<IManagedStatementAdapter> PrepareAsync(
+            string sql,
+            CancellationToken cancellationToken = default)
+            => new FaultInjectingStatementAdapter(
+                await inner.PrepareAsync(sql, cancellationToken).ConfigureAwait(false),
+                faults);
+
+        public void ResetForPooling() => inner.ResetForPooling();
+
+        public void RegisterScalarFunction(string name, int arity, Func<IReadOnlyList<SqlValue>, SqlValue> function)
+            => inner.RegisterScalarFunction(name, arity, function);
+
+        public int UnregisterScalarFunctions(string name) => inner.UnregisterScalarFunctions(name);
+
+        public void RegisterAggregateFunction(
+            string name,
+            int arity,
+            SqlValue seed,
+            Func<SqlValue, IReadOnlyList<SqlValue>, SqlValue> step,
+            Func<SqlValue, SqlValue> finalize)
+            => inner.RegisterAggregateFunction(name, arity, seed, step, finalize);
+
+        public int UnregisterAggregateFunctions(string name) => inner.UnregisterAggregateFunctions(name);
+
+        public void RegisterCollation(string name, Func<string, string, int> compare)
+            => inner.RegisterCollation(name, compare);
+
+        public bool UnregisterCollation(string name) => inner.UnregisterCollation(name);
+
+        public void Dispose() => inner.Dispose();
+
+        public ValueTask DisposeAsync() => inner.DisposeAsync();
+    }
+
+    private sealed class FaultInjectingStatementAdapter(
+        IManagedStatementAdapter inner,
+        FaultInjectingManagedDatabaseFactory faults) : IManagedStatementAdapter
+    {
+        public int ParameterCount => inner.ParameterCount;
+
+        public int RowsAffected => inner.RowsAffected;
+
+        public void Bind(int index, SqlValue value) => inner.Bind(index, value);
+
+        public int GetParameterIndex(string name) => inner.GetParameterIndex(name);
+
+        public StatementStepResult Step() => inner.Step();
+
+        public ValueTask<StatementStepResult> StepAsync(CancellationToken cancellationToken = default)
+            => inner.StepAsync(cancellationToken);
+
+        public bool HasRows() => inner.HasRows();
+
+        public void Reset() => inner.Reset();
+
+        public ValueTask ResetAsync(CancellationToken cancellationToken = default)
+            => inner.ResetAsync(cancellationToken);
+
+        public void ClearBindings() => inner.ClearBindings();
+
+        public SqlValue GetValue(int ordinal) => inner.GetValue(ordinal);
+
+        public string GetColumnName(int ordinal) => inner.GetColumnName(ordinal);
+
+        public int GetColumnCount() => inner.GetColumnCount();
+
+        public string? GetParameterName(int index) => inner.GetParameterName(index);
+
+        public void Dispose() => inner.Dispose();
+
+        public ValueTask DisposeAsync()
+        {
+            var fault = faults.PendingStatementDisposeFault;
+            faults.PendingStatementDisposeFault = null;
+
+            // The real statement is still released even when a fault is armed: the synthetic
+            // failure models a disposal channel (e.g. a JS interop promise) that reports an
+            // error after the underlying resource has, in fact, already been freed.
+            inner.Dispose();
+
+            if (fault is not null)
+                throw fault;
+
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    #endregion
+}

--- a/src/Ahtola.Tests/ManagedSchemaAndReaderCorrectnessTests.cs
+++ b/src/Ahtola.Tests/ManagedSchemaAndReaderCorrectnessTests.cs
@@ -81,7 +81,8 @@ public sealed class ManagedSchemaAndReaderCorrectnessTests
             Action getSchemaTable = () => reader.GetSchemaTable();
             getSchemaTable.Should().NotThrow();
             var schema = reader.GetSchemaTable();
-            schema.Rows.Count.Should().Be(1);
+            schema.Should().NotBeNull();
+            schema!.Rows.Count.Should().Be(1);
             schema.Rows[0][System.Data.Common.SchemaTableColumn.ColumnName].Should().Be("value");
         }
         finally


### PR DESCRIPTION
## Summary

- add `Devolutions.Ahtola.Data.Sqlite.Browser`, a multi-target Razor/NuGet package for Blazor and .NET WebAssembly
- persist SQLite-compatible databases in OPFS through dedicated same-origin module workers, bounded `SharedArrayBuffer` transport, Web Locks, cancellation, path isolation, capability probing, and crash-recoverable atomic replacement intents
- add async storage contracts, synchronization gates, page store, WAL, rollback journal, pager primitives, and genuinely async managed ADO.NET execution/lifecycle paths
- expose `AhtolaBrowserDataSource` while preserving existing `SqliteConnection`, `AhtolaConnection`, and EF Core `UseAhtola(connection)` APIs
- support persistent ADO.NET/EF Core, ATTACH, WAL/checkpoint/recovery, unencrypted MVCC, VACUUM/VACUUM INTO, page-size migration, incremental blobs, backups, and an async-only shared `:memory:` data source
- add byte-compatible AHTLA AES-128/256-GCM encryption through Web Crypto, including password-v1 PBKDF2, encrypted database/WAL/journal bytes, desktop/browser interoperability, pre-auth crash recovery, role-safe sidecars, transient cleanup, wrong-key/tamper rejection, and key zeroing/release
- add packed-package automation, exact-version artifact validation, closure validation, Chromium+AOT CI, Firefox smoke coverage, a narrowly documented Playwright-WebKit OPFS notice path, release validation, samples, and deployment/encryption documentation
- pin the read-only Turso reference to `v0.8.0-pre.7`

## Browser contract

Browser-created connections are async-only and fail before mutation when a synchronous lifecycle/execution API is used. Persistent storage requires a secure, cross-origin-isolated host:

```text
Cross-Origin-Opener-Policy: same-origin
Cross-Origin-Embedder-Policy: require-corp
```

The package ships no native/Rust companion and no custom database WebAssembly binary. Encrypted browser MVCC is rejected explicitly because the current MVCC logical log is outside the page-codec format and would otherwise expose plaintext row data.

## Review hardening

The final whole-branch review findings are addressed, including:

- stable DELETE-mode snapshots and exclusive commit upgrades
- WAL visibility only after durable flush, physical rollback of abandoned frames, durable-commit preservation across cancellation/bookkeeping failure, and safe read-only/new-open behavior
- shared async lock identity across filesystem adapters and case aliases
- cancellation-aware nonblocking `StepAsync` contention
- managed schema dispatch only for managed connections
- exception-safe synchronous/async reader cleanup with primary+cleanup error aggregation and current-statement metadata
- reserved OPFS namespace enforcement, collision-free intent journals bound to full lock identity, and real synchronous-handle probing through a packaged same-origin worker
- exact CI package-version preservation and deterministic version checks

## Validation

- full managed suite on net10.0: **5,045 passed, 0 failed**
- final review regression matrix: **118/118 passed** on each of net8.0, net9.0, and net10.0
- OPFS worker Node suite: **15/15 passed**
- package-version guard suite: **4/4 passed**
- canonical Release build: passed across all shipped projects/TFMs with 0 warnings/errors
- managed project closure, pack, exact package-version assertion, and packed-package closure: passed
- packed Chromium/Web Crypto consumer: passed capabilities, OPFS transport, reserved-path rejection, colliding-directory isolation, ADO.NET, EF Core, reopen persistence, ATTACH/MVCC/VACUUM, blobs, bidirectional backup, shared `:memory:`, raw-key/password encryption, wrong-key/cipher rejection, encrypted page-size migration, and encrypted `VACUUM INTO`
- changed-file formatting, JavaScript syntax, PowerShell parser, and workflow actionlint checks: passed
- CI publishes/runs the packed consumer with browser AOT; Firefox is a normal smoke gate. Playwright's bundled Linux WebKit lacks OPFS entirely, so only its structured OPFS capability gap is downgraded to a notice; unexpected WebKit failures remain blocking.

The local trimmed publish continues to report the pre-existing upstream EF Core `IL2037` warning for `ExecuteUpdateAsync`; no Ahtola-specific trim/AOT warning was introduced.