### PR TITLE
Implement lazy ordered MVCC execution

### DIFF
--- a/src/Ahtola.Core/EmbeddedDatabase.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.cs
@@ -2755,10 +2755,10 @@ public sealed partial class EmbeddedDatabase : IDisposable
                     Busy: false,
                     LogFramesBefore: 0,
                     CheckpointedFrames: 0,
-                    CompletedThrough: MvccCheckpointPhase.Finalize);
+                    CompletedThrough: MvccCheckpointPhase.Complete);
             }
 
-            var phase = MvccCheckpointPhase.Prepare;
+            var stateMachine = new MvccCheckpointStateMachine();
             var log = store.LogicalLog;
             var logBefore = log?.ApproximatePayloadBytes ?? 0L;
             var requiresLogUpgrade = log?.RequiresVersion4Upgrade == true;
@@ -2768,94 +2768,81 @@ public sealed partial class EmbeddedDatabase : IDisposable
                     "cannot safely checkpoint a legacy MVCC logical log with unresolved table identities.");
             }
 
-            phase = MvccCheckpointPhase.AcquireLock;
+            stateMachine.Enter(MvccCheckpointPhase.AcquireLock);
             var wantTruncate = MvccCheckpoint.ShouldTruncateLog(mode);
 
-            // An active concurrent transaction pins an MVCC reader floor. Do not
-            // materialize, retire the log, or reset the WAL beneath that snapshot.
-            if (store.HasActiveTransactions())
+            if (!store.TryAcquireCheckpoint(out var checkpointLease))
+                return stateMachine.Result(busy: true, logBefore, checkpointedFrames: 0);
+            using (checkpointLease)
             {
-                return new MvccCheckpointResult(
-                    Busy: true,
-                    LogFramesBefore: logBefore,
-                    CheckpointedFrames: 0,
-                    CompletedThrough: phase);
-            }
+                stateMachine.Enter(MvccCheckpointPhase.BuildSnapshot);
+                // The current catalog serializer remains the pager commit boundary.
 
-            phase = MvccCheckpointPhase.CollectRows;
-            // Snapshot is taken inside MergeConcurrentCatalogFromStoreLocked.
+                stateMachine.Enter(MvccCheckpointPhase.MaterializeRows);
+                var merged = MergeConcurrentCatalogFromStoreLocked(LiveCatalog);
 
-            phase = MvccCheckpointPhase.MaterializeCatalog;
-            var merged = MergeConcurrentCatalogFromStoreLocked(LiveCatalog);
-
-            phase = MvccCheckpointPhase.PersistCatalog;
-            if (_fileStore is null)
-            {
-                PublishCatalog(merged);
-            }
-            else
-            {
-                PersistFileCatalog(
-                    merged,
-                    pragmaHeader: null,
-                    forceFullRewrite: false,
-                    busyTimeout,
-                    checkpointAfterCommit: false);
-
-                phase = MvccCheckpointPhase.BackfillMainStore;
-                try
+                stateMachine.Enter(MvccCheckpointPhase.CommitPager);
+                if (_fileStore is null)
                 {
-                    _ = _fileStore.BackfillMvccCheckpoint(busyTimeout);
+                    PublishCatalog(merged);
                 }
-                catch (SqlitePagerBusyException)
+                else
                 {
-                    return new MvccCheckpointResult(
-                        Busy: true,
-                        LogFramesBefore: logBefore,
-                        CheckpointedFrames: 0,
-                        CompletedThrough: phase);
+                    PersistFileCatalog(
+                        merged,
+                        pragmaHeader: null,
+                        forceFullRewrite: false,
+                        busyTimeout,
+                        checkpointAfterCommit: false);
+
+                    try
+                    {
+                        _ = _fileStore.BackfillMvccCheckpoint(busyTimeout);
+                    }
+                    catch (SqlitePagerBusyException)
+                    {
+                        return stateMachine.Result(busy: true, logBefore, checkpointedFrames: 0);
+                    }
+
+                    stateMachine.Enter(MvccCheckpointPhase.BackfillMainStore);
+                    stateMachine.Enter(MvccCheckpointPhase.SyncMainStore);
                 }
-            }
 
-            var checkpointed = logBefore;
-            if ((wantTruncate || requiresLogUpgrade) && log is not null)
-            {
-                phase = MvccCheckpointPhase.TruncateLogicalLog;
-                log.TruncateAfterCheckpoint(synchronousMode);
-                if (requiresLogUpgrade)
-                    log.UpgradeToVersion4AfterCheckpoint(synchronousMode);
-                if (wantTruncate)
-                    checkpointed = logBefore;
-            }
-
-            if (wantTruncate && _fileStore is not null)
-            {
-                phase = MvccCheckpointPhase.ResetWal;
-                try
+                var checkpointed = logBefore;
+                if ((wantTruncate || requiresLogUpgrade) && log is not null)
                 {
-                    _ = _fileStore.ResetMvccCheckpointWal(busyTimeout);
+                    log.TruncateAfterCheckpoint(synchronousMode);
+                    if (requiresLogUpgrade)
+                        log.UpgradeToVersion4AfterCheckpoint(synchronousMode);
+                    if (wantTruncate)
+                        checkpointed = logBefore;
+                    stateMachine.Enter(MvccCheckpointPhase.RetireLogicalLog);
                 }
-                catch (SqlitePagerBusyException)
+
+                if (wantTruncate && _fileStore is not null)
                 {
-                    // The main store and logical log are already durable. Retain the
-                    // validated WAL for a later restart rather than losing reader data.
-                    return new MvccCheckpointResult(
-                        Busy: true,
-                        LogFramesBefore: logBefore,
-                        CheckpointedFrames: checkpointed,
-                        CompletedThrough: phase);
+                    try
+                    {
+                        _ = _fileStore.ResetMvccCheckpointWal(busyTimeout);
+                    }
+                    catch (SqlitePagerBusyException)
+                    {
+                        // The main store and logical log are already durable. Retain the
+                        // validated WAL for a later restart rather than losing reader data.
+                        return stateMachine.Result(busy: true, logBefore, checkpointed);
+                    }
+                    stateMachine.Enter(MvccCheckpointPhase.ResetWal);
                 }
+
+                store.GarbageCollectAfterCheckpoint();
+                stateMachine.Enter(MvccCheckpointPhase.GarbageCollect);
+
+                stateMachine.Enter(MvccCheckpointPhase.Complete);
+                return stateMachine.Result(
+                    busy: false,
+                    logBefore,
+                    checkpointedFrames: wantTruncate ? checkpointed : 0);
             }
-
-            phase = MvccCheckpointPhase.GarbageCollect;
-            store.GarbageCollectAfterCheckpoint();
-
-            phase = MvccCheckpointPhase.Finalize;
-            return new MvccCheckpointResult(
-                Busy: false,
-                LogFramesBefore: logBefore,
-                CheckpointedFrames: wantTruncate ? checkpointed : 0,
-                CompletedThrough: phase);
         }
     }
 
@@ -3959,7 +3946,9 @@ public sealed partial class EmbeddedDatabase : IDisposable
             ExecuteTableList: executeTableList,
             ConcurrentMvStore: concurrentMvStore,
             ConcurrentMvccTxId: concurrentMvccTxId,
-            ConcurrentBaseTables: concurrentMvStore is null ? null : CloneTablesShallow(catalog.Tables),
+            ConcurrentBaseTables: concurrentMvStore is null || !MayMutate(statement)
+                ? null
+                : CloneTablesShallow(catalog.Tables),
             ConcurrentMvccIdentityTracker: concurrentMvStore is null ? null : new ConcurrentMvccIdentityTracker(),
             MvccTextEncoding: GetTextEncoding(),
             VirtualTables: catalog.VirtualTables,
@@ -28828,61 +28817,66 @@ out bool hasReturning)
         if (context.ConcurrentMvStore is { } store
             && context.ConcurrentMvccTxId is { } txId)
         {
-            SqliteIndexRecordComparer? primaryKeyComparer = null;
+            IComparer<MvccKey> keyComparer = MvccKeyComparer.Integer;
             if (!table.HasRowid)
             {
                 var primaryKey = table.PrimaryKeySchema
                     ?? throw new EmbeddedSqlException(
                         $"WITHOUT ROWID table '{source.Name}' is missing primary-key metadata for concurrent MVCC.");
-                primaryKeyComparer = new SqliteIndexRecordComparer(
-                    context.MvccTextEncoding,
-                    primaryKey.Terms.Select(term =>
-                        new SqliteIndexComparisonTerm(term.SortOrder, term.Collation)).ToArray());
+                keyComparer = MvccKeyComparer.ForRecord(
+                    new SqliteIndexRecordComparer(
+                        context.MvccTextEncoding,
+                        primaryKey.Terms.Select(term =>
+                            new SqliteIndexComparisonTerm(term.SortOrder, term.Collation)).ToArray()));
             }
 
-            var baseRows = new MvccDualCursor.Row[table.Rows.Count];
-            for (var i = 0; i < table.Rows.Count; i++)
+            IEnumerable<MvccDualCursor.Row> EnumerateBaseRows()
             {
-                var rowId = i < table.RowIds.Count ? table.RowIds[i] : i + 1;
-                var key = table.HasRowid
-                    ? MvccKey.FromInteger(rowId)
-                    : MvccKey.FromPrimaryKey(
-                        table.PrimaryKeySchema!,
-                        table.Rows[i],
-                        context.MvccTextEncoding);
-                baseRows[i] = new MvccDualCursor.Row(key, table.Rows[i]);
+                foreach (var index in table.GetScanOrderIndices())
+                {
+                    var rowId = index < table.RowIds.Count ? table.RowIds[index] : index + 1;
+                    var key = table.HasRowid
+                        ? MvccKey.FromInteger(rowId)
+                        : MvccKey.FromPrimaryKey(
+                            table.PrimaryKeySchema!,
+                            table.Rows[index],
+                            context.MvccTextEncoding);
+                    yield return new MvccDualCursor.Row(key, table.Rows[index]);
+                }
             }
 
             var tableId = store.GetOrCreateTableId(source.Name);
-            var merged = MvccDualCursor.MergeVisibleRows(
+            var merged = MvccDualCursor.EnumerateVisibleRows(
                 store,
                 txId,
                 tableId,
-                baseRows,
-                (left, right) => table.HasRowid
-                    ? left.Integer.CompareTo(right.Integer)
-                    : primaryKeyComparer!.Compare(left.Record.Span, right.Record.Span));
-            var count = merged.Count;
-            if (maximumRows is { } maximum && maximum < count)
-                count = (int)maximum;
+                EnumerateBaseRows(),
+                keyComparer);
 
-            var dualSourceRows = new SourceRow[count];
-            for (var outputIndex = 0; outputIndex < count; outputIndex++)
+            IEnumerable<SourceRow> EnumerateSourceRows()
             {
-                var row = merged[outputIndex];
-                dualSourceRows[outputIndex] = new SourceRow(
-                    table.Columns,
-                    row.Cells,
-                    qualifiedColumns,
-                    outerRow,
-                    RowId: table.HasRowid ? row.Key.Integer : null,
-                    RowIdQualifier: qualifier,
-                    ColumnDefinitions: table.ColumnDefinitions,
-                    QualifiedColumnDefinitions: qualifiedColumnDefinitions,
-                    MethodIndexSource: methodIndexSource);
+                long emitted = 0;
+                using var cursor = merged.GetEnumerator();
+                while (maximumRows is not { } maximum || emitted < maximum)
+                {
+                    if (!cursor.MoveNext())
+                        yield break;
+                    emitted++;
+                    var row = cursor.Current;
+                    yield return new SourceRow(
+                        table.Columns,
+                        row.Cells,
+                        qualifiedColumns,
+                        outerRow,
+                        RowId: table.HasRowid ? row.Key.Integer : null,
+                        RowIdQualifier: qualifier,
+                        ColumnDefinitions: table.ColumnDefinitions,
+                        QualifiedColumnDefinitions: qualifiedColumnDefinitions,
+                        MethodIndexSource: methodIndexSource);
+                }
             }
 
-            return new SourceData(table.Columns, dualSourceRows);
+            return new SourceData(table.Columns, new LazyReadOnlyList<SourceRow>(EnumerateSourceRows()));
         }
 
         var rowCount = table.Rows.Count;
@@ -49243,6 +49237,8 @@ internal sealed class EmbeddedTable
     private readonly Dictionary<string, int> _columnIndices;
     private bool _hasEffectivePrimaryKeyConflictAlgorithm;
     private InsertConflictAlgorithm? _effectivePrimaryKeyConflictAlgorithm;
+    private int[]? _cachedRowidScanOrder;
+    private long _cachedRowidScanOrderRevision = -1;
 
     public EmbeddedTable(
         string name,
@@ -49973,6 +49969,33 @@ internal sealed class EmbeddedTable
     public bool HasRowid => !WithoutRowid;
 
     public bool WithoutRowid { get; }
+
+    internal IEnumerable<int> GetScanOrderIndices()
+    {
+        if (!HasRowid)
+        {
+            for (var index = 0; index < Rows.Count; index++)
+                yield return index;
+            yield break;
+        }
+
+        if (_cachedRowidScanOrder is null
+            || _cachedRowidScanOrderRevision != Rows.Revision
+            || _cachedRowidScanOrder.Length != Rows.Count)
+        {
+            if (RowIds.Count != Rows.Count)
+                throw new InvalidOperationException($"Table '{Name}' has inconsistent row identity metadata.");
+
+            _cachedRowidScanOrder = Enumerable.Range(0, Rows.Count).ToArray();
+            Array.Sort(
+                _cachedRowidScanOrder,
+                (left, right) => RowIds[left].CompareTo(RowIds[right]));
+            _cachedRowidScanOrderRevision = Rows.Revision;
+        }
+
+        foreach (var index in _cachedRowidScanOrder)
+            yield return index;
+    }
 
     public bool Strict { get; }
 
@@ -52301,3 +52324,83 @@ internal sealed record SourceData(
     IReadOnlyList<string?>? Collations = null,
     IReadOnlyList<EmbeddedColumn?>? ColumnDefinitions = null,
     IReadOnlyList<Expression>? OmittedVirtualTablePredicates = null);
+
+internal sealed class LazyReadOnlyList<T>(IEnumerable<T> source) : IReadOnlyList<T>
+{
+    private readonly object _gate = new();
+    private readonly List<T> _cache = [];
+    private IEnumerator<T>? _source = (source ?? throw new ArgumentNullException(nameof(source))).GetEnumerator();
+
+    public int Count
+    {
+        get
+        {
+            lock (_gate)
+            {
+                while (MoveNextLocked())
+                {
+                }
+                return _cache.Count;
+            }
+        }
+    }
+
+    public T this[int index]
+    {
+        get
+        {
+            if (index < 0)
+                throw new ArgumentOutOfRangeException(nameof(index));
+            lock (_gate)
+            {
+                while (_cache.Count <= index && MoveNextLocked())
+                {
+                }
+                return index < _cache.Count
+                    ? _cache[index]
+                    : throw new ArgumentOutOfRangeException(nameof(index));
+            }
+        }
+    }
+
+    public IEnumerator<T> GetEnumerator()
+    {
+        for (var index = 0; TryGet(index, out var item); index++)
+            yield return item!;
+    }
+
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private bool TryGet(int index, out T? item)
+    {
+        lock (_gate)
+        {
+            while (_cache.Count <= index && MoveNextLocked())
+            {
+            }
+            if (index < _cache.Count)
+            {
+                item = _cache[index];
+                return true;
+            }
+        }
+
+        item = default;
+        return false;
+    }
+
+    private bool MoveNextLocked()
+    {
+        if (_source is null)
+            return false;
+        if (_source.MoveNext())
+        {
+            _cache.Add(_source.Current);
+            return true;
+        }
+
+        _source.Dispose();
+        _source = null;
+        return false;
+    }
+}

--- a/src/Ahtola.Core/Mvcc/MvStore.cs
+++ b/src/Ahtola.Core/Mvcc/MvStore.cs
@@ -262,6 +262,7 @@ internal sealed class MvStore
     private readonly Dictionary<ulong, MvccTransactionState> _finalizedStates = [];
     private readonly Dictionary<ulong, ulong> _finalizedCommitTimestamps = [];
     private readonly Dictionary<MvccRowId, List<MvccRowVersion>> _rows = [];
+    private readonly Dictionary<long, OrderedTableKeys> _orderedTableKeys = [];
     private readonly Dictionary<string, long> _tableIds = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<long, string> _tableNames = [];
     private readonly Dictionary<long, long> _nextRowIds = [];
@@ -272,6 +273,7 @@ internal sealed class MvStore
     private ulong _schemaGeneration;
     private ulong _commitGeneration;
     private ulong? _schemaChangeTransaction;
+    private bool _checkpointInProgress;
     private bool _hasUnresolvedLegacyRows;
     private bool _hasIndeterminateCommit;
     private MvccLogicalLog? _logicalLog;
@@ -339,6 +341,7 @@ internal sealed class MvStore
                 {
                     chain = [];
                     _rows[op.RowId] = chain;
+                    IndexRowLocked(op.RowId);
                 }
 
                 if (op.IsDelete)
@@ -484,7 +487,9 @@ internal sealed class MvStore
                 throw new EmbeddedSqlException(
                     "The MVCC store has an indeterminate logical-log commit; dispose and reopen the database before starting another transaction.");
             }
-            if (_exclusiveTxId is not null || _schemaChangeTransaction is not null)
+            if (_checkpointInProgress
+                || _exclusiveTxId is not null
+                || _schemaChangeTransaction is not null)
                 throw new EmbeddedBusyException();
 
             var beginTs = NextBeginTimestamp();
@@ -504,8 +509,9 @@ internal sealed class MvStore
                 throw new EmbeddedSqlException(
                     "The MVCC store has an indeterminate logical-log commit; dispose and reopen the database before starting another transaction.");
             }
-            if (_exclusiveTxId is { } held
-                && (existing is null || held != existing.Value.Value))
+            if (_checkpointInProgress
+                || (_exclusiveTxId is { } held
+                    && (existing is null || held != existing.Value.Value)))
             {
                 throw new EmbeddedBusyException();
             }
@@ -549,6 +555,8 @@ internal sealed class MvStore
         lock (_gate)
         {
             var tx = RequireActive(id);
+            if (_checkpointInProgress)
+                throw new EmbeddedBusyException();
             if (tx.BeginCommitGeneration != _commitGeneration)
                 throw new EmbeddedBusyException();
             if (_schemaChangeTransaction is { } owner && owner != id.Value)
@@ -621,6 +629,7 @@ internal sealed class MvStore
             }
 
             _rows.Clear();
+            _orderedTableKeys.Clear();
             _tableIds.Clear();
             _tableNames.Clear();
             _nextRowIds.Clear();
@@ -646,6 +655,7 @@ internal sealed class MvStore
             {
                 chain = [];
                 _rows[rowId] = chain;
+                IndexRowLocked(rowId);
             }
             else if (!rowId.Key.IsInteger)
             {
@@ -725,6 +735,7 @@ internal sealed class MvStore
             {
                 chain = [];
                 _rows[rowId] = chain;
+                IndexRowLocked(rowId);
             }
 
             chain.Add(new MvccRowVersion(
@@ -848,6 +859,29 @@ internal sealed class MvStore
             }
 
             return results;
+        }
+    }
+
+    /// <summary>
+    /// Enumerates this table's visible MVCC effects in SQLite key order. Each
+    /// move locks only long enough to locate and clone the next entry, so the
+    /// caller retains no store lock and buffers no table-sized snapshot.
+    /// </summary>
+    internal IEnumerable<MvccVisibleRow> EnumerateVisible(
+        MvccTxId txId,
+        long tableId,
+        IComparer<MvccKey> comparer)
+    {
+        ArgumentNullException.ThrowIfNull(comparer);
+        RegisterTableKeyComparer(tableId, comparer);
+
+        var hasPrevious = false;
+        var previous = default(MvccKey);
+        while (TryGetNextVisible(txId, tableId, comparer, hasPrevious, previous, out var row))
+        {
+            yield return row;
+            previous = row.Key;
+            hasPrevious = true;
         }
     }
 
@@ -1107,7 +1141,7 @@ internal sealed class MvStore
         }
 
         if (chain.Count == 0)
-            _rows.Remove(op.RowId);
+            RemoveRowLocked(op.RowId);
     }
 
     private void AbortLocked(MvccTxId id, MvccTransaction tx)
@@ -1128,7 +1162,7 @@ internal sealed class MvStore
             }
 
             if (chain.Count == 0)
-                _rows.Remove(rowId);
+                RemoveRowLocked(rowId);
         }
 
         tx.MarkAborted();
@@ -1323,6 +1357,29 @@ internal sealed class MvStore
             return HasActiveTransactionsLocked();
     }
 
+    /// <summary>
+    /// Acquires the process-shared stop-the-world checkpoint boundary. The lease
+    /// closes the transaction-admission race between checking the reader floor
+    /// and beginning catalog materialization.
+    /// </summary>
+    internal bool TryAcquireCheckpoint(out CheckpointLease? lease)
+    {
+        lock (_gate)
+        {
+            if (_checkpointInProgress
+                || _schemaChangeTransaction is not null
+                || HasActiveTransactionsLocked())
+            {
+                lease = null;
+                return false;
+            }
+
+            _checkpointInProgress = true;
+            lease = new CheckpointLease(this);
+            return true;
+        }
+    }
+
     /// <summary>Count of version chains currently held (test/diagnostic).</summary>
     internal int VersionChainCount
     {
@@ -1342,6 +1399,8 @@ internal sealed class MvStore
             if (!HasActiveTransactionsLocked())
             {
                 _rows.Clear();
+                foreach (var ordered in _orderedTableKeys.Values)
+                    ordered.Keys.Clear();
                 return;
             }
 
@@ -1359,7 +1418,7 @@ internal sealed class MvStore
                     && beginTs < lwm);
 
                 if (chain.Count == 0)
-                    _rows.Remove(rowId);
+                    RemoveRowLocked(rowId);
             }
         }
     }
@@ -1373,6 +1432,32 @@ internal sealed class MvStore
         }
 
         return false;
+    }
+
+    private void ReleaseCheckpoint()
+    {
+        lock (_gate)
+        {
+            if (!_checkpointInProgress)
+                throw new InvalidOperationException("The MVCC checkpoint lease is not held.");
+            _checkpointInProgress = false;
+        }
+    }
+
+    internal sealed class CheckpointLease : IDisposable
+    {
+        private MvStore? _store;
+
+        internal CheckpointLease(MvStore store)
+        {
+            _store = store;
+        }
+
+        public void Dispose()
+        {
+            var store = Interlocked.Exchange(ref _store, null);
+            store?.ReleaseCheckpoint();
+        }
     }
 
     private ulong ComputeReaderLowWaterMarkLocked()
@@ -1407,7 +1492,7 @@ internal sealed class MvStore
                 && endTs < lowestActiveBegin);
 
             if (chain.Count == 0)
-                _rows.Remove(rowId);
+                RemoveRowLocked(rowId);
         }
 
         if (_finalizedStates.Count > 4096)
@@ -1423,4 +1508,178 @@ internal sealed class MvStore
             }
         }
     }
+
+    private void RegisterTableKeyComparer(long tableId, IComparer<MvccKey> comparer)
+    {
+        lock (_gate)
+        {
+            if (_orderedTableKeys.TryGetValue(tableId, out var existing))
+            {
+                var compatible = ReferenceEquals(existing.Comparer, comparer)
+                    || existing.Comparer is MvccKeyComparer registered
+                        && comparer is MvccKeyComparer requested
+                        && registered.IsCompatibleWith(requested);
+                if (!compatible)
+                {
+                    throw new InvalidOperationException(
+                        "The MVCC table key descriptor changed while its identity remained live.");
+                }
+                return;
+            }
+
+            var ordered = new OrderedTableKeys(comparer);
+            foreach (var rowId in _rows.Keys)
+            {
+                if (rowId.TableId == tableId)
+                    AddOrderedKey(ordered.Keys, rowId.Key);
+            }
+            _orderedTableKeys.Add(tableId, ordered);
+        }
+    }
+
+    private bool TryGetNextVisible(
+        MvccTxId txId,
+        long tableId,
+        IComparer<MvccKey> comparer,
+        bool hasPrevious,
+        MvccKey previous,
+        out MvccVisibleRow row)
+    {
+        lock (_gate)
+        {
+            var tx = RequireActive(txId);
+            if (!_orderedTableKeys.TryGetValue(tableId, out var ordered))
+                throw new InvalidOperationException("MVCC ordered table registration was lost.");
+
+            var hasCandidate = TryGetNextKey(ordered.Keys, comparer, hasPrevious, previous, out var candidate);
+            while (hasCandidate)
+            {
+                var rowId = new MvccRowId(tableId, candidate);
+                if (_rows.TryGetValue(rowId, out var chain)
+                    && TryResolveVisibleEffectLocked(tx, chain, out var cells, out var isDelete))
+                {
+                    row = new MvccVisibleRow(candidate, cells, isDelete);
+                    return true;
+                }
+
+                previous = candidate;
+                hasPrevious = true;
+                hasCandidate = TryGetNextKey(ordered.Keys, comparer, hasPrevious, previous, out candidate);
+            }
+
+            row = default;
+            return false;
+        }
+    }
+
+    private bool TryResolveVisibleEffectLocked(
+        MvccTransaction tx,
+        IReadOnlyList<MvccRowVersion> chain,
+        out SqlValue[]? cells,
+        out bool isDelete)
+    {
+        for (var index = chain.Count - 1; index >= 0; index--)
+        {
+            var version = chain[index];
+            if (!IsVisibleTo(version, tx))
+                continue;
+
+            isDelete = version.IsTombstone;
+            cells = isDelete ? null : (SqlValue[])version.Cells.Clone();
+            return true;
+        }
+
+        foreach (var version in chain)
+        {
+            if (version.End is null)
+                continue;
+
+            var end = version.End.Value;
+            if (end.IsTimestamp
+                    ? end.Value <= tx.BeginTimestamp
+                    : end.Value == tx.Id.Value || LookupCreatorVisibility(end.Value, tx))
+            {
+                cells = null;
+                isDelete = true;
+                return true;
+            }
+        }
+
+        cells = null;
+        isDelete = false;
+        return false;
+    }
+
+    private static bool TryGetNextKey(
+        SortedSet<MvccKey> keys,
+        IComparer<MvccKey> comparer,
+        bool hasPrevious,
+        MvccKey previous,
+        out MvccKey key)
+    {
+        if (keys.Count == 0)
+        {
+            key = default;
+            return false;
+        }
+
+        if (!hasPrevious)
+        {
+            key = keys.Min;
+            return true;
+        }
+
+        var maximum = keys.Max;
+        if (comparer.Compare(previous, maximum) >= 0)
+        {
+            key = default;
+            return false;
+        }
+
+        foreach (var candidate in keys.GetViewBetween(previous, maximum))
+        {
+            if (comparer.Compare(candidate, previous) > 0)
+            {
+                key = candidate;
+                return true;
+            }
+        }
+
+        key = default;
+        return false;
+    }
+
+    private void IndexRowLocked(MvccRowId rowId)
+    {
+        if (_orderedTableKeys.TryGetValue(rowId.TableId, out var ordered))
+            AddOrderedKey(ordered.Keys, rowId.Key);
+    }
+
+    private static void AddOrderedKey(SortedSet<MvccKey> keys, MvccKey key)
+    {
+        if (keys.Add(key))
+            return;
+        if (keys.TryGetValue(key, out var existing) && existing.Equals(key))
+            return;
+        throw new InvalidDataException(
+            "Distinct MVCC identities compare equal under the table's SQLite key descriptor.");
+    }
+
+    private void RemoveRowLocked(MvccRowId rowId)
+    {
+        _rows.Remove(rowId);
+        if (_orderedTableKeys.TryGetValue(rowId.TableId, out var ordered))
+            ordered.Keys.Remove(rowId.Key);
+    }
+
+    private sealed class OrderedTableKeys(IComparer<MvccKey> comparer)
+    {
+        internal IComparer<MvccKey> Comparer { get; } =
+            comparer ?? throw new ArgumentNullException(nameof(comparer));
+
+        internal SortedSet<MvccKey> Keys { get; } =
+            new(comparer);
+    }
 }
+
+internal readonly record struct MvccVisibleRow(MvccKey Key, SqlValue[]? Cells, bool IsDelete);

--- a/src/Ahtola.Core/Mvcc/MvccCheckpoint.cs
+++ b/src/Ahtola.Core/Mvcc/MvccCheckpoint.cs
@@ -9,14 +9,15 @@ internal enum MvccCheckpointPhase : byte
 {
     Prepare = 0,
     AcquireLock = 1,
-    CollectRows = 2,
-    MaterializeCatalog = 3,
-    PersistCatalog = 4,
+    BuildSnapshot = 2,
+    MaterializeRows = 3,
+    CommitPager = 4,
     BackfillMainStore = 5,
-    TruncateLogicalLog = 6,
-    ResetWal = 7,
-    GarbageCollect = 8,
-    Finalize = 9,
+    SyncMainStore = 6,
+    RetireLogicalLog = 7,
+    ResetWal = 8,
+    GarbageCollect = 9,
+    Complete = 10,
 }
 
 /// <summary>Outcome of a managed MVCC checkpoint attempt.</summary>
@@ -45,4 +46,32 @@ internal static class MvccCheckpoint
     internal static bool IsPassive(string? mode)
         => mode is null
             || mode.Equals("PASSIVE", StringComparison.OrdinalIgnoreCase);
+}
+
+/// <summary>
+/// Retained phase driver for the managed synchronous checkpoint. Unlike Turso's
+/// cooperative driver, each entered phase completes synchronously before the
+/// next phase is published.
+/// </summary>
+internal sealed class MvccCheckpointStateMachine
+{
+    internal MvccCheckpointPhase Phase { get; private set; } = MvccCheckpointPhase.Prepare;
+
+    internal void Enter(MvccCheckpointPhase phase)
+    {
+        if (phase <= Phase)
+            throw new InvalidOperationException(
+                $"MVCC checkpoint cannot move from {Phase} to {phase}.");
+        Phase = phase;
+    }
+
+    internal MvccCheckpointResult Result(
+        bool busy,
+        long logFramesBefore,
+        long checkpointedFrames)
+        => new(
+            Busy: busy,
+            LogFramesBefore: logFramesBefore,
+            CheckpointedFrames: checkpointedFrames,
+            CompletedThrough: Phase);
 }

--- a/src/Ahtola.Core/Mvcc/MvccDualCursor.cs
+++ b/src/Ahtola.Core/Mvcc/MvccDualCursor.cs
@@ -11,53 +11,79 @@ internal static class MvccDualCursor
     internal readonly record struct Row(MvccKey Key, SqlValue[] Cells);
 
     /// <summary>
-    /// Merges an ordered base image with typed MVCC overlays. The supplied
-    /// comparison must be the owning table's SQLite key comparison, including
-    /// collations and directions for a WITHOUT ROWID primary key.
+    /// Lazily overlays an ordered base image with the ordered MVCC range. This
+    /// mirrors Turso's two-peek cursor: equal keys consume both inputs, and only
+    /// the winning input advances for unequal keys.
     /// </summary>
+    internal static IEnumerable<Row> EnumerateVisibleRows(
+        MvStore store,
+        MvccTxId txId,
+        long tableId,
+        IEnumerable<Row> baseRows,
+        IComparer<MvccKey> comparer)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(baseRows);
+        ArgumentNullException.ThrowIfNull(comparer);
+
+        using var baseCursor = baseRows.GetEnumerator();
+        using var overlayCursor = store.EnumerateVisible(txId, tableId, comparer).GetEnumerator();
+        var hasBase = baseCursor.MoveNext();
+        var hasOverlay = overlayCursor.MoveNext();
+
+        while (hasBase || hasOverlay)
+        {
+            if (!hasOverlay)
+            {
+                var baseRow = baseCursor.Current;
+                yield return new Row(baseRow.Key, (SqlValue[])baseRow.Cells.Clone());
+                hasBase = baseCursor.MoveNext();
+                continue;
+            }
+
+            if (!hasBase)
+            {
+                var overlay = overlayCursor.Current;
+                if (!overlay.IsDelete)
+                    yield return new Row(overlay.Key, overlay.Cells!);
+                hasOverlay = overlayCursor.MoveNext();
+                continue;
+            }
+
+            var comparison = comparer.Compare(baseCursor.Current.Key, overlayCursor.Current.Key);
+            if (comparison < 0)
+            {
+                var baseRow = baseCursor.Current;
+                yield return new Row(baseRow.Key, (SqlValue[])baseRow.Cells.Clone());
+                hasBase = baseCursor.MoveNext();
+                continue;
+            }
+
+            var winner = overlayCursor.Current;
+            if (!winner.IsDelete)
+                yield return new Row(winner.Key, winner.Cells!);
+            hasOverlay = overlayCursor.MoveNext();
+            if (comparison == 0)
+                hasBase = baseCursor.MoveNext();
+        }
+    }
+
+    /// <summary>Compatibility materializer for callers that require a list.</summary>
     internal static IReadOnlyList<Row> MergeVisibleRows(
         MvStore store,
         MvccTxId txId,
         long tableId,
         IReadOnlyList<Row> baseRows,
-        Comparison<MvccKey> compare)
+        IComparer<MvccKey> comparer)
     {
-        ArgumentNullException.ThrowIfNull(store);
-        ArgumentNullException.ThrowIfNull(baseRows);
-        ArgumentNullException.ThrowIfNull(compare);
-
-        var results = new List<Row>(baseRows.Count);
-        var covered = new HashSet<MvccKey>();
-
-        foreach (var baseRow in baseRows)
-        {
-            var identity = new MvccRowId(tableId, baseRow.Key);
-            if (store.TryRead(txId, identity, out var overlay) && overlay is not null)
-            {
-                results.Add(new Row(baseRow.Key, overlay));
-                covered.Add(baseRow.Key);
-                continue;
-            }
-
-            if (store.IsBaseRowInvalidated(txId, identity))
-            {
-                covered.Add(baseRow.Key);
-                continue;
-            }
-
-            results.Add(new Row(baseRow.Key, (SqlValue[])baseRow.Cells.Clone()));
-            covered.Add(baseRow.Key);
-        }
-
-        foreach (var (identity, cells) in store.ScanVisible(txId))
-        {
-            if (identity.TableId != tableId || covered.Contains(identity.Key))
-                continue;
-            results.Add(new Row(identity.Key, cells));
-        }
-
-        results.Sort((left, right) => compare(left.Key, right.Key));
-        return results;
+        ArgumentNullException.ThrowIfNull(comparer);
+        return EnumerateVisibleRows(
+                store,
+                txId,
+                tableId,
+                baseRows,
+                comparer)
+            .ToArray();
     }
 
     /// <summary>
@@ -77,18 +103,16 @@ internal static class MvccDualCursor
         if (baseRowIds.Count != baseRows.Count)
             throw new ArgumentException("Base row id and cell lists must have equal length.");
 
-        var typedBaseRows = new Row[baseRowIds.Count];
-        for (var i = 0; i < baseRowIds.Count; i++)
-        {
-            typedBaseRows[i] = new Row(MvccKey.FromInteger(baseRowIds[i]), baseRows[i]);
-        }
+        var typedBaseRows = baseRowIds
+            .Select((rowId, index) => new Row(MvccKey.FromInteger(rowId), baseRows[index]))
+            .OrderBy(static row => row.Key.Integer);
 
-        return MergeVisibleRows(
+        return EnumerateVisibleRows(
                 store,
                 txId,
                 tableId,
                 typedBaseRows,
-                static (left, right) => left.Integer.CompareTo(right.Integer))
+                MvccKeyComparer.Integer)
             .Select(static row => (row.Key.Integer, row.Cells))
             .ToArray();
     }

--- a/src/Ahtola.Core/Mvcc/MvccKey.cs
+++ b/src/Ahtola.Core/Mvcc/MvccKey.cs
@@ -130,3 +130,47 @@ internal enum MvccKeyKind : byte
     Integer = 0,
     Record = 1,
 }
+
+/// <summary>
+/// SQLite ordering for one MVCC object. Encoded SQLite records are never
+/// compared bytewise because serial types, collations, and DESC terms all
+/// participate in their B-tree order.
+/// </summary>
+internal sealed class MvccKeyComparer : IComparer<MvccKey>
+{
+    private static readonly MvccKeyComparer IntegerInstance = new(recordComparer: null);
+    private readonly SqliteIndexRecordComparer? _recordComparer;
+
+    private MvccKeyComparer(SqliteIndexRecordComparer? recordComparer)
+        => _recordComparer = recordComparer;
+
+    internal static IComparer<MvccKey> Integer => IntegerInstance;
+
+    internal static IComparer<MvccKey> ForRecord(SqliteIndexRecordComparer comparer)
+        => new MvccKeyComparer(comparer ?? throw new ArgumentNullException(nameof(comparer)));
+
+    internal bool IsCompatibleWith(MvccKeyComparer other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+        if (_recordComparer is null || other._recordComparer is null)
+            return _recordComparer is null && other._recordComparer is null;
+        return _recordComparer.HasSameSemantics(other._recordComparer);
+    }
+
+    public int Compare(MvccKey left, MvccKey right)
+    {
+        if (left.Kind != right.Kind)
+            throw new InvalidOperationException("An MVCC object cannot mix integer and record keys.");
+
+        if (left.IsInteger)
+        {
+            if (_recordComparer is not null)
+                throw new InvalidOperationException("A record-key MVCC object received an integer key.");
+            return left.Integer.CompareTo(right.Integer);
+        }
+
+        if (_recordComparer is null)
+            throw new InvalidOperationException("An integer-key MVCC object received a record key.");
+        return _recordComparer.Compare(left.Record.Span, right.Record.Span);
+    }
+}

--- a/src/Ahtola.Core/Storage/SqliteIndexRecordComparer.cs
+++ b/src/Ahtola.Core/Storage/SqliteIndexRecordComparer.cs
@@ -77,6 +77,13 @@ public sealed class SqliteIndexRecordComparer
     /// <summary>The database text encoding used to interpret text record fields.</summary>
     public SqliteTextEncoding TextEncoding { get; }
 
+    internal bool HasSameSemantics(SqliteIndexRecordComparer other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+        return TextEncoding == other.TextEncoding
+            && _terms.SequenceEqual(other._terms);
+    }
+
     /// <summary>Compares two complete SQLite record payloads.</summary>
     public int Compare(ReadOnlySpan<byte> leftRecord, ReadOnlySpan<byte> rightRecord)
         => Compare(SqliteRecordCodec.Decode(leftRecord, TextEncoding), SqliteRecordCodec.Decode(rightRecord, TextEncoding));

--- a/src/Ahtola.Tests/MvccCheckpointStateMachineTests.cs
+++ b/src/Ahtola.Tests/MvccCheckpointStateMachineTests.cs
@@ -140,6 +140,10 @@ public sealed class MvccCheckpointStateMachineTests
 
             ReadFileLength(fileSystem, path + "-log").Should().Be(logLength);
             AssertCommittedWal(fileSystem, path + "-wal");
+
+            // A failed durability phase must release process-local admission.
+            Execute(connection, "BEGIN CONCURRENT;");
+            Execute(connection, "ROLLBACK;");
         }
 
         using var reopened = EmbeddedDatabase.OpenFile(path, fileSystem);
@@ -184,6 +188,39 @@ public sealed class MvccCheckpointStateMachineTests
         finalWal.ScanRecovery().LastCommittedFrameNumber.Should().Be(0);
     }
 
+    [TestCase(FileSystemOperation.Write)]
+    [TestCase(FileSystemOperation.FlushToDisk)]
+    public void MaterializationFaultColdReopensFromTheLogicalLog(FileSystemOperation operation)
+    {
+        var faults = new DeterministicFaultInjector();
+        var fileSystem = new InMemoryFileSystem(faults);
+        var path = $"mvcc-{operation}-materialization-failure.db";
+
+        using (var database = EmbeddedDatabase.OpenFile(path, fileSystem))
+        using (var connection = database.Connect())
+        {
+            Execute(connection, "CREATE TABLE t(v INTEGER);");
+            Execute(connection, "PRAGMA journal_mode=mvcc;");
+            Execute(connection, "BEGIN CONCURRENT;");
+            Execute(connection, "INSERT INTO t VALUES (59);");
+            Execute(connection, "COMMIT;");
+
+            faults.FailNext(operation);
+            Assert.Throws<IOException>(() => database.RunMvccCheckpoint("TRUNCATE"));
+        }
+
+        using (var reopened = EmbeddedDatabase.OpenFile(path, fileSystem))
+        using (var connection = reopened.Connect())
+        {
+            ReadScalar(connection, "SELECT v FROM t;").Should().Be(59L);
+            reopened.RunMvccCheckpoint("TRUNCATE").Busy.Should().BeFalse();
+        }
+
+        using var final = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var finalConnection = final.Connect();
+        ReadScalar(finalConnection, "SELECT v FROM t;").Should().Be(59L);
+    }
+
     [Test]
     public void ActiveConcurrentReaderPreventsLogicalLogRetirement()
     {
@@ -210,6 +247,31 @@ public sealed class MvccCheckpointStateMachineTests
         Execute(reader, "ROLLBACK;");
         database.RunMvccCheckpoint("TRUNCATE").Busy.Should().BeFalse();
         ReadFileLength(fileSystem, path + "-log").Should().Be(56);
+    }
+
+    [Test]
+    public void SharedCheckpointLeaseBlocksAdmissionFromASecondDatabaseInstance()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        const string path = "mvcc-shared-checkpoint-lease.db";
+        using var first = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var second = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var firstConnection = first.Connect();
+        using var secondConnection = second.Connect();
+        Execute(firstConnection, "CREATE TABLE t(v INTEGER);");
+        Execute(firstConnection, "PRAGMA journal_mode=mvcc;");
+        second.EnsureMvccAttachedIfDurable();
+
+        ReferenceEquals(first.MvStore, second.MvStore).Should().BeTrue();
+        first.MvStore!.TryAcquireCheckpoint(out var lease).Should().BeTrue();
+        using (lease)
+        {
+            Assert.Throws<EmbeddedBusyException>(
+                () => Execute(secondConnection, "BEGIN CONCURRENT;"));
+        }
+
+        Execute(secondConnection, "BEGIN CONCURRENT;");
+        Execute(secondConnection, "ROLLBACK;");
     }
 
     [Test]

--- a/src/Ahtola.Tests/MvccHeaderAndDualCursorTests.cs
+++ b/src/Ahtola.Tests/MvccHeaderAndDualCursorTests.cs
@@ -95,6 +95,99 @@ public sealed class MvccHeaderAndDualCursorTests
         merged.Select(r => r.RowId).OrderBy(x => x).Should().Equal(1L, 99L);
     }
 
+    [Test]
+    public void DualCursorConsumesOnlyThePrefixNeededForFirstWinner()
+    {
+        var store = new MvStore();
+        var table = store.GetOrCreateTableId("t");
+        var tx = store.BeginTransaction();
+        store.Insert(tx.Id, new MvccRowId(table, 50_000), [SqlValue.Integer(50_000)]);
+        var visitedBaseRows = 0;
+
+        IEnumerable<MvccDualCursor.Row> BaseRows()
+        {
+            for (var rowId = 1L; rowId <= 100_000; rowId++)
+            {
+                visitedBaseRows++;
+                yield return new MvccDualCursor.Row(
+                    MvccKey.FromInteger(rowId),
+                    [SqlValue.Integer(rowId)]);
+            }
+        }
+
+        var rows = MvccDualCursor.EnumerateVisibleRows(
+            store,
+            tx.Id,
+            table,
+            BaseRows(),
+            MvccKeyComparer.Integer);
+        visitedBaseRows.Should().Be(0);
+
+        using var cursor = rows.GetEnumerator();
+        cursor.MoveNext().Should().BeTrue();
+        cursor.Current.Key.Integer.Should().Be(1);
+        visitedBaseRows.Should().Be(1);
+    }
+
+    [Test]
+    public void DualCursorUsesCompositePrimaryKeyCollationAndDirection()
+    {
+        var schema = new SqlitePrimaryKeySchema(
+        [
+            new SqlitePrimaryKeyTerm(
+                0,
+                "name",
+                SqliteKeySortOrder.Ascending,
+                SqliteKeyCollation.FromName("NOCASE")),
+            new SqlitePrimaryKeyTerm(
+                1,
+                "rank",
+                SqliteKeySortOrder.Descending,
+                SqliteKeyCollation.Binary),
+        ]);
+        var recordComparer = new SqliteIndexRecordComparer(
+            SqliteTextEncoding.Utf8,
+            schema.Terms.Select(term =>
+                new SqliteIndexComparisonTerm(term.SortOrder, term.Collation)).ToArray());
+        var comparer = MvccKeyComparer.ForRecord(recordComparer);
+        var store = new MvStore();
+        var table = store.GetOrCreateTableId("t");
+        var tx = store.BeginTransaction();
+        var alphaTwo = MvccKey.FromPrimaryKey(
+            schema,
+            [SqlValue.Text("ALPHA"), SqlValue.Integer(2)],
+            SqliteTextEncoding.Utf8);
+        var betaOne = MvccKey.FromPrimaryKey(
+            schema,
+            [SqlValue.Text("beta"), SqlValue.Integer(1)],
+            SqliteTextEncoding.Utf8);
+        store.Insert(tx.Id, new MvccRowId(table, betaOne), [SqlValue.Text("beta-1")]);
+        store.Insert(tx.Id, new MvccRowId(table, alphaTwo), [SqlValue.Text("alpha-2")]);
+
+        var alphaThree = MvccKey.FromPrimaryKey(
+            schema,
+            [SqlValue.Text("alpha"), SqlValue.Integer(3)],
+            SqliteTextEncoding.Utf8);
+        var alphaOne = MvccKey.FromPrimaryKey(
+            schema,
+            [SqlValue.Text("alpha"), SqlValue.Integer(1)],
+            SqliteTextEncoding.Utf8);
+        var merged = MvccDualCursor.EnumerateVisibleRows(
+                store,
+                tx.Id,
+                table,
+                [
+                    new MvccDualCursor.Row(alphaThree, [SqlValue.Text("alpha-3")]),
+                    new MvccDualCursor.Row(alphaOne, [SqlValue.Text("alpha-1")]),
+                ],
+                comparer)
+            .ToArray();
+
+        merged.Select(row => row.Cells[0].AsText())
+            .Should()
+            .Equal("alpha-3", "alpha-2", "alpha-1", "beta-1");
+    }
+
     private static SqlValue ReadValue(EmbeddedConnection connection, string sql)
     {
         using var statement = connection.Prepare(sql);

--- a/src/Ahtola.Tests/MvccSelectDualCursorRoutingTests.cs
+++ b/src/Ahtola.Tests/MvccSelectDualCursorRoutingTests.cs
@@ -443,6 +443,18 @@ public sealed class MvccSelectDualCursorRoutingTests
         Convert.ToInt64(Scalar(connection, "SELECT COUNT(*) FROM child;")).Should().Be(0L);
     }
 
+    [Test]
+    public void ConcurrentLimitOneAllocationDoesNotScaleWithTheBaseCatalog()
+    {
+        const int largeRowCount = 10_000;
+        var smallAllocation = MeasureConcurrentLimitOneAllocation(rowCount: 10);
+        var largeAllocation = MeasureConcurrentLimitOneAllocation(largeRowCount);
+
+        largeAllocation.Should().BeLessThan(
+            smallAllocation + 256 * 1024,
+            "a warmed LIMIT 1 scan should retain only the lazy cursor peeks and consumed row");
+    }
+
     private static object? Scalar(SqliteConnection connection, string sql)
     {
         using var command = connection.CreateCommand();
@@ -464,6 +476,49 @@ public sealed class MvccSelectDualCursorRoutingTests
         {
             return exception;
         }
+    }
+
+    private static long MeasureConcurrentLimitOneAllocation(int rowCount)
+    {
+        var fileSystem = new Ahtola.Core.Storage.InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile($"mvcc-limit-{rowCount}.db", fileSystem);
+        using var connection = database.Connect();
+        using (var create = connection.Prepare("CREATE TABLE t(v INTEGER);"))
+            _ = create.Step();
+
+        var values = new System.Text.StringBuilder("INSERT INTO t VALUES ");
+        for (var value = 1; value <= rowCount; value++)
+        {
+            if (value != 1)
+                values.Append(',');
+            values.Append('(').Append(value).Append(')');
+        }
+        values.Append(';');
+        using (var seed = connection.Prepare(values.ToString()))
+            _ = seed.Step();
+        using (var mode = connection.Prepare("PRAGMA journal_mode=mvcc;"))
+            _ = mode.Step();
+        using (var begin = connection.Prepare("BEGIN CONCURRENT;"))
+            _ = begin.Step();
+
+        // Build and cache the rowid scan order before measuring statement execution.
+        ExecuteLimitOne(connection);
+        ExecuteLimitOne(connection);
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        ExecuteLimitOne(connection);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        using (var rollback = connection.Prepare("ROLLBACK;"))
+            _ = rollback.Step();
+        return allocated;
+    }
+
+    private static void ExecuteLimitOne(EmbeddedConnection connection)
+    {
+        using var statement = connection.Prepare("SELECT v FROM t LIMIT 1;");
+        statement.Step().Should().Be(StatementStepResult.Row);
+        statement.GetValue(0).AsInteger().Should().Be(1L);
     }
 
     private sealed class RoutingFileDatabase : IDisposable

--- a/src/Ahtola.Tests/MvccStoreUnitTests.cs
+++ b/src/Ahtola.Tests/MvccStoreUnitTests.cs
@@ -122,6 +122,35 @@ public sealed class MvccStoreUnitTests
     }
 
     [Test]
+    public void CheckpointLeaseClosesTransactionAdmissionUntilReleased()
+    {
+        var store = new MvStore();
+
+        store.TryAcquireCheckpoint(out var lease).Should().BeTrue();
+        lease.Should().NotBeNull();
+        ((Action)(() => store.BeginTransaction())).Should().Throw<EmbeddedBusyException>();
+        ((Action)(() => store.BeginExclusiveTransaction())).Should().Throw<EmbeddedBusyException>();
+
+        lease!.Dispose();
+        var transaction = store.BeginTransaction();
+        store.Rollback(transaction.Id);
+    }
+
+    [Test]
+    public void ActiveTransactionPreventsCheckpointLease()
+    {
+        var store = new MvStore();
+        var transaction = store.BeginTransaction();
+
+        store.TryAcquireCheckpoint(out var lease).Should().BeFalse();
+        lease.Should().BeNull();
+
+        store.Rollback(transaction.Id);
+        store.TryAcquireCheckpoint(out lease).Should().BeTrue();
+        lease!.Dispose();
+    }
+
+    [Test]
     public void ScanVisibleReturnsCommittedRowsOnly()
     {
         var store = new MvStore();
@@ -228,5 +257,28 @@ public sealed class MvccStoreUnitTests
             [MvccLogOp.Upsert(new MvccRowId(-2, 1), [SqlValue.Text("legacy")])]);
 
         store.CanUpgradeLegacyLog.Should().BeFalse();
+    }
+
+    [Test]
+    public void OrderedRangeDropsKeyRolledBackToSavepoint()
+    {
+        var store = new MvStore();
+        var table = store.GetOrCreateTableId("t");
+        var tx = store.BeginTransaction();
+        store.Insert(tx.Id, new MvccRowId(table, 1), [SqlValue.Integer(1)]);
+
+        store.EnumerateVisible(tx.Id, table, MvccKeyComparer.Integer)
+            .Select(row => row.Key.Integer)
+            .Should()
+            .Equal(1L);
+
+        store.BeginNamedSavepoint(tx.Id, "s");
+        store.Insert(tx.Id, new MvccRowId(table, 2), [SqlValue.Integer(2)]);
+        store.RollbackToNamedSavepoint(tx.Id, "s");
+
+        store.EnumerateVisible(tx.Id, table, MvccKeyComparer.Integer)
+            .Select(row => row.Key.Integer)
+            .Should()
+            .Equal(1L);
     }
 }


### PR DESCRIPTION
## Summary

- replace eager concurrent table-snapshot materialization with a forward-only, two-peek base/version overlay cursor
- preserve signed rowid ordering and SQLite-aware composite primary-key ordering, including collation and sort direction
- maintain per-table ordered MVCC key indexes through recovery, writes, savepoints, rollback, checkpoint retirement, and GC
- make simple fixed-LIMIT scans consume and cache only the visible prefix, including avoiding read-only base-table clones
- add a process-shared checkpoint lease and explicit crash-ordered checkpoint phases without changing the durable WAL/main-file/log ordering
- keep concurrent DDL fail-closed while readers, writers, or checkpoints are active

The cursor and checkpoint orchestration are aligned with pinned Turso `v0.8.0-pre.7` (`277ddd050`), specifically:

- `turso-src/core/mvcc/cursor.rs`
- `turso-src/core/mvcc/database/checkpoint_state_machine.rs`

## Correctness and durability

The overlay consumes equal base/version keys together, lets visible updates shadow base rows, suppresses tombstones, and emits MVCC-only inserts in typed key order. Version selection remains under `MvStore`'s transaction snapshot rules, preserving own writes, first-committer-wins conflicts, logical-log publication, savepoints, low-water GC, and cold reopen.

Checkpoint ordering remains:

1. materialize committed MVCC state into WAL
2. backfill and sync the main database
3. retire and sync the logical log
4. reset WAL
5. garbage-collect versions

Fault-injection coverage now includes write, flush, log-retirement, and WAL-reset boundaries, plus shared-store admission and lease release after failure.

## Validation

- targeted MVCC suites: 72 passed on each of `net8.0`, `net9.0`, and `net10.0`
- canonical build: succeeded with zero warnings and errors
- full managed package/test gate: 6,401 passed on `net10.0`
- changed-file formatting and `git diff --check`: passed

The repository-wide format gate remains red on unrelated pre-existing whitespace in files outside this change, including `JoinProgramBuilder.cs` and `VdbeDmlFkEmissionTests.cs`.

## Residual MVCC work

This PR intentionally does **not** claim full Turso parity. Remaining follow-ups are:

- versioned `sqlite_schema` rows, snapshot-local schema/root bindings, and old-reader root retirement
- lazy persisted secondary-index MVCC cursors; current index plans remain materialized but snapshot-correct
- reader-concurrent checkpoints using WAL read marks/materialization positions
- pager-native per-page checkpoint mutation states; the existing catalog serializer remains the pager commit boundary

No native companion, reflection, trim suppression, `turso-src` edit, or conformance-corpus edit is introduced.