### PR TITLE
Harden managed replica recovery for ambiguous pushes

### DIFF
--- a/docs/replica-conflict-resolution.md
+++ b/docs/replica-conflict-resolution.md
@@ -107,7 +107,41 @@ assigned high-water mark is a header field the file's own length does not
 constrain, so a header implying an implausible gap span (or a saturated
 sequence) is rejected as corruption rather than walked.
 
-## 2. Recording a conflict
+## 2. Push outcome publication and conflict recording
+
+### Ambiguous push outcomes
+
+Every non-empty push now publishes an independent push-intent record before
+remote SQL can be sent. Metadata version 7 carries push intent without a
+checkpoint revert bundle; version 8 carries both. Versions 2–6 remain readable,
+and a version-6 `PushOutcomeUnknown` revert phase is projected into the same
+in-memory push intent for recovery.
+
+The local binary record is exact and integrity protected: version byte `1`,
+followed by the source pull generation, first journal sequence, and exclusive
+watermark as three little-endian signed 64-bit integers, followed by SHA-256 of
+that 25-byte payload. Bad base64, wrong length or version, checksum failure,
+negative generation, non-positive first sequence, a non-ascending watermark,
+trailing bytes, or disagreement with a legacy revert attempt fails closed while
+loading metadata, before network access or journal movement.
+
+Recovery queries the remote `turso_sync_last_change_id` row for the persisted
+client id before replaying SQL:
+
+- the same pull generation with `change_id` at or beyond the batch's last
+  sequence proves the whole batch committed and performs only local
+  acknowledgement;
+- no row, no table, or a watermark strictly before the batch permits one replay;
+- a watermark inside the batch, or a different pull generation in either
+  direction, is `InvalidLocalState` and preserves the intent and journal.
+
+The intent is cleared only after the journal acknowledgement is durable or the
+server has definitively rejected the batch. A transport error, cancellation, or
+process exit leaves the exact recovery range in metadata. Once remote commit or
+refusal is known, acknowledgement or conflict publication runs with
+`CancellationToken.None`.
+
+### Recording a definitive conflict
 
 `ManagedReplicaConnectionHost.PushLocalChangesAsync` catches any push failure
 that `AhtolaReplicaPushFailure.Classify` maps to
@@ -116,14 +150,16 @@ that `AhtolaReplicaPushFailure.Classify` maps to
 1. If a revert-WAL bundle was captured for this push, restores the exact
    pre-push database image (`ManagedReplicaRevertWal.RestorePendingCheckpoint`).
    The revert phase graph is unchanged; no new phase was added.
-2. Durably publishes the conflict marker for the exact batch that was rejected
+2. Durably retires the now-resolved push intent.
+3. Durably publishes the conflict marker for the exact batch that was rejected
    (`BatchFirstSequence`, `BatchWatermark`, the server-reported sequence, and
    the conservatively classified unresolved subset).
-3. Rethrows the original `AhtolaReplicaConflictException`.
+4. Rethrows the original `AhtolaReplicaConflictException`.
 
-A crash between (1) and (2) leaves **no** marker. That is safe: the journal was
-never acknowledged, so the next push re-attempts the same batch and re-observes
-the same conflict, and the ordinary revert-phase recovery handles the bundle
+A crash before (3) leaves **no** marker. That is safe: the journal was never
+acknowledged, so recovery either verifies the still-present intent or re-attempts
+the same batch after its retirement and re-observes the same definitive
+conflict. The ordinary revert-phase recovery handles a half-restored bundle
 exactly as it does today. Recording before restoring would instead risk blocking
 synchronization while the database is still mid-restore.
 
@@ -141,6 +177,13 @@ short name resolves to the same key as the canonical path) and is backed by an
 OS byte-range lock on a carrier file, so a second **process** serializes too.
 Explicit conflict resolution takes the same lease around its journal discard and
 marker retirement.
+
+A third physical-identity carrier (`push`) provides a dedicated cross-process
+push-flight lease. It is acquired before local batch selection and held across
+watermark verification and remote SQL replay. This closes the check-then-send
+race where two processes could both observe a pre-batch watermark and replay one
+non-idempotent batch. It excludes only another push; local commands, journal
+append, and unrelated apply work continue under their existing leases.
 
 `ManagedReplicaLockCarrier` names that carrier from the database's physical
 identity (volume/device plus file/inode id) inside one stable, per-user lock
@@ -168,17 +211,18 @@ where closing any descriptor for a file drops every lock the process holds on
 it. Lock order is always apply lease first, journal lease second — the journal
 lease is only ever taken as a leaf — so the two can never deadlock.
 
-The network round trips are deliberately **outside** the lease: holding a
-physical lock across unbounded remote I/O would let one stalled replica block
-every other participant indefinitely. Releasing it means local state can move
-underneath a push, so every re-acquisition re-validates the generation it was
-negotiated against — the metadata revision, the revert phase, and the journal's
-durable shape (`ReplicaJournalGeneration`: assigned sequence, acknowledgement
-watermark, retained count, discard count). A mismatch fails closed with
-`AhtolaReplicaPushFailureKind.InvalidLocalState` rather than persisting a stale
-in-memory journal over another writer's work. The single benign exception is
-"another participant already acknowledged at least this batch", which completes
-as a no-op and adopts the durable journal.
+The network round trips are deliberately **outside the apply and journal
+leases**. They remain inside the push-flight lease, which blocks no local
+publication. Local state can therefore move underneath a push, so every
+re-acquisition of the apply lease re-validates the generation it was negotiated
+against — the metadata revision, revert phase, independent push state, and the
+journal's durable shape (`ReplicaJournalGeneration`: assigned sequence,
+acknowledgement watermark, retained count, discard count). A mismatch fails
+closed with `AhtolaReplicaPushFailureKind.InvalidLocalState` rather than
+persisting a stale in-memory journal over another writer's work. Recovery then
+uses the durable intent and remote watermark. The single benign exception is
+"already acknowledged at least this batch", which completes as a no-op and
+adopts the durable journal.
 
 The acknowledgement and conflict-recording steps are deliberately uncancellable:
 by the time either runs, the remote has already committed or definitively
@@ -356,3 +400,12 @@ ownership and generation validation, cancellation at the publication boundary
 and after a durable discard, deterministic staging artifacts, publication reopen
 failure, crash points before metadata publication and before marker retirement,
 the page-protocol and schema-quarantine fail-closed paths, and artifact cleanup.
+
+`src/Ahtola.Tests/ManagedEmbeddedReplicaPushRecoveryTests.cs` covers ordinary
+lost-response recovery, intent-before-send ordering, remote-commit and
+acknowledgement interruptions, a journal append racing the remote commit,
+split/ahead/regressed watermarks, malformed v7/v8 records, legacy v6 projection,
+and cancellation on both sides of the remote-decision boundary.
+`ManagedReplicaJournalAndLockCarrierRegressionTests` additionally proves that
+the push carrier converges across hard-link aliases and excludes a real child
+process until release.

--- a/docs/turso-gap-analysis.md
+++ b/docs/turso-gap-analysis.md
@@ -948,15 +948,22 @@ The earlier behavioral gaps below are closed or reduced:
 ## 9. Sync / replication & provider surface
 The conformance suite exercises the local engine, not replication, so these
 gaps have little sqltest coverage. Ahtola.Data now has a pure-managed,
-pull-capable sync path: raw-page bootstrap/page protocol, MVCC `lml3` logical
+push/pull sync path: raw-page bootstrap/page protocol, MVCC `lml3` logical
 decode and transactional replay, opaque revision/protocol/table-map metadata,
-local-change push journaling, self-origin filtering, and atomic ReplaceBase
-fallback. It does not claim Turso's full native sync engine (query/lazy
-bootstrap, zstd page sets, remote encryption, or push-side automatic conflict
-resolution). Optional companion dispatch remains an intentional extension
-point and is not shipped by this repository.
+local-change push journaling, independent ambiguous-push recovery, self-origin
+filtering, partial/query bootstrap with lazy page faults, remote page encryption,
+typed conflict quarantine/resolution, and atomic ReplaceBase fallback. It does
+not claim Turso's full native sync engine: zstd page sets, the reusable
+passive-synced-prefix/history checkpoint policy, wait-for-changes, and full
+reference-server qualification remain residuals. Optional companion dispatch
+remains an intentional extension point and is not shipped by this repository.
 
-### 9.1 Managed Cloud replica support matrix (Turso v0.7.2)
+### 9.1 Managed Cloud replica support matrix
+
+The historical analysis baseline is Turso v0.7.2, but current sync behavior is
+audited against the read-only submodule pinned at **v0.8.0-pre.7**
+(`277ddd050`). Citations that explicitly name v0.7.2 remain historical baseline
+evidence; the submodule pointer is the source of truth for current parity work.
 
 This matrix applies only to the pure-managed `ManagedReplicaConnectionHost`
 fallback reached by `AhtolaConnection.CreateReplica`, not to an explicitly
@@ -978,6 +985,7 @@ while staged, before either the database or its replica metadata is published.
 | MVCC logical streams / `MvccLogical` protocol | **Qualified (pull-only)** | After raw bootstrap, the client requests `mvcc_logical_log`, validates the complete `lml3` body and CRC chain, replays header/schema/row operations in one transaction, filters this client's transactions, and advances metadata only after durable publication. Pending deletes use v4 journal before-images to rebase by declared primary key. Pending additive `ALTER TABLE ... ADD COLUMN` is rebased across remote refresh/row ops; legacy journals without a before-image and destructive schema changes fail closed until pushed. |
 | Protocol-2 page fallback | **Qualified for validated full replacement** | `Pages + ReplaceBase` checkpoints/removes safe sidecars and atomically installs every page, then replays still-unpushed journal SQL onto the snapshot before metadata publication. Incremental page fallback still requires a provably unchanged page base and rejects pending local changes or WAL divergence. |
 | Local divergence before an incremental pull | **Mode-aware** | Logical pulls precollect/reapply safe pending local rows. Page pulls reject pending journal entries or an unproven physical base. |
+| Ambiguous ordinary push outcome | **Qualified with remote watermark recovery** | Every non-empty batch durably publishes an integrity-protected `(pull generation, first sequence, exclusive watermark)` intent before SQL. A physical-identity push-flight lease serializes watermark-check plus replay across aliases and processes without holding apply/journal leases over network I/O. A covering `turso_sync_last_change_id` row acknowledges locally without replay; absent/strictly-behind state resends; split or different-generation state fails closed. |
 | Non-4 KiB Cloud page streams | **Unknown/deferred — rejected by the gate** | Turso v0.7.2's physical sync protocol uses `PAGE_SIZE = 4096` (`sync/engine/src/database_sync_operations.rs`); the managed decoder intentionally has the same fixed 4 KiB stream boundary. Ahtola's local SQLite engine can use other database page sizes, but that does not qualify them for Cloud replica streaming. |
 
 Turso v0.7.2 exposes the broader option surface in
@@ -997,11 +1005,11 @@ qualified subset in the matrix above.
 | `sync-ef-core-provider-no-sync-surface` | closed | s3-perf | M | 0 | 0 | `UseAhtola` accepts direct Turso/Hrana and `Replica Path` connection strings. EF queries, CRUD, migrations, creator operations, and transactions route through the remote/replica-capable SQLite facade; explicit sync remains on the underlying `SqliteConnection`. |
 | `sync-http-pipeline-v2-only-no-v3-websocket` | closed | s4-intentional | M | 0 | 0 | `http`/`https`/`libsql`/`turso` use the Hrana HTTP pipeline (v3 with v2 fallback); `ws`/`wss` open a persistent Hrana WebSocket connection with hrana3/hrana2/hrana1 subprotocol negotiation, request-id multiplexing, v3 cursor paging and bounded reconnect. Targets the legacy libSQL/sqld Hrana WS server — the pinned Turso engine has no native Hrana WS server and maps ws/wss to its HTTP endpoint. wal_push/pull_updates stay with the unported sync engine entries. |
 | `sync-native-provider-companion-intentional` | extension | s4-intentional | S | 0 | 0 | AhtolaNativeProvider's explicit `Register(factory)` hook for an optional 'Turso.Data.Native' companion (used for Local Provider=Native) exists purely as an extension point for… |
-| `sync-no-embedded-sync-engine-port` | partial | s2-capability | L | 0 | 0 | The managed provider now implements raw bootstrap/page pulls, partial prefix and server-side query selection with durable lazy page faults, pull-only MVCC logical replay, durable local push journaling, protocol metadata, and atomic publication. zstd, remote encryption, and Turso's complete conflict/checkpoint policy remain outside the managed subset. |
+| `sync-no-embedded-sync-engine-port` | partial | s2-capability | L | 0 | 0 | The managed provider now implements raw bootstrap/page pulls, partial prefix and server-side query selection with durable lazy page faults, remote page encryption, pull-only MVCC logical replay, durable local push journaling, independent watermark-based ambiguous-outcome recovery, typed conflict resolution, protocol metadata, and atomic publication. zstd, wait-for-changes, and Turso's reusable passive-prefix/history checkpoint policy remain outside the managed subset. |
 | `sync-no-mvcc-logical-log-replay` | closed | s2-capability | L | 0 | 0 | The managed pull path decodes Turso v0.7.2 portable `lml3` transactions, validates range/frame CRCs and bounds, replays header/schema/row changes atomically, persists protocol/table maps, filters client echoes, and compensates post-commit metadata failures. |
 | `sync-no-page-protocol-pull-decode` | partial | s2-capability | M | 0 | 0 | Raw 4-KiB page bootstrap/incremental streams and protocol-2 full ReplaceBase fallback are decoded and atomically published. Prefix and targeted missing-page selectors use Turso's portable RoaringBitmap page-selector protocol (tag 5); query bootstrap emits the tag-7 `server_query_selector` string alone on the one bootstrap request. zstd remains explicitly rejected. |
 | `sync-no-partial-sync-lazy-page-storage` | closed | s2-capability | L | 0 | 0 | Incomplete prefix and query-selected images publish only after their bootstrap marker, metadata, and integrity-protected page-state sidecar are durable. The sidecar stores arbitrary unordered/non-contiguous page sets as a run list, so worst-case scattered query selections cost one run per page. Pager reads coalesce targeted pulls pinned to the bootstrap revision, validate page identity and size before durable publication, support optional segment prefetch, persist across reopen, and use write-ahead mutation intents plus process-exclusive physical ownership. Tracked local changes are pushed before the pinned image is completed for ordinary revision-advancing sync. |
-| `sync-no-revert-db-checkpoint-safety` | partial | s1-correctness | L | 0 | 0 | Managed ReplaceBase checkpointing now durably publishes an integrity-checked `<db>-wal-revert` plus source-WAL watermark metadata before overwriting or truncating rollback-relevant frames. The sidecar contains both the exact pre-checkpoint bytes and the committed checkpoint image: interrupted publication resumes from the committed image, while only a typed push conflict restores the pre-checkpoint bytes. Missing/corrupt recovery state fails closed and pending journal entries remain durable. Turso's reusable passive-prefix/history checkpoint policy remains tracked by `sync-checkpoint-mode-mismatch-vs-managed-storage`. |
+| `sync-no-revert-db-checkpoint-safety` | partial | s1-correctness | L | 0 | 0 | Managed ReplaceBase checkpointing durably publishes an integrity-checked `<db>-wal-revert` plus source-WAL watermark metadata before overwriting or truncating rollback-relevant frames. Push ambiguity is now independent of that bundle: metadata v7/v8 records every ordinary or checkpoint-bound batch before transport, recovers from `turso_sync_last_change_id`, and clears only after durable acknowledgement or definitive conflict. The revert sidecar still contains both exact pre-checkpoint bytes and the committed checkpoint image: interrupted publication resumes from the committed image, while only a typed push conflict restores the pre-checkpoint bytes. Missing/corrupt recovery state fails closed. Turso's reusable passive-prefix/history checkpoint policy remains tracked by `sync-checkpoint-mode-mismatch-vs-managed-storage`. |
 | `sync-partial-encryption-mutual-exclusion-unenforced` | divergent | s1-correctness | S | 0 | 0 | Turso hard-errors when partial-sync + remote-encryption + MVCC-logical-pull are combined incompatibly. Ahtola's AhtolaReplicaOptions.Validate() checks PartialBootstrap/Bo… |
 | `sync-remote-encryption-header-not-wired-for-remote-client` | missing | s2-capability | S | 0 | 0 | AhtolaRemoteEncryptionOptions models the cipher/base64 key surface used to compute reserved-bytes for encrypted Turso Cloud databases (consumed by the not-yet-existing re… |
 | `sync-remote-execute-stream-only-two-request-kinds` | divergent | s4-intentional | S | 0 | 0 | Turso's own vendored server_proto.rs already restricts the Hrana-like pipeline to Execute and Batch stream kinds (no cursor/describe/sequence/store_sql variants seen in f… |
@@ -1029,11 +1037,42 @@ implementation order within those entries.
 | 8 | Project the replica journal through CDC | `sync-no-cdc-capture-pragma` | — | Public CDC can read the same ordered pending before/after images used for push without dual-writing or treating external CDC rows as trusted push input. |
 | 9 | Add rollback-journal OS locks | storage pager lock-state gap, `sync-checkpoint-mode-mismatch-vs-managed-storage` | — | DELETE mode exposes SQLite-compatible SHARED/RESERVED/PENDING/EXCLUSIVE main-file locks across processes on Windows and Unix. |
 | 10 | Hold locks across replica file replacement | `sync-checkpoint-mode-mismatch-vs-managed-storage` | Rollback-journal OS locks | Sidecar validation, checkpoint, main-file swap, and metadata publication execute under one exclusive lock with no check-then-act writer race. |
+| 11 | Recover every ambiguous push independently of checkpoint state | `sync-no-embedded-sync-engine-port`, `sync-no-revert-db-checkpoint-safety` | Remote push watermark | Intent is durable before transport; lost responses never replay a remotely covered batch; split/different-generation watermarks fail closed; aliases and processes share one push flight. **Completed.** |
 
 zstd decompression is intentionally not a separate parity item at the pinned
 Turso v0.7.2 baseline: `database_sync_operations.rs::decode_page` also rejects
 zstd page sets. Explicit raw negotiation closes the interoperability hazard
 without introducing a compression dependency into the shipped managed closure.
+
+### 9.3 Ambiguous-push acceptance boundary
+
+The managed claim is deliberately exact:
+
+1. A non-empty batch cannot reach remote SQL before metadata durably names its
+   source pull generation, first sequence, and exclusive watermark.
+2. The local record is versioned, length/range checked, SHA-256 protected, and
+   backward compatible with metadata versions 2–6. Corruption or disagreement
+   between v8 push and legacy revert ranges fails before network access.
+3. One physical database identity has one push-flight carrier across aliases
+   and processes. Apply and journal leases are never held over remote I/O.
+4. Recovery always reads `turso_sync_last_change_id` before replay. A covered
+   batch is acknowledged locally; no/strictly-behind state may resend; split,
+   regressed, or ahead state sends nothing and preserves evidence.
+5. Journal acknowledgement precedes metadata intent retirement. A crash at
+   either durable boundary converges on restart without duplicate SQL or lost
+   concurrently appended entries.
+6. Cancellation before intent publication has no durable consequence.
+   Cancellation after intent publication preserves recovery evidence, and after
+   a definitive remote outcome cannot interrupt local acknowledgement/conflict
+   publication.
+7. Fake-server tests assert replay counts, fault-injection tests interrupt every
+   durable publication boundary, and a child-process test proves OS-level
+   exclusion and release.
+
+This closure does not add zstd or any native asset/dependency. Residual sync
+work remains the passive synced-prefix/history checkpoint policy,
+wait-for-changes, broader reference-server interoperability, and intentionally
+unsupported MVCC-logical plus remote-encryption/partial combinations.
 
 
 ## 10. Top-impact ranking and suggested closure order

--- a/src/Ahtola.Data/ManagedReplicaApplyLock.cs
+++ b/src/Ahtola.Data/ManagedReplicaApplyLock.cs
@@ -49,6 +49,9 @@ internal static class ManagedReplicaLockCarrier
     /// <summary>Carrier kind for the change-journal append/persist lease.</summary>
     internal const string JournalKind = "journal";
 
+    /// <summary>Carrier kind for the cross-process remote push flight.</summary>
+    internal const string PushKind = "push";
+
     /// <summary>
     /// Resolves and creates the carrier file for <paramref name="databasePath"/>, failing closed
     /// when the physical identity behind the path cannot be proven.
@@ -331,6 +334,64 @@ internal static class ManagedReplicaJournalLock
         {
             Interlocked.Exchange(ref _carrierLease, null)?.Dispose();
             Interlocked.Exchange(ref _gate, null)?.Release();
+        }
+    }
+}
+
+/// <summary>
+/// Serializes remote push flights for one physical replica across aliases and processes.
+/// </summary>
+/// <remarks>
+/// The apply and journal leases remain short and are never held across network I/O. This separate
+/// lease spans watermark verification and SQL replay so two processes cannot both observe the same
+/// pre-batch watermark and replay one non-idempotent batch concurrently. It excludes only another
+/// push flight; local commands and unrelated apply work continue to use their existing leases.
+/// </remarks>
+internal static class ManagedReplicaPushLock
+{
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> Gates =
+        new(StringComparer.Ordinal);
+
+    internal static async ValueTask<IAsyncDisposable> AcquireExclusiveAsync(
+        string databasePath,
+        CancellationToken cancellationToken)
+    {
+        var carrierPath = ManagedReplicaLockCarrier.Ensure(
+            databasePath,
+            ManagedReplicaLockCarrier.PushKind);
+        var gate = Gates.GetOrAdd(carrierPath, static _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        SqliteWalByteRangeLockLease? carrierLease = null;
+        try
+        {
+            carrierLease = new SqliteWalByteRangeLock(carrierPath).AcquireExclusive(
+                offset: 0,
+                length: 1,
+                Timeout.InfiniteTimeSpan,
+                cancellationToken);
+            return new Lease(gate, carrierLease);
+        }
+        catch
+        {
+            carrierLease?.Dispose();
+            gate.Release();
+            throw;
+        }
+    }
+
+    private sealed class Lease(
+        SemaphoreSlim gate,
+        SqliteWalByteRangeLockLease carrierLease) : IAsyncDisposable
+    {
+        private SemaphoreSlim? _gate = gate;
+        private SqliteWalByteRangeLockLease? _carrierLease = carrierLease;
+
+        public ValueTask DisposeAsync()
+        {
+            Interlocked.Exchange(ref _carrierLease, null)?.Dispose();
+            Interlocked.Exchange(ref _gate, null)?.Release();
+            return ValueTask.CompletedTask;
         }
     }
 }

--- a/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
+++ b/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
@@ -311,6 +311,8 @@ internal static class ManagedReplicaBootstrapper
             "4" => LoadV4Metadata(values),
             "5" => LoadV5Metadata(values),
             "6" => LoadV6Metadata(values),
+            "7" => LoadV7Metadata(values),
+            "8" => LoadV8Metadata(values),
             _ => throw new InvalidDataException($"Managed embedded replica metadata has an unsupported version '{version}'."),
         };
     }
@@ -365,28 +367,17 @@ internal static class ManagedReplicaBootstrapper
             values,
             expectedFieldCount: 6,
             revertState: null,
+            pushState: null,
             journalBaseWatermark: 1,
             remoteBaseSha256: null);
 
     private static ManagedReplicaMetadata LoadV4Metadata(Dictionary<string, string> values)
     {
-        if (!values.TryGetValue("revert_state_base64", out var revertStateEncoded))
-            throw new InvalidDataException("Managed embedded replica metadata is incomplete.");
-
-        ManagedReplicaRevertState revertState;
-        try
-        {
-            revertState = DecodeRevertState(Convert.FromBase64String(revertStateEncoded));
-        }
-        catch (FormatException exception)
-        {
-            throw new InvalidDataException("Managed embedded replica metadata is invalid.", exception);
-        }
-
         return LoadCurrentMetadata(
             values,
             expectedFieldCount: 8,
-            revertState,
+            DecodeRevertStateField(values),
+            pushState: null,
             journalBaseWatermark: 1,
             remoteBaseSha256: null);
     }
@@ -396,28 +387,55 @@ internal static class ManagedReplicaBootstrapper
             values,
             expectedFieldCount: 8,
             revertState: null,
+            pushState: null,
             DecodeJournalBaseWatermark(values),
             DecodeRemoteBaseSha256(values));
 
     private static ManagedReplicaMetadata LoadV6Metadata(Dictionary<string, string> values)
     {
-        if (!values.TryGetValue("revert_state_base64", out var revertStateEncoded))
-            throw new InvalidDataException("Managed embedded replica metadata is incomplete.");
-
-        ManagedReplicaRevertState revertState;
-        try
-        {
-            revertState = DecodeRevertState(Convert.FromBase64String(revertStateEncoded));
-        }
-        catch (FormatException exception)
-        {
-            throw new InvalidDataException("Managed embedded replica metadata is invalid.", exception);
-        }
+        var revertState = DecodeRevertStateField(values);
+        ManagedReplicaPushState? pushState = revertState.Phase == ManagedReplicaRevertPhase.PushOutcomeUnknown
+            ? new ManagedReplicaPushState(
+                0,
+                revertState.AttemptedFirstSequence,
+                revertState.AttemptedWatermark)
+            : null;
 
         return LoadCurrentMetadata(
             values,
             expectedFieldCount: 9,
             revertState,
+            pushState,
+            DecodeJournalBaseWatermark(values),
+            DecodeRemoteBaseSha256(values));
+    }
+
+    private static ManagedReplicaMetadata LoadV7Metadata(Dictionary<string, string> values)
+        => LoadCurrentMetadata(
+            values,
+            expectedFieldCount: 9,
+            revertState: null,
+            DecodePushStateField(values),
+            DecodeJournalBaseWatermark(values),
+            DecodeRemoteBaseSha256(values));
+
+    private static ManagedReplicaMetadata LoadV8Metadata(Dictionary<string, string> values)
+    {
+        var revertState = DecodeRevertStateField(values);
+        var pushState = DecodePushStateField(values);
+        if (revertState.Phase == ManagedReplicaRevertPhase.PushOutcomeUnknown
+            && (revertState.AttemptedFirstSequence != pushState.FirstSequence
+                || revertState.AttemptedWatermark != pushState.Watermark))
+        {
+            throw new InvalidDataException(
+                "Managed embedded replica metadata contains inconsistent push recovery state.");
+        }
+
+        return LoadCurrentMetadata(
+            values,
+            expectedFieldCount: 10,
+            revertState,
+            pushState,
             DecodeJournalBaseWatermark(values),
             DecodeRemoteBaseSha256(values));
     }
@@ -426,6 +444,7 @@ internal static class ManagedReplicaBootstrapper
         Dictionary<string, string> values,
         int expectedFieldCount,
         ManagedReplicaRevertState? revertState,
+        ManagedReplicaPushState? pushState,
         long journalBaseWatermark,
         string? remoteBaseSha256)
     {
@@ -466,9 +485,42 @@ internal static class ManagedReplicaBootstrapper
             tableMap)
         {
             RevertState = revertState,
+            PushState = pushState,
             JournalBaseWatermark = journalBaseWatermark,
             RemoteBaseSha256 = remoteBaseSha256 ?? validatedFingerprint,
         };
+    }
+
+    private static ManagedReplicaRevertState DecodeRevertStateField(
+        IReadOnlyDictionary<string, string> values)
+    {
+        if (!values.TryGetValue("revert_state_base64", out var encoded))
+            throw new InvalidDataException("Managed embedded replica metadata is incomplete.");
+
+        try
+        {
+            return DecodeRevertState(Convert.FromBase64String(encoded));
+        }
+        catch (FormatException exception)
+        {
+            throw new InvalidDataException("Managed embedded replica metadata is invalid.", exception);
+        }
+    }
+
+    private static ManagedReplicaPushState DecodePushStateField(
+        IReadOnlyDictionary<string, string> values)
+    {
+        if (!values.TryGetValue("push_state_base64", out var encoded))
+            throw new InvalidDataException("Managed embedded replica metadata is incomplete.");
+
+        try
+        {
+            return DecodePushState(Convert.FromBase64String(encoded));
+        }
+        catch (FormatException exception)
+        {
+            throw new InvalidDataException("Managed embedded replica metadata is invalid.", exception);
+        }
     }
 
     private static long DecodeJournalBaseWatermark(IReadOnlyDictionary<string, string> values)
@@ -700,6 +752,40 @@ internal static class ManagedReplicaBootstrapper
             originalDatabaseSha256,
             committedDatabaseSha256,
             revertWalSha256);
+    }
+
+    private static byte[] EncodePushState(ManagedReplicaPushState state)
+    {
+        using var buffer = new MemoryStream();
+        using var writer = new BinaryWriter(buffer, Encoding.UTF8, leaveOpen: true);
+        writer.Write((byte)1);
+        writer.Write(state.SourcePullGeneration);
+        writer.Write(state.FirstSequence);
+        writer.Write(state.Watermark);
+        writer.Flush();
+        writer.Write(SHA256.HashData(buffer.GetBuffer().AsSpan(0, checked((int)buffer.Length))));
+        return buffer.ToArray();
+    }
+
+    private static ManagedReplicaPushState DecodePushState(byte[] bytes)
+    {
+        const int payloadLength = 1 + (3 * sizeof(long));
+        const int encodedLength = payloadLength + 32;
+        if (bytes.Length != encodedLength || bytes[0] != 1)
+            throw new InvalidDataException("Managed embedded replica push state is malformed.");
+        if (!CryptographicOperations.FixedTimeEquals(
+                SHA256.HashData(bytes.AsSpan(0, payloadLength)),
+                bytes.AsSpan(payloadLength)))
+        {
+            throw new InvalidDataException("Managed embedded replica push state failed its integrity check.");
+        }
+
+        var sourcePullGeneration = BinaryPrimitives.ReadInt64LittleEndian(bytes.AsSpan(1));
+        var firstSequence = BinaryPrimitives.ReadInt64LittleEndian(bytes.AsSpan(1 + sizeof(long)));
+        var watermark = BinaryPrimitives.ReadInt64LittleEndian(bytes.AsSpan(1 + (2 * sizeof(long))));
+        if (sourcePullGeneration < 0 || firstSequence <= 0 || watermark <= firstSequence)
+            throw new InvalidDataException("Managed embedded replica push state is invalid.");
+        return new ManagedReplicaPushState(sourcePullGeneration, firstSequence, watermark);
     }
 
     public static Task<AhtolaSyncResult> CheckForUpdatesAsync(
@@ -1724,6 +1810,7 @@ internal static class ManagedReplicaBootstrapper
 
         metadata = ManagedReplicaRevertWal.PrepareSynchronization(options.Path, metadata);
         var pendingRevert = metadata.RevertState.HasValue;
+        var pendingPush = metadata.PushState.HasValue;
         var metadataPath = options.Path + MetadataSuffix;
         var directory = Path.GetDirectoryName(Path.GetFullPath(metadataPath))!;
         var stagingPath = Path.Combine(
@@ -1767,7 +1854,10 @@ internal static class ManagedReplicaBootstrapper
             {
                 DatabaseSha256 = fingerprint,
                 RevertState = null,
+                PushState = null,
             };
+            if (pendingPush)
+                ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.ReplicaPushIntentRetired);
             if (pendingRevert)
             {
                 ManagedReplicaRevertWal.Retire(options.Path);
@@ -2498,6 +2588,7 @@ internal static class ManagedReplicaBootstrapper
         bool replaceExisting = false,
         string? clientId = null,
         ManagedReplicaRevertState? revertState = null,
+        ManagedReplicaPushState? pushState = null,
         long journalBaseWatermark = 1,
         string? remoteBaseSha256 = null)
     {
@@ -2508,6 +2599,7 @@ internal static class ManagedReplicaBootstrapper
             tableNamesByStableId,
             clientId ?? Guid.NewGuid().ToString("N"),
             revertState,
+            pushState,
             journalBaseWatermark,
             remoteBaseSha256 ?? fingerprint);
         await using (var stream = new FileStream(
@@ -2532,8 +2624,7 @@ internal static class ManagedReplicaBootstrapper
     internal static void WriteMetadata(
         string stagingPath,
         string metadataPath,
-        ManagedReplicaMetadata metadata,
-        ManagedReplicaRevertState? revertState)
+        ManagedReplicaMetadata metadata)
     {
         var bytes = CreateMetadataBytes(
             metadata.Revision,
@@ -2541,7 +2632,8 @@ internal static class ManagedReplicaBootstrapper
             metadata.Protocol,
             metadata.TableNamesByStableId,
             metadata.ClientId,
-            revertState,
+            metadata.RevertState,
+            metadata.PushState,
             metadata.JournalBaseWatermark,
             metadata.RemoteBaseSha256);
         using (var stream = new FileStream(
@@ -2570,6 +2662,7 @@ internal static class ManagedReplicaBootstrapper
         IReadOnlyDictionary<ulong, string> tableNamesByStableId,
         string clientId,
         ManagedReplicaRevertState? revertState,
+        ManagedReplicaPushState? pushState,
         long journalBaseWatermark,
         string remoteBaseSha256)
     {
@@ -2580,8 +2673,15 @@ internal static class ManagedReplicaBootstrapper
             RemotePullProtocol.MvccLogical => "mvcc_logical",
             _ => throw new ArgumentOutOfRangeException(nameof(protocol), protocol, "Unknown remote pull protocol."),
         };
+        var version = (revertState.HasValue, pushState.HasValue) switch
+        {
+            (false, false) => 5,
+            (true, false) => 6,
+            (false, true) => 7,
+            (true, true) => 8,
+        };
         var metadata = string.Concat(
-            revertState is null ? "version=5\n" : "version=6\n",
+            "version=", version.ToString(CultureInfo.InvariantCulture), "\n",
             "server_revision_base64=", Convert.ToBase64String(StrictUtf8.GetBytes(revision)), "\n",
             "database_sha256=", fingerprint, "\n",
             "client_id=", clientId, "\n",
@@ -2591,6 +2691,9 @@ internal static class ManagedReplicaBootstrapper
             "remote_base_sha256=", remoteBaseSha256, "\n",
             revertState is { } value
                 ? string.Concat("revert_state_base64=", Convert.ToBase64String(EncodeRevertState(value)), "\n")
+                : string.Empty,
+            pushState is { } push
+                ? string.Concat("push_state_base64=", Convert.ToBase64String(EncodePushState(push)), "\n")
                 : string.Empty);
         return Encoding.UTF8.GetBytes(metadata);
     }
@@ -3469,7 +3572,12 @@ internal static class ManagedReplicaBootstrapper
 
     private static IEnumerable<string> GetLockCarrierPaths(string databasePath)
     {
-        foreach (var kind in new[] { ManagedReplicaLockCarrier.ApplyKind, ManagedReplicaLockCarrier.JournalKind })
+        foreach (var kind in new[]
+                 {
+                     ManagedReplicaLockCarrier.ApplyKind,
+                     ManagedReplicaLockCarrier.JournalKind,
+                     ManagedReplicaLockCarrier.PushKind,
+                 })
         {
             if (ManagedReplicaLockCarrier.TryResolve(databasePath, kind) is { } carrier)
                 yield return carrier;
@@ -3650,8 +3758,8 @@ internal static class ManagedReplicaBootstrapper
     /// resume token echoed back verbatim on the next pull request; it is never parsed or
     /// interpreted. <see cref="Protocol"/> is the detected remote sync capability, and
     /// <see cref="TableNamesByStableId"/> is the persisted portable table-id-to-name map used to
-    /// resolve logical row operations that omit an explicit table name. Version 4 metadata also
-    /// carries an internal pending checkpoint-revert marker until publication completes.
+    /// resolve logical row operations that omit an explicit table name. Current metadata may also
+    /// carry independent checkpoint-revert and ambiguous-push recovery records.
     /// </summary>
     public readonly record struct ManagedReplicaMetadata(
         string Revision,
@@ -3661,6 +3769,8 @@ internal static class ManagedReplicaBootstrapper
         IReadOnlyDictionary<ulong, string> TableNamesByStableId)
     {
         internal ManagedReplicaRevertState? RevertState { get; init; }
+
+        internal ManagedReplicaPushState? PushState { get; init; }
 
         internal long JournalBaseWatermark { get; init; } = 1;
 
@@ -3908,6 +4018,12 @@ internal static class ManagedReplicaBootstrapper
         string OriginalDatabaseSha256,
         string CommittedDatabaseSha256,
         string RevertWalSha256);
+
+    internal readonly record struct ManagedReplicaPushState(
+        long SourcePullGeneration,
+        long FirstSequence,
+        long Watermark);
+
     private enum PullStreamKind
     {
         Pages = 0,

--- a/src/Ahtola.Data/ManagedReplicaConnectionHost.cs
+++ b/src/Ahtola.Data/ManagedReplicaConnectionHost.cs
@@ -1049,6 +1049,12 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
         ManagedReplicaPageMaterializingFileSystem? retainedMaterializer,
         CancellationToken cancellationToken)
     {
+        await using var pushFlight = await ManagedReplicaPushLock
+            .AcquireExclusiveAsync(replicaOptions.Path, cancellationToken)
+            .ConfigureAwait(false);
+        ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.ReplicaPushFlightLockAcquired);
+        cancellationToken.ThrowIfCancellationRequested();
+
         // Every step below that mutates durable local state -- selecting the batch, publishing the
         // push intent, restoring the pre-push image, acknowledging the journal, and publishing the
         // conflict marker -- runs while the exclusive physical apply lease is held (see
@@ -1068,14 +1074,19 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
         {
             ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.ReplicaPushPublicationLockAcquired);
             cancellationToken.ThrowIfCancellationRequested();
-            recoveringUnknownPush = metadata.RevertState is
-            {
-                Phase: ManagedReplicaBootstrapper.ManagedReplicaRevertPhase.PushOutcomeUnknown,
-            };
+            ThrowIfReplicaConflictIsPending(replicaOptions.Path);
+            metadata = ManagedReplicaBootstrapper.LoadMetadata(replicaOptions.Path)
+                ?? throw new AhtolaException(
+                    "Managed embedded replica metadata was removed before a push could begin.",
+                    AhtolaReplicaPushFailureKind.InvalidLocalState);
+            metadata = ManagedReplicaRevertWal.PrepareSynchronization(replicaOptions.Path, metadata);
+            _metadata = metadata;
+            _changeJournal = ManagedReplicaChangeJournal.Open(replicaOptions.Path);
+            recoveringUnknownPush = metadata.PushState.HasValue;
             if (recoveringUnknownPush)
             {
-                var state = metadata.RevertState!.Value;
-                batch = _changeJournal.ReadBatch(state.AttemptedFirstSequence, state.AttemptedWatermark);
+                var state = metadata.PushState!.Value;
+                batch = _changeJournal.ReadBatch(state.FirstSequence, state.Watermark);
             }
             else
             {
@@ -1106,6 +1117,7 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
         var generation = new PushPublicationGeneration(
             selectionMetadata.Revision,
             selectionMetadata.RevertState?.Phase,
+            selectionMetadata.PushState,
             _changeJournal.Generation);
 
         syncOptions.Progress?.Report(new AhtolaSyncProgress(AhtolaSyncProgressStage.Pushing));
@@ -1119,24 +1131,25 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
             disposeHttpClient: false,
             automaticRedirectsDisabled: true);
 
-        const long sourcePullGeneration = 0;
+        var sourcePullGeneration = selectionMetadata.PushState?.SourcePullGeneration ?? 0;
         if (recoveringUnknownPush)
         {
             var remoteWatermark = await remote.ReadReplicaPushWatermarkAsync(
-                    metadata.ClientId,
+                    selectionMetadata.ClientId,
                     ToCommandTimeoutSeconds(replicaOptions.HttpPolicy.RequestTimeout),
                     cancellationToken)
                 .ConfigureAwait(false);
             if (remoteWatermark is { } watermark)
             {
-                if (watermark.PullGeneration > sourcePullGeneration)
+                if (watermark.PullGeneration != sourcePullGeneration)
                 {
                     throw new AhtolaException(
-                        "Remote replica push acknowledgement is ahead of the local pull generation.",
+                        watermark.PullGeneration > sourcePullGeneration
+                            ? "Remote replica push acknowledgement is ahead of the local pull generation."
+                            : "Remote replica push acknowledgement regressed behind the local pull generation.",
                         AhtolaReplicaPushFailureKind.InvalidLocalState);
                 }
-                if (watermark.PullGeneration == sourcePullGeneration
-                    && watermark.ChangeId >= batch.Changes[^1].Sequence)
+                if (watermark.ChangeId >= batch.Changes[^1].Sequence)
                 {
                     return await PublishPushAcknowledgementAsync(
                             replicaOptions,
@@ -1145,8 +1158,7 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
                             retainedMaterializer)
                         .ConfigureAwait(false);
                 }
-                if (watermark.PullGeneration == sourcePullGeneration
-                    && watermark.ChangeId >= batch.FirstSequence)
+                if (watermark.ChangeId >= batch.FirstSequence)
                 {
                     throw new AhtolaException(
                         "Remote replica push acknowledgement splits the pending local batch.",
@@ -1162,9 +1174,17 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
             ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.ReplicaPushPublicationLockAcquired);
             cancellationToken.ThrowIfCancellationRequested();
             metadata = ValidatePushPublicationGeneration(replicaOptions.Path, generation, batch);
-            metadata = ManagedReplicaRevertWal.MarkPushStarted(replicaOptions.Path, metadata, batch);
+            metadata = ManagedReplicaRevertWal.MarkPushStarted(
+                replicaOptions.Path,
+                metadata,
+                batch,
+                sourcePullGeneration);
             _metadata = metadata;
-            generation = generation with { RevertPhase = metadata.RevertState?.Phase };
+            generation = generation with
+            {
+                RevertPhase = metadata.RevertState?.Phase,
+                PushState = metadata.PushState,
+            };
         }
 
         try
@@ -1176,6 +1196,7 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
                     ToCommandTimeoutSeconds(replicaOptions.HttpPolicy.RequestTimeout),
                     cancellationToken)
                 .ConfigureAwait(false);
+            ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.ReplicaPushRemoteCommitObserved);
         }
         catch (Exception exception) when (
             AhtolaReplicaPushFailure.Classify(exception) == AhtolaReplicaPushFailureKind.Conflict)
@@ -1213,6 +1234,12 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
                     _metadata = ManagedReplicaBootstrapper.LoadMetadata(replicaOptions.Path);
                 }
 
+                current = ManagedReplicaBootstrapper.LoadMetadata(replicaOptions.Path)
+                    ?? throw new AhtolaException(
+                        "Managed embedded replica metadata was removed while recording a push conflict.",
+                        AhtolaReplicaPushFailureKind.InvalidLocalState);
+                current = ManagedReplicaRevertWal.ClearPushIntent(replicaOptions.Path, current);
+                _metadata = current;
                 RecordPushConflict(replicaOptions.Path, batch, exception);
             }
 
@@ -1235,6 +1262,7 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
     private readonly record struct PushPublicationGeneration(
         string Revision,
         ManagedReplicaBootstrapper.ManagedReplicaRevertPhase? RevertPhase,
+        ManagedReplicaBootstrapper.ManagedReplicaPushState? PushState,
         ReplicaJournalGeneration Journal);
 
     /// <summary>
@@ -1325,6 +1353,7 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
         var durable = ManagedReplicaChangeJournal.Open(databasePath);
         if (!string.Equals(current.Revision, generation.Revision, StringComparison.Ordinal)
             || current.RevertState?.Phase != generation.RevertPhase
+            || current.PushState != generation.PushState
             || durable.Generation != generation.Journal)
         {
             throw new AhtolaException(

--- a/src/Ahtola.Data/ManagedReplicaFaultInjection.cs
+++ b/src/Ahtola.Data/ManagedReplicaFaultInjection.cs
@@ -45,6 +45,30 @@ internal enum ManagedReplicaDurableBoundary
     ReplicaPushPublicationLockAcquired,
 
     /// <summary>
+    /// Hit after the physical-identity push-flight lease has excluded every competing process,
+    /// before local state is selected or any remote request is made.
+    /// </summary>
+    ReplicaPushFlightLockAcquired,
+
+    /// <summary>
+    /// Hit immediately after metadata durably records the exact pending batch and source pull
+    /// generation, before watermark verification or remote SQL replay.
+    /// </summary>
+    ReplicaPushIntentPublished,
+
+    /// <summary>
+    /// Hit after the remote push transaction returned success, before uncancellable local
+    /// acknowledgement publication begins.
+    /// </summary>
+    ReplicaPushRemoteCommitObserved,
+
+    /// <summary>
+    /// Hit after metadata durably retires a push intent following acknowledgement or a definitive
+    /// conflict.
+    /// </summary>
+    ReplicaPushIntentRetired,
+
+    /// <summary>
     /// Hit immediately after the exclusive physical apply lease is acquired for an explicit
     /// conflict resolution's local publication (journal discard and marker retirement), before any
     /// irreversible work.
@@ -135,7 +159,6 @@ internal enum ManagedReplicaDurableBoundary
     RevertCommittedRestoreStagedDatabase,
     RevertCommittedRestoreDatabasePublished,
     RevertCommittedReadyMetadataPublished,
-    RevertPushIntentPublished,
     RevertConflictRestoreIntentPublished,
     RevertRestoreStagedDatabase,
     RevertRestoreDatabasePublished,

--- a/src/Ahtola.Data/ManagedReplicaRevertWal.cs
+++ b/src/Ahtola.Data/ManagedReplicaRevertWal.cs
@@ -39,8 +39,7 @@ internal static class ManagedReplicaRevertWal
                         ManagedReplicaBootstrapper.WriteMetadata(
                             metadataStagingPath,
                             databasePath + ManagedReplicaBootstrapper.MetadataSuffix,
-                            metadata,
-                            state);
+                            metadata with { RevertState = state });
                     }
                     finally
                     {
@@ -193,47 +192,68 @@ internal static class ManagedReplicaRevertWal
     internal static ManagedReplicaBootstrapper.ManagedReplicaMetadata MarkPushStarted(
         string databasePath,
         ManagedReplicaBootstrapper.ManagedReplicaMetadata metadata,
-        ReplicaLocalChangeBatch batch)
+        ReplicaLocalChangeBatch batch,
+        long sourcePullGeneration)
     {
         ArgumentException.ThrowIfNullOrEmpty(databasePath);
         if (batch.Changes.Count == 0
             || batch.FirstSequence <= 0
-            || batch.Watermark <= batch.FirstSequence)
+            || batch.Watermark <= batch.FirstSequence
+            || sourcePullGeneration < 0)
         {
             throw new ArgumentException("The protected replica push batch is empty or invalid.", nameof(batch));
         }
-        if (metadata.RevertState is not { } state)
-            return metadata;
-        _ = ReadAndValidate(databasePath, state);
-        if (state.Phase == ManagedReplicaBootstrapper.ManagedReplicaRevertPhase.PushOutcomeUnknown)
+
+        var pushState = new ManagedReplicaBootstrapper.ManagedReplicaPushState(
+            sourcePullGeneration,
+            batch.FirstSequence,
+            batch.Watermark);
+        if (metadata.PushState is { } existing)
         {
-            if (state.AttemptedFirstSequence != batch.FirstSequence
-                || state.AttemptedWatermark != batch.Watermark)
+            if (existing != pushState)
             {
                 throw new InvalidDataException(
-                    "Managed embedded replica checkpoint recovery references a different protected push batch.");
+                    "Managed embedded replica push recovery references a different protected batch.");
             }
-            ValidateCommittedReady(databasePath, state);
+
+            if (metadata.RevertState is { } protectedState)
+            {
+                _ = ReadAndValidate(databasePath, protectedState);
+                ValidateCommittedReady(databasePath, protectedState);
+            }
             return metadata;
         }
-        if (state.Phase != ManagedReplicaBootstrapper.ManagedReplicaRevertPhase.CommittedReady)
+
+        if (metadata.RevertState is { } state)
         {
-            throw new InvalidOperationException(
-                "Managed embedded replica checkpoint recovery is not ready to push local changes.");
+            _ = ReadAndValidate(databasePath, state);
+            if (state.Phase is not (
+                    ManagedReplicaBootstrapper.ManagedReplicaRevertPhase.CommittedReady
+                    or ManagedReplicaBootstrapper.ManagedReplicaRevertPhase.PushOutcomeUnknown))
+            {
+                throw new InvalidOperationException(
+                    "Managed embedded replica checkpoint recovery is not ready to push local changes.");
+            }
+            ValidateCommittedReady(databasePath, state);
         }
 
-        ValidateCommittedReady(databasePath, state);
-        var updated = metadata with
-        {
-            RevertState = state with
-            {
-                Phase = ManagedReplicaBootstrapper.ManagedReplicaRevertPhase.PushOutcomeUnknown,
-                AttemptedFirstSequence = batch.FirstSequence,
-                AttemptedWatermark = batch.Watermark,
-            },
-        };
+        var updated = metadata with { PushState = pushState };
         WritePhaseMetadata(databasePath, updated);
-        ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.RevertPushIntentPublished);
+        ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.ReplicaPushIntentPublished);
+        return updated;
+    }
+
+    internal static ManagedReplicaBootstrapper.ManagedReplicaMetadata ClearPushIntent(
+        string databasePath,
+        ManagedReplicaBootstrapper.ManagedReplicaMetadata metadata)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(databasePath);
+        if (metadata.PushState is null)
+            return metadata;
+
+        var updated = metadata with { PushState = null };
+        WritePhaseMetadata(databasePath, updated);
+        ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.ReplicaPushIntentRetired);
         return updated;
     }
 
@@ -748,8 +768,7 @@ internal static class ManagedReplicaRevertWal
             ManagedReplicaBootstrapper.WriteMetadata(
                 metadataStagingPath,
                 databasePath + ManagedReplicaBootstrapper.MetadataSuffix,
-                metadata with { DatabaseSha256 = databaseSha256, RevertState = null },
-                revertState: null);
+                metadata with { DatabaseSha256 = databaseSha256, RevertState = null });
         }
         finally
         {
@@ -794,8 +813,7 @@ internal static class ManagedReplicaRevertWal
             ManagedReplicaBootstrapper.WriteMetadata(
                 metadataStagingPath,
                 databasePath + ManagedReplicaBootstrapper.MetadataSuffix,
-                updated,
-                updated.RevertState);
+                updated);
         }
         finally
         {

--- a/src/Ahtola.Tests/ManagedEmbeddedReplicaConnectionTests.cs
+++ b/src/Ahtola.Tests/ManagedEmbeddedReplicaConnectionTests.cs
@@ -37,7 +37,6 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
     private const int RevertCommittedRestoreStagedDatabaseBoundary = (int)ManagedReplicaDurableBoundary.RevertCommittedRestoreStagedDatabase;
     private const int RevertCommittedRestoreDatabasePublishedBoundary = (int)ManagedReplicaDurableBoundary.RevertCommittedRestoreDatabasePublished;
     private const int RevertCommittedReadyMetadataPublishedBoundary = (int)ManagedReplicaDurableBoundary.RevertCommittedReadyMetadataPublished;
-    private const int RevertPushIntentPublishedBoundary = (int)ManagedReplicaDurableBoundary.RevertPushIntentPublished;
     private const int RevertConflictRestoreIntentPublishedBoundary = (int)ManagedReplicaDurableBoundary.RevertConflictRestoreIntentPublished;
     private const int RevertRestoreStagedDatabaseBoundary = (int)ManagedReplicaDurableBoundary.RevertRestoreStagedDatabase;
     private const int RevertRestoreDatabasePublishedBoundary = (int)ManagedReplicaDurableBoundary.RevertRestoreDatabasePublished;
@@ -2610,7 +2609,7 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
             connection.Open();
             using (ManagedReplicaFaultInjection.Push(point =>
                    {
-                       if (point == ManagedReplicaDurableBoundary.RevertPushIntentPublished)
+                       if (point == ManagedReplicaDurableBoundary.ReplicaPushIntentPublished)
                            throw new InvalidOperationException("Injected push-intent interruption.");
                    }))
             {
@@ -2618,8 +2617,10 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
                     () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
             }
 
-            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.RevertState!.Value.Phase.Should()
-                .Be(ManagedReplicaBootstrapper.ManagedReplicaRevertPhase.PushOutcomeUnknown);
+            var interrupted = ManagedReplicaBootstrapper.LoadMetadata(path)!.Value;
+            interrupted.RevertState!.Value.Phase.Should()
+                .Be(ManagedReplicaBootstrapper.ManagedReplicaRevertPhase.CommittedReady);
+            interrupted.PushState.Should().NotBeNull();
             scenario.Handler.PushCallCount.Should().Be(1);
 
             var result = await connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
@@ -3279,6 +3280,8 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
             exception.ReplicaPushFailureKind.Should().Be(AhtolaReplicaPushFailureKind.Conflict);
             AhtolaReplicaPushFailure.Classify(exception).Should().Be(AhtolaReplicaPushFailureKind.Conflict);
             connection.ReadManagedReplicaLocalChanges(10).Changes.Should().ContainSingle();
+            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.PushState.Should().BeNull(
+                "a definitive remote conflict resolves the ambiguous push outcome");
             handler.PullCallCount.Should().Be(1);
             handler.PushCallCount.Should().Be(1);
         }

--- a/src/Ahtola.Tests/ManagedEmbeddedReplicaPushRecoveryTests.cs
+++ b/src/Ahtola.Tests/ManagedEmbeddedReplicaPushRecoveryTests.cs
@@ -1,0 +1,583 @@
+using System.Buffers.Binary;
+using AwesomeAssertions;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text.Json;
+
+namespace Ahtola.Tests;
+
+public sealed partial class ManagedEmbeddedReplicaConnectionTests
+{
+    [Test]
+    public async Task OrdinaryAmbiguousPushUsesRemoteWatermarkWithoutReplayingSql()
+    {
+        var path = NewReplicaPath("managed-replica-ordinary-ambiguous-push");
+        var image = CreateJournalDatabaseImage(path + ".source");
+        var replayCount = 0;
+        var watermarkReadCount = 0;
+        var handler = new ReplicaPushHandler(
+            [
+                CreatePullResponse("revision-42", image),
+                CreatePullResponse("revision-42", [], declaredPages: 1),
+            ],
+            (request, _) =>
+            {
+                if (IsReplicaPushBatch(request))
+                {
+                    replayCount++;
+                    return Task.FromException<HttpResponseMessage>(
+                        new HttpRequestException("Response was lost after the remote commit."));
+                }
+
+                watermarkReadCount++;
+                return Task.FromResult(ReplicaPushHandler.WatermarkResponse(0, 1));
+            });
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            connection.Open();
+            connection.ExecuteNonQuery("INSERT INTO journal_events VALUES (10);");
+
+            Assert.ThrowsAsync<HttpRequestException>(
+                () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+            var interrupted = ManagedReplicaBootstrapper.LoadMetadata(path)!.Value;
+            interrupted.RevertState.Should().BeNull();
+            interrupted.PushState.Should().Be(
+                new ManagedReplicaBootstrapper.ManagedReplicaPushState(0, 1, 2));
+            connection.ReadManagedReplicaLocalChanges(10).Changes.Should().ContainSingle();
+
+            var result = await connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
+
+            result.Statistics.CdcOperations.Should().Be(1);
+            replayCount.Should().Be(1, "the remote watermark proves the first replay committed");
+            watermarkReadCount.Should().Be(1);
+            connection.ReadManagedReplicaLocalChanges(10).Changes.Should().BeEmpty();
+            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.PushState.Should().BeNull();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task OrdinaryPushIntentInterruptionQueriesThenSendsTheBatchOnce()
+    {
+        var path = NewReplicaPath("managed-replica-ordinary-push-intent");
+        var image = CreateJournalDatabaseImage(path + ".source");
+        var replayCount = 0;
+        var watermarkReadCount = 0;
+        var handler = new ReplicaPushHandler(
+            [
+                CreatePullResponse("revision-42", image),
+                CreatePullResponse("revision-42", [], declaredPages: 1),
+            ],
+            (request, _) =>
+            {
+                if (IsReplicaPushBatch(request))
+                {
+                    replayCount++;
+                    return Task.FromResult(ReplicaPushHandler.SuccessfulBatchResponse(5));
+                }
+
+                watermarkReadCount++;
+                return Task.FromResult(ReplicaPushHandler.EmptyWatermarkResponse());
+            });
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            connection.Open();
+            connection.ExecuteNonQuery("INSERT INTO journal_events VALUES (10);");
+            using (ManagedReplicaFaultInjection.Push(boundary =>
+                   {
+                       if (boundary == ManagedReplicaDurableBoundary.ReplicaPushIntentPublished)
+                           throw new InvalidOperationException("Injected push-intent interruption.");
+                   }))
+            {
+                Assert.ThrowsAsync<InvalidOperationException>(
+                    () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+            }
+
+            handler.PushCallCount.Should().Be(0, "intent publication precedes every remote request");
+            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.PushState.Should().NotBeNull();
+
+            var result = await connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
+
+            result.Statistics.CdcOperations.Should().Be(1);
+            watermarkReadCount.Should().Be(1);
+            replayCount.Should().Be(1);
+            connection.ReadManagedReplicaLocalChanges(10).Changes.Should().BeEmpty();
+            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.PushState.Should().BeNull();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task CrashAfterRemoteCommitObservationRecoversWithoutReplayingSql()
+    {
+        var path = NewReplicaPath("managed-replica-remote-commit-observed");
+        var image = CreateJournalDatabaseImage(path + ".source");
+        var replayCount = 0;
+        var handler = new ReplicaPushHandler(
+            [
+                CreatePullResponse("revision-42", image),
+                CreatePullResponse("revision-42", [], declaredPages: 1),
+            ],
+            (request, _) =>
+            {
+                if (IsReplicaPushBatch(request))
+                {
+                    replayCount++;
+                    return Task.FromResult(ReplicaPushHandler.SuccessfulBatchResponse(5));
+                }
+
+                return Task.FromResult(ReplicaPushHandler.WatermarkResponse(0, 1));
+            });
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            connection.Open();
+            connection.ExecuteNonQuery("INSERT INTO journal_events VALUES (10);");
+            using (ManagedReplicaFaultInjection.Push(boundary =>
+                   {
+                       if (boundary == ManagedReplicaDurableBoundary.ReplicaPushRemoteCommitObserved)
+                           throw new InvalidOperationException("Injected post-commit interruption.");
+                   }))
+            {
+                Assert.ThrowsAsync<InvalidOperationException>(
+                    () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+            }
+
+            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.PushState.Should().NotBeNull();
+            var result = await connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
+
+            result.Statistics.CdcOperations.Should().Be(1);
+            replayCount.Should().Be(1);
+            connection.ReadManagedReplicaLocalChanges(10).Changes.Should().BeEmpty();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task JournalAppendDuringRemoteCommitRecoversTheProtectedBatchWithoutLosingTheAppend()
+    {
+        var path = NewReplicaPath("managed-replica-concurrent-append-during-push");
+        var image = CreateJournalDatabaseImage(path + ".source");
+        var replayCount = 0;
+        var watermarkReadCount = 0;
+        var handler = new ReplicaPushHandler(
+            [CreatePullResponse("revision-42", image)],
+            (request, _) =>
+            {
+                if (IsReplicaPushBatch(request))
+                {
+                    replayCount++;
+                    ManagedReplicaChangeJournal.Open(path).AppendCommitted(
+                    [
+                        ReplicaLocalChange.Schema(
+                            "CREATE TABLE concurrently_journaled(value INTEGER);"),
+                    ]);
+                    return Task.FromResult(ReplicaPushHandler.SuccessfulBatchResponse(5));
+                }
+
+                watermarkReadCount++;
+                return Task.FromResult(ReplicaPushHandler.WatermarkResponse(0, 1));
+            });
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            connection.Open();
+            connection.ExecuteNonQuery("INSERT INTO journal_events VALUES (10);");
+
+            var interrupted = Assert.ThrowsAsync<AhtolaException>(
+                () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+            interrupted!.ReplicaPushFailureKind.Should().Be(AhtolaReplicaPushFailureKind.InvalidLocalState);
+            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.PushState.Should().NotBeNull();
+            ManagedReplicaChangeJournal.Open(path).ReadBatch(int.MaxValue).Changes
+                .Select(change => change.Sequence).Should().Equal(1L, 2L);
+
+            using (ManagedReplicaFaultInjection.Push(boundary =>
+                   {
+                       if (boundary == ManagedReplicaDurableBoundary.ReplicaPushIntentRetired)
+                           throw new InvalidOperationException("Injected intent-retirement interruption.");
+                   }))
+            {
+                Assert.ThrowsAsync<InvalidOperationException>(
+                    () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+            }
+
+            replayCount.Should().Be(1, "the remote watermark covers the protected first batch");
+            watermarkReadCount.Should().Be(1);
+            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.PushState.Should().BeNull();
+            var durable = ManagedReplicaChangeJournal.Open(path);
+            durable.AcknowledgedWatermark.Should().Be(2);
+            durable.ReadBatch(int.MaxValue).Changes.Select(change => change.Sequence).Should().Equal(2L);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task CrashAfterJournalAcknowledgementCompletesIntentRetirementOnRetry()
+    {
+        var path = NewReplicaPath("managed-replica-push-ack-interruption");
+        var image = CreateJournalDatabaseImage(path + ".source");
+        var replayCount = 0;
+        var handler = new ReplicaPushHandler(
+            [
+                CreatePullResponse("revision-42", image),
+                CreatePullResponse("revision-42", [], declaredPages: 1),
+            ],
+            (request, _) =>
+            {
+                if (IsReplicaPushBatch(request))
+                {
+                    replayCount++;
+                    return Task.FromResult(ReplicaPushHandler.SuccessfulBatchResponse(5));
+                }
+
+                return Task.FromResult(ReplicaPushHandler.WatermarkResponse(0, 1));
+            });
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            connection.Open();
+            connection.ExecuteNonQuery("INSERT INTO journal_events VALUES (10);");
+            using (ManagedReplicaFaultInjection.Push(boundary =>
+                   {
+                       if (boundary == ManagedReplicaDurableBoundary.JournalAcknowledgementPersisted)
+                           throw new InvalidOperationException("Injected acknowledgement interruption.");
+                   }))
+            {
+                Assert.ThrowsAsync<InvalidOperationException>(
+                    () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+            }
+
+            ManagedReplicaChangeJournal.Open(path).AcknowledgedWatermark.Should().Be(2);
+            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.PushState.Should().NotBeNull();
+
+            var result = await connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
+
+            result.Statistics.CdcOperations.Should().Be(1);
+            replayCount.Should().Be(1);
+            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.PushState.Should().BeNull();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [TestCase(0, 1, "splits")]
+    [TestCase(1, 0, "ahead")]
+    public void InvalidRemoteWatermarkFailsClosedWithoutReplayingSql(
+        long pullGeneration,
+        long changeId,
+        string expectedMessage)
+    {
+        var path = NewReplicaPath("managed-replica-invalid-push-watermark");
+        var image = CreateJournalDatabaseImage(path + ".source");
+        var replayCount = 0;
+        var handler = new ReplicaPushHandler(
+            [CreatePullResponse("revision-42", image)],
+            (request, _) =>
+            {
+                if (IsReplicaPushBatch(request))
+                    replayCount++;
+                return Task.FromResult(
+                    ReplicaPushHandler.WatermarkResponse(pullGeneration, changeId));
+            });
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            connection.Open();
+            connection.ExecuteNonQuery("INSERT INTO journal_events VALUES (10);");
+            connection.ExecuteNonQuery("INSERT INTO journal_events VALUES (20);");
+            using (ManagedReplicaFaultInjection.Push(boundary =>
+                   {
+                       if (boundary == ManagedReplicaDurableBoundary.ReplicaPushIntentPublished)
+                           throw new InvalidOperationException("Injected push-intent interruption.");
+                   }))
+            {
+                Assert.ThrowsAsync<InvalidOperationException>(
+                    () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+            }
+
+            var exception = Assert.ThrowsAsync<AhtolaException>(
+                () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+
+            exception!.ReplicaPushFailureKind.Should().Be(AhtolaReplicaPushFailureKind.InvalidLocalState);
+            exception.Message.Should().Contain(expectedMessage);
+            replayCount.Should().Be(0);
+            connection.ReadManagedReplicaLocalChanges(10).Changes.Should().HaveCount(2);
+            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.PushState.Should().NotBeNull();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [TestCase("bad-base64")]
+    [TestCase("checksum")]
+    [TestCase("truncated")]
+    [TestCase("trailing")]
+    [TestCase("version")]
+    [TestCase("negative-generation")]
+    [TestCase("zero-first-sequence")]
+    [TestCase("invalid-watermark")]
+    public void MalformedPushIntentFailsClosedBeforeNetworkAccess(string corruption)
+    {
+        var path = NewReplicaPath("managed-replica-corrupt-push-intent");
+        var image = CreateJournalDatabaseImage(path + ".source");
+        var handler = new ReplicaPushHandler(
+            [CreatePullResponse("revision-42", image)],
+            _ => ReplicaPushHandler.SuccessfulBatchResponse(5));
+
+        try
+        {
+            var options = CreateOptions(path, handler);
+            using (var connection = AhtolaConnection.CreateReplica(options))
+            {
+                connection.Open();
+                connection.ExecuteNonQuery("INSERT INTO journal_events VALUES (10);");
+                using (ManagedReplicaFaultInjection.Push(boundary =>
+                       {
+                           if (boundary == ManagedReplicaDurableBoundary.ReplicaPushIntentPublished)
+                               throw new InvalidOperationException("Injected push-intent interruption.");
+                       }))
+                {
+                    Assert.ThrowsAsync<InvalidOperationException>(
+                        () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+                }
+            }
+
+            CorruptPushState(path + ManagedReplicaBootstrapper.MetadataSuffix, corruption);
+
+            using var reopened = AhtolaConnection.CreateReplica(options);
+            Assert.Throws<InvalidDataException>(() => reopened.Open());
+            handler.PushCallCount.Should().Be(0);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task CancellationWhileWaitingForPushFlightLeavesNoIntent()
+    {
+        var path = NewReplicaPath("managed-replica-push-lock-cancellation");
+        var image = CreateJournalDatabaseImage(path + ".source");
+        var handler = new ReplicaPushHandler(
+            [CreatePullResponse("revision-42", image)],
+            _ => ReplicaPushHandler.SuccessfulBatchResponse(5));
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            connection.Open();
+            connection.ExecuteNonQuery("INSERT INTO journal_events VALUES (10);");
+            await using var held = await ManagedReplicaPushLock
+                .AcquireExclusiveAsync(path, CancellationToken.None)
+                .ConfigureAwait(false);
+            using var cancellation = new CancellationTokenSource();
+            var sync = connection.SyncAsync(new AhtolaSyncOptions(), cancellation.Token);
+            await Task.Delay(100);
+            cancellation.Cancel();
+
+            Assert.CatchAsync<OperationCanceledException>(() => sync);
+            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.PushState.Should().BeNull();
+            connection.ReadManagedReplicaLocalChanges(10).Changes.Should().ContainSingle();
+            handler.PushCallCount.Should().Be(0);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public void CancellationAfterRemoteCommitStillPublishesAcknowledgement()
+    {
+        var path = NewReplicaPath("managed-replica-post-commit-cancellation");
+        var image = CreateJournalDatabaseImage(path + ".source");
+        var handler = new ReplicaPushHandler(
+            [CreatePullResponse("revision-42", image)],
+            _ => ReplicaPushHandler.SuccessfulBatchResponse(5));
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            connection.Open();
+            connection.ExecuteNonQuery("INSERT INTO journal_events VALUES (10);");
+            using var cancellation = new CancellationTokenSource();
+            using (ManagedReplicaFaultInjection.Push(boundary =>
+                   {
+                       if (boundary == ManagedReplicaDurableBoundary.ReplicaPushRemoteCommitObserved)
+                           cancellation.Cancel();
+                   }))
+            {
+                Assert.CatchAsync<OperationCanceledException>(
+                    () => connection.SyncAsync(new AhtolaSyncOptions(), cancellation.Token));
+            }
+
+            ManagedReplicaChangeJournal.Open(path).AcknowledgedWatermark.Should().Be(2);
+            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.PushState.Should().BeNull();
+            connection.ReadManagedReplicaLocalChanges(10).Changes.Should().BeEmpty();
+            handler.PushCallCount.Should().Be(1);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task LegacyCheckpointBoundPushOutcomeRecoversThroughIndependentIntent()
+    {
+        var path = NewReplicaPath("managed-replica-legacy-v6-push-intent");
+        try
+        {
+            var scenario = PreparePendingCheckpointPush(
+                path,
+                static (_, _) => Task.FromResult(ReplicaPushHandler.WatermarkResponse(0, 2)));
+            using var connection = AhtolaConnection.CreateReplica(scenario.Options);
+            connection.Open();
+            using (ManagedReplicaFaultInjection.Push(boundary =>
+                   {
+                       if (boundary == ManagedReplicaDurableBoundary.ReplicaPushIntentPublished)
+                           throw new InvalidOperationException("Injected push-intent interruption.");
+                   }))
+            {
+                Assert.ThrowsAsync<InvalidOperationException>(
+                    () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+            }
+
+            var metadata = ManagedReplicaBootstrapper.LoadMetadata(path)!.Value;
+            var push = metadata.PushState!.Value;
+            var legacy = metadata with
+            {
+                PushState = null,
+                RevertState = metadata.RevertState!.Value with
+                {
+                    Phase = ManagedReplicaBootstrapper.ManagedReplicaRevertPhase.PushOutcomeUnknown,
+                    AttemptedFirstSequence = push.FirstSequence,
+                    AttemptedWatermark = push.Watermark,
+                },
+            };
+            var metadataPath = path + ManagedReplicaBootstrapper.MetadataSuffix;
+            var inconsistentStagingPath = metadataPath + $".inconsistent-{Guid.NewGuid():N}.tmp";
+            ManagedReplicaBootstrapper.WriteMetadata(
+                inconsistentStagingPath,
+                metadataPath,
+                legacy with { PushState = push with { Watermark = push.Watermark + 1 } });
+            File.ReadAllText(metadataPath).Should().StartWith("version=8\n");
+            Assert.Throws<InvalidDataException>(() => ManagedReplicaBootstrapper.LoadMetadata(path));
+
+            var stagingPath = metadataPath + $".legacy-{Guid.NewGuid():N}.tmp";
+            ManagedReplicaBootstrapper.WriteMetadata(stagingPath, metadataPath, legacy);
+            File.ReadAllText(metadataPath).Should().StartWith("version=6\n");
+
+            var loaded = ManagedReplicaBootstrapper.LoadMetadata(path)!.Value;
+            loaded.PushState.Should().Be(push);
+            loaded.RevertState!.Value.Phase.Should()
+                .Be(ManagedReplicaBootstrapper.ManagedReplicaRevertPhase.PushOutcomeUnknown);
+
+            var result = await connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
+
+            result.Statistics.CdcOperations.Should().Be(1);
+            connection.ReadManagedReplicaLocalChanges(10).Changes.Should().BeEmpty();
+            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.PushState.Should().BeNull();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    private static bool IsReplicaPushBatch(HttpRequestMessage request)
+    {
+        using var document = JsonDocument.Parse(
+            request.Content!.ReadAsStringAsync().GetAwaiter().GetResult());
+        return document.RootElement.GetProperty("requests")[0].TryGetProperty("batch", out _);
+    }
+
+    private static void CorruptPushState(string metadataPath, string corruption)
+    {
+        const string field = "push_state_base64=";
+        const int payloadLength = 1 + (3 * sizeof(long));
+        var text = File.ReadAllText(metadataPath);
+        var valueOffset = text.IndexOf(field, StringComparison.Ordinal) + field.Length;
+        valueOffset.Should().BeGreaterThanOrEqualTo(field.Length);
+        var valueEnd = text.IndexOf('\n', valueOffset);
+        valueEnd.Should().BeGreaterThan(valueOffset);
+        var encoded = text[valueOffset..valueEnd];
+        string replacement;
+        if (corruption == "bad-base64")
+        {
+            replacement = "***";
+        }
+        else
+        {
+            var bytes = Convert.FromBase64String(encoded);
+            bytes = corruption switch
+            {
+                "checksum" => CorruptChecksum(bytes),
+                "truncated" => bytes[..^1],
+                "trailing" => [.. bytes, 0],
+                "version" => RewriteAndRehash(bytes, static value => value[0] = 2),
+                "negative-generation" => RewriteAndRehash(
+                    bytes,
+                    static value => BinaryPrimitives.WriteInt64LittleEndian(value.AsSpan(1), -1)),
+                "zero-first-sequence" => RewriteAndRehash(
+                    bytes,
+                    static value => BinaryPrimitives.WriteInt64LittleEndian(
+                        value.AsSpan(1 + sizeof(long)),
+                        0)),
+                "invalid-watermark" => RewriteAndRehash(
+                    bytes,
+                    static value =>
+                    {
+                        var firstSequence = BinaryPrimitives.ReadInt64LittleEndian(
+                            value.AsSpan(1 + sizeof(long)));
+                        BinaryPrimitives.WriteInt64LittleEndian(
+                            value.AsSpan(1 + (2 * sizeof(long))),
+                            firstSequence);
+                    }),
+                _ => throw new ArgumentOutOfRangeException(nameof(corruption), corruption, null),
+            };
+            replacement = Convert.ToBase64String(bytes);
+        }
+
+        File.WriteAllText(metadataPath, text[..valueOffset] + replacement + text[valueEnd..]);
+        return;
+
+        static byte[] CorruptChecksum(byte[] bytes)
+        {
+            bytes[^1] ^= 0xff;
+            return bytes;
+        }
+
+        static byte[] RewriteAndRehash(byte[] bytes, Action<byte[]> rewrite)
+        {
+            rewrite(bytes);
+            SHA256.HashData(bytes.AsSpan(0, payloadLength)).CopyTo(bytes.AsSpan(payloadLength));
+            return bytes;
+        }
+    }
+}

--- a/src/Ahtola.Tests/ManagedReplicaConflictRebaseTests.cs
+++ b/src/Ahtola.Tests/ManagedReplicaConflictRebaseTests.cs
@@ -1504,7 +1504,7 @@ public sealed class ManagedReplicaConflictRebaseTests
     }
 
     [Test]
-    public void PushFailsClosedWhenAnotherWriterAdvancesTheJournalDuringTheRoundTrip()
+    public void PushFailsClosedWhenAnotherWriterAdvancesTheJournalBetweenSelectionAndIntent()
     {
         var path = NewReplicaPath("conflict-push-generation");
         var image = CreateJournalDatabaseImage(path + ".source");
@@ -1518,11 +1518,13 @@ public sealed class ManagedReplicaConflictRebaseTests
             using (ManagedReplicaFaultInjection.Push(boundary =>
             {
                 if (boundary != ManagedReplicaDurableBoundary.ReplicaPushPublicationLockAcquired
-                    || Interlocked.Increment(ref hits) != 1)
+                    || Interlocked.Increment(ref hits) != 2)
                 {
                     return;
                 }
-                // Another participant journals a new local change while this push holds nothing.
+                // Journal append uses its own leaf lease, so another participant can move it while
+                // this call holds the apply lease. The generation selected under the first apply
+                // acquisition must reject that movement under this second one, before intent or I/O.
                 ManagedReplicaChangeJournal.Open(path).AppendCommitted(
                     [Row(0, "journal_events", 99, "INSERT INTO journal_events VALUES (99)")]);
             }))

--- a/src/Ahtola.Tests/ManagedReplicaJournalAndLockCarrierRegressionTests.cs
+++ b/src/Ahtola.Tests/ManagedReplicaJournalAndLockCarrierRegressionTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Text;
 using Ahtola.Core;
 using AwesomeAssertions;
 
@@ -268,7 +269,12 @@ public sealed class ManagedReplicaJournalAndLockCarrierRegressionTests
                 Path.GetFullPath(path),
                 "the point of this case is that the two names stay textually distinct");
 
-            foreach (var kind in new[] { ManagedReplicaLockCarrier.ApplyKind, ManagedReplicaLockCarrier.JournalKind })
+            foreach (var kind in new[]
+                     {
+                         ManagedReplicaLockCarrier.ApplyKind,
+                         ManagedReplicaLockCarrier.JournalKind,
+                         ManagedReplicaLockCarrier.PushKind,
+                     })
             {
                 ManagedReplicaLockCarrier.Ensure(aliasPath, kind)
                     .Should().Be(ManagedReplicaLockCarrier.Ensure(path, kind));
@@ -341,6 +347,65 @@ public sealed class ManagedReplicaJournalAndLockCarrierRegressionTests
     }
 
     [Test]
+    public async Task PushFlightLeaseSerializesAHardLinkAliasAcrossProcesses()
+    {
+        var path = NewReplicaPath("push-flight-hard-link-process");
+        var aliasPath = path + ".hardlink";
+        try
+        {
+            File.WriteAllBytes(path, [1, 2, 3, 4]);
+            RequireHardLink(aliasPath, path);
+            using var worker = new CrossProcessPushLockWorker(
+                TestContext.CurrentContext.WorkDirectory,
+                path);
+
+            var contenderStarted = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var contender = Task.Run(async () =>
+            {
+                contenderStarted.TrySetResult();
+                await using var lease = await ManagedReplicaPushLock
+                    .AcquireExclusiveAsync(aliasPath, CancellationToken.None)
+                    .ConfigureAwait(false);
+            });
+
+            await contenderStarted.Task.WaitAsync(Settle);
+            await Task.Delay(BlockedProbe);
+            contender.IsCompleted.Should().BeFalse(
+                "a child process holding the real path's push flight must exclude a hard-link alias");
+
+            worker.Release();
+            await contender.WaitAsync(Settle);
+        }
+        finally
+        {
+            if (File.Exists(aliasPath))
+                File.Delete(aliasPath);
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    [Category("ProcessWorker")]
+    [NonParallelizable]
+    public async Task CrossProcessPushFlightLockWorker()
+    {
+        var databasePath = Environment.GetEnvironmentVariable("AHTOLA_PUSH_LOCK_WORKER_DATABASE");
+        if (string.IsNullOrEmpty(databasePath))
+            return;
+
+        var readyPath = ReadWorkerValue("AHTOLA_PUSH_LOCK_WORKER_READY");
+        var releasePath = ReadWorkerValue("AHTOLA_PUSH_LOCK_WORKER_RELEASE");
+        var resultPath = ReadWorkerValue("AHTOLA_PUSH_LOCK_WORKER_RESULT");
+        await using var lease = await ManagedReplicaPushLock
+            .AcquireExclusiveAsync(databasePath, CancellationToken.None)
+            .ConfigureAwait(false);
+        File.WriteAllText(readyPath, string.Empty);
+        WaitForFile(releasePath, Settle, "The push-flight worker was not released.");
+        File.WriteAllText(resultPath, "released");
+    }
+
+    [Test]
     public void JournalLeaseSerializesAHardLinkAliasBehindItsRealPath()
     {
         var path = NewReplicaPath("journal-lease-hard-link");
@@ -409,7 +474,7 @@ public sealed class ManagedReplicaJournalAndLockCarrierRegressionTests
     }
 
     [Test]
-    public void GetLocalArtifactPathsListsBothPhysicalIdentityCarriersSoCleanupRemovesThem()
+    public void GetLocalArtifactPathsListsEveryPhysicalIdentityCarrierSoCleanupRemovesThem()
     {
         var path = NewReplicaPath("carrier-artifact-enumeration");
         try
@@ -417,12 +482,14 @@ public sealed class ManagedReplicaJournalAndLockCarrierRegressionTests
             File.WriteAllBytes(path, [1, 2, 3, 4]);
             var apply = ManagedReplicaLockCarrier.Ensure(path, ManagedReplicaLockCarrier.ApplyKind);
             var journal = ManagedReplicaLockCarrier.Ensure(path, ManagedReplicaLockCarrier.JournalKind);
+            var push = ManagedReplicaLockCarrier.Ensure(path, ManagedReplicaLockCarrier.PushKind);
 
-            ManagedReplicaBootstrapper.GetLocalArtifactPaths(path).Should().Contain([apply, journal]);
+            ManagedReplicaBootstrapper.GetLocalArtifactPaths(path).Should().Contain([apply, journal, push]);
 
             DeleteReplicaFiles(path);
             File.Exists(apply).Should().BeFalse();
             File.Exists(journal).Should().BeFalse();
+            File.Exists(push).Should().BeFalse();
         }
         finally
         {
@@ -431,6 +498,112 @@ public sealed class ManagedReplicaJournalAndLockCarrierRegressionTests
     }
 
     // ---- helpers ------------------------------------------------------------------------------
+
+    private static string ReadWorkerValue(string name)
+        => Environment.GetEnvironmentVariable(name)
+           ?? throw new InvalidOperationException($"The push-flight worker is missing {name}.");
+
+    private static void WaitForFile(
+        string path,
+        TimeSpan timeout,
+        string message,
+        Process? worker = null)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (!File.Exists(path))
+        {
+            if (worker is { HasExited: true })
+                Assert.Fail($"{message} The worker exited with code {worker.ExitCode}.");
+            if (stopwatch.Elapsed >= timeout)
+                Assert.Fail(message);
+            Thread.Sleep(25);
+        }
+    }
+
+    private sealed class CrossProcessPushLockWorker : IDisposable
+    {
+        private readonly Process _worker;
+        private readonly string _releasePath;
+        private readonly string _resultPath;
+        private readonly StringBuilder _output = new();
+        private bool _released;
+
+        internal CrossProcessPushLockWorker(string workDirectory, string databasePath)
+        {
+            var token = Guid.NewGuid().ToString("N");
+            var readyPath = Path.Combine(workDirectory, $"push-lock-ready-{token}");
+            _releasePath = Path.Combine(workDirectory, $"push-lock-release-{token}");
+            _resultPath = Path.Combine(workDirectory, $"push-lock-result-{token}");
+            var testDirectory = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
+            var startInfo = new ProcessStartInfo(
+                Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ?? "dotnet")
+            {
+                WorkingDirectory = testDirectory.FullName,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+            startInfo.ArgumentList.Add("vstest");
+            startInfo.ArgumentList.Add(Path.Combine(testDirectory.FullName, "Ahtola.Tests.dll"));
+            startInfo.ArgumentList.Add(
+                "--TestCaseFilter:FullyQualifiedName=Ahtola.Tests.ManagedReplicaJournalAndLockCarrierRegressionTests."
+                + nameof(CrossProcessPushFlightLockWorker));
+            startInfo.Environment["AHTOLA_PUSH_LOCK_WORKER_DATABASE"] = databasePath;
+            startInfo.Environment["AHTOLA_PUSH_LOCK_WORKER_READY"] = readyPath;
+            startInfo.Environment["AHTOLA_PUSH_LOCK_WORKER_RELEASE"] = _releasePath;
+            startInfo.Environment["AHTOLA_PUSH_LOCK_WORKER_RESULT"] = _resultPath;
+
+            _worker = Process.Start(startInfo)
+                ?? throw new InvalidOperationException("Failed to start the push-flight lock worker.");
+            _worker.OutputDataReceived += AppendOutput;
+            _worker.ErrorDataReceived += AppendOutput;
+            _worker.BeginOutputReadLine();
+            _worker.BeginErrorReadLine();
+            WaitForFile(
+                readyPath,
+                TimeSpan.FromSeconds(60),
+                "The push-flight lock worker did not report readiness.",
+                _worker);
+        }
+
+        internal void Release()
+        {
+            if (_released)
+                return;
+            _released = true;
+            File.WriteAllText(_releasePath, string.Empty);
+            if (!_worker.WaitForExit(TimeSpan.FromSeconds(60)))
+            {
+                _worker.Kill(entireProcessTree: true);
+                Assert.Fail(
+                    "The push-flight lock worker did not exit within 60 seconds:"
+                    + Environment.NewLine
+                    + _output);
+            }
+
+            _worker.WaitForExit();
+            _worker.ExitCode.Should().Be(0, $"worker output:{Environment.NewLine}{_output}");
+            File.ReadAllText(_resultPath).Should().Be("released");
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Release();
+            }
+            finally
+            {
+                _worker.Dispose();
+            }
+        }
+
+        private void AppendOutput(object sender, DataReceivedEventArgs args)
+        {
+            if (args.Data is { } line)
+                _output.AppendLine(line);
+        }
+    }
 
     /// <summary>
     /// Holds <paramref name="holderPath"/>'s lease, proves a second acquisition through


### PR DESCRIPTION
## Summary

- persist an independent, SHA-256-protected push intent before every non-empty remote push, with metadata v7/v8 and backward-compatible recovery from v2-v6 / legacy v6 `PushOutcomeUnknown`
- serialize watermark verification and SQL replay with a physical-identity push-flight lease shared across aliases and processes, while keeping apply/journal leases out of remote I/O
- recover lost responses through `turso_sync_last_change_id`: acknowledge covered batches without replay, resend only absent/strictly-behind batches, and fail closed on split or different-generation watermarks
- make acknowledgement/conflict publication uncancellable after a definitive remote outcome and preserve crash-consistent journal-before-intent-retirement ordering
- add fake-server replay-count tests, malformed wire-state coverage, durable-boundary fault injection, concurrent-journal recovery, cancellation tests, and real child-process lock exclusion
- update the replica publication contract and pinned Turso gap analysis

## Validation

- `pwsh .\scripts\Invoke-ManagedTestSuite.ps1 -Framework net10.0 -Filter "FullyQualifiedName~Ahtola.Tests.ManagedEmbeddedReplicaConnectionTests|FullyQualifiedName~Ahtola.Tests.ManagedReplicaConflictRebaseTests|FullyQualifiedName~Ahtola.Tests.ManagedReplicaJournalAndLockCarrierRegressionTests" -MinimumExecutedTests 290` — 296 passed
- `pwsh .\build.ps1 test` — package/managed-closure consumer validation on net8.0, net9.0, and net10.0; 6,412 tests passed
- focused `dotnet format ... --include <changed C# files> --verify-no-changes` — passed

The repository-wide format gate remains red on unrelated pre-existing files; no changed file is reported.

## Residual follow-ups

This PR intentionally does not add zstd, Turso's reusable passive synced-prefix/history checkpoint policy, wait-for-changes, broader reference-server interoperability qualification, or the unsupported MVCC-logical plus remote-encryption/partial combinations. No native assets or dependencies are added.