### PR TITLE
Bound compiled hash join execution memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,12 +328,16 @@ connection, and a managed embedded replica — see
 
 Treat Ahtola as SQLite-*compatible*, not a full SQLite replacement:
 
-- **Working set** — tables and most intermediates stay in the process heap.
-  Sorters spill stable runs through the managed temporary file system once their
-  memory budget is exceeded, but hash joins, DISTINCT/compound operations, and
-  opaque aggregate state do not yet spill. Prefer modest databases and explicit
-  transactions for writes (managed writes are slower than native SQLite and the
-  gap grows with table size).
+- **Working set** — base-table rows and several intermediates still stay in the
+  process heap. Sorters and compiled equijoins bound retained rows to the
+  `cache_size`-derived execution budget and spill deterministic runs/partitions
+  through the managed temporary file system; skewed hash partitions fall back
+  to bounded scans. With `temp_store=MEMORY`, exceeding that finite budget fails
+  instead of moving the same data into a heap-backed temporary file. Non-equijoin
+  build sides, DISTINCT/compound sets, recursive worktables, buffered windows,
+  ephemeral tables, and opaque aggregate state do not yet spill. Prefer modest
+  databases and explicit transactions for writes (managed writes are slower
+  than native SQLite and the gap grows with table size).
 - **Planner** — `ANALYZE` / `sqlite_stat1` feed index scoring, System-R DP join
   reordering for up to eight freely reorderable INNER members (greedy above
   that), hash-build selection, and durable secondary-index equality seeks bound

--- a/src/Ahtola.Core/EmbeddedDatabase.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.cs
@@ -43163,14 +43163,6 @@ public sealed partial class EmbeddedConnection : IDisposable
     private VdbeExecutionOptions CreateVdbeExecutionOptions(EmbeddedDatabase database)
     {
         ArgumentNullException.ThrowIfNull(database);
-        if (_tempStore == 2)
-        {
-            return new VdbeExecutionOptions(
-                new InMemoryFileSystem(),
-                long.MaxValue,
-                temporaryDirectory: "ahtola-memory-sorter");
-        }
-
         var cacheSize = _cacheSizes.GetValueOrDefault(database, -2000);
         Int128 bytes = cacheSize < 0
             ? (Int128)(cacheSize == long.MinValue ? long.MaxValue : -cacheSize) * 1024
@@ -43180,6 +43172,15 @@ public sealed partial class EmbeddedConnection : IDisposable
             : bytes >= long.MaxValue
                 ? long.MaxValue
                 : (long)bytes;
+
+        if (_tempStore == 2)
+        {
+            return new VdbeExecutionOptions(
+                new InMemoryFileSystem(),
+                budget,
+                temporaryDirectory: "ahtola-memory-execution",
+                allowTemporaryFileSpill: false);
+        }
 
         return new VdbeExecutionOptions(
             PhysicalFileSystem.Instance,

--- a/src/Ahtola.Core/Execution/ResumableStatement.cs
+++ b/src/Ahtola.Core/Execution/ResumableStatement.cs
@@ -1,9 +1,7 @@
-using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Runtime.ExceptionServices;
-using System.Text;
 using Ahtola.Core.Parsing;
 using Ahtola.Core.Storage;
 
@@ -60,6 +58,7 @@ public sealed class ResumableStatement : IDisposable
     private readonly IReadOnlyList<VdbeWriteTarget?>? _writeTargets;
     private readonly IReadOnlyList<VdbeVirtualTableBinding?>? _virtualTableBindings;
     private readonly VdbeExecutionOptions _executionOptions;
+    private readonly VdbeExecutionMemory _memory;
     private readonly VdbeTransactionContext _transaction;
     private readonly bool _ownsTransaction;
     private VdbeParameterBinding? _binding;
@@ -116,7 +115,8 @@ public sealed class ResumableStatement : IDisposable
         VdbeParameterBinding? parameterBinding,
         VdbeTransactionContext? sharedTransaction,
         IReadOnlyList<VdbeVirtualTableBinding?>? virtualTableBindings,
-        VdbeExecutionOptions executionOptions)
+        VdbeExecutionOptions executionOptions,
+        VdbeExecutionMemory? executionMemory = null)
     {
         ArgumentNullException.ThrowIfNull(program);
         ArgumentNullException.ThrowIfNull(executionOptions);
@@ -166,6 +166,8 @@ public sealed class ResumableStatement : IDisposable
         _writeTargets = writeTargets;
         _virtualTableBindings = virtualTableBindings;
         _executionOptions = executionOptions;
+        _memory = executionMemory
+            ?? new VdbeExecutionMemory(executionOptions.MemoryLimitBytes, executionOptions.Metrics);
         _binding = parameterBinding;
         _ownsTransaction = sharedTransaction is null;
         _transaction = sharedTransaction ?? new VdbeTransactionContext();
@@ -328,7 +330,7 @@ public sealed class ResumableStatement : IDisposable
                     {
                         OpenCursor(openJoin.Cursor);
                         var state = new JoinCursorState();
-                        state.Open(openJoin.Plan.Enumerate().GetEnumerator());
+                        state.Open(openJoin.Plan, _executionOptions, _memory);
                         _joinCursorStates[openJoin.Cursor.Index] = state;
                         _cursorPositions[openJoin.Cursor.Index] = -1;
                         _materializedRows[openJoin.Cursor.Index] = null;
@@ -365,14 +367,25 @@ public sealed class ResumableStatement : IDisposable
                         break;
                     }
                 case CloseCursorInstruction close:
-                    CloseCursor(close.Cursor);
-                    _virtualCursors[close.Cursor.Index]?.Dispose();
-                    _virtualCursors[close.Cursor.Index] = null;
-                    _joinCursorStates[close.Cursor.Index]?.Close();
-                    _joinCursorStates[close.Cursor.Index] = null;
-                    _ephemeralTables[close.Cursor.Index] = null;
-                    AdvanceInstructionPointer();
-                    break;
+                    {
+                        CloseCursor(close.Cursor);
+                        _virtualCursors[close.Cursor.Index]?.Dispose();
+                        _virtualCursors[close.Cursor.Index] = null;
+                        var joinState = _joinCursorStates[close.Cursor.Index];
+                        _joinCursorStates[close.Cursor.Index] = null;
+                        try
+                        {
+                            joinState?.Close();
+                        }
+                        catch
+                        {
+                            State = ResumableStatementState.Faulted;
+                            throw;
+                        }
+                        _ephemeralTables[close.Cursor.Index] = null;
+                        AdvanceInstructionPointer();
+                        break;
+                    }
                 case RewindCursorInstruction rewind:
                     {
                         _materializedRows[rewind.Cursor.Index] = null;
@@ -381,14 +394,22 @@ public sealed class ResumableStatement : IDisposable
                             // Streaming join cursor: the row count is not known up front, so
                             // emptiness is decided by pulling the first row. A successful pull
                             // also positions the cursor on that first row.
-                            if (joinState.MoveNext())
+                            try
                             {
-                                _cursorPositions[rewind.Cursor.Index] = 0;
-                                AdvanceInstructionPointer();
+                                if (joinState.MoveNext(cancellationToken))
+                                {
+                                    _cursorPositions[rewind.Cursor.Index] = 0;
+                                    AdvanceInstructionPointer();
+                                }
+                                else
+                                {
+                                    _instructionPointer = rewind.EmptyTarget;
+                                }
                             }
-                            else
+                            catch
                             {
-                                _instructionPointer = rewind.EmptyTarget;
+                                State = ResumableStatementState.Faulted;
+                                throw;
                             }
                         }
                         else if (CursorRowCount(rewind.Cursor) == 0)
@@ -853,10 +874,18 @@ public sealed class ResumableStatement : IDisposable
                         {
                             // Streaming join cursor: advance the enumerator and loop back while
                             // another row exists; the count is not known up front.
-                            if (joinState.MoveNext())
-                                _instructionPointer = next.LoopTarget;
-                            else
-                                AdvanceInstructionPointer();
+                            try
+                            {
+                                if (joinState.MoveNext(cancellationToken))
+                                    _instructionPointer = next.LoopTarget;
+                                else
+                                    AdvanceInstructionPointer();
+                            }
+                            catch
+                            {
+                                State = ResumableStatementState.Faulted;
+                                throw;
+                            }
                         }
                         else
                         {
@@ -1490,9 +1519,15 @@ public sealed class ResumableStatement : IDisposable
                 case HaltInstruction halt:
                     {
                         Array.Clear(_openCursors);
-                        DisposeAllJoinCursors();
-                        DisposeAllSorters();
-                        DisposeAllVirtualCursors();
+                        try
+                        {
+                            DisposeExecutionResources();
+                        }
+                        catch
+                        {
+                            State = ResumableStatementState.Faulted;
+                            throw;
+                        }
                         Array.Clear(_windowBuffers);
                         Array.Clear(_ephemeralTables);
                         if (halt.ErrorCode != 0)
@@ -1507,9 +1542,15 @@ public sealed class ResumableStatement : IDisposable
                         if (_registers[haltIfNull.Target.Index].Kind == SqlValueKind.Null)
                         {
                             Array.Clear(_openCursors);
-                            DisposeAllJoinCursors();
-                            DisposeAllSorters();
-                            DisposeAllVirtualCursors();
+                            try
+                            {
+                                DisposeExecutionResources();
+                            }
+                            catch
+                            {
+                                State = ResumableStatementState.Faulted;
+                                throw;
+                            }
                             Array.Clear(_windowBuffers);
                             Array.Clear(_ephemeralTables);
                             throw CreateHaltIfNullException(haltIfNull);
@@ -1546,9 +1587,7 @@ public sealed class ResumableStatement : IDisposable
         Array.Clear(_skipLastInsertRowId);
         Array.Clear(_materializedRows);
         Array.Clear(_materializedRowIds);
-        DisposeAllJoinCursors();
-        DisposeAllSorters();
-        DisposeAllVirtualCursors();
+        DisposeExecutionResources();
         Array.Clear(_accumulatorContexts);
         Array.Clear(_accumulatorInitialized);
         Array.Clear(_distinctSets);
@@ -1631,9 +1670,7 @@ public sealed class ResumableStatement : IDisposable
         Array.Clear(_registers);
         Array.Clear(_openCursors);
         Array.Clear(_materializedRows);
-        DisposeAllJoinCursors();
-        DisposeAllSorters();
-        DisposeAllVirtualCursors();
+        DisposeExecutionResources();
         Array.Clear(_accumulatorContexts);
         Array.Clear(_accumulatorInitialized);
         Array.Clear(_distinctSets);
@@ -1684,7 +1721,8 @@ public sealed class ResumableStatement : IDisposable
             subprogram?.Dispose();
             subprogram = instruction.Subprogram.CreateRuntime(
                 CreateSubprogramBinding(instruction),
-                _executionOptions);
+                _executionOptions,
+                _memory);
             _subprogramStatements[instructionOffset] = subprogram;
         }
         else if (subprogram!.State == ResumableStatementState.Yielded)
@@ -1736,7 +1774,8 @@ public sealed class ResumableStatement : IDisposable
             instruction.Comparer,
             instruction.ColumnCount,
             instruction.BufferRowCapacity,
-            _executionOptions);
+            _executionOptions,
+            _memory);
     }
 
     private void CloseSorter(Sorter sorter)
@@ -1778,22 +1817,80 @@ public sealed class ResumableStatement : IDisposable
 
     private void DisposeAllJoinCursors()
     {
+        Exception? cleanupFailure = null;
         for (var index = 0; index < _joinCursorStates.Length; index++)
         {
-            _joinCursorStates[index]?.Close();
+            var joinState = _joinCursorStates[index];
             _joinCursorStates[index] = null;
+            try
+            {
+                joinState?.Close();
+            }
+            catch (Exception exception)
+            {
+                cleanupFailure ??= exception;
+            }
         }
+
+        if (cleanupFailure is not null)
+            ExceptionDispatchInfo.Capture(cleanupFailure).Throw();
     }
 
     private void DisposeAllVirtualCursors()
     {
+        List<Exception>? cleanupFailures = null;
         for (var index = 0; index < _virtualCursors.Length; index++)
         {
-            _virtualCursors[index]?.Dispose();
-            _virtualCursors[index] = null;
-            _indexMethodCursors[index]?.Dispose();
-            _indexMethodCursors[index] = null;
+            try
+            {
+                _virtualCursors[index]?.Dispose();
+                _virtualCursors[index] = null;
+            }
+            catch (Exception exception)
+            {
+                (cleanupFailures ??= []).Add(exception);
+            }
+            try
+            {
+                _indexMethodCursors[index]?.Dispose();
+                _indexMethodCursors[index] = null;
+            }
+            catch (Exception exception)
+            {
+                (cleanupFailures ??= []).Add(exception);
+            }
         }
+
+        ThrowCleanupFailures(cleanupFailures);
+    }
+
+    private void DisposeExecutionResources()
+    {
+        List<Exception>? cleanupFailures = null;
+        TryDispose(DisposeAllJoinCursors, ref cleanupFailures);
+        TryDispose(DisposeAllSorters, ref cleanupFailures);
+        TryDispose(DisposeAllVirtualCursors, ref cleanupFailures);
+        ThrowCleanupFailures(cleanupFailures);
+    }
+
+    private static void TryDispose(Action dispose, ref List<Exception>? failures)
+    {
+        try
+        {
+            dispose();
+        }
+        catch (Exception exception)
+        {
+            (failures ??= []).Add(exception);
+        }
+    }
+
+    private static void ThrowCleanupFailures(List<Exception>? failures)
+    {
+        if (failures is [var failure])
+            ExceptionDispatchInfo.Capture(failure).Throw();
+        if (failures is { Count: > 1 })
+            throw new AggregateException(failures);
     }
 
     private SorterRuntime RequireOpenSorter(Sorter sorter)
@@ -2607,6 +2704,7 @@ public sealed class ResumableStatement : IDisposable
         private readonly int _bufferRowCapacity;
         private readonly long _bufferMemoryLimitBytes;
         private readonly VdbeExecutionOptions _executionOptions;
+        private readonly VdbeExecutionMemory _memory;
         private readonly List<SqlValue[]> _rows = [];
         private long _bufferedBytes;
         private SorterSpill? _spill;
@@ -2621,11 +2719,13 @@ public sealed class ResumableStatement : IDisposable
             VdbeRowComparer comparer,
             int columnCount,
             int bufferRowCapacity,
-            VdbeExecutionOptions executionOptions)
+            VdbeExecutionOptions executionOptions,
+            VdbeExecutionMemory memory)
         {
             _comparer = comparer;
             _columnCount = columnCount;
             _executionOptions = executionOptions;
+            _memory = memory;
             // 0 means "no spill" (the historical in-memory default). Treat anything
             // non-positive the same way so a stray negative capacity can never force a
             // single-row spill loop.
@@ -2644,13 +2744,27 @@ public sealed class ResumableStatement : IDisposable
             }
 
             var recordBytes = EstimateRecordBytes(record);
-            if (_rows.Count > 0
-                && (_rows.Count >= _bufferRowCapacity
-                    || _bufferedBytes > _bufferMemoryLimitBytes - recordBytes))
-            {
+            if (_rows.Count >= _bufferRowCapacity)
                 FlushBuffered(cancellationToken);
+
+            if (!_memory.TryRetain(recordBytes))
+            {
+                if (_rows.Count > 0)
+                {
+                    FlushBuffered(cancellationToken);
+                    if (_memory.TryRetain(recordBytes))
+                        goto retained;
+                }
+
+                if (!_executionOptions.AllowTemporaryFileSpill)
+                    throw new VdbeMemoryLimitExceededException(_bufferMemoryLimitBytes, recordBytes);
+
+                _spill ??= new SorterSpill(_columnCount, _executionOptions);
+                _spill.WriteRun([record], cancellationToken);
+                return;
             }
 
+        retained:
             _rows.Add(record);
             _bufferedBytes = checked(_bufferedBytes + recordBytes);
         }
@@ -2814,19 +2928,27 @@ public sealed class ResumableStatement : IDisposable
 
         public void Dispose()
         {
-            if (_readers is not null)
+            try
             {
-                foreach (var reader in _readers)
-                    reader?.Dispose();
-                _readers = null;
-            }
+                if (_readers is not null)
+                {
+                    foreach (var reader in _readers)
+                        reader?.Dispose();
+                    _readers = null;
+                }
 
-            _spill?.Dispose();
-            _spill = null;
-            _rows.Clear();
-            _bufferedBytes = 0;
-            _merge = null;
-            _pending = null;
+                _spill?.Dispose();
+                _spill = null;
+            }
+            finally
+            {
+                if (_bufferedBytes > 0)
+                    _memory.Release(_bufferedBytes, _rows.Count);
+                _rows.Clear();
+                _bufferedBytes = 0;
+                _merge = null;
+                _pending = null;
+            }
         }
 
         private void FlushBuffered(CancellationToken cancellationToken)
@@ -2834,29 +2956,22 @@ public sealed class ResumableStatement : IDisposable
             if (_rows.Count == 0)
                 return;
 
+            if (!_executionOptions.AllowTemporaryFileSpill)
+            {
+                throw new VdbeMemoryLimitExceededException(
+                    _bufferMemoryLimitBytes,
+                    _bufferedBytes);
+            }
+
             _spill ??= new SorterSpill(_columnCount, _executionOptions);
             _spill.WriteRun(SortBufferedRows(cancellationToken), cancellationToken);
+            _memory.Release(_bufferedBytes, _rows.Count);
             _rows.Clear();
             _bufferedBytes = 0;
         }
 
-        private static long EstimateRecordBytes(SqlValue[] record)
-        {
-            long total = 0;
-            foreach (var value in record)
-            {
-                total = checked(total + value.Kind switch
-                {
-                    SqlValueKind.Null => 1,
-                    SqlValueKind.Integer or SqlValueKind.Real => 9,
-                    SqlValueKind.Text => 5L + Encoding.UTF8.GetByteCount(value.AsText()),
-                    SqlValueKind.Blob => 5L + value.AsBlob().Length,
-                    _ => throw new InvalidOperationException($"Unknown SQL value kind {value.Kind}."),
-                });
-            }
-
-            return total;
-        }
+        private static long EstimateRecordBytes(SqlValue[] record) =>
+            VdbeSpillRecordCodec.EstimateRetainedBytes(record);
 
         // Heap priority: orders by the row comparer, then by RunIndex so equal-key rows
         // across runs keep their global insertion order. The record is carried alongside
@@ -2889,8 +3004,8 @@ public sealed class ResumableStatement : IDisposable
     private sealed class SorterSpill : IDisposable
     {
         private readonly int _columnCount;
-        private readonly IFileSystem _fileSystem;
-        private readonly string _path;
+        private readonly VdbeExecutionOptions _executionOptions;
+        private readonly VdbeTemporaryFile _temporaryFile;
         private readonly IFile _file;
         private readonly List<(long Offset, int RowCount)> _runs = [];
         private long _writePosition;
@@ -2898,8 +3013,31 @@ public sealed class ResumableStatement : IDisposable
         public SorterSpill(int columnCount, VdbeExecutionOptions executionOptions)
         {
             _columnCount = columnCount;
-            _fileSystem = executionOptions.TemporaryFileSystem;
-            (_path, _file) = CreateFile(executionOptions);
+            _executionOptions = executionOptions;
+            var temporaryFile = VdbeTemporaryFile.Create(executionOptions, "sorter");
+            try
+            {
+                _writePosition = VdbeSpillRecordCodec.InitializeFile(
+                    temporaryFile.File,
+                    VdbeSpillFileKind.SorterRun,
+                    executionOptions.Metrics);
+            }
+            catch (Exception primaryFailure)
+            {
+                try
+                {
+                    temporaryFile.Dispose();
+                }
+                catch (Exception cleanupFailure)
+                {
+                    throw new AggregateException(primaryFailure, cleanupFailure);
+                }
+                ExceptionDispatchInfo.Capture(primaryFailure).Throw();
+                throw;
+            }
+
+            _temporaryFile = temporaryFile;
+            _file = temporaryFile.File;
         }
 
         public int RunCount => _runs.Count;
@@ -2911,21 +3049,38 @@ public sealed class ResumableStatement : IDisposable
             var offset = _writePosition;
             try
             {
-                Span<byte> header = stackalloc byte[8];
                 foreach (var row in sorted)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-                    for (var column = 0; column < _columnCount; column++)
-                        WriteValue(_file, ref _writePosition, row[column], header);
+                    var recordStart = VdbeSpillRecordCodec.BeginRecord(ref _writePosition);
+                    VdbeSpillRecordCodec.WriteValues(
+                        _file,
+                        ref _writePosition,
+                        row,
+                        _executionOptions.Metrics);
+                    VdbeSpillRecordCodec.CompleteRecord(
+                        _file,
+                        recordStart,
+                        _writePosition,
+                        _executionOptions.Metrics);
                 }
 
                 _file.FlushToDisk();
                 _runs.Add((offset, sorted.Count));
+                _executionOptions.Metrics.SorterRunWritten();
             }
-            catch
+            catch (Exception primaryFailure)
             {
-                _file.SetLength(offset);
-                _writePosition = offset;
+                try
+                {
+                    _file.SetLength(offset);
+                    _writePosition = offset;
+                }
+                catch (Exception rollbackFailure)
+                {
+                    throw new AggregateException(primaryFailure, rollbackFailure);
+                }
+                ExceptionDispatchInfo.Capture(primaryFailure).Throw();
                 throw;
             }
         }
@@ -2960,10 +3115,18 @@ public sealed class ResumableStatement : IDisposable
                     _runs.Clear();
                     _runs.AddRange(consolidated);
                 }
-                catch
+                catch (Exception primaryFailure)
                 {
-                    _file.SetLength(passOffset);
-                    _writePosition = passOffset;
+                    try
+                    {
+                        _file.SetLength(passOffset);
+                        _writePosition = passOffset;
+                    }
+                    catch (Exception rollbackFailure)
+                    {
+                        throw new AggregateException(primaryFailure, rollbackFailure);
+                    }
+                    ExceptionDispatchInfo.Capture(primaryFailure).Throw();
                     throw;
                 }
             }
@@ -2982,19 +3145,32 @@ public sealed class ResumableStatement : IDisposable
                 for (var index = 0; index < inputs.Count; index++)
                 {
                     var input = inputs[index];
-                    var reader = new RunReader(_file, input.Offset, input.RowCount, _columnCount);
+                    var reader = new RunReader(
+                        _file,
+                        input.Offset,
+                        input.RowCount,
+                        _columnCount,
+                        _executionOptions.Metrics);
                     readers[index] = reader;
                     if (reader.TryReadNext(out var row, cancellationToken))
                         heap.Enqueue(index, new SpillMergeKey(row, index, comparer));
                 }
 
                 var rowsWritten = 0;
-                Span<byte> header = stackalloc byte[8];
                 while (heap.TryDequeue(out var readerIndex, out var key))
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-                    for (var column = 0; column < _columnCount; column++)
-                        WriteValue(_file, ref _writePosition, key.Record[column], header);
+                    var recordStart = VdbeSpillRecordCodec.BeginRecord(ref _writePosition);
+                    VdbeSpillRecordCodec.WriteValues(
+                        _file,
+                        ref _writePosition,
+                        key.Record,
+                        _executionOptions.Metrics);
+                    VdbeSpillRecordCodec.CompleteRecord(
+                        _file,
+                        recordStart,
+                        _writePosition,
+                        _executionOptions.Metrics);
                     rowsWritten = checked(rowsWritten + 1);
 
                     if (readers[readerIndex].TryReadNext(out var next, cancellationToken))
@@ -3002,12 +3178,21 @@ public sealed class ResumableStatement : IDisposable
                 }
 
                 _file.FlushToDisk();
+                _executionOptions.Metrics.SorterRunWritten();
                 return (offset, rowsWritten);
             }
-            catch
+            catch (Exception primaryFailure)
             {
-                _file.SetLength(offset);
-                _writePosition = offset;
+                try
+                {
+                    _file.SetLength(offset);
+                    _writePosition = offset;
+                }
+                catch (Exception rollbackFailure)
+                {
+                    throw new AggregateException(primaryFailure, rollbackFailure);
+                }
+                ExceptionDispatchInfo.Capture(primaryFailure).Throw();
                 throw;
             }
             finally
@@ -3020,96 +3205,19 @@ public sealed class ResumableStatement : IDisposable
         public RunReader OpenRunReader(int runIndex)
         {
             var (offset, rowCount) = _runs[runIndex];
-            return new RunReader(_file, offset, rowCount, _columnCount);
+            VdbeSpillRecordCodec.ValidateFile(
+                _file,
+                VdbeSpillFileKind.SorterRun,
+                _executionOptions.Metrics);
+            return new RunReader(
+                _file,
+                offset,
+                rowCount,
+                _columnCount,
+                _executionOptions.Metrics);
         }
 
-        public void Dispose()
-        {
-            try
-            {
-                _file.Dispose();
-            }
-            finally
-            {
-                _fileSystem.DeleteFile(_path);
-            }
-        }
-
-        private static (string Path, IFile File) CreateFile(VdbeExecutionOptions executionOptions)
-        {
-            for (var attempt = 0; attempt < 16; attempt++)
-            {
-                var path = Path.Combine(
-                    executionOptions.TemporaryDirectory,
-                    "ahtola-sorter-" + Guid.NewGuid().ToString("N") + ".run");
-                try
-                {
-                    var fileSystem = executionOptions.TemporaryFileSystem;
-                    var file = fileSystem is ITemporaryFileSystem temporaryFileSystem
-                        ? temporaryFileSystem.OpenTemporaryFile(path)
-                        : fileSystem.OpenFile(path, FileOpenMode.CreateNew);
-                    return (path, file);
-                }
-                catch (IOException) when (executionOptions.TemporaryFileSystem.FileExists(path))
-                {
-                    // Extremely unlikely name collision: select another statement-local name.
-                }
-            }
-
-            throw new IOException("Unable to allocate a unique temporary sorter run file.");
-        }
-
-        private static void WriteValue(IFile file, ref long position, SqlValue value, Span<byte> header)
-        {
-            switch (value.Kind)
-            {
-                case SqlValueKind.Null:
-                    WriteByte(file, ref position, 0x00);
-                    break;
-                case SqlValueKind.Integer:
-                    WriteByte(file, ref position, 0x01);
-                    BinaryPrimitives.WriteInt64LittleEndian(header, value.AsInteger());
-                    Write(file, ref position, header);
-                    break;
-                case SqlValueKind.Real:
-                    WriteByte(file, ref position, 0x02);
-                    BinaryPrimitives.WriteDoubleLittleEndian(header, value.AsReal());
-                    Write(file, ref position, header);
-                    break;
-                case SqlValueKind.Text:
-                    {
-                        var bytes = Encoding.UTF8.GetBytes(value.AsText());
-                        WriteByte(file, ref position, value.IsJson ? (byte)0x83 : (byte)0x03);
-                        BinaryPrimitives.WriteInt32LittleEndian(header, bytes.Length);
-                        Write(file, ref position, header[..4]);
-                        Write(file, ref position, bytes);
-                        break;
-                    }
-                case SqlValueKind.Blob:
-                    {
-                        var bytes = value.AsBlob().ToArray();
-                        WriteByte(file, ref position, 0x04);
-                        BinaryPrimitives.WriteInt32LittleEndian(header, bytes.Length);
-                        Write(file, ref position, header[..4]);
-                        Write(file, ref position, bytes);
-                        break;
-                    }
-                default:
-                    throw new InvalidOperationException($"Unknown SQL value kind {value.Kind}.");
-            }
-        }
-
-        private static void WriteByte(IFile file, ref long position, byte value)
-        {
-            Span<byte> bytes = stackalloc byte[1] { value };
-            Write(file, ref position, bytes);
-        }
-
-        private static void Write(IFile file, ref long position, ReadOnlySpan<byte> source)
-        {
-            file.Write(position, source);
-            position = checked(position + source.Length);
-        }
+        public void Dispose() => _temporaryFile.Dispose();
 
         private readonly struct SpillMergeKey
         {
@@ -3138,12 +3246,19 @@ public sealed class ResumableStatement : IDisposable
         {
             private readonly IFile _file;
             private readonly int _columnCount;
+            private readonly VdbeExecutionMetrics _metrics;
             private long _position;
 
-            public RunReader(IFile file, long offset, int rowCount, int columnCount)
+            public RunReader(
+                IFile file,
+                long offset,
+                int rowCount,
+                int columnCount,
+                VdbeExecutionMetrics metrics)
             {
                 _file = file;
                 _columnCount = columnCount;
+                _metrics = metrics;
                 _position = offset;
                 RowsRemaining = rowCount;
             }
@@ -3161,15 +3276,17 @@ public sealed class ResumableStatement : IDisposable
                 var rowStart = _position;
                 try
                 {
-                    row = new SqlValue[_columnCount];
-                    Span<byte> header = stackalloc byte[8];
-
-                    for (var column = 0; column < _columnCount; column++)
-                    {
-                        cancellationToken.ThrowIfCancellationRequested();
-                        ReadValue(_file, ref _position, header, out row[column]);
-                    }
-
+                    var recordEnd = VdbeSpillRecordCodec.ReadRecordEnd(
+                        _file,
+                        ref _position,
+                        _metrics);
+                    row = VdbeSpillRecordCodec.ReadValues(
+                        _file,
+                        ref _position,
+                        _columnCount,
+                        _metrics,
+                        cancellationToken);
+                    VdbeSpillRecordCodec.RequireRecordEnd(_position, recordEnd);
                     RowsRemaining--;
                     return true;
                 }
@@ -3183,70 +3300,6 @@ public sealed class ResumableStatement : IDisposable
             public void Dispose()
             {
                 // The IFile is shared and owned by SorterSpill.
-            }
-
-            private static void ReadValue(IFile file, ref long position, Span<byte> header, out SqlValue value)
-            {
-                var kindByte = ReadByte(file, ref position);
-
-                var isJson = (kindByte & 0x80) != 0;
-                var kind = (SqlValueKind)(kindByte & 0x0F);
-                switch (kind)
-                {
-                    case SqlValueKind.Null:
-                        value = SqlValue.Null;
-                        break;
-                    case SqlValueKind.Integer:
-                        ReadExact(file, ref position, header[..8]);
-                        value = SqlValue.Integer(BinaryPrimitives.ReadInt64LittleEndian(header));
-                        break;
-                    case SqlValueKind.Real:
-                        ReadExact(file, ref position, header[..8]);
-                        value = SqlValue.Real(BinaryPrimitives.ReadDoubleLittleEndian(header));
-                        break;
-                    case SqlValueKind.Text:
-                        ReadExact(file, ref position, header[..4]);
-                        var textLength = BinaryPrimitives.ReadInt32LittleEndian(header);
-                        if (textLength < 0)
-                            throw new InvalidDataException("Sorter spill text length is negative.");
-                        var textBytes = new byte[textLength];
-                        ReadExact(file, ref position, textBytes);
-                        var text = Encoding.UTF8.GetString(textBytes);
-                        value = isJson ? SqlValue.JsonText(text) : SqlValue.Text(text);
-                        break;
-                    case SqlValueKind.Blob:
-                        ReadExact(file, ref position, header[..4]);
-                        var blobLength = BinaryPrimitives.ReadInt32LittleEndian(header);
-                        if (blobLength < 0)
-                            throw new InvalidDataException("Sorter spill blob length is negative.");
-                        var blob = new byte[blobLength];
-                        ReadExact(file, ref position, blob);
-                        value = SqlValue.Blob(blob);
-                        break;
-                    default:
-                        throw new InvalidOperationException($"Unknown spilled value kind {kind}.");
-                }
-            }
-
-            private static byte ReadByte(IFile file, ref long position)
-            {
-                Span<byte> value = stackalloc byte[1];
-                ReadExact(file, ref position, value);
-                return value[0];
-            }
-
-            private static void ReadExact(IFile file, ref long position, Span<byte> buffer)
-            {
-                var total = 0;
-                while (total < buffer.Length)
-                {
-                    var read = file.Read(checked(position + total), buffer[total..]);
-                    if (read <= 0)
-                        throw new EndOfStreamException("Sorter spill stream ended mid-record.");
-                    total += read;
-                }
-
-                position = checked(position + total);
             }
         }
     }
@@ -3543,32 +3596,75 @@ public sealed class ResumableStatement : IDisposable
 
         public SqlValue[]? CurrentRow { get; private set; }
 
-        public void Open(IEnumerator<SqlValue[]> enumerator)
+        private VdbeJoinExecutionContext? _context;
+
+        public void Open(
+            VdbeJoinPlan plan,
+            VdbeExecutionOptions executionOptions,
+            VdbeExecutionMemory memory)
         {
-            _enumerator = enumerator;
+            _context = new VdbeJoinExecutionContext(executionOptions, memory);
+            _enumerator = plan.Enumerate(_context).GetEnumerator();
             CurrentRow = null;
         }
 
-        public bool MoveNext()
+        public bool MoveNext(CancellationToken cancellationToken)
         {
             if (_enumerator is null)
                 return false;
 
-            if (_enumerator.MoveNext())
+            _context!.SetCancellationToken(cancellationToken);
+            try
             {
-                CurrentRow = _enumerator.Current;
-                return true;
-            }
+                if (_enumerator.MoveNext())
+                {
+                    CurrentRow = _enumerator.Current;
+                    return true;
+                }
 
-            CurrentRow = null;
-            return false;
+                CurrentRow = null;
+                if (_context.TakeCleanupFailure() is { } cleanupFailure)
+                    ExceptionDispatchInfo.Capture(cleanupFailure).Throw();
+                return false;
+            }
+            catch (Exception executionFailure)
+            {
+                try
+                {
+                    Close();
+                }
+                catch (Exception cleanupFailure)
+                {
+                    throw new AggregateException(executionFailure, cleanupFailure);
+                }
+                throw;
+            }
         }
 
         public void Close()
         {
-            _enumerator?.Dispose();
+            Exception? failure = null;
+            try
+            {
+                _enumerator?.Dispose();
+            }
+            catch (Exception exception)
+            {
+                failure = exception;
+            }
+
+            if (_context?.TakeCleanupFailure() is { } cleanupFailure)
+            {
+                failure = failure is null
+                    ? cleanupFailure
+                    : new AggregateException(failure, cleanupFailure);
+            }
+
             _enumerator = null;
+            _context = null;
             CurrentRow = null;
+            if (failure is not null)
+                ExceptionDispatchInfo.Capture(failure).Throw();
         }
     }
 }

--- a/src/Ahtola.Core/Execution/ResumableStatement.cs
+++ b/src/Ahtola.Core/Execution/ResumableStatement.cs
@@ -2705,6 +2705,7 @@ public sealed class ResumableStatement : IDisposable
         private readonly long _bufferMemoryLimitBytes;
         private readonly VdbeExecutionOptions _executionOptions;
         private readonly VdbeExecutionMemory _memory;
+        private readonly VdbePendingCleanupRegistry _pendingCleanup = new();
         private readonly List<SqlValue[]> _rows = [];
         private long _bufferedBytes;
         private long _sortWorkspaceBytes;
@@ -2764,11 +2765,10 @@ public sealed class ResumableStatement : IDisposable
                 if (!_executionOptions.AllowTemporaryFileSpill)
                     throw new VdbeMemoryLimitExceededException(_bufferMemoryLimitBytes, recordBytes);
 
-                _spill ??= new SorterSpill(_columnCount, _executionOptions, _memory);
+                _spill ??= CreateSpill();
                 _spill.WriteSingleRow(record, recordBytes, cancellationToken);
-                _spill.ConsolidateRuns(
+                _spill.CompactRunTiers(
                     _comparer,
-                    _executionOptions.SorterMergeFanIn,
                     _memory,
                     cancellationToken);
                 return;
@@ -2797,7 +2797,7 @@ public sealed class ResumableStatement : IDisposable
                     return false;
                 }
 
-                _spill.ConsolidateRuns(
+                _spill.PrepareFinalMerge(
                     _comparer,
                     _executionOptions.SorterMergeFanIn,
                     _memory,
@@ -2968,11 +2968,23 @@ public sealed class ResumableStatement : IDisposable
 
         public void Dispose()
         {
+            List<Exception>? cleanupFailures = null;
             try
             {
-                DisposeMerge();
-                _spill?.Dispose();
-                _spill = null;
+                TryDispose(DisposeMerge, ref cleanupFailures);
+                if (_spill is not null)
+                {
+                    try
+                    {
+                        _spill.Dispose();
+                        _spill = null;
+                    }
+                    catch (Exception exception)
+                    {
+                        (cleanupFailures ??= []).Add(exception);
+                    }
+                }
+                TryDispose(_pendingCleanup.Retry, ref cleanupFailures);
             }
             finally
             {
@@ -2985,6 +2997,7 @@ public sealed class ResumableStatement : IDisposable
                 _merge = null;
                 _pending = null;
             }
+            ThrowCleanupFailures(cleanupFailures);
         }
 
         private void FlushBuffered(CancellationToken cancellationToken)
@@ -2999,19 +3012,25 @@ public sealed class ResumableStatement : IDisposable
                     _bufferedBytes);
             }
 
-            _spill ??= new SorterSpill(_columnCount, _executionOptions, _memory);
+            _spill ??= CreateSpill();
             _spill.WriteRun(SortBufferedRows(cancellationToken), cancellationToken);
             _memory.Release(_bufferedBytes, _rows.Count);
             _rows.Clear();
             _rows.Capacity = 0;
             _bufferedBytes = 0;
             _sortWorkspaceBytes = 0;
-            _spill.ConsolidateRuns(
+            _spill.CompactRunTiers(
                 _comparer,
-                _executionOptions.SorterMergeFanIn,
                 _memory,
                 cancellationToken);
         }
+
+        private SorterSpill CreateSpill() =>
+            SorterSpill.Create(
+                _columnCount,
+                _executionOptions,
+                _memory,
+                _pendingCleanup);
 
         private static long EstimateRecordBytes(SqlValue[] record) =>
             Math.Max(
@@ -3108,51 +3127,91 @@ public sealed class ResumableStatement : IDisposable
         private readonly int _columnCount;
         private readonly VdbeExecutionOptions _executionOptions;
         private readonly VdbeExecutionMemory _memory;
-        private readonly VdbeTemporaryFile _temporaryFile;
-        private readonly IFile _file;
+        private VdbeTemporaryFile? _temporaryFile;
+        private IFile? _file;
         private List<RunDescriptor>? _runs;
         private long _writePosition;
         private long _runDescriptorBytes;
         private bool _disposed;
 
-        public SorterSpill(
+        private IFile File =>
+            _file ?? throw new ObjectDisposedException(nameof(SorterSpill));
+
+        private SorterSpill(
             int columnCount,
             VdbeExecutionOptions executionOptions,
-            VdbeExecutionMemory memory)
+            VdbeExecutionMemory memory,
+            long runDescriptorBytes)
         {
             _columnCount = columnCount;
             _executionOptions = executionOptions;
             _memory = memory;
-            _runDescriptorBytes = VdbeManagedFootprint.ListObjectBytes;
-            memory.RetainOrThrow(_runDescriptorBytes, rows: 0);
-            VdbeTemporaryFile? temporaryFile = null;
+            _runDescriptorBytes = runDescriptorBytes;
+        }
+
+        public static SorterSpill Create(
+            int columnCount,
+            VdbeExecutionOptions executionOptions,
+            VdbeExecutionMemory memory,
+            VdbePendingCleanupRegistry pendingCleanup)
+        {
+            var runDescriptorBytes = VdbeManagedFootprint.ListObjectBytes;
+            memory.RetainOrThrow(runDescriptorBytes, rows: 0);
+            SorterSpill spill;
             try
             {
-                _runs = [];
-                temporaryFile = VdbeTemporaryFile.Create(executionOptions, "sorter");
-                _writePosition = VdbeSpillRecordCodec.InitializeFile(
-                    temporaryFile.File,
-                    VdbeSpillFileKind.SorterRun,
-                    executionOptions.Metrics);
+                spill = new SorterSpill(
+                    columnCount,
+                    executionOptions,
+                    memory,
+                    runDescriptorBytes);
+            }
+            catch
+            {
+                memory.Release(runDescriptorBytes, rows: 0);
+                throw;
+            }
+
+            try
+            {
+                pendingCleanup.Register(spill);
+            }
+            catch
+            {
+                spill.Dispose();
+                throw;
+            }
+            try
+            {
+                spill.Initialize();
+                pendingCleanup.Unregister(spill);
+                return spill;
             }
             catch (Exception primaryFailure)
             {
                 try
                 {
-                    temporaryFile?.Dispose();
+                    spill.Dispose();
+                    pendingCleanup.Unregister(spill);
                 }
                 catch (Exception cleanupFailure)
                 {
-                    memory.Release(_runDescriptorBytes, rows: 0);
                     throw new AggregateException(primaryFailure, cleanupFailure);
                 }
-                memory.Release(_runDescriptorBytes, rows: 0);
                 ExceptionDispatchInfo.Capture(primaryFailure).Throw();
                 throw;
             }
+        }
 
-            _temporaryFile = temporaryFile;
-            _file = temporaryFile.File;
+        private void Initialize()
+        {
+            _runs = [];
+            _temporaryFile = VdbeTemporaryFile.Create(_executionOptions, "sorter");
+            _file = _temporaryFile.File;
+            _writePosition = VdbeSpillRecordCodec.InitializeFile(
+                File,
+                VdbeSpillFileKind.SorterRun,
+                _executionOptions.Metrics);
         }
 
         public int RunCount => _runs?.Count ?? 0;
@@ -3169,24 +3228,24 @@ public sealed class ResumableStatement : IDisposable
                 cancellationToken.ThrowIfCancellationRequested();
                 var recordStart = VdbeSpillRecordCodec.BeginRecord(ref _writePosition);
                 VdbeSpillRecordCodec.WriteValues(
-                    _file,
+                    File,
                     ref _writePosition,
                     row,
                     _executionOptions.Metrics);
                 VdbeSpillRecordCodec.CompleteRecord(
-                    _file,
+                    File,
                     recordStart,
                     _writePosition,
                     _executionOptions.Metrics);
-                _file.FlushToDisk();
-                _runs!.Add(new RunDescriptor(offset, 1, retainedBytes));
+                File.FlushToDisk();
+                _runs!.Add(new RunDescriptor(offset, 1, retainedBytes, MergeLevel: 0));
                 _executionOptions.Metrics.SorterRunWritten();
             }
             catch (Exception primaryFailure)
             {
                 try
                 {
-                    _file.SetLength(offset);
+                    File.SetLength(offset);
                     _writePosition = offset;
                 }
                 catch (Exception rollbackFailure)
@@ -3220,29 +3279,30 @@ public sealed class ResumableStatement : IDisposable
                                 row.Length)));
                     var recordStart = VdbeSpillRecordCodec.BeginRecord(ref _writePosition);
                     VdbeSpillRecordCodec.WriteValues(
-                        _file,
+                        File,
                         ref _writePosition,
                         row,
                         _executionOptions.Metrics);
                     VdbeSpillRecordCodec.CompleteRecord(
-                        _file,
+                        File,
                         recordStart,
                         _writePosition,
                         _executionOptions.Metrics);
                 }
 
-                _file.FlushToDisk();
+                File.FlushToDisk();
                 _runs!.Add(new RunDescriptor(
                     offset,
                     sorted.Count,
-                    maximumRetainedRowBytes));
+                    maximumRetainedRowBytes,
+                    MergeLevel: 0));
                 _executionOptions.Metrics.SorterRunWritten();
             }
             catch (Exception primaryFailure)
             {
                 try
                 {
-                    _file.SetLength(offset);
+                    File.SetLength(offset);
                     _writePosition = offset;
                 }
                 catch (Exception rollbackFailure)
@@ -3254,12 +3314,52 @@ public sealed class ResumableStatement : IDisposable
             }
         }
 
-        public void ConsolidateRuns(
+        public void CompactRunTiers(
+            VdbeRowComparer comparer,
+            VdbeExecutionMemory memory,
+            CancellationToken cancellationToken)
+        {
+            var runs = _runs
+                ?? throw new ObjectDisposedException(nameof(SorterSpill));
+            while (true)
+            {
+                var start = -1;
+                for (var index = runs.Count - 2; index >= 0; index--)
+                {
+                    if (runs[index].MergeLevel == runs[index + 1].MergeLevel)
+                    {
+                        start = index;
+                        break;
+                    }
+                }
+
+                if (start < 0)
+                    return;
+                if (GetEffectiveFanIn(start, 2, memory.AvailableBytes) < 2)
+                {
+                    throw new VdbeMemoryLimitExceededException(
+                        memory.LimitBytes,
+                        EstimateMergeBytes(start, 2));
+                }
+
+                var merged = MergeRunGroup(
+                    start,
+                    count: 2,
+                    comparer,
+                    memory,
+                    cancellationToken);
+                runs[start] = merged;
+                runs.RemoveAt(start + 1);
+            }
+        }
+
+        public void PrepareFinalMerge(
             VdbeRowComparer comparer,
             int maximumFanIn,
             VdbeExecutionMemory memory,
             CancellationToken cancellationToken)
         {
+            CompactRunTiers(comparer, memory, cancellationToken);
             var runs = _runs
                 ?? throw new ObjectDisposedException(nameof(SorterSpill));
             while (runs.Count > 1)
@@ -3317,7 +3417,7 @@ public sealed class ResumableStatement : IDisposable
                 {
                     try
                     {
-                        _file.SetLength(passOffset);
+                        File.SetLength(passOffset);
                         _writePosition = passOffset;
                     }
                     catch (Exception rollbackFailure)
@@ -3358,7 +3458,7 @@ public sealed class ResumableStatement : IDisposable
                 {
                     var input = _runs![start + index];
                     var reader = new RunReader(
-                        _file,
+                        File,
                         input.Offset,
                         input.RowCount,
                         _columnCount,
@@ -3381,12 +3481,12 @@ public sealed class ResumableStatement : IDisposable
                     heads[readerIndex] = null!;
                     var recordStart = VdbeSpillRecordCodec.BeginRecord(ref _writePosition);
                     VdbeSpillRecordCodec.WriteValues(
-                        _file,
+                        File,
                         ref _writePosition,
                         key.Record,
                         _executionOptions.Metrics);
                     VdbeSpillRecordCodec.CompleteRecord(
-                        _file,
+                        File,
                         recordStart,
                         _writePosition,
                         _executionOptions.Metrics);
@@ -3403,18 +3503,19 @@ public sealed class ResumableStatement : IDisposable
                     }
                 }
 
-                _file.FlushToDisk();
+                File.FlushToDisk();
                 _executionOptions.Metrics.SorterRunWritten();
                 return new RunDescriptor(
                     offset,
                     rowsWritten,
-                    GetMaximumRetainedRowBytes(start, count));
+                    GetMaximumRetainedRowBytes(start, count),
+                    checked(GetMaximumMergeLevel(start, count) + 1));
             }
             catch (Exception primaryFailure)
             {
                 try
                 {
-                    _file.SetLength(offset);
+                    File.SetLength(offset);
                     _writePosition = offset;
                 }
                 catch (Exception rollbackFailure)
@@ -3445,11 +3546,11 @@ public sealed class ResumableStatement : IDisposable
         {
             var run = _runs![runIndex];
             VdbeSpillRecordCodec.ValidateFile(
-                _file,
+                File,
                 VdbeSpillFileKind.SorterRun,
                 _executionOptions.Metrics);
             return new RunReader(
-                _file,
+                File,
                 run.Offset,
                 run.RowCount,
                 _columnCount,
@@ -3460,9 +3561,10 @@ public sealed class ResumableStatement : IDisposable
         {
             if (_disposed)
                 return;
-            _temporaryFile.Dispose();
+            _temporaryFile?.Dispose();
             _disposed = true;
             _runs = null;
+            _file = null;
             _memory.Release(_runDescriptorBytes, rows: 0);
             _runDescriptorBytes = 0;
         }
@@ -3499,6 +3601,14 @@ public sealed class ResumableStatement : IDisposable
             return maximum;
         }
 
+        private int GetMaximumMergeLevel(int start, int count)
+        {
+            var maximum = 0;
+            for (var index = 0; index < count; index++)
+                maximum = Math.Max(maximum, _runs![start + index].MergeLevel);
+            return maximum;
+        }
+
         private void ReserveRunDescriptor()
         {
             var runs = _runs
@@ -3527,7 +3637,8 @@ public sealed class ResumableStatement : IDisposable
         private readonly record struct RunDescriptor(
             long Offset,
             int RowCount,
-            long MaximumRetainedRowBytes);
+            long MaximumRetainedRowBytes,
+            int MergeLevel);
 
         private readonly struct SpillMergeKey
         {
@@ -3622,6 +3733,7 @@ public sealed class ResumableStatement : IDisposable
                         _file,
                         ref _position,
                         _columnCount,
+                        recordEnd,
                         _metrics,
                         cancellationToken);
                     VdbeSpillRecordCodec.RequireRecordEnd(_position, recordEnd);

--- a/src/Ahtola.Core/Execution/ResumableStatement.cs
+++ b/src/Ahtola.Core/Execution/ResumableStatement.cs
@@ -3025,12 +3025,27 @@ public sealed class ResumableStatement : IDisposable
                 cancellationToken);
         }
 
-        private SorterSpill CreateSpill() =>
-            SorterSpill.Create(
-                _columnCount,
-                _executionOptions,
-                _memory,
-                _pendingCleanup);
+        private SorterSpill CreateSpill()
+        {
+            VdbeMemoryReservation? infrastructureReservation =
+                VdbeMemoryReservation.Create(
+                    _memory,
+                    VdbeManagedFootprint.EstimateSorterSpillInfrastructure(
+                        _executionOptions.TemporaryDirectory));
+            try
+            {
+                return SorterSpill.Create(
+                    _columnCount,
+                    _executionOptions,
+                    _memory,
+                    _pendingCleanup,
+                    ref infrastructureReservation);
+            }
+            finally
+            {
+                infrastructureReservation?.Dispose();
+            }
+        }
 
         private static long EstimateRecordBytes(SqlValue[] record) =>
             Math.Max(
@@ -3127,6 +3142,7 @@ public sealed class ResumableStatement : IDisposable
         private readonly int _columnCount;
         private readonly VdbeExecutionOptions _executionOptions;
         private readonly VdbeExecutionMemory _memory;
+        private readonly VdbeMemoryReservation _infrastructureReservation;
         private VdbeTemporaryFile? _temporaryFile;
         private IFile? _file;
         private List<RunDescriptor>? _runs;
@@ -3141,22 +3157,23 @@ public sealed class ResumableStatement : IDisposable
             int columnCount,
             VdbeExecutionOptions executionOptions,
             VdbeExecutionMemory memory,
-            long runDescriptorBytes)
+            VdbeMemoryReservation infrastructureReservation)
         {
             _columnCount = columnCount;
             _executionOptions = executionOptions;
             _memory = memory;
-            _runDescriptorBytes = runDescriptorBytes;
+            _infrastructureReservation = infrastructureReservation;
         }
 
         public static SorterSpill Create(
             int columnCount,
             VdbeExecutionOptions executionOptions,
             VdbeExecutionMemory memory,
-            VdbePendingCleanupRegistry pendingCleanup)
+            VdbePendingCleanupRegistry pendingCleanup,
+            ref VdbeMemoryReservation? infrastructureReservation)
         {
-            var runDescriptorBytes = VdbeManagedFootprint.ListObjectBytes;
-            memory.RetainOrThrow(runDescriptorBytes, rows: 0);
+            var reservation = infrastructureReservation
+                ?? throw new InvalidOperationException("Sorter spill infrastructure was not reserved.");
             SorterSpill spill;
             try
             {
@@ -3164,14 +3181,16 @@ public sealed class ResumableStatement : IDisposable
                     columnCount,
                     executionOptions,
                     memory,
-                    runDescriptorBytes);
+                    reservation);
             }
             catch
             {
-                memory.Release(runDescriptorBytes, rows: 0);
+                reservation.Dispose();
+                infrastructureReservation = null;
                 throw;
             }
 
+            infrastructureReservation = null;
             try
             {
                 pendingCleanup.Register(spill);
@@ -3205,7 +3224,10 @@ public sealed class ResumableStatement : IDisposable
 
         private void Initialize()
         {
-            _runs = [];
+            _runs = new List<RunDescriptor>(
+                VdbeManagedFootprint.GetListCapacityForCount(
+                    currentCapacity: 0,
+                    requiredCount: 1));
             _temporaryFile = VdbeTemporaryFile.Create(_executionOptions, "sorter");
             _file = _temporaryFile.File;
             _writePosition = VdbeSpillRecordCodec.InitializeFile(
@@ -3562,11 +3584,16 @@ public sealed class ResumableStatement : IDisposable
             if (_disposed)
                 return;
             _temporaryFile?.Dispose();
-            _disposed = true;
+            if (_runDescriptorBytes > 0)
+            {
+                _memory.Release(_runDescriptorBytes, rows: 0);
+                _runDescriptorBytes = 0;
+            }
+            _infrastructureReservation.Dispose();
+            _temporaryFile = null;
             _runs = null;
             _file = null;
-            _memory.Release(_runDescriptorBytes, rows: 0);
-            _runDescriptorBytes = 0;
+            _disposed = true;
         }
 
         private int GetEffectiveFanIn(int start, int maximumFanIn, long availableBytes)

--- a/src/Ahtola.Core/Execution/ResumableStatement.cs
+++ b/src/Ahtola.Core/Execution/ResumableStatement.cs
@@ -2765,12 +2765,20 @@ public sealed class ResumableStatement : IDisposable
                 if (!_executionOptions.AllowTemporaryFileSpill)
                     throw new VdbeMemoryLimitExceededException(_bufferMemoryLimitBytes, recordBytes);
 
-                _spill ??= CreateSpill();
-                _spill.WriteSingleRow(record, recordBytes, cancellationToken);
-                _spill.CompactRunTiers(
-                    _comparer,
-                    _memory,
-                    cancellationToken);
+                _memory.RetainOrThrow(recordBytes);
+                try
+                {
+                    _spill ??= CreateSpill();
+                    _spill.WriteSingleRow(record, recordBytes, cancellationToken);
+                    _spill.CompactRunTiers(
+                        _comparer,
+                        _memory,
+                        cancellationToken);
+                }
+                finally
+                {
+                    _memory.Release(recordBytes);
+                }
                 return;
             }
         }
@@ -3060,9 +3068,12 @@ public sealed class ResumableStatement : IDisposable
             var capacity = VdbeManagedFootprint.GetListCapacityForCount(
                 _rows.Capacity,
                 requiredCount);
-            var listGrowth = checked(
-                VdbeManagedFootprint.EstimateReferenceListStorage(capacity)
-                - VdbeManagedFootprint.EstimateReferenceListStorage(_rows.Capacity));
+            var currentListBytes =
+                VdbeManagedFootprint.EstimateReferenceListStorage(_rows.Capacity);
+            var listGrowth = VdbeManagedFootprint.EstimateContainerReplacement(
+                currentListBytes,
+                VdbeManagedFootprint.EstimateReferenceListStorage(capacity));
+            var replacedListBytes = listGrowth > 0 ? currentListBytes : 0;
             var workspaceBytes = VdbeManagedFootprint.EstimateSortWorkspace(requiredCount);
             var workspaceGrowth = checked(workspaceBytes - _sortWorkspaceBytes);
             var retainedBytes = checked(recordBytes + listGrowth + workspaceGrowth);
@@ -3074,7 +3085,12 @@ public sealed class ResumableStatement : IDisposable
                 if (capacity != _rows.Capacity)
                     _rows.Capacity = capacity;
                 _rows.Add(record);
-                _bufferedBytes = checked(_bufferedBytes + retainedBytes);
+                if (replacedListBytes > 0)
+                    _memory.Release(replacedListBytes, rows: 0);
+                _bufferedBytes = checked(
+                    _bufferedBytes
+                    + retainedBytes
+                    - replacedListBytes);
                 _sortWorkspaceBytes = workspaceBytes;
                 return true;
             }
@@ -3645,14 +3661,18 @@ public sealed class ResumableStatement : IDisposable
                 runs.Count + 1);
             if (capacity == runs.Capacity)
                 return;
-            var growthBytes = checked(
-                VdbeManagedFootprint.EstimateRunDescriptorListStorage(capacity)
-                - VdbeManagedFootprint.EstimateRunDescriptorListStorage(runs.Capacity));
+            var currentStorageBytes =
+                VdbeManagedFootprint.EstimateRunDescriptorListStorage(runs.Capacity);
+            var growthBytes = VdbeManagedFootprint.EstimateContainerReplacement(
+                currentStorageBytes,
+                VdbeManagedFootprint.EstimateRunDescriptorListStorage(capacity));
             _memory.RetainOrThrow(growthBytes, rows: 0);
             try
             {
                 runs.Capacity = capacity;
-                _runDescriptorBytes = checked(_runDescriptorBytes + growthBytes);
+                if (_runDescriptorBytes > 0)
+                    _memory.Release(_runDescriptorBytes, rows: 0);
+                _runDescriptorBytes = growthBytes;
             }
             catch
             {

--- a/src/Ahtola.Core/Execution/ResumableStatement.cs
+++ b/src/Ahtola.Core/Execution/ResumableStatement.cs
@@ -372,10 +372,10 @@ public sealed class ResumableStatement : IDisposable
                         _virtualCursors[close.Cursor.Index]?.Dispose();
                         _virtualCursors[close.Cursor.Index] = null;
                         var joinState = _joinCursorStates[close.Cursor.Index];
-                        _joinCursorStates[close.Cursor.Index] = null;
                         try
                         {
                             joinState?.Close();
+                            _joinCursorStates[close.Cursor.Index] = null;
                         }
                         catch
                         {
@@ -1821,10 +1821,10 @@ public sealed class ResumableStatement : IDisposable
         for (var index = 0; index < _joinCursorStates.Length; index++)
         {
             var joinState = _joinCursorStates[index];
-            _joinCursorStates[index] = null;
             try
             {
                 joinState?.Close();
+                _joinCursorStates[index] = null;
             }
             catch (Exception exception)
             {
@@ -2707,13 +2707,16 @@ public sealed class ResumableStatement : IDisposable
         private readonly VdbeExecutionMemory _memory;
         private readonly List<SqlValue[]> _rows = [];
         private long _bufferedBytes;
+        private long _sortWorkspaceBytes;
         private SorterSpill? _spill;
         private bool _sorted;
         private int _position = -1;
         private PriorityQueue<int, MergeKey>? _merge;
         private SorterSpill.RunReader[]? _readers;
-        private SqlValue[]? _pending;
+        private SorterSpill.RowLease?[]? _mergeHeads;
+        private SorterSpill.RowLease? _pending;
         private int _pendingRunIndex;
+        private long _mergeInfrastructureBytes;
 
         public SorterRuntime(
             VdbeRowComparer comparer,
@@ -2744,29 +2747,32 @@ public sealed class ResumableStatement : IDisposable
             }
 
             var recordBytes = EstimateRecordBytes(record);
+            if (recordBytes > _memory.LimitBytes)
+                throw new VdbeMemoryLimitExceededException(_memory.LimitBytes, recordBytes);
             if (_rows.Count >= _bufferRowCapacity)
                 FlushBuffered(cancellationToken);
 
-            if (!_memory.TryRetain(recordBytes))
+            if (!TryBuffer(record, recordBytes))
             {
                 if (_rows.Count > 0)
                 {
                     FlushBuffered(cancellationToken);
-                    if (_memory.TryRetain(recordBytes))
-                        goto retained;
+                    if (TryBuffer(record, recordBytes))
+                        return;
                 }
 
                 if (!_executionOptions.AllowTemporaryFileSpill)
                     throw new VdbeMemoryLimitExceededException(_bufferMemoryLimitBytes, recordBytes);
 
-                _spill ??= new SorterSpill(_columnCount, _executionOptions);
-                _spill.WriteRun([record], cancellationToken);
+                _spill ??= new SorterSpill(_columnCount, _executionOptions, _memory);
+                _spill.WriteSingleRow(record, recordBytes, cancellationToken);
+                _spill.ConsolidateRuns(
+                    _comparer,
+                    _executionOptions.SorterMergeFanIn,
+                    _memory,
+                    cancellationToken);
                 return;
             }
-
-        retained:
-            _rows.Add(record);
-            _bufferedBytes = checked(_bufferedBytes + recordBytes);
         }
 
         // Sorts the buffered records and positions on the first one. Returns false (and
@@ -2794,6 +2800,7 @@ public sealed class ResumableStatement : IDisposable
                 _spill.ConsolidateRuns(
                     _comparer,
                     _executionOptions.SorterMergeFanIn,
+                    _memory,
                     cancellationToken);
                 StartMerge(cancellationToken);
                 _position = 0;
@@ -2810,6 +2817,12 @@ public sealed class ResumableStatement : IDisposable
             var sorted = SortBufferedRows(cancellationToken);
             _rows.Clear();
             _rows.AddRange(sorted);
+            if (_sortWorkspaceBytes > 0)
+            {
+                _memory.Release(_sortWorkspaceBytes, rows: 0);
+                _bufferedBytes -= _sortWorkspaceBytes;
+                _sortWorkspaceBytes = 0;
+            }
             _sorted = true;
             _position = 0;
             return true;
@@ -2825,7 +2838,8 @@ public sealed class ResumableStatement : IDisposable
             // Spill path: the current record is the head of the merge heap, staged in
             // _pending. MoveNext refills the heap and re-stages the next head.
             if (_merge is not null)
-                return _pending ?? throw new InvalidOperationException("Sorter is not positioned on a record.");
+                return _pending?.Record
+                    ?? throw new InvalidOperationException("Sorter is not positioned on a record.");
 
             if (_position >= _rows.Count)
                 throw new InvalidOperationException("Sorter is not positioned on a record.");
@@ -2845,16 +2859,27 @@ public sealed class ResumableStatement : IDisposable
             // drops the run association and would emit at most one record per run.
             if (_merge is not null)
             {
-                if (_readers![_pendingRunIndex].TryReadNext(out var next, cancellationToken))
-                    _merge.Enqueue(_pendingRunIndex, new MergeKey(next, _pendingRunIndex, _comparer));
+                var refillRunIndex = _pendingRunIndex;
+                _pending?.Dispose();
+                _pending = null;
+                if (_readers![refillRunIndex].TryReadNext(
+                    _memory,
+                    out var next,
+                    cancellationToken))
+                {
+                    _mergeHeads![refillRunIndex] = next;
+                    _merge.Enqueue(
+                        refillRunIndex,
+                        new MergeKey(next.Record, refillRunIndex, _comparer));
+                }
 
                 if (!_merge.TryDequeue(out _pendingRunIndex, out var key))
                 {
-                    _pending = null;
                     return false;
                 }
 
-                _pending = key.Record;
+                _pending = _mergeHeads![_pendingRunIndex];
+                _mergeHeads[_pendingRunIndex] = null;
                 return true;
             }
 
@@ -2904,39 +2929,48 @@ public sealed class ResumableStatement : IDisposable
         // equal-key rows across runs keep their global insertion order — stability.
         private void StartMerge(CancellationToken cancellationToken)
         {
-            _merge = new PriorityQueue<int, MergeKey>(MergeKey.Comparer);
-            _readers = new SorterSpill.RunReader[_spill!.RunCount];
-
-            for (var runIndex = 0; runIndex < _spill.RunCount; runIndex++)
+            var runCount = _spill!.RunCount;
+            var infrastructureBytes = VdbeManagedFootprint.EstimateMergeInfrastructure(runCount);
+            _memory.RetainOrThrow(infrastructureBytes, rows: 0);
+            _mergeInfrastructureBytes = infrastructureBytes;
+            try
             {
-                cancellationToken.ThrowIfCancellationRequested();
-                var reader = _spill.OpenRunReader(runIndex);
-                _readers[runIndex] = reader;
-                if (reader.TryReadNext(out var first, cancellationToken))
-                    _merge.Enqueue(runIndex, new MergeKey(first, runIndex, _comparer));
-            }
+                _merge = new PriorityQueue<int, MergeKey>(runCount, MergeKey.Comparer);
+                _readers = new SorterSpill.RunReader[runCount];
+                _mergeHeads = new SorterSpill.RowLease[runCount];
 
-            // Stage the first head so Current() can return it before the first MoveNext.
-            if (!_merge.TryDequeue(out _pendingRunIndex, out var key))
+                for (var runIndex = 0; runIndex < runCount; runIndex++)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var reader = _spill.OpenRunReader(runIndex);
+                    _readers[runIndex] = reader;
+                    if (reader.TryReadNext(_memory, out var first, cancellationToken))
+                    {
+                        _mergeHeads[runIndex] = first;
+                        _merge.Enqueue(
+                            runIndex,
+                            new MergeKey(first.Record, runIndex, _comparer));
+                    }
+                }
+
+                // Stage the first head so Current() can return it before the first MoveNext.
+                if (!_merge.TryDequeue(out _pendingRunIndex, out _))
+                    return;
+                _pending = _mergeHeads[_pendingRunIndex];
+                _mergeHeads[_pendingRunIndex] = null;
+            }
+            catch
             {
-                _pending = null;
-                return;
+                DisposeMerge();
+                throw;
             }
-
-            _pending = key.Record;
         }
 
         public void Dispose()
         {
             try
             {
-                if (_readers is not null)
-                {
-                    foreach (var reader in _readers)
-                        reader?.Dispose();
-                    _readers = null;
-                }
-
+                DisposeMerge();
                 _spill?.Dispose();
                 _spill = null;
             }
@@ -2945,7 +2979,9 @@ public sealed class ResumableStatement : IDisposable
                 if (_bufferedBytes > 0)
                     _memory.Release(_bufferedBytes, _rows.Count);
                 _rows.Clear();
+                _rows.Capacity = 0;
                 _bufferedBytes = 0;
+                _sortWorkspaceBytes = 0;
                 _merge = null;
                 _pending = null;
             }
@@ -2963,15 +2999,81 @@ public sealed class ResumableStatement : IDisposable
                     _bufferedBytes);
             }
 
-            _spill ??= new SorterSpill(_columnCount, _executionOptions);
+            _spill ??= new SorterSpill(_columnCount, _executionOptions, _memory);
             _spill.WriteRun(SortBufferedRows(cancellationToken), cancellationToken);
             _memory.Release(_bufferedBytes, _rows.Count);
             _rows.Clear();
+            _rows.Capacity = 0;
             _bufferedBytes = 0;
+            _sortWorkspaceBytes = 0;
+            _spill.ConsolidateRuns(
+                _comparer,
+                _executionOptions.SorterMergeFanIn,
+                _memory,
+                cancellationToken);
         }
 
         private static long EstimateRecordBytes(SqlValue[] record) =>
-            VdbeSpillRecordCodec.EstimateRetainedBytes(record);
+            Math.Max(
+                VdbeManagedFootprint.EstimateSorterRow(record),
+                VdbeManagedFootprint.EstimateSorterRowFromEncodedLength(
+                    VdbeSpillRecordCodec.EstimateEncodedValuesLength(record),
+                    record.Length));
+
+        private bool TryBuffer(SqlValue[] record, long recordBytes)
+        {
+            var requiredCount = checked(_rows.Count + 1);
+            var capacity = VdbeManagedFootprint.GetListCapacityForCount(
+                _rows.Capacity,
+                requiredCount);
+            var listGrowth = checked(
+                VdbeManagedFootprint.EstimateReferenceListStorage(capacity)
+                - VdbeManagedFootprint.EstimateReferenceListStorage(_rows.Capacity));
+            var workspaceBytes = VdbeManagedFootprint.EstimateSortWorkspace(requiredCount);
+            var workspaceGrowth = checked(workspaceBytes - _sortWorkspaceBytes);
+            var retainedBytes = checked(recordBytes + listGrowth + workspaceGrowth);
+            if (!_memory.TryRetain(retainedBytes))
+                return false;
+
+            try
+            {
+                if (capacity != _rows.Capacity)
+                    _rows.Capacity = capacity;
+                _rows.Add(record);
+                _bufferedBytes = checked(_bufferedBytes + retainedBytes);
+                _sortWorkspaceBytes = workspaceBytes;
+                return true;
+            }
+            catch
+            {
+                _memory.Release(retainedBytes);
+                throw;
+            }
+        }
+
+        private void DisposeMerge()
+        {
+            _pending?.Dispose();
+            _pending = null;
+            if (_mergeHeads is not null)
+            {
+                foreach (var head in _mergeHeads)
+                    head?.Dispose();
+                _mergeHeads = null;
+            }
+            if (_readers is not null)
+            {
+                foreach (var reader in _readers)
+                    reader?.Dispose();
+                _readers = null;
+            }
+            _merge = null;
+            if (_mergeInfrastructureBytes > 0)
+            {
+                _memory.Release(_mergeInfrastructureBytes, rows: 0);
+                _mergeInfrastructureBytes = 0;
+            }
+        }
 
         // Heap priority: orders by the row comparer, then by RunIndex so equal-key rows
         // across runs keep their global insertion order. The record is carried alongside
@@ -3005,18 +3107,29 @@ public sealed class ResumableStatement : IDisposable
     {
         private readonly int _columnCount;
         private readonly VdbeExecutionOptions _executionOptions;
+        private readonly VdbeExecutionMemory _memory;
         private readonly VdbeTemporaryFile _temporaryFile;
         private readonly IFile _file;
-        private readonly List<(long Offset, int RowCount)> _runs = [];
+        private List<RunDescriptor>? _runs;
         private long _writePosition;
+        private long _runDescriptorBytes;
+        private bool _disposed;
 
-        public SorterSpill(int columnCount, VdbeExecutionOptions executionOptions)
+        public SorterSpill(
+            int columnCount,
+            VdbeExecutionOptions executionOptions,
+            VdbeExecutionMemory memory)
         {
             _columnCount = columnCount;
             _executionOptions = executionOptions;
-            var temporaryFile = VdbeTemporaryFile.Create(executionOptions, "sorter");
+            _memory = memory;
+            _runDescriptorBytes = VdbeManagedFootprint.ListObjectBytes;
+            memory.RetainOrThrow(_runDescriptorBytes, rows: 0);
+            VdbeTemporaryFile? temporaryFile = null;
             try
             {
+                _runs = [];
+                temporaryFile = VdbeTemporaryFile.Create(executionOptions, "sorter");
                 _writePosition = VdbeSpillRecordCodec.InitializeFile(
                     temporaryFile.File,
                     VdbeSpillFileKind.SorterRun,
@@ -3026,12 +3139,14 @@ public sealed class ResumableStatement : IDisposable
             {
                 try
                 {
-                    temporaryFile.Dispose();
+                    temporaryFile?.Dispose();
                 }
                 catch (Exception cleanupFailure)
                 {
+                    memory.Release(_runDescriptorBytes, rows: 0);
                     throw new AggregateException(primaryFailure, cleanupFailure);
                 }
+                memory.Release(_runDescriptorBytes, rows: 0);
                 ExceptionDispatchInfo.Capture(primaryFailure).Throw();
                 throw;
             }
@@ -3040,18 +3155,69 @@ public sealed class ResumableStatement : IDisposable
             _file = temporaryFile.File;
         }
 
-        public int RunCount => _runs.Count;
+        public int RunCount => _runs?.Count ?? 0;
+
+        public void WriteSingleRow(
+            SqlValue[] row,
+            long retainedBytes,
+            CancellationToken cancellationToken)
+        {
+            var offset = _writePosition;
+            ReserveRunDescriptor();
+            try
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var recordStart = VdbeSpillRecordCodec.BeginRecord(ref _writePosition);
+                VdbeSpillRecordCodec.WriteValues(
+                    _file,
+                    ref _writePosition,
+                    row,
+                    _executionOptions.Metrics);
+                VdbeSpillRecordCodec.CompleteRecord(
+                    _file,
+                    recordStart,
+                    _writePosition,
+                    _executionOptions.Metrics);
+                _file.FlushToDisk();
+                _runs!.Add(new RunDescriptor(offset, 1, retainedBytes));
+                _executionOptions.Metrics.SorterRunWritten();
+            }
+            catch (Exception primaryFailure)
+            {
+                try
+                {
+                    _file.SetLength(offset);
+                    _writePosition = offset;
+                }
+                catch (Exception rollbackFailure)
+                {
+                    throw new AggregateException(primaryFailure, rollbackFailure);
+                }
+                ExceptionDispatchInfo.Capture(primaryFailure).Throw();
+                throw;
+            }
+        }
 
         // Appends one stably-sorted run and remembers its descriptor. The caller hands
         // in already-sorted rows; this store is format-only and does not re-sort.
         public void WriteRun(List<SqlValue[]> sorted, CancellationToken cancellationToken)
         {
             var offset = _writePosition;
+            var maximumRetainedRowBytes = 0L;
+            ReserveRunDescriptor();
             try
             {
                 foreach (var row in sorted)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
+                    var encodedLength = VdbeSpillRecordCodec.EstimateEncodedValuesLength(row);
+                    maximumRetainedRowBytes = Math.Max(
+                        maximumRetainedRowBytes,
+                        Math.Max(
+                            VdbeManagedFootprint.EstimateSorterRow(row),
+                            VdbeManagedFootprint.EstimateSorterRowFromEncodedLength(
+                                encodedLength,
+                                row.Length)));
                     var recordStart = VdbeSpillRecordCodec.BeginRecord(ref _writePosition);
                     VdbeSpillRecordCodec.WriteValues(
                         _file,
@@ -3066,7 +3232,10 @@ public sealed class ResumableStatement : IDisposable
                 }
 
                 _file.FlushToDisk();
-                _runs.Add((offset, sorted.Count));
+                _runs!.Add(new RunDescriptor(
+                    offset,
+                    sorted.Count,
+                    maximumRetainedRowBytes));
                 _executionOptions.Metrics.SorterRunWritten();
             }
             catch (Exception primaryFailure)
@@ -3088,32 +3257,61 @@ public sealed class ResumableStatement : IDisposable
         public void ConsolidateRuns(
             VdbeRowComparer comparer,
             int maximumFanIn,
+            VdbeExecutionMemory memory,
             CancellationToken cancellationToken)
         {
-            while (_runs.Count > maximumFanIn)
+            var runs = _runs
+                ?? throw new ObjectDisposedException(nameof(SorterSpill));
+            while (runs.Count > 1)
             {
+                var finalFanIn = GetEffectiveFanIn(
+                    start: 0,
+                    Math.Min(maximumFanIn, runs.Count),
+                    memory.AvailableBytes);
+                if (runs.Count <= maximumFanIn && finalFanIn == runs.Count)
+                    return;
+
                 var passOffset = _writePosition;
+                var consolidatedBytes = checked(
+                    VdbeManagedFootprint.ListObjectBytes
+                    + VdbeManagedFootprint.EstimateRunDescriptorListStorage(runs.Count));
+                memory.RetainOrThrow(consolidatedBytes, rows: 0);
                 try
                 {
-                    var consolidated = new List<(long Offset, int RowCount)>();
-                    for (var start = 0; start < _runs.Count; start += maximumFanIn)
+                    var consolidated = new List<RunDescriptor>(runs.Count);
+                    for (var start = 0; start < runs.Count;)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
-                        var count = Math.Min(maximumFanIn, _runs.Count - start);
-                        if (count == 1)
+                        var remaining = runs.Count - start;
+                        if (remaining == 1)
                         {
-                            consolidated.Add(_runs[start]);
+                            consolidated.Add(runs[start]);
+                            start++;
                             continue;
                         }
 
+                        var count = GetEffectiveFanIn(
+                            start,
+                            Math.Min(maximumFanIn, remaining),
+                            memory.AvailableBytes);
+                        if (count < 2)
+                        {
+                            var requestedBytes = EstimateMergeBytes(start, 2);
+                            throw new VdbeMemoryLimitExceededException(
+                                memory.LimitBytes,
+                                requestedBytes);
+                        }
                         consolidated.Add(MergeRunGroup(
-                            _runs.GetRange(start, count),
+                            start,
+                            count,
                             comparer,
+                            memory,
                             cancellationToken));
+                        start += count;
                     }
 
-                    _runs.Clear();
-                    _runs.AddRange(consolidated);
+                    runs.Clear();
+                    runs.AddRange(consolidated);
                 }
                 catch (Exception primaryFailure)
                 {
@@ -3129,22 +3327,36 @@ public sealed class ResumableStatement : IDisposable
                     ExceptionDispatchInfo.Capture(primaryFailure).Throw();
                     throw;
                 }
+                finally
+                {
+                    memory.Release(consolidatedBytes, rows: 0);
+                }
             }
         }
 
-        private (long Offset, int RowCount) MergeRunGroup(
-            IReadOnlyList<(long Offset, int RowCount)> inputs,
+        private RunDescriptor MergeRunGroup(
+            int start,
+            int count,
             VdbeRowComparer comparer,
+            VdbeExecutionMemory memory,
             CancellationToken cancellationToken)
         {
             var offset = _writePosition;
-            var readers = new RunReader[inputs.Count];
+            RunReader[]? readers = null;
+            RowLease[]? heads = null;
+            RowLease? current = null;
+            var infrastructureBytes = VdbeManagedFootprint.EstimateMergeInfrastructure(count);
+            memory.RetainOrThrow(infrastructureBytes, rows: 0);
             try
             {
-                var heap = new PriorityQueue<int, SpillMergeKey>(SpillMergeKey.Comparer);
-                for (var index = 0; index < inputs.Count; index++)
+                readers = new RunReader[count];
+                heads = new RowLease[count];
+                var heap = new PriorityQueue<int, SpillMergeKey>(
+                    count,
+                    SpillMergeKey.Comparer);
+                for (var index = 0; index < count; index++)
                 {
-                    var input = inputs[index];
+                    var input = _runs![start + index];
                     var reader = new RunReader(
                         _file,
                         input.Offset,
@@ -3152,14 +3364,21 @@ public sealed class ResumableStatement : IDisposable
                         _columnCount,
                         _executionOptions.Metrics);
                     readers[index] = reader;
-                    if (reader.TryReadNext(out var row, cancellationToken))
-                        heap.Enqueue(index, new SpillMergeKey(row, index, comparer));
+                    if (reader.TryReadNext(memory, out var row, cancellationToken))
+                    {
+                        heads[index] = row;
+                        heap.Enqueue(
+                            index,
+                            new SpillMergeKey(row.Record, index, comparer));
+                    }
                 }
 
                 var rowsWritten = 0;
                 while (heap.TryDequeue(out var readerIndex, out var key))
                 {
                     cancellationToken.ThrowIfCancellationRequested();
+                    current = heads[readerIndex];
+                    heads[readerIndex] = null!;
                     var recordStart = VdbeSpillRecordCodec.BeginRecord(ref _writePosition);
                     VdbeSpillRecordCodec.WriteValues(
                         _file,
@@ -3173,13 +3392,23 @@ public sealed class ResumableStatement : IDisposable
                         _executionOptions.Metrics);
                     rowsWritten = checked(rowsWritten + 1);
 
-                    if (readers[readerIndex].TryReadNext(out var next, cancellationToken))
-                        heap.Enqueue(readerIndex, new SpillMergeKey(next, readerIndex, comparer));
+                    current.Dispose();
+                    current = null;
+                    if (readers[readerIndex].TryReadNext(memory, out var next, cancellationToken))
+                    {
+                        heads[readerIndex] = next;
+                        heap.Enqueue(
+                            readerIndex,
+                            new SpillMergeKey(next.Record, readerIndex, comparer));
+                    }
                 }
 
                 _file.FlushToDisk();
                 _executionOptions.Metrics.SorterRunWritten();
-                return (offset, rowsWritten);
+                return new RunDescriptor(
+                    offset,
+                    rowsWritten,
+                    GetMaximumRetainedRowBytes(start, count));
             }
             catch (Exception primaryFailure)
             {
@@ -3197,27 +3426,108 @@ public sealed class ResumableStatement : IDisposable
             }
             finally
             {
-                foreach (var reader in readers)
-                    reader?.Dispose();
+                current?.Dispose();
+                if (heads is not null)
+                {
+                    foreach (var head in heads)
+                        head?.Dispose();
+                }
+                if (readers is not null)
+                {
+                    foreach (var reader in readers)
+                        reader?.Dispose();
+                }
+                memory.Release(infrastructureBytes, rows: 0);
             }
         }
 
         public RunReader OpenRunReader(int runIndex)
         {
-            var (offset, rowCount) = _runs[runIndex];
+            var run = _runs![runIndex];
             VdbeSpillRecordCodec.ValidateFile(
                 _file,
                 VdbeSpillFileKind.SorterRun,
                 _executionOptions.Metrics);
             return new RunReader(
                 _file,
-                offset,
-                rowCount,
+                run.Offset,
+                run.RowCount,
                 _columnCount,
                 _executionOptions.Metrics);
         }
 
-        public void Dispose() => _temporaryFile.Dispose();
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+            _temporaryFile.Dispose();
+            _disposed = true;
+            _runs = null;
+            _memory.Release(_runDescriptorBytes, rows: 0);
+            _runDescriptorBytes = 0;
+        }
+
+        private int GetEffectiveFanIn(int start, int maximumFanIn, long availableBytes)
+        {
+            var fanIn = 0;
+            for (var count = 1; count <= maximumFanIn; count++)
+            {
+                if (EstimateMergeBytes(start, count) > availableBytes)
+                    break;
+                fanIn = count;
+            }
+            return fanIn;
+        }
+
+        private long EstimateMergeBytes(int start, int count)
+        {
+            var total = VdbeManagedFootprint.EstimateMergeInfrastructure(count);
+            for (var index = 0; index < count; index++)
+            {
+                total = checked(
+                    total
+                    + _runs![start + index].MaximumRetainedRowBytes);
+            }
+            return total;
+        }
+
+        private long GetMaximumRetainedRowBytes(int start, int count)
+        {
+            var maximum = 0L;
+            for (var index = 0; index < count; index++)
+                maximum = Math.Max(maximum, _runs![start + index].MaximumRetainedRowBytes);
+            return maximum;
+        }
+
+        private void ReserveRunDescriptor()
+        {
+            var runs = _runs
+                ?? throw new ObjectDisposedException(nameof(SorterSpill));
+            var capacity = VdbeManagedFootprint.GetListCapacityForCount(
+                runs.Capacity,
+                runs.Count + 1);
+            if (capacity == runs.Capacity)
+                return;
+            var growthBytes = checked(
+                VdbeManagedFootprint.EstimateRunDescriptorListStorage(capacity)
+                - VdbeManagedFootprint.EstimateRunDescriptorListStorage(runs.Capacity));
+            _memory.RetainOrThrow(growthBytes, rows: 0);
+            try
+            {
+                runs.Capacity = capacity;
+                _runDescriptorBytes = checked(_runDescriptorBytes + growthBytes);
+            }
+            catch
+            {
+                _memory.Release(growthBytes, rows: 0);
+                throw;
+            }
+        }
+
+        private readonly record struct RunDescriptor(
+            long Offset,
+            int RowCount,
+            long MaximumRetainedRowBytes);
 
         private readonly struct SpillMergeKey
         {
@@ -3242,6 +3552,24 @@ public sealed class ResumableStatement : IDisposable
 
         // Reads one run's records back one at a time using positional IFile access. Multiple
         // readers share the file safely because each carries its own explicit offset.
+        public sealed class RowLease(
+            SqlValue[] record,
+            VdbeExecutionMemory memory,
+            long retainedBytes) : IDisposable
+        {
+            private bool _disposed;
+
+            public SqlValue[] Record { get; } = record;
+
+            public void Dispose()
+            {
+                if (_disposed)
+                    return;
+                _disposed = true;
+                memory.Release(retainedBytes);
+            }
+        }
+
         public sealed class RunReader : IDisposable
         {
             private readonly IFile _file;
@@ -3265,22 +3593,32 @@ public sealed class ResumableStatement : IDisposable
 
             public int RowsRemaining { get; private set; }
 
-            public bool TryReadNext(out SqlValue[] row, CancellationToken cancellationToken)
+            public bool TryReadNext(
+                VdbeExecutionMemory memory,
+                out RowLease row,
+                CancellationToken cancellationToken)
             {
                 if (RowsRemaining <= 0)
                 {
-                    row = Array.Empty<SqlValue>();
+                    row = null!;
                     return false;
                 }
 
                 var rowStart = _position;
+                var retainedBytes = 0L;
+                var retained = false;
                 try
                 {
                     var recordEnd = VdbeSpillRecordCodec.ReadRecordEnd(
                         _file,
                         ref _position,
                         _metrics);
-                    row = VdbeSpillRecordCodec.ReadValues(
+                    retainedBytes = VdbeManagedFootprint.EstimateSorterRowFromEncodedLength(
+                        recordEnd - _position,
+                        _columnCount);
+                    memory.RetainOrThrow(retainedBytes);
+                    retained = true;
+                    var values = VdbeSpillRecordCodec.ReadValues(
                         _file,
                         ref _position,
                         _columnCount,
@@ -3288,11 +3626,14 @@ public sealed class ResumableStatement : IDisposable
                         cancellationToken);
                     VdbeSpillRecordCodec.RequireRecordEnd(_position, recordEnd);
                     RowsRemaining--;
+                    row = new RowLease(values, memory, retainedBytes);
                     return true;
                 }
                 catch
                 {
                     _position = rowStart;
+                    if (retained)
+                        memory.Release(retainedBytes);
                     throw;
                 }
             }
@@ -3652,6 +3993,10 @@ public sealed class ResumableStatement : IDisposable
             {
                 failure = exception;
             }
+            finally
+            {
+                _enumerator = null;
+            }
 
             if (_context?.TakeCleanupFailure() is { } cleanupFailure)
             {
@@ -3660,9 +4005,25 @@ public sealed class ResumableStatement : IDisposable
                     : new AggregateException(failure, cleanupFailure);
             }
 
-            _enumerator = null;
-            _context = null;
-            CurrentRow = null;
+            if (_context?.HasPendingCleanup == true)
+            {
+                try
+                {
+                    _context.RetryPendingCleanup();
+                }
+                catch (Exception retryFailure)
+                {
+                    failure = failure is null
+                        ? retryFailure
+                        : new AggregateException(failure, retryFailure);
+                }
+            }
+
+            if (_context?.HasPendingCleanup != true)
+            {
+                _context = null;
+                CurrentRow = null;
+            }
             if (failure is not null)
                 ExceptionDispatchInfo.Capture(failure).Throw();
         }

--- a/src/Ahtola.Core/Execution/VdbeExecutionMemory.cs
+++ b/src/Ahtola.Core/Execution/VdbeExecutionMemory.cs
@@ -1,3 +1,5 @@
+using System.Runtime.ExceptionServices;
+
 namespace Ahtola.Core.Execution;
 
 /// <summary>
@@ -134,6 +136,89 @@ internal sealed class VdbeExecutionMemory(long limitBytes, VdbeExecutionMetrics 
     }
 }
 
+internal sealed class VdbeMemoryReservation : IDisposable
+{
+    private readonly VdbeExecutionMemory _memory;
+    private readonly long _bytes;
+    private bool _retained;
+
+    private VdbeMemoryReservation(VdbeExecutionMemory memory, long bytes)
+    {
+        _memory = memory;
+        _bytes = bytes;
+    }
+
+    public static VdbeMemoryReservation? TryCreate(VdbeExecutionMemory memory, long bytes)
+    {
+        ArgumentNullException.ThrowIfNull(memory);
+        ArgumentOutOfRangeException.ThrowIfNegative(bytes);
+        var reservation = new VdbeMemoryReservation(memory, bytes);
+        if (!memory.TryRetain(bytes, rows: 0))
+            return null;
+        reservation._retained = true;
+        return reservation;
+    }
+
+    public static VdbeMemoryReservation Create(VdbeExecutionMemory memory, long bytes)
+    {
+        ArgumentNullException.ThrowIfNull(memory);
+        ArgumentOutOfRangeException.ThrowIfNegative(bytes);
+        var reservation = new VdbeMemoryReservation(memory, bytes);
+        memory.RetainOrThrow(bytes, rows: 0);
+        reservation._retained = true;
+        return reservation;
+    }
+
+    public void Dispose()
+    {
+        if (!_retained)
+            return;
+        _retained = false;
+        _memory.Release(_bytes, rows: 0);
+    }
+}
+
+internal sealed class VdbePendingCleanupRegistry
+{
+    private List<IDisposable>? _pending;
+
+    public bool HasPending => _pending is { Count: > 0 };
+
+    public void Register(IDisposable cleanup)
+    {
+        ArgumentNullException.ThrowIfNull(cleanup);
+        if (!(_pending?.Contains(cleanup) ?? false))
+            (_pending ??= []).Add(cleanup);
+    }
+
+    public void Unregister(IDisposable cleanup) => _pending?.Remove(cleanup);
+
+    public void Retry()
+    {
+        if (_pending is not { Count: > 0 } pending)
+            return;
+
+        List<Exception>? failures = null;
+        for (var index = pending.Count - 1; index >= 0; index--)
+        {
+            try
+            {
+                pending[index].Dispose();
+                pending.RemoveAt(index);
+            }
+            catch (Exception exception)
+            {
+                (failures ??= []).Add(exception);
+            }
+        }
+
+        if (failures is [var failure])
+            ExceptionDispatchInfo.Capture(failure).Throw();
+        if (failures is { Count: > 1 })
+            throw new AggregateException(failures);
+    }
+}
+
 internal static class VdbeManagedFootprint
 {
     public const long ReferenceBytes = 8;
@@ -152,7 +237,11 @@ internal static class VdbeManagedFootprint
     private const long PriorityQueueObjectBytes = 64;
     private const long PriorityQueueNodeBytes = 48;
     private const long RunReaderObjectBytes = 64;
-    private const long RunDescriptorSlotBytes = 24;
+    private const long RunDescriptorSlotBytes = 32;
+    private const long HashSpillObjectBytes = 96;
+    private const long HashPartitionObjectBytes = 32;
+    private const long TemporaryFileObjectBytes = 64;
+    private const long TemporaryFileWrapperBytes = 128;
 
     public static long EstimateSorterRow(IReadOnlyList<SqlValue> values)
     {
@@ -248,6 +337,35 @@ internal static class VdbeManagedFootprint
             + (runCount * RunReaderObjectBytes));
     }
 
+    public static long EstimateHashSpillInfrastructure(
+        string temporaryDirectory,
+        int partitionCount,
+        bool trackUnmatchedBuild)
+    {
+        ArgumentNullException.ThrowIfNull(temporaryDirectory);
+        ArgumentOutOfRangeException.ThrowIfNegative(partitionCount);
+
+        var partitionFileBytes = EstimateTemporaryFileInfrastructure(
+            temporaryDirectory.Length,
+            "hash-p000".Length);
+        var total = checked(
+            HashSpillObjectBytes
+            + EstimateArray(ReferenceBytes, partitionCount)
+            + (partitionCount * (HashPartitionObjectBytes + partitionFileBytes)));
+        if (trackUnmatchedBuild)
+        {
+            total = checked(
+                total
+                + EstimateTemporaryFileInfrastructure(
+                    temporaryDirectory.Length,
+                    "hash-build-order".Length)
+                + EstimateTemporaryFileInfrastructure(
+                    temporaryDirectory.Length,
+                    "hash-matches".Length));
+        }
+        return total;
+    }
+
     public static int GetListCapacityForCount(int currentCapacity, int requiredCount)
     {
         ArgumentOutOfRangeException.ThrowIfNegative(currentCapacity);
@@ -289,6 +407,24 @@ internal static class VdbeManagedFootprint
         if (capacity > int.MaxValue)
             throw new OutOfMemoryException("A managed execution dictionary exceeded the supported capacity.");
         return (int)capacity;
+    }
+
+    private static long EstimateTemporaryFileInfrastructure(
+        int directoryCharacterCount,
+        int purposeCharacterCount)
+    {
+        var pathCharacterCount = checked(
+            directoryCharacterCount
+            + 1
+            + "ahtola-".Length
+            + purposeCharacterCount
+            + 1
+            + 32
+            + ".spill".Length);
+        return checked(
+            TemporaryFileObjectBytes
+            + TemporaryFileWrapperBytes
+            + EstimateString(pathCharacterCount));
     }
 
     private static long Align(long bytes) => checked((bytes + 7) & ~7L);

--- a/src/Ahtola.Core/Execution/VdbeExecutionMemory.cs
+++ b/src/Ahtola.Core/Execution/VdbeExecutionMemory.cs
@@ -133,3 +133,163 @@ internal sealed class VdbeExecutionMemory(long limitBytes, VdbeExecutionMetrics 
         metrics.Release(bytes, rows);
     }
 }
+
+internal static class VdbeManagedFootprint
+{
+    public const long ReferenceBytes = 8;
+    public const long ListObjectBytes = 32;
+    public const long DictionaryObjectBytes = 64;
+    public const long BucketListObjectBytes = 32;
+
+    private const long ArrayHeaderBytes = 24;
+    private const long StringHeaderBytes = 24;
+    private const long SqlValueSlotBytes = 56;
+    private const long NullableInt64SlotBytes = 16;
+    private const long JoinRowObjectBytes = 32;
+    private const long BuildEntryObjectBytes = 48;
+    private const long SpillPayloadObjectBytes = 32;
+    private const long DictionaryEntryBytes = 24;
+    private const long PriorityQueueObjectBytes = 64;
+    private const long PriorityQueueNodeBytes = 48;
+    private const long RunReaderObjectBytes = 64;
+    private const long RunDescriptorSlotBytes = 24;
+
+    public static long EstimateSorterRow(IReadOnlyList<SqlValue> values)
+    {
+        var total = EstimateArray(SqlValueSlotBytes, values.Count);
+        foreach (var value in values)
+            total = checked(total + EstimateValuePayload(value));
+        return total;
+    }
+
+    public static long EstimateHashBuildEntry(
+        IReadOnlyList<SqlValue> values,
+        string? key,
+        int rowIdCount)
+    {
+        var total = checked(
+            BuildEntryObjectBytes
+            + JoinRowObjectBytes
+            + EstimateArray(SqlValueSlotBytes, values.Count)
+            + EstimateArray(NullableInt64SlotBytes, rowIdCount));
+        if (key is not null)
+            total = checked(total + EstimateString(key.Length));
+        foreach (var value in values)
+            total = checked(total + EstimateValuePayload(value));
+        return total;
+    }
+
+    public static long EstimateSorterRowFromEncodedLength(long payloadLength, int columnCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(payloadLength);
+        ArgumentOutOfRangeException.ThrowIfNegative(columnCount);
+        return checked(
+            EstimateArray(SqlValueSlotBytes, columnCount)
+            + (columnCount * SpillPayloadObjectBytes)
+            + (payloadLength * sizeof(char)));
+    }
+
+    public static long EstimateHashBuildEntryFromEncodedLength(
+        long payloadLength,
+        int columnCount,
+        int rowIdCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(payloadLength);
+        ArgumentOutOfRangeException.ThrowIfNegative(columnCount);
+        ArgumentOutOfRangeException.ThrowIfNegative(rowIdCount);
+        return checked(
+            BuildEntryObjectBytes
+            + JoinRowObjectBytes
+            + EstimateArray(SqlValueSlotBytes, columnCount)
+            + EstimateArray(NullableInt64SlotBytes, rowIdCount)
+            + ((columnCount + 1L) * SpillPayloadObjectBytes)
+            + (payloadLength * sizeof(char)));
+    }
+
+    public static long EstimateReferenceListStorage(int capacity) =>
+        capacity == 0 ? 0 : EstimateArray(ReferenceBytes, capacity);
+
+    public static long EstimateInt32ListStorage(int capacity) =>
+        capacity == 0 ? 0 : EstimateArray(sizeof(int), capacity);
+
+    public static long EstimateRunDescriptorListStorage(int capacity) =>
+        capacity == 0 ? 0 : EstimateArray(RunDescriptorSlotBytes, capacity);
+
+    public static long EstimateDictionaryStorage(int count)
+    {
+        if (count == 0)
+            return 0;
+        var capacity = GetConservativeDictionaryCapacity(count);
+        return checked(
+            EstimateArray(sizeof(int), capacity)
+            + EstimateArray(DictionaryEntryBytes, capacity));
+    }
+
+    public static long EstimateBooleanArray(int count) =>
+        count == 0 ? 0 : EstimateArray(sizeof(byte), count);
+
+    public static long EstimateSortWorkspace(int count) =>
+        count == 0
+            ? 0
+            : checked(
+                EstimateArray(sizeof(int), count)
+                + ListObjectBytes
+                + EstimateArray(ReferenceBytes, count));
+
+    public static long EstimateMergeInfrastructure(int runCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(runCount);
+        if (runCount == 0)
+            return 0;
+        return checked(
+            PriorityQueueObjectBytes
+            + EstimateArray(PriorityQueueNodeBytes, runCount)
+            + (2 * EstimateArray(ReferenceBytes, runCount))
+            + (runCount * RunReaderObjectBytes));
+    }
+
+    public static int GetListCapacityForCount(int currentCapacity, int requiredCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(currentCapacity);
+        ArgumentOutOfRangeException.ThrowIfNegative(requiredCount);
+        if (requiredCount <= currentCapacity)
+            return currentCapacity;
+
+        var capacity = currentCapacity == 0 ? 4 : currentCapacity;
+        while (capacity < requiredCount)
+        {
+            var doubled = (long)capacity * 2;
+            capacity = doubled >= int.MaxValue ? int.MaxValue : (int)doubled;
+            if (capacity < requiredCount && capacity == int.MaxValue)
+                throw new OutOfMemoryException("A managed execution container exceeded the supported capacity.");
+        }
+        return capacity;
+    }
+
+    private static long EstimateValuePayload(SqlValue value) => value.Kind switch
+    {
+        SqlValueKind.Null or SqlValueKind.Integer or SqlValueKind.Real => 0,
+        SqlValueKind.Text => EstimateString(value.AsText().Length),
+        SqlValueKind.Blob => EstimateArray(sizeof(byte), value.AsBlobSpan().Length),
+        _ => throw new InvalidOperationException($"Unknown SQL value kind {value.Kind}."),
+    };
+
+    private static long EstimateString(int characterCount) =>
+        Align(checked(StringHeaderBytes + ((characterCount + 1L) * sizeof(char))));
+
+    private static long EstimateArray(long slotBytes, int count) =>
+        Align(checked(ArrayHeaderBytes + (slotBytes * count)));
+
+    private static int GetConservativeDictionaryCapacity(int count)
+    {
+        var required = checked((long)count * 4);
+        var capacity = 4L;
+        while (capacity < required)
+            capacity = checked(capacity * 2);
+        if (capacity > int.MaxValue)
+            throw new OutOfMemoryException("A managed execution dictionary exceeded the supported capacity.");
+        return (int)capacity;
+    }
+
+    private static long Align(long bytes) => checked((bytes + 7) & ~7L);
+}

--- a/src/Ahtola.Core/Execution/VdbeExecutionMemory.cs
+++ b/src/Ahtola.Core/Execution/VdbeExecutionMemory.cs
@@ -232,7 +232,7 @@ internal static class VdbeManagedFootprint
     private const long NullableInt64SlotBytes = 16;
     private const long JoinRowObjectBytes = 32;
     private const long BuildEntryObjectBytes = 48;
-    private const long SpillPayloadObjectBytes = 32;
+    private const long SpillPayloadObjectBytes = 48;
     private const long DictionaryEntryBytes = 24;
     private const long PriorityQueueObjectBytes = 64;
     private const long PriorityQueueNodeBytes = 48;
@@ -276,7 +276,7 @@ internal static class VdbeManagedFootprint
         return checked(
             EstimateArray(SqlValueSlotBytes, columnCount)
             + (columnCount * SpillPayloadObjectBytes)
-            + (payloadLength * sizeof(char)));
+            + (payloadLength * 3));
     }
 
     public static long EstimateHashBuildEntryFromEncodedLength(
@@ -293,8 +293,11 @@ internal static class VdbeManagedFootprint
             + EstimateArray(SqlValueSlotBytes, columnCount)
             + EstimateArray(NullableInt64SlotBytes, rowIdCount)
             + ((columnCount + 1L) * SpillPayloadObjectBytes)
-            + (payloadLength * sizeof(char)));
+            + (payloadLength * 3));
     }
+
+    public static long EstimateUtf8Scratch(int byteCount) =>
+        byteCount == 0 ? 0 : EstimateArray(sizeof(byte), byteCount);
 
     public static long EstimateReferenceListStorage(int capacity) =>
         capacity == 0 ? 0 : EstimateArray(ReferenceBytes, capacity);
@@ -398,6 +401,13 @@ internal static class VdbeManagedFootprint
                 throw new OutOfMemoryException("A managed execution container exceeded the supported capacity.");
         }
         return capacity;
+    }
+
+    public static long EstimateContainerReplacement(long currentBytes, long replacementBytes)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(currentBytes);
+        ArgumentOutOfRangeException.ThrowIfNegative(replacementBytes);
+        return replacementBytes > currentBytes ? replacementBytes : 0;
     }
 
     private static long EstimateValuePayload(SqlValue value) => value.Kind switch

--- a/src/Ahtola.Core/Execution/VdbeExecutionMemory.cs
+++ b/src/Ahtola.Core/Execution/VdbeExecutionMemory.cs
@@ -1,0 +1,135 @@
+namespace Ahtola.Core.Execution;
+
+/// <summary>
+/// Raised when an execution intermediate cannot stay within its configured retained-memory budget
+/// and temporary-file spill is disabled.
+/// </summary>
+public sealed class VdbeMemoryLimitExceededException : InvalidOperationException
+{
+    internal VdbeMemoryLimitExceededException(long limitBytes, long requestedBytes)
+        : base($"The managed execution memory limit of {limitBytes} bytes cannot retain a {requestedBytes}-byte intermediate.")
+    {
+        LimitBytes = limitBytes;
+        RequestedBytes = requestedBytes;
+    }
+
+    public long LimitBytes { get; }
+
+    public long RequestedBytes { get; }
+}
+
+/// <summary>Statement-local high-water and spill metrics for managed VDBE execution.</summary>
+public sealed class VdbeExecutionMetrics
+{
+    public long CurrentRetainedBytes { get; private set; }
+
+    public long PeakRetainedBytes { get; private set; }
+
+    public long CurrentRetainedRows { get; private set; }
+
+    public long PeakRetainedRows { get; private set; }
+
+    public long SpillFilesCreated { get; private set; }
+
+    public long ActiveSpillFiles { get; private set; }
+
+    public long SpillBytesWritten { get; private set; }
+
+    public long SpillBytesRead { get; private set; }
+
+    public long SorterRunsWritten { get; private set; }
+
+    public long HashPartitionsCreated { get; private set; }
+
+    public long HashPartitionScans { get; private set; }
+
+    public long HashPartitionLoads { get; private set; }
+
+    public long HashPartitionFallbackScans { get; private set; }
+
+    internal void Retain(long bytes, long rows)
+    {
+        CurrentRetainedBytes = checked(CurrentRetainedBytes + bytes);
+        CurrentRetainedRows = checked(CurrentRetainedRows + rows);
+        PeakRetainedBytes = Math.Max(PeakRetainedBytes, CurrentRetainedBytes);
+        PeakRetainedRows = Math.Max(PeakRetainedRows, CurrentRetainedRows);
+    }
+
+    internal void Release(long bytes, long rows)
+    {
+        CurrentRetainedBytes = checked(CurrentRetainedBytes - bytes);
+        CurrentRetainedRows = checked(CurrentRetainedRows - rows);
+        if (CurrentRetainedBytes < 0 || CurrentRetainedRows < 0)
+            throw new InvalidOperationException("Execution memory accounting was released below zero.");
+    }
+
+    internal void SpillFileOpened()
+    {
+        SpillFilesCreated = checked(SpillFilesCreated + 1);
+        ActiveSpillFiles = checked(ActiveSpillFiles + 1);
+    }
+
+    internal void SpillFileClosed()
+    {
+        ActiveSpillFiles = checked(ActiveSpillFiles - 1);
+        if (ActiveSpillFiles < 0)
+            throw new InvalidOperationException("Execution spill-file accounting was released below zero.");
+    }
+
+    internal void AddSpillBytesWritten(long bytes) =>
+        SpillBytesWritten = checked(SpillBytesWritten + bytes);
+
+    internal void AddSpillBytesRead(long bytes) =>
+        SpillBytesRead = checked(SpillBytesRead + bytes);
+
+    internal void SorterRunWritten() => SorterRunsWritten = checked(SorterRunsWritten + 1);
+
+    internal void HashPartitionCreated() => HashPartitionsCreated = checked(HashPartitionsCreated + 1);
+
+    internal void HashPartitionScanned() => HashPartitionScans = checked(HashPartitionScans + 1);
+
+    internal void HashPartitionLoaded() => HashPartitionLoads = checked(HashPartitionLoads + 1);
+
+    internal void HashPartitionFallbackScan() =>
+        HashPartitionFallbackScans = checked(HashPartitionFallbackScans + 1);
+}
+
+internal sealed class VdbeExecutionMemory(long limitBytes, VdbeExecutionMetrics metrics)
+{
+    private long _retainedBytes;
+    private long _retainedRows;
+
+    public long LimitBytes { get; } = limitBytes;
+
+    public long AvailableBytes => LimitBytes - _retainedBytes;
+
+    public bool TryRetain(long bytes, long rows = 1)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(bytes);
+        ArgumentOutOfRangeException.ThrowIfNegative(rows);
+        if (bytes > LimitBytes - _retainedBytes)
+            return false;
+
+        _retainedBytes = checked(_retainedBytes + bytes);
+        _retainedRows = checked(_retainedRows + rows);
+        metrics.Retain(bytes, rows);
+        return true;
+    }
+
+    public void RetainOrThrow(long bytes, long rows = 1)
+    {
+        if (!TryRetain(bytes, rows))
+            throw new VdbeMemoryLimitExceededException(LimitBytes, bytes);
+    }
+
+    public void Release(long bytes, long rows = 1)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(bytes);
+        ArgumentOutOfRangeException.ThrowIfNegative(rows);
+        _retainedBytes = checked(_retainedBytes - bytes);
+        _retainedRows = checked(_retainedRows - rows);
+        if (_retainedBytes < 0 || _retainedRows < 0)
+            throw new InvalidOperationException("Execution memory accounting was released below zero.");
+        metrics.Release(bytes, rows);
+    }
+}

--- a/src/Ahtola.Core/Execution/VdbeExecutionMemory.cs
+++ b/src/Ahtola.Core/Execution/VdbeExecutionMemory.cs
@@ -238,6 +238,7 @@ internal static class VdbeManagedFootprint
     private const long PriorityQueueNodeBytes = 48;
     private const long RunReaderObjectBytes = 64;
     private const long RunDescriptorSlotBytes = 32;
+    private const long SorterSpillObjectBytes = 96;
     private const long HashSpillObjectBytes = 96;
     private const long HashPartitionObjectBytes = 32;
     private const long TemporaryFileObjectBytes = 64;
@@ -364,6 +365,21 @@ internal static class VdbeManagedFootprint
                     "hash-matches".Length));
         }
         return total;
+    }
+
+    public static long EstimateSorterSpillInfrastructure(string temporaryDirectory)
+    {
+        ArgumentNullException.ThrowIfNull(temporaryDirectory);
+        return checked(
+            SorterSpillObjectBytes
+            + ListObjectBytes
+            + EstimateRunDescriptorListStorage(
+                GetListCapacityForCount(
+                    currentCapacity: 0,
+                    requiredCount: 1))
+            + EstimateTemporaryFileInfrastructure(
+                temporaryDirectory.Length,
+                "sorter".Length));
     }
 
     public static int GetListCapacityForCount(int currentCapacity, int requiredCount)

--- a/src/Ahtola.Core/Execution/VdbeExecutionOptions.cs
+++ b/src/Ahtola.Core/Execution/VdbeExecutionOptions.cs
@@ -27,7 +27,10 @@ public sealed class VdbeExecutionOptions
     /// The retained-memory budget for spill-aware operators. The name is retained for source compatibility.
     /// </param>
     /// <param name="temporaryDirectory">The existing directory or logical path prefix for spill files.</param>
-    /// <param name="sorterMergeFanIn">The maximum run heads retained by a merge pass.</param>
+    /// <param name="sorterMergeFanIn">
+    /// The upper bound on run heads retained by a merge pass. The runtime reduces it when
+    /// the statement's available memory cannot hold that many managed rows and heap nodes.
+    /// </param>
     /// <param name="allowTemporaryFileSpill">
     /// Whether an operator may exceed its in-memory share by writing to the temporary file system.
     /// Set this to <see langword="false"/> for <c>temp_store=MEMORY</c>, where writing the same
@@ -69,7 +72,10 @@ public sealed class VdbeExecutionOptions
     /// </summary>
     public long MemoryLimitBytes => SorterMemoryLimitBytes;
 
-    /// <summary>The maximum run heads retained by a single merge pass.</summary>
+    /// <summary>
+    /// The configured upper bound on run heads retained by a single merge pass.
+    /// The effective fan-in is also bounded by the statement's available memory.
+    /// </summary>
     public int SorterMergeFanIn { get; }
 
     /// <summary>Whether operators may use the temporary file system after exhausting memory.</summary>

--- a/src/Ahtola.Core/Execution/VdbeExecutionOptions.cs
+++ b/src/Ahtola.Core/Execution/VdbeExecutionOptions.cs
@@ -6,8 +6,9 @@ namespace Ahtola.Core.Execution;
 /// Supplies statement-local execution resources to a <see cref="ResumableStatement"/>.
 /// </summary>
 /// <remarks>
-/// Sorter runs are transient execution artifacts. They use <see cref="TemporaryFileSystem"/>
-/// exclusively and are never part of the SQLite database, WAL, or catalog format.
+/// Spilled execution intermediates are transient artifacts. They use
+/// <see cref="TemporaryFileSystem"/> exclusively and are never part of the SQLite
+/// database, WAL, or catalog format.
 /// </remarks>
 public sealed class VdbeExecutionOptions
 {
@@ -21,15 +22,25 @@ public sealed class VdbeExecutionOptions
     /// <summary>
     /// Creates execution resources for one or more statements.
     /// </summary>
-    /// <param name="temporaryFileSystem">The backend that owns temporary sorter runs.</param>
-    /// <param name="sorterMemoryLimitBytes">The maximum buffered sorter payload before spilling.</param>
-    /// <param name="temporaryDirectory">The existing directory or logical path prefix for run files.</param>
+    /// <param name="temporaryFileSystem">The backend that owns temporary execution spill files.</param>
+    /// <param name="sorterMemoryLimitBytes">
+    /// The retained-memory budget for spill-aware operators. The name is retained for source compatibility.
+    /// </param>
+    /// <param name="temporaryDirectory">The existing directory or logical path prefix for spill files.</param>
     /// <param name="sorterMergeFanIn">The maximum run heads retained by a merge pass.</param>
+    /// <param name="allowTemporaryFileSpill">
+    /// Whether an operator may exceed its in-memory share by writing to the temporary file system.
+    /// Set this to <see langword="false"/> for <c>temp_store=MEMORY</c>, where writing the same
+    /// payload to an in-memory file system would not bound the managed heap.
+    /// </param>
+    /// <param name="metrics">Optional execution metrics. A new instance is created when omitted.</param>
     public VdbeExecutionOptions(
         IFileSystem temporaryFileSystem,
         long sorterMemoryLimitBytes = DefaultSorterMemoryLimitBytes,
         string? temporaryDirectory = null,
-        int sorterMergeFanIn = DefaultSorterMergeFanIn)
+        int sorterMergeFanIn = DefaultSorterMergeFanIn,
+        bool allowTemporaryFileSpill = true,
+        VdbeExecutionMetrics? metrics = null)
     {
         ArgumentNullException.ThrowIfNull(temporaryFileSystem);
         ArgumentOutOfRangeException.ThrowIfLessThan(sorterMemoryLimitBytes, 1);
@@ -38,21 +49,36 @@ public sealed class VdbeExecutionOptions
         TemporaryFileSystem = temporaryFileSystem;
         SorterMemoryLimitBytes = sorterMemoryLimitBytes;
         SorterMergeFanIn = sorterMergeFanIn;
+        AllowTemporaryFileSpill = allowTemporaryFileSpill;
+        Metrics = metrics ?? new VdbeExecutionMetrics();
         TemporaryDirectory = string.IsNullOrWhiteSpace(temporaryDirectory)
             ? Path.GetTempPath()
             : temporaryDirectory;
     }
 
-    /// <summary>The file-system abstraction that stores transient sorter runs.</summary>
+    /// <summary>The file-system abstraction that stores transient execution spill files.</summary>
     public IFileSystem TemporaryFileSystem { get; }
 
-    /// <summary>The maximum buffered sorter payload before an external run is written.</summary>
+    /// <summary>
+    /// The retained-memory budget for spill-aware operators. The property name is retained for compatibility.
+    /// </summary>
     public long SorterMemoryLimitBytes { get; }
+
+    /// <summary>
+    /// The hard retained-memory budget shared by spill-aware execution intermediates in one statement.
+    /// </summary>
+    public long MemoryLimitBytes => SorterMemoryLimitBytes;
 
     /// <summary>The maximum run heads retained by a single merge pass.</summary>
     public int SorterMergeFanIn { get; }
 
-    /// <summary>The existing directory or logical path prefix used for temporary run names.</summary>
+    /// <summary>Whether operators may use the temporary file system after exhausting memory.</summary>
+    public bool AllowTemporaryFileSpill { get; }
+
+    /// <summary>High-water and spill counters for executions using these options.</summary>
+    public VdbeExecutionMetrics Metrics { get; }
+
+    /// <summary>The existing directory or logical path prefix used for temporary spill names.</summary>
     public string TemporaryDirectory { get; }
 
     internal static VdbeExecutionOptions Default { get; } =

--- a/src/Ahtola.Core/Execution/VdbeHashJoinRuntime.cs
+++ b/src/Ahtola.Core/Execution/VdbeHashJoinRuntime.cs
@@ -7,6 +7,8 @@ internal sealed class VdbeJoinExecutionContext(
     VdbeExecutionOptions options,
     VdbeExecutionMemory memory)
 {
+    private List<IDisposable>? _pendingCleanup;
+
     public VdbeExecutionOptions Options { get; } = options;
 
     public VdbeExecutionMemory Memory { get; } = memory;
@@ -20,12 +22,17 @@ internal sealed class VdbeJoinExecutionContext(
 
     public Exception? CleanupFailure { get; private set; }
 
-    public void RecordCleanupFailure(Exception exception)
+    public void RecordCleanupFailure(Exception exception, IDisposable? retryable = null)
     {
         ArgumentNullException.ThrowIfNull(exception);
         CleanupFailure = CleanupFailure is null
             ? exception
             : new AggregateException(CleanupFailure, exception);
+        if (retryable is not null
+            && !(_pendingCleanup?.Contains(retryable) ?? false))
+        {
+            (_pendingCleanup ??= []).Add(retryable);
+        }
     }
 
     public Exception? TakeCleanupFailure()
@@ -33,6 +40,33 @@ internal sealed class VdbeJoinExecutionContext(
         var failure = CleanupFailure;
         CleanupFailure = null;
         return failure;
+    }
+
+    public bool HasPendingCleanup => _pendingCleanup is { Count: > 0 };
+
+    public void RetryPendingCleanup()
+    {
+        if (_pendingCleanup is not { Count: > 0 } pending)
+            return;
+
+        List<Exception>? failures = null;
+        for (var index = pending.Count - 1; index >= 0; index--)
+        {
+            try
+            {
+                pending[index].Dispose();
+                pending.RemoveAt(index);
+            }
+            catch (Exception exception)
+            {
+                (failures ??= []).Add(exception);
+            }
+        }
+
+        if (failures is [var failure])
+            ExceptionDispatchInfo.Capture(failure).Throw();
+        if (failures is { Count: > 1 })
+            throw new AggregateException(failures);
     }
 
     public static VdbeJoinExecutionContext CreateDefault()
@@ -138,12 +172,11 @@ internal static class VdbeHashJoinRuntime
         int? maximumRows,
         VdbeJoinExecutionContext context)
     {
-        var retained = new List<BuildEntry>();
-        var buckets = new Dictionary<string, List<int>>(StringComparer.Ordinal);
         HashSpill? spill = null;
         LoadedPartition? loadedPartition = null;
         var unloadablePartition = -1;
         var trackUnmatchedBuild = buildIsRight && plan.Kind is VdbeJoinKind.Right or VdbeJoinKind.Full;
+        HashBuildBuffer? buffered = HashBuildBuffer.TryCreate(context.Memory, trackUnmatchedBuild);
         var emitted = 0;
 
         try
@@ -153,26 +186,23 @@ internal static class VdbeHashJoinRuntime
             {
                 context.ThrowIfCancellationRequested();
                 var key = buildKey(row);
-                var retainedBytes = checked(
-                    VdbeSpillRecordCodec.EstimateRetainedBytes(row.Values, key, row.RowIds.Length)
-                    + (trackUnmatchedBuild ? 1 : 0));
-                var entry = new BuildEntry(row, key, ordinal++, retainedBytes);
+                var retainedBytes = Math.Max(
+                    VdbeManagedFootprint.EstimateHashBuildEntry(
+                        row.Values,
+                        key,
+                        row.RowIds.Length),
+                    VdbeManagedFootprint.EstimateHashBuildEntryFromEncodedLength(
+                        EstimateEncodedEntryPayload(row, key),
+                        row.Values.Length,
+                        row.RowIds.Length));
+                if (retainedBytes > context.Memory.LimitBytes)
+                    throw new VdbeMemoryLimitExceededException(context.Memory.LimitBytes, retainedBytes);
+                var currentOrdinal = ordinal++;
 
-                if (spill is null && context.Memory.TryRetain(retainedBytes))
-                {
-                    var index = retained.Count;
-                    retained.Add(entry);
-                    if (key is not null)
-                    {
-                        if (!buckets.TryGetValue(key, out var bucket))
-                        {
-                            bucket = [];
-                            buckets.Add(key, bucket);
-                        }
-                        bucket.Add(index);
-                    }
+                if (spill is null
+                    && buffered is not null
+                    && buffered.TryAdd(row, key, currentOrdinal, retainedBytes))
                     continue;
-                }
 
                 if (!context.Options.AllowTemporaryFileSpill)
                     throw new VdbeMemoryLimitExceededException(context.Memory.LimitBytes, retainedBytes);
@@ -184,21 +214,34 @@ internal static class VdbeHashJoinRuntime
                         buildNode.ColumnCount,
                         buildNode.SourceCount,
                         trackUnmatchedBuild);
-                    foreach (var buffered in retained)
-                        spill.WriteBuild(buffered, context);
-                    foreach (var buffered in retained)
-                        context.Memory.Release(buffered.RetainedBytes);
-                    retained.Clear();
-                    buckets.Clear();
+                    if (buffered is not null)
+                    {
+                        foreach (var retained in buffered.Entries)
+                            spill.WriteBuild(retained, context);
+                        buffered.Dispose();
+                        buffered = null;
+                    }
                 }
 
-                spill.WriteBuild(entry, context);
+                context.Memory.RetainOrThrow(retainedBytes);
+                try
+                {
+                    spill.WriteBuild(
+                        new BuildEntry(row, key, currentOrdinal, retainedBytes),
+                        context);
+                }
+                finally
+                {
+                    context.Memory.Release(retainedBytes);
+                }
             }
 
             if (spill is not null)
                 spill.CompleteBuild(context);
 
-            bool[]? matched = trackUnmatchedBuild && spill is null ? new bool[retained.Count] : null;
+            bool[]? matched = trackUnmatchedBuild && spill is null
+                ? buffered!.CreateMatchedMap()
+                : null;
             foreach (var probe in probeNode.Enumerate(maximumRows: null, context))
             {
                 context.ThrowIfCancellationRequested();
@@ -209,12 +252,12 @@ internal static class VdbeHashJoinRuntime
                 {
                     if (spill is null)
                     {
-                        if (buckets.TryGetValue(key, out var candidateIndices))
+                        if (buffered!.TryGetCandidates(key, out var candidateIndices))
                         {
                             foreach (var buildIndex in candidateIndices)
                             {
                                 context.ThrowIfCancellationRequested();
-                                var build = retained[buildIndex];
+                                var build = buffered[buildIndex];
                                 var combined = Combine(build.Row, probe, buildIsRight);
                                 if (!Matches(plan, build.Row, probe, combined, buildIsRight))
                                     continue;
@@ -242,33 +285,50 @@ internal static class VdbeHashJoinRuntime
                             }
                         }
 
-                        IEnumerable<BuildEntry> candidates;
                         if (loadedPartition is not null)
                         {
-                            candidates = loadedPartition.Find(key);
+                            foreach (var build in loadedPartition.Find(key))
+                            {
+                                context.ThrowIfCancellationRequested();
+                                var combined = Combine(build.Row, probe, buildIsRight);
+                                if (!Matches(plan, build.Row, probe, combined, buildIsRight))
+                                    continue;
+
+                                matchedProbe = true;
+                                if (trackUnmatchedBuild)
+                                    spill.MarkMatched(build.Ordinal, context);
+                                yield return combined;
+                                if (maximumRows is { } maximum && ++emitted >= maximum)
+                                    yield break;
+                            }
                         }
                         else
                         {
                             context.Options.Metrics.HashPartitionFallbackScan();
-                            candidates = spill.ReadPartition(partition, context);
-                        }
+                            foreach (var lease in spill.ReadPartition(partition, context))
+                            {
+                                VdbeJoinRow? combinedResult = null;
+                                using (lease)
+                                {
+                                    context.ThrowIfCancellationRequested();
+                                    var build = lease.Entry;
+                                    if (!string.Equals(build.Key, key, StringComparison.Ordinal))
+                                        continue;
 
-                        foreach (var build in candidates)
-                        {
-                            context.ThrowIfCancellationRequested();
-                            if (!string.Equals(build.Key, key, StringComparison.Ordinal))
-                                continue;
+                                    var combined = Combine(build.Row, probe, buildIsRight);
+                                    if (!Matches(plan, build.Row, probe, combined, buildIsRight))
+                                        continue;
 
-                            var combined = Combine(build.Row, probe, buildIsRight);
-                            if (!Matches(plan, build.Row, probe, combined, buildIsRight))
-                                continue;
+                                    matchedProbe = true;
+                                    if (trackUnmatchedBuild)
+                                        spill.MarkMatched(build.Ordinal, context);
+                                    combinedResult = combined;
+                                }
 
-                            matchedProbe = true;
-                            if (trackUnmatchedBuild)
-                                spill.MarkMatched(build.Ordinal, context);
-                            yield return combined;
-                            if (maximumRows is { } maximum && ++emitted >= maximum)
-                                yield break;
+                                yield return combinedResult;
+                                if (maximumRows is { } maximum && ++emitted >= maximum)
+                                    yield break;
+                            }
                         }
                     }
                 }
@@ -288,24 +348,30 @@ internal static class VdbeHashJoinRuntime
                 var nullProbe = NullRow(probeNode);
                 if (spill is null)
                 {
-                    for (var index = 0; index < retained.Count; index++)
+                    for (var index = 0; index < buffered!.Count; index++)
                     {
                         context.ThrowIfCancellationRequested();
                         if (matched![index])
                             continue;
-                        yield return Combine(nullProbe, retained[index].Row);
+                        yield return Combine(nullProbe, buffered[index].Row);
                         if (maximumRows is { } maximum && ++emitted >= maximum)
                             yield break;
                     }
                 }
                 else
                 {
-                    foreach (var build in spill.ReadBuildOrder(context))
+                    foreach (var lease in spill.ReadBuildOrder(context))
                     {
-                        context.ThrowIfCancellationRequested();
-                        if (spill.IsMatched(build.Ordinal, context))
-                            continue;
-                        yield return Combine(nullProbe, build.Row);
+                        VdbeJoinRow? combined = null;
+                        using (lease)
+                        {
+                            context.ThrowIfCancellationRequested();
+                            var build = lease.Entry;
+                            if (spill.IsMatched(build.Ordinal, context))
+                                continue;
+                            combined = Combine(nullProbe, build.Row);
+                        }
+                        yield return combined;
                         if (maximumRows is { } maximum && ++emitted >= maximum)
                             yield break;
                     }
@@ -322,16 +388,13 @@ internal static class VdbeHashJoinRuntime
             {
                 context.RecordCleanupFailure(exception);
             }
-            foreach (var entry in retained)
+            try
             {
-                try
-                {
-                    context.Memory.Release(entry.RetainedBytes);
-                }
-                catch (Exception exception)
-                {
-                    context.RecordCleanupFailure(exception);
-                }
+                buffered?.Dispose();
+            }
+            catch (Exception exception)
+            {
+                context.RecordCleanupFailure(exception);
             }
             try
             {
@@ -339,7 +402,7 @@ internal static class VdbeHashJoinRuntime
             }
             catch (Exception exception)
             {
-                context.RecordCleanupFailure(exception);
+                context.RecordCleanupFailure(exception, spill);
             }
         }
     }
@@ -386,11 +449,203 @@ internal static class VdbeHashJoinRuntime
         return hash;
     }
 
+    private static long EstimateEncodedEntryPayload(VdbeJoinRow row, string? key)
+    {
+        var total = checked(
+            sizeof(long)
+            + sizeof(byte)
+            + VdbeSpillRecordCodec.EstimateEncodedValuesLength(row.Values));
+        if (key is not null)
+            total = checked(total + VdbeSpillRecordCodec.EstimateEncodedStringLength(key));
+        foreach (var rowId in row.RowIds)
+            total = checked(total + sizeof(byte) + (rowId.HasValue ? sizeof(long) : 0));
+        return total;
+    }
+
     private sealed record BuildEntry(
         VdbeJoinRow Row,
         string? Key,
         long Ordinal,
         long RetainedBytes);
+
+    private sealed class BuildEntryLease(
+        BuildEntry entry,
+        VdbeExecutionMemory memory,
+        long retainedBytes) : IDisposable
+    {
+        private bool _transferred;
+
+        public BuildEntry Entry { get; } = entry;
+
+        public long RetainedBytes { get; } = retainedBytes;
+
+        public void Transfer() => _transferred = true;
+
+        public void Dispose()
+        {
+            if (_transferred)
+                return;
+            _transferred = true;
+            memory.Release(RetainedBytes);
+        }
+    }
+
+    private sealed class HashBuildBuffer : IDisposable
+    {
+        private const long BufferObjectBytes = 64;
+
+        private readonly VdbeExecutionMemory _memory;
+        private readonly bool _trackMatches;
+        private List<BuildEntry>? _entries;
+        private Dictionary<string, List<int>>? _buckets;
+        private long _retainedBytes;
+        private int _retainedRows;
+
+        private HashBuildBuffer(VdbeExecutionMemory memory, bool trackMatches, long retainedBytes)
+        {
+            _memory = memory;
+            _trackMatches = trackMatches;
+            _retainedBytes = retainedBytes;
+            _entries = [];
+            _buckets = new Dictionary<string, List<int>>(StringComparer.Ordinal);
+        }
+
+        public int Count => _entries?.Count ?? 0;
+
+        public BuildEntry this[int index] => _entries![index];
+
+        public IEnumerable<BuildEntry> Entries => _entries ?? [];
+
+        public static HashBuildBuffer? TryCreate(VdbeExecutionMemory memory, bool trackMatches)
+        {
+            var retainedBytes = checked(
+                BufferObjectBytes
+                + VdbeManagedFootprint.ListObjectBytes
+                + VdbeManagedFootprint.DictionaryObjectBytes);
+            if (!memory.TryRetain(retainedBytes, rows: 0))
+                return null;
+            try
+            {
+                return new HashBuildBuffer(memory, trackMatches, retainedBytes);
+            }
+            catch
+            {
+                memory.Release(retainedBytes, rows: 0);
+                throw;
+            }
+        }
+
+        public bool TryAdd(
+            VdbeJoinRow row,
+            string? key,
+            long ordinal,
+            long entryBytes)
+        {
+            var entries = _entries
+                ?? throw new ObjectDisposedException(nameof(HashBuildBuffer));
+            var buckets = _buckets
+                ?? throw new ObjectDisposedException(nameof(HashBuildBuffer));
+            var requiredCount = checked(entries.Count + 1);
+            var entriesCapacity = VdbeManagedFootprint.GetListCapacityForCount(
+                entries.Capacity,
+                requiredCount);
+            var growthBytes = checked(
+                VdbeManagedFootprint.EstimateReferenceListStorage(entriesCapacity)
+                - VdbeManagedFootprint.EstimateReferenceListStorage(entries.Capacity));
+
+            List<int>? bucket = null;
+            var isNewKey = key is not null && !buckets.TryGetValue(key, out bucket);
+            var bucketCapacity = 0;
+            if (key is not null)
+            {
+                if (isNewKey)
+                {
+                    growthBytes = checked(
+                        growthBytes
+                        + VdbeManagedFootprint.BucketListObjectBytes
+                        + VdbeManagedFootprint.EstimateDictionaryStorage(buckets.Count + 1)
+                        - VdbeManagedFootprint.EstimateDictionaryStorage(buckets.Count));
+                    bucketCapacity = VdbeManagedFootprint.GetListCapacityForCount(0, 1);
+                    growthBytes = checked(
+                        growthBytes
+                        + VdbeManagedFootprint.EstimateInt32ListStorage(bucketCapacity));
+                }
+                else
+                {
+                    bucketCapacity = VdbeManagedFootprint.GetListCapacityForCount(
+                        bucket!.Capacity,
+                        bucket.Count + 1);
+                    growthBytes = checked(
+                        growthBytes
+                        + VdbeManagedFootprint.EstimateInt32ListStorage(bucketCapacity)
+                        - VdbeManagedFootprint.EstimateInt32ListStorage(bucket.Capacity));
+                }
+            }
+
+            if (_trackMatches)
+            {
+                growthBytes = checked(
+                    growthBytes
+                    + VdbeManagedFootprint.EstimateBooleanArray(requiredCount)
+                    - VdbeManagedFootprint.EstimateBooleanArray(entries.Count));
+            }
+
+            var retainedBytes = checked(entryBytes + growthBytes);
+            if (!_memory.TryRetain(retainedBytes))
+                return false;
+
+            try
+            {
+                if (entriesCapacity != entries.Capacity)
+                    entries.Capacity = entriesCapacity;
+                var entry = new BuildEntry(row, key, ordinal, entryBytes);
+                var entryIndex = entries.Count;
+                entries.Add(entry);
+                if (key is not null)
+                {
+                    if (isNewKey)
+                    {
+                        bucket = new List<int>(bucketCapacity);
+                        buckets.Add(key, bucket);
+                    }
+                    else if (bucketCapacity != bucket!.Capacity)
+                    {
+                        bucket.Capacity = bucketCapacity;
+                    }
+                    bucket!.Add(entryIndex);
+                }
+                _retainedBytes = checked(_retainedBytes + retainedBytes);
+                _retainedRows++;
+                return true;
+            }
+            catch
+            {
+                _memory.Release(retainedBytes);
+                throw;
+            }
+        }
+
+        public bool TryGetCandidates(string key, out List<int> candidates) =>
+            _buckets!.TryGetValue(key, out candidates!);
+
+        public bool[] CreateMatchedMap()
+        {
+            if (!_trackMatches)
+                throw new InvalidOperationException("This hash build does not track matches.");
+            return new bool[Count];
+        }
+
+        public void Dispose()
+        {
+            if (_entries is null)
+                return;
+            _entries = null;
+            _buckets = null;
+            _memory.Release(_retainedBytes, _retainedRows);
+            _retainedBytes = 0;
+            _retainedRows = 0;
+        }
+    }
 
     private sealed class LoadedPartition : IDisposable
     {
@@ -507,7 +762,7 @@ internal static class VdbeHashJoinRuntime
             _buildOrder?.File.FlushToDisk();
         }
 
-        public IEnumerable<BuildEntry> ReadPartition(
+        public IEnumerable<BuildEntryLease> ReadPartition(
             int partitionIndex,
             VdbeJoinExecutionContext context)
         {
@@ -524,31 +779,91 @@ internal static class VdbeHashJoinRuntime
             int partitionIndex,
             VdbeJoinExecutionContext context)
         {
-            var retainedBytes = 0L;
+            var dictionaryBytes = VdbeManagedFootprint.DictionaryObjectBytes;
+            if (!context.Memory.TryRetain(dictionaryBytes, rows: 0))
+                return null;
+
+            var retainedBytes = dictionaryBytes;
             var retainedRows = 0;
-            var buckets = new Dictionary<string, List<BuildEntry>>(StringComparer.Ordinal);
+            Dictionary<string, List<BuildEntry>>? buckets = null;
             var transferred = false;
             try
             {
-                foreach (var entry in ReadPartition(partitionIndex, context))
+                buckets = new Dictionary<string, List<BuildEntry>>(StringComparer.Ordinal);
+                var partition = _partitions[partitionIndex];
+                _options.Metrics.HashPartitionScanned();
+                VdbeSpillRecordCodec.ValidateFile(
+                    partition.File.File,
+                    VdbeSpillFileKind.HashPartition,
+                    _options.Metrics);
+                long position = VdbeSpillRecordCodec.FileHeaderSize;
+                for (var index = 0; index < partition.Count; index++)
                 {
-                    var bytes = VdbeSpillRecordCodec.EstimateRetainedBytes(
-                        entry.Row.Values,
-                        entry.Key,
-                        entry.Row.RowIds.Length);
-                    if (!context.Memory.TryRetain(bytes))
+                    using var lease = TryReadEntry(
+                        partition.File.File,
+                        ref position,
+                        context,
+                        requireAvailable: false);
+                    if (lease is null)
                         return null;
 
-                    retainedBytes = checked(retainedBytes + bytes);
-                    retainedRows++;
+                    var entry = lease.Entry;
                     if (entry.Key is null)
                         continue;
-                    if (!buckets.TryGetValue(entry.Key, out var bucket))
+
+                    List<BuildEntry>? bucket = null;
+                    var isNewKey = !buckets.TryGetValue(entry.Key, out bucket);
+                    var growthBytes = 0L;
+                    var bucketCapacity = 0;
+                    if (isNewKey)
                     {
-                        bucket = [];
-                        buckets.Add(entry.Key, bucket);
+                        growthBytes = checked(
+                            VdbeManagedFootprint.BucketListObjectBytes
+                            + VdbeManagedFootprint.EstimateDictionaryStorage(buckets.Count + 1)
+                            - VdbeManagedFootprint.EstimateDictionaryStorage(buckets.Count));
+                        bucketCapacity = VdbeManagedFootprint.GetListCapacityForCount(0, 1);
+                        growthBytes = checked(
+                            growthBytes
+                            + VdbeManagedFootprint.EstimateReferenceListStorage(bucketCapacity));
                     }
-                    bucket.Add(entry with { RetainedBytes = bytes });
+                    else
+                    {
+                        bucketCapacity = VdbeManagedFootprint.GetListCapacityForCount(
+                            bucket!.Capacity,
+                            bucket.Count + 1);
+                        growthBytes = checked(
+                            VdbeManagedFootprint.EstimateReferenceListStorage(bucketCapacity)
+                            - VdbeManagedFootprint.EstimateReferenceListStorage(bucket.Capacity));
+                    }
+
+                    if (!context.Memory.TryRetain(growthBytes, rows: 0))
+                        return null;
+
+                    try
+                    {
+                        if (isNewKey)
+                        {
+                            bucket = new List<BuildEntry>(bucketCapacity);
+                            buckets.Add(entry.Key, bucket);
+                        }
+                        else if (bucketCapacity != bucket!.Capacity)
+                        {
+                            bucket.Capacity = bucketCapacity;
+                        }
+                        bucket!.Add(entry);
+                    }
+                    catch
+                    {
+                        context.Memory.Release(growthBytes, rows: 0);
+                        throw;
+                    }
+
+                    retainedBytes = checked(
+                        retainedBytes
+                        + growthBytes
+                        + lease.RetainedBytes);
+                    retainedRows++;
+                    lease.Transfer();
                 }
 
                 transferred = true;
@@ -567,7 +882,7 @@ internal static class VdbeHashJoinRuntime
             }
         }
 
-        public IEnumerable<BuildEntry> ReadBuildOrder(VdbeJoinExecutionContext context)
+        public IEnumerable<BuildEntryLease> ReadBuildOrder(VdbeJoinExecutionContext context)
         {
             if (_buildOrder is null)
                 return [];
@@ -649,7 +964,7 @@ internal static class VdbeHashJoinRuntime
             }
         }
 
-        private IEnumerable<BuildEntry> ReadEntries(
+        private IEnumerable<BuildEntryLease> ReadEntries(
             IFile file,
             int count,
             VdbeJoinExecutionContext context)
@@ -657,11 +972,42 @@ internal static class VdbeHashJoinRuntime
             long position = VdbeSpillRecordCodec.FileHeaderSize;
             for (var index = 0; index < count; index++)
             {
-                context.ThrowIfCancellationRequested();
-                var recordEnd = VdbeSpillRecordCodec.ReadRecordEnd(
+                yield return TryReadEntry(
                     file,
                     ref position,
-                    _options.Metrics);
+                    context,
+                    requireAvailable: true)!;
+            }
+        }
+
+        private BuildEntryLease? TryReadEntry(
+            IFile file,
+            ref long position,
+            VdbeJoinExecutionContext context,
+            bool requireAvailable)
+        {
+            context.ThrowIfCancellationRequested();
+            var recordStart = position;
+            var recordEnd = VdbeSpillRecordCodec.ReadRecordEnd(
+                file,
+                ref position,
+                _options.Metrics);
+            var retainedBytes = VdbeManagedFootprint.EstimateHashBuildEntryFromEncodedLength(
+                recordEnd - position,
+                _columnCount,
+                _rowIdCount);
+            if (retainedBytes > context.Memory.LimitBytes)
+                throw new VdbeMemoryLimitExceededException(context.Memory.LimitBytes, retainedBytes);
+            if (!context.Memory.TryRetain(retainedBytes))
+            {
+                position = recordStart;
+                if (requireAvailable)
+                    throw new VdbeMemoryLimitExceededException(context.Memory.LimitBytes, retainedBytes);
+                return null;
+            }
+
+            try
+            {
                 var ordinal = VdbeSpillRecordCodec.ReadInt64(file, ref position, _options.Metrics);
                 var hasKey = VdbeSpillRecordCodec.ReadByte(file, ref position, _options.Metrics);
                 var key = hasKey switch
@@ -688,11 +1034,18 @@ internal static class VdbeHashJoinRuntime
                     };
                 }
                 VdbeSpillRecordCodec.RequireRecordEnd(position, recordEnd);
-                yield return new BuildEntry(
+                var entry = new BuildEntry(
                     new VdbeJoinRow(values, rowIds),
                     key,
                     ordinal,
-                    RetainedBytes: 0);
+                    retainedBytes);
+                return new BuildEntryLease(entry, context.Memory, retainedBytes);
+            }
+            catch
+            {
+                position = recordStart;
+                context.Memory.Release(retainedBytes);
+                throw;
             }
         }
 
@@ -700,7 +1053,6 @@ internal static class VdbeHashJoinRuntime
         {
             if (_disposed)
                 return;
-            _disposed = true;
 
             List<Exception>? cleanupFailures = null;
             foreach (var partition in _partitions)
@@ -735,6 +1087,8 @@ internal static class VdbeHashJoinRuntime
                 (cleanupFailures ??= []).Add(exception);
             }
 
+            if (cleanupFailures is null)
+                _disposed = true;
             if (cleanupFailures is [var cleanupFailure])
                 ExceptionDispatchInfo.Capture(cleanupFailure).Throw();
             if (cleanupFailures is { Count: > 1 })

--- a/src/Ahtola.Core/Execution/VdbeHashJoinRuntime.cs
+++ b/src/Ahtola.Core/Execution/VdbeHashJoinRuntime.cs
@@ -546,9 +546,12 @@ internal static class VdbeHashJoinRuntime
             var entriesCapacity = VdbeManagedFootprint.GetListCapacityForCount(
                 entries.Capacity,
                 requiredCount);
-            var growthBytes = checked(
-                VdbeManagedFootprint.EstimateReferenceListStorage(entriesCapacity)
-                - VdbeManagedFootprint.EstimateReferenceListStorage(entries.Capacity));
+            var currentEntriesBytes =
+                VdbeManagedFootprint.EstimateReferenceListStorage(entries.Capacity);
+            var growthBytes = VdbeManagedFootprint.EstimateContainerReplacement(
+                currentEntriesBytes,
+                VdbeManagedFootprint.EstimateReferenceListStorage(entriesCapacity));
+            var replacedBytes = growthBytes > 0 ? currentEntriesBytes : 0;
 
             List<int>? bucket = null;
             var isNewKey = key is not null && !buckets.TryGetValue(key, out bucket);
@@ -557,11 +560,17 @@ internal static class VdbeHashJoinRuntime
             {
                 if (isNewKey)
                 {
+                    var currentDictionaryBytes =
+                        VdbeManagedFootprint.EstimateDictionaryStorage(buckets.Count);
+                    var dictionaryGrowth = VdbeManagedFootprint.EstimateContainerReplacement(
+                        currentDictionaryBytes,
+                        VdbeManagedFootprint.EstimateDictionaryStorage(buckets.Count + 1));
                     growthBytes = checked(
                         growthBytes
                         + VdbeManagedFootprint.BucketListObjectBytes
-                        + VdbeManagedFootprint.EstimateDictionaryStorage(buckets.Count + 1)
-                        - VdbeManagedFootprint.EstimateDictionaryStorage(buckets.Count));
+                        + dictionaryGrowth);
+                    if (dictionaryGrowth > 0)
+                        replacedBytes = checked(replacedBytes + currentDictionaryBytes);
                     bucketCapacity = VdbeManagedFootprint.GetListCapacityForCount(0, 1);
                     growthBytes = checked(
                         growthBytes
@@ -569,13 +578,19 @@ internal static class VdbeHashJoinRuntime
                 }
                 else
                 {
+                    var currentBucketBytes =
+                        VdbeManagedFootprint.EstimateInt32ListStorage(bucket!.Capacity);
                     bucketCapacity = VdbeManagedFootprint.GetListCapacityForCount(
-                        bucket!.Capacity,
+                        bucket.Capacity,
                         bucket.Count + 1);
+                    var bucketGrowth = VdbeManagedFootprint.EstimateContainerReplacement(
+                        currentBucketBytes,
+                        VdbeManagedFootprint.EstimateInt32ListStorage(bucketCapacity));
                     growthBytes = checked(
                         growthBytes
-                        + VdbeManagedFootprint.EstimateInt32ListStorage(bucketCapacity)
-                        - VdbeManagedFootprint.EstimateInt32ListStorage(bucket.Capacity));
+                        + bucketGrowth);
+                    if (bucketGrowth > 0)
+                        replacedBytes = checked(replacedBytes + currentBucketBytes);
                 }
             }
 
@@ -611,7 +626,12 @@ internal static class VdbeHashJoinRuntime
                     }
                     bucket!.Add(entryIndex);
                 }
-                _retainedBytes = checked(_retainedBytes + retainedBytes);
+                if (replacedBytes > 0)
+                    _memory.Release(replacedBytes, rows: 0);
+                _retainedBytes = checked(
+                    _retainedBytes
+                    + retainedBytes
+                    - replacedBytes);
                 _retainedRows++;
                 return true;
             }
@@ -856,13 +876,22 @@ internal static class VdbeHashJoinRuntime
                     List<BuildEntry>? bucket = null;
                     var isNewKey = !buckets.TryGetValue(entry.Key, out bucket);
                     var growthBytes = 0L;
+                    var replacedBytes = 0L;
                     var bucketCapacity = 0;
                     if (isNewKey)
                     {
+                        var currentDictionaryBytes =
+                            VdbeManagedFootprint.EstimateDictionaryStorage(buckets.Count);
+                        var dictionaryGrowth =
+                            VdbeManagedFootprint.EstimateContainerReplacement(
+                                currentDictionaryBytes,
+                                VdbeManagedFootprint.EstimateDictionaryStorage(
+                                    buckets.Count + 1));
                         growthBytes = checked(
                             VdbeManagedFootprint.BucketListObjectBytes
-                            + VdbeManagedFootprint.EstimateDictionaryStorage(buckets.Count + 1)
-                            - VdbeManagedFootprint.EstimateDictionaryStorage(buckets.Count));
+                            + dictionaryGrowth);
+                        if (dictionaryGrowth > 0)
+                            replacedBytes = currentDictionaryBytes;
                         bucketCapacity = VdbeManagedFootprint.GetListCapacityForCount(0, 1);
                         growthBytes = checked(
                             growthBytes
@@ -870,12 +899,16 @@ internal static class VdbeHashJoinRuntime
                     }
                     else
                     {
+                        var currentBucketBytes =
+                            VdbeManagedFootprint.EstimateReferenceListStorage(bucket!.Capacity);
                         bucketCapacity = VdbeManagedFootprint.GetListCapacityForCount(
-                            bucket!.Capacity,
+                            bucket.Capacity,
                             bucket.Count + 1);
-                        growthBytes = checked(
-                            VdbeManagedFootprint.EstimateReferenceListStorage(bucketCapacity)
-                            - VdbeManagedFootprint.EstimateReferenceListStorage(bucket.Capacity));
+                        growthBytes = VdbeManagedFootprint.EstimateContainerReplacement(
+                            currentBucketBytes,
+                            VdbeManagedFootprint.EstimateReferenceListStorage(bucketCapacity));
+                        if (growthBytes > 0)
+                            replacedBytes = currentBucketBytes;
                     }
 
                     if (!context.Memory.TryRetain(growthBytes, rows: 0))
@@ -893,6 +926,8 @@ internal static class VdbeHashJoinRuntime
                             bucket.Capacity = bucketCapacity;
                         }
                         bucket!.Add(entry);
+                        if (replacedBytes > 0)
+                            context.Memory.Release(replacedBytes, rows: 0);
                     }
                     catch
                     {
@@ -903,6 +938,7 @@ internal static class VdbeHashJoinRuntime
                     retainedBytes = checked(
                         retainedBytes
                         + growthBytes
+                        - replacedBytes
                         + lease.RetainedBytes);
                     retainedRows++;
                     lease.Transfer();
@@ -955,7 +991,11 @@ internal static class VdbeHashJoinRuntime
             var position = checked(VdbeSpillRecordCodec.FileHeaderSize + ordinal);
             if (position >= _matched.File.Length)
                 return false;
-            return VdbeSpillRecordCodec.ReadByte(_matched.File, ref position, _options.Metrics) != 0;
+            return VdbeSpillRecordCodec.ReadBoolean(
+                _matched.File,
+                ref position,
+                _options.Metrics,
+                "hash match-map");
         }
 
         private void WriteEntry(

--- a/src/Ahtola.Core/Execution/VdbeHashJoinRuntime.cs
+++ b/src/Ahtola.Core/Execution/VdbeHashJoinRuntime.cs
@@ -1,0 +1,779 @@
+using Ahtola.Core.Storage;
+using System.Runtime.ExceptionServices;
+
+namespace Ahtola.Core.Execution;
+
+internal sealed class VdbeJoinExecutionContext(
+    VdbeExecutionOptions options,
+    VdbeExecutionMemory memory)
+{
+    public VdbeExecutionOptions Options { get; } = options;
+
+    public VdbeExecutionMemory Memory { get; } = memory;
+
+    public CancellationToken CancellationToken { get; private set; }
+
+    public void SetCancellationToken(CancellationToken cancellationToken) =>
+        CancellationToken = cancellationToken;
+
+    public void ThrowIfCancellationRequested() => CancellationToken.ThrowIfCancellationRequested();
+
+    public Exception? CleanupFailure { get; private set; }
+
+    public void RecordCleanupFailure(Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        CleanupFailure = CleanupFailure is null
+            ? exception
+            : new AggregateException(CleanupFailure, exception);
+    }
+
+    public Exception? TakeCleanupFailure()
+    {
+        var failure = CleanupFailure;
+        CleanupFailure = null;
+        return failure;
+    }
+
+    public static VdbeJoinExecutionContext CreateDefault()
+    {
+        var options = VdbeExecutionOptions.Default;
+        return new VdbeJoinExecutionContext(
+            options,
+            new VdbeExecutionMemory(options.MemoryLimitBytes, options.Metrics));
+    }
+}
+
+internal static class VdbeHashJoinRuntime
+{
+    private const int PartitionCount = 16;
+    private const ulong HashOffsetBasis = 14695981039346656037UL;
+    private const ulong HashPrime = 1099511628211UL;
+
+    public static IEnumerable<VdbeJoinRow> Enumerate(
+        VdbeJoinOperatorPlan plan,
+        int? maximumRows,
+        VdbeJoinExecutionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(context);
+        var rows = plan.HashBuildRight
+            ? EnumerateCore(
+                plan,
+                plan.Right,
+                plan.Left,
+                buildKey: plan.EquiProbe!.BuildRightKey,
+                probeKey: plan.EquiProbe.BuildLeftKey,
+                buildIsRight: true,
+                maximumRows,
+                context)
+            : EnumerateCore(
+                plan,
+                plan.Left,
+                plan.Right,
+                buildKey: plan.EquiProbe!.BuildLeftKey,
+                probeKey: plan.EquiProbe.BuildRightKey,
+                buildIsRight: false,
+                maximumRows,
+                context);
+        return ObserveCleanup(rows, context);
+    }
+
+    private static IEnumerable<VdbeJoinRow> ObserveCleanup(
+        IEnumerable<VdbeJoinRow> source,
+        VdbeJoinExecutionContext context)
+    {
+        var enumerator = source.GetEnumerator();
+        Exception? primaryFailure = null;
+        try
+        {
+            while (true)
+            {
+                bool hasNext;
+                try
+                {
+                    hasNext = enumerator.MoveNext();
+                }
+                catch (Exception exception)
+                {
+                    primaryFailure = exception;
+                    break;
+                }
+
+                if (!hasNext)
+                    break;
+                yield return enumerator.Current;
+            }
+        }
+        finally
+        {
+            try
+            {
+                enumerator.Dispose();
+            }
+            catch (Exception exception)
+            {
+                context.RecordCleanupFailure(exception);
+            }
+        }
+
+        var cleanupFailure = context.TakeCleanupFailure();
+        if (primaryFailure is not null)
+        {
+            if (cleanupFailure is not null)
+                throw new AggregateException(primaryFailure, cleanupFailure);
+            ExceptionDispatchInfo.Capture(primaryFailure).Throw();
+        }
+        if (cleanupFailure is not null)
+            ExceptionDispatchInfo.Capture(cleanupFailure).Throw();
+    }
+
+    private static IEnumerable<VdbeJoinRow> EnumerateCore(
+        VdbeJoinOperatorPlan plan,
+        VdbeJoinPlanNode buildNode,
+        VdbeJoinPlanNode probeNode,
+        Func<VdbeJoinRow, string?> buildKey,
+        Func<VdbeJoinRow, string?> probeKey,
+        bool buildIsRight,
+        int? maximumRows,
+        VdbeJoinExecutionContext context)
+    {
+        var retained = new List<BuildEntry>();
+        var buckets = new Dictionary<string, List<int>>(StringComparer.Ordinal);
+        HashSpill? spill = null;
+        LoadedPartition? loadedPartition = null;
+        var unloadablePartition = -1;
+        var trackUnmatchedBuild = buildIsRight && plan.Kind is VdbeJoinKind.Right or VdbeJoinKind.Full;
+        var emitted = 0;
+
+        try
+        {
+            long ordinal = 0;
+            foreach (var row in buildNode.Enumerate(maximumRows: null, context))
+            {
+                context.ThrowIfCancellationRequested();
+                var key = buildKey(row);
+                var retainedBytes = checked(
+                    VdbeSpillRecordCodec.EstimateRetainedBytes(row.Values, key, row.RowIds.Length)
+                    + (trackUnmatchedBuild ? 1 : 0));
+                var entry = new BuildEntry(row, key, ordinal++, retainedBytes);
+
+                if (spill is null && context.Memory.TryRetain(retainedBytes))
+                {
+                    var index = retained.Count;
+                    retained.Add(entry);
+                    if (key is not null)
+                    {
+                        if (!buckets.TryGetValue(key, out var bucket))
+                        {
+                            bucket = [];
+                            buckets.Add(key, bucket);
+                        }
+                        bucket.Add(index);
+                    }
+                    continue;
+                }
+
+                if (!context.Options.AllowTemporaryFileSpill)
+                    throw new VdbeMemoryLimitExceededException(context.Memory.LimitBytes, retainedBytes);
+
+                if (spill is null)
+                {
+                    spill = new HashSpill(
+                        context.Options,
+                        buildNode.ColumnCount,
+                        buildNode.SourceCount,
+                        trackUnmatchedBuild);
+                    foreach (var buffered in retained)
+                        spill.WriteBuild(buffered, context);
+                    foreach (var buffered in retained)
+                        context.Memory.Release(buffered.RetainedBytes);
+                    retained.Clear();
+                    buckets.Clear();
+                }
+
+                spill.WriteBuild(entry, context);
+            }
+
+            if (spill is not null)
+                spill.CompleteBuild(context);
+
+            bool[]? matched = trackUnmatchedBuild && spill is null ? new bool[retained.Count] : null;
+            foreach (var probe in probeNode.Enumerate(maximumRows: null, context))
+            {
+                context.ThrowIfCancellationRequested();
+                var matchedProbe = false;
+                var key = probeKey(probe);
+
+                if (key is not null)
+                {
+                    if (spill is null)
+                    {
+                        if (buckets.TryGetValue(key, out var candidateIndices))
+                        {
+                            foreach (var buildIndex in candidateIndices)
+                            {
+                                context.ThrowIfCancellationRequested();
+                                var build = retained[buildIndex];
+                                var combined = Combine(build.Row, probe, buildIsRight);
+                                if (!Matches(plan, build.Row, probe, combined, buildIsRight))
+                                    continue;
+
+                                matchedProbe = true;
+                                if (matched is not null)
+                                    matched[buildIndex] = true;
+                                yield return combined;
+                                if (maximumRows is { } maximum && ++emitted >= maximum)
+                                    yield break;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        var partition = GetPartition(key);
+                        if (loadedPartition?.Index != partition)
+                        {
+                            loadedPartition?.Dispose();
+                            loadedPartition = null;
+                            if (unloadablePartition != partition)
+                            {
+                                loadedPartition = spill.TryLoadPartition(partition, context);
+                                unloadablePartition = loadedPartition is null ? partition : -1;
+                            }
+                        }
+
+                        IEnumerable<BuildEntry> candidates;
+                        if (loadedPartition is not null)
+                        {
+                            candidates = loadedPartition.Find(key);
+                        }
+                        else
+                        {
+                            context.Options.Metrics.HashPartitionFallbackScan();
+                            candidates = spill.ReadPartition(partition, context);
+                        }
+
+                        foreach (var build in candidates)
+                        {
+                            context.ThrowIfCancellationRequested();
+                            if (!string.Equals(build.Key, key, StringComparison.Ordinal))
+                                continue;
+
+                            var combined = Combine(build.Row, probe, buildIsRight);
+                            if (!Matches(plan, build.Row, probe, combined, buildIsRight))
+                                continue;
+
+                            matchedProbe = true;
+                            if (trackUnmatchedBuild)
+                                spill.MarkMatched(build.Ordinal, context);
+                            yield return combined;
+                            if (maximumRows is { } maximum && ++emitted >= maximum)
+                                yield break;
+                        }
+                    }
+                }
+
+                if (!matchedProbe && buildIsRight && plan.Kind is VdbeJoinKind.Left or VdbeJoinKind.Full)
+                {
+                    yield return Combine(probe, NullRow(buildNode));
+                    if (maximumRows is { } maximum && ++emitted >= maximum)
+                        yield break;
+                }
+            }
+
+            if (trackUnmatchedBuild)
+            {
+                loadedPartition?.Dispose();
+                loadedPartition = null;
+                var nullProbe = NullRow(probeNode);
+                if (spill is null)
+                {
+                    for (var index = 0; index < retained.Count; index++)
+                    {
+                        context.ThrowIfCancellationRequested();
+                        if (matched![index])
+                            continue;
+                        yield return Combine(nullProbe, retained[index].Row);
+                        if (maximumRows is { } maximum && ++emitted >= maximum)
+                            yield break;
+                    }
+                }
+                else
+                {
+                    foreach (var build in spill.ReadBuildOrder(context))
+                    {
+                        context.ThrowIfCancellationRequested();
+                        if (spill.IsMatched(build.Ordinal, context))
+                            continue;
+                        yield return Combine(nullProbe, build.Row);
+                        if (maximumRows is { } maximum && ++emitted >= maximum)
+                            yield break;
+                    }
+                }
+            }
+        }
+        finally
+        {
+            try
+            {
+                loadedPartition?.Dispose();
+            }
+            catch (Exception exception)
+            {
+                context.RecordCleanupFailure(exception);
+            }
+            foreach (var entry in retained)
+            {
+                try
+                {
+                    context.Memory.Release(entry.RetainedBytes);
+                }
+                catch (Exception exception)
+                {
+                    context.RecordCleanupFailure(exception);
+                }
+            }
+            try
+            {
+                spill?.Dispose();
+            }
+            catch (Exception exception)
+            {
+                context.RecordCleanupFailure(exception);
+            }
+        }
+    }
+
+    private static bool Matches(
+        VdbeJoinOperatorPlan plan,
+        VdbeJoinRow build,
+        VdbeJoinRow probe,
+        VdbeJoinRow combined,
+        bool buildIsRight)
+    {
+        if (plan.Condition is null)
+            return true;
+        return buildIsRight
+            ? plan.Condition(probe, build, combined)
+            : plan.Condition(build, probe, combined);
+    }
+
+    private static VdbeJoinRow Combine(VdbeJoinRow build, VdbeJoinRow probe, bool buildIsRight) =>
+        buildIsRight
+            ? Combine(probe, build)
+            : Combine(build, probe);
+
+    private static VdbeJoinRow Combine(VdbeJoinRow left, VdbeJoinRow right) =>
+        new([.. left.Values, .. right.Values], [.. left.RowIds, .. right.RowIds]);
+
+    private static VdbeJoinRow NullRow(VdbeJoinPlanNode node) =>
+        new(
+            Enumerable.Repeat(SqlValue.Null, node.ColumnCount).ToArray(),
+            new long?[node.SourceCount]);
+
+    private static int GetPartition(string key) => (int)(StableHash(key) & (PartitionCount - 1));
+
+    private static ulong StableHash(string value)
+    {
+        var hash = HashOffsetBasis;
+        foreach (var character in value)
+        {
+            hash ^= (byte)character;
+            hash *= HashPrime;
+            hash ^= (byte)(character >> 8);
+            hash *= HashPrime;
+        }
+        return hash;
+    }
+
+    private sealed record BuildEntry(
+        VdbeJoinRow Row,
+        string? Key,
+        long Ordinal,
+        long RetainedBytes);
+
+    private sealed class LoadedPartition : IDisposable
+    {
+        private readonly VdbeExecutionMemory _memory;
+        private readonly Dictionary<string, List<BuildEntry>> _buckets;
+        private readonly long _retainedBytes;
+        private readonly int _retainedRows;
+        private bool _disposed;
+
+        public LoadedPartition(
+            int index,
+            VdbeExecutionMemory memory,
+            Dictionary<string, List<BuildEntry>> buckets,
+            long retainedBytes,
+            int retainedRows)
+        {
+            Index = index;
+            _memory = memory;
+            _buckets = buckets;
+            _retainedBytes = retainedBytes;
+            _retainedRows = retainedRows;
+        }
+
+        public int Index { get; }
+
+        public IEnumerable<BuildEntry> Find(string key) =>
+            _buckets.TryGetValue(key, out var entries) ? entries : [];
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+            _memory.Release(_retainedBytes, _retainedRows);
+        }
+    }
+
+    private sealed class HashSpill : IDisposable
+    {
+        private readonly VdbeExecutionOptions _options;
+        private readonly int _columnCount;
+        private readonly int _rowIdCount;
+        private readonly Partition[] _partitions;
+        private readonly VdbeTemporaryFile? _buildOrder;
+        private readonly VdbeTemporaryFile? _matched;
+        private long _buildOrderPosition;
+        private bool _disposed;
+
+        public HashSpill(
+            VdbeExecutionOptions options,
+            int columnCount,
+            int rowIdCount,
+            bool trackUnmatchedBuild)
+        {
+            _options = options;
+            _columnCount = columnCount;
+            _rowIdCount = rowIdCount;
+            _partitions = new Partition[PartitionCount];
+            try
+            {
+                for (var index = 0; index < _partitions.Length; index++)
+                {
+                    _partitions[index] = CreatePartition(options, index);
+                    options.Metrics.HashPartitionCreated();
+                }
+
+                if (trackUnmatchedBuild)
+                {
+                    _buildOrder = VdbeTemporaryFile.Create(options, "hash-build-order");
+                    _buildOrderPosition = VdbeSpillRecordCodec.InitializeFile(
+                        _buildOrder.File,
+                        VdbeSpillFileKind.HashBuildOrder,
+                        options.Metrics);
+                    _matched = VdbeTemporaryFile.Create(options, "hash-matches");
+                    VdbeSpillRecordCodec.InitializeFile(
+                        _matched.File,
+                        VdbeSpillFileKind.HashMatchMap,
+                        options.Metrics);
+                }
+            }
+            catch (Exception primaryFailure)
+            {
+                try
+                {
+                    Dispose();
+                }
+                catch (Exception cleanupFailure)
+                {
+                    throw new AggregateException(primaryFailure, cleanupFailure);
+                }
+                ExceptionDispatchInfo.Capture(primaryFailure).Throw();
+                throw;
+            }
+        }
+
+        public void WriteBuild(BuildEntry entry, VdbeJoinExecutionContext context)
+        {
+            context.ThrowIfCancellationRequested();
+            var partition = _partitions[entry.Key is null ? 0 : GetPartition(entry.Key)];
+            var position = partition.Position;
+            WriteEntry(partition.File.File, ref position, entry, context);
+            partition.Position = position;
+            partition.Count++;
+
+            if (_buildOrder is not null)
+                WriteEntry(_buildOrder.File, ref _buildOrderPosition, entry, context);
+        }
+
+        public void CompleteBuild(VdbeJoinExecutionContext context)
+        {
+            context.ThrowIfCancellationRequested();
+            foreach (var partition in _partitions)
+                partition.File.File.FlushToDisk();
+            _buildOrder?.File.FlushToDisk();
+        }
+
+        public IEnumerable<BuildEntry> ReadPartition(
+            int partitionIndex,
+            VdbeJoinExecutionContext context)
+        {
+            var partition = _partitions[partitionIndex];
+            _options.Metrics.HashPartitionScanned();
+            VdbeSpillRecordCodec.ValidateFile(
+                partition.File.File,
+                VdbeSpillFileKind.HashPartition,
+                _options.Metrics);
+            return ReadEntries(partition.File.File, partition.Count, context);
+        }
+
+        public LoadedPartition? TryLoadPartition(
+            int partitionIndex,
+            VdbeJoinExecutionContext context)
+        {
+            var retainedBytes = 0L;
+            var retainedRows = 0;
+            var buckets = new Dictionary<string, List<BuildEntry>>(StringComparer.Ordinal);
+            var transferred = false;
+            try
+            {
+                foreach (var entry in ReadPartition(partitionIndex, context))
+                {
+                    var bytes = VdbeSpillRecordCodec.EstimateRetainedBytes(
+                        entry.Row.Values,
+                        entry.Key,
+                        entry.Row.RowIds.Length);
+                    if (!context.Memory.TryRetain(bytes))
+                        return null;
+
+                    retainedBytes = checked(retainedBytes + bytes);
+                    retainedRows++;
+                    if (entry.Key is null)
+                        continue;
+                    if (!buckets.TryGetValue(entry.Key, out var bucket))
+                    {
+                        bucket = [];
+                        buckets.Add(entry.Key, bucket);
+                    }
+                    bucket.Add(entry with { RetainedBytes = bytes });
+                }
+
+                transferred = true;
+                _options.Metrics.HashPartitionLoaded();
+                return new LoadedPartition(
+                    partitionIndex,
+                    context.Memory,
+                    buckets,
+                    retainedBytes,
+                    retainedRows);
+            }
+            finally
+            {
+                if (!transferred && retainedBytes > 0)
+                    context.Memory.Release(retainedBytes, retainedRows);
+            }
+        }
+
+        public IEnumerable<BuildEntry> ReadBuildOrder(VdbeJoinExecutionContext context)
+        {
+            if (_buildOrder is null)
+                return [];
+            VdbeSpillRecordCodec.ValidateFile(
+                _buildOrder.File,
+                VdbeSpillFileKind.HashBuildOrder,
+                _options.Metrics);
+            return ReadEntries(
+                _buildOrder.File,
+                _partitions.Sum(static partition => partition.Count),
+                context);
+        }
+
+        public void MarkMatched(long ordinal, VdbeJoinExecutionContext context)
+        {
+            context.ThrowIfCancellationRequested();
+            if (_matched is null)
+                throw new InvalidOperationException("This hash spill does not track unmatched build rows.");
+            var position = checked(VdbeSpillRecordCodec.FileHeaderSize + ordinal);
+            VdbeSpillRecordCodec.WriteByte(_matched.File, ref position, 1, _options.Metrics);
+        }
+
+        public bool IsMatched(long ordinal, VdbeJoinExecutionContext context)
+        {
+            context.ThrowIfCancellationRequested();
+            if (_matched is null)
+                throw new InvalidOperationException("This hash spill does not track unmatched build rows.");
+            var position = checked(VdbeSpillRecordCodec.FileHeaderSize + ordinal);
+            if (position >= _matched.File.Length)
+                return false;
+            return VdbeSpillRecordCodec.ReadByte(_matched.File, ref position, _options.Metrics) != 0;
+        }
+
+        private void WriteEntry(
+            IFile file,
+            ref long position,
+            BuildEntry entry,
+            VdbeJoinExecutionContext context)
+        {
+            var start = position;
+            try
+            {
+                VdbeSpillRecordCodec.BeginRecord(ref position);
+                VdbeSpillRecordCodec.WriteInt64(file, ref position, entry.Ordinal, _options.Metrics);
+                VdbeSpillRecordCodec.WriteByte(
+                    file,
+                    ref position,
+                    entry.Key is null ? (byte)0 : (byte)1,
+                    _options.Metrics);
+                if (entry.Key is not null)
+                    VdbeSpillRecordCodec.WriteString(file, ref position, entry.Key, _options.Metrics);
+                VdbeSpillRecordCodec.WriteValues(file, ref position, entry.Row.Values, _options.Metrics);
+                foreach (var rowId in entry.Row.RowIds)
+                {
+                    VdbeSpillRecordCodec.WriteByte(
+                        file,
+                        ref position,
+                        rowId.HasValue ? (byte)1 : (byte)0,
+                        _options.Metrics);
+                    if (rowId.HasValue)
+                        VdbeSpillRecordCodec.WriteInt64(file, ref position, rowId.Value, _options.Metrics);
+                }
+                context.ThrowIfCancellationRequested();
+                VdbeSpillRecordCodec.CompleteRecord(file, start, position, _options.Metrics);
+            }
+            catch (Exception primaryFailure)
+            {
+                try
+                {
+                    file.SetLength(start);
+                    position = start;
+                }
+                catch (Exception rollbackFailure)
+                {
+                    throw new AggregateException(primaryFailure, rollbackFailure);
+                }
+                ExceptionDispatchInfo.Capture(primaryFailure).Throw();
+                throw;
+            }
+        }
+
+        private IEnumerable<BuildEntry> ReadEntries(
+            IFile file,
+            int count,
+            VdbeJoinExecutionContext context)
+        {
+            long position = VdbeSpillRecordCodec.FileHeaderSize;
+            for (var index = 0; index < count; index++)
+            {
+                context.ThrowIfCancellationRequested();
+                var recordEnd = VdbeSpillRecordCodec.ReadRecordEnd(
+                    file,
+                    ref position,
+                    _options.Metrics);
+                var ordinal = VdbeSpillRecordCodec.ReadInt64(file, ref position, _options.Metrics);
+                var hasKey = VdbeSpillRecordCodec.ReadByte(file, ref position, _options.Metrics);
+                var key = hasKey switch
+                {
+                    0 => null,
+                    1 => VdbeSpillRecordCodec.ReadString(file, ref position, _options.Metrics),
+                    _ => throw new InvalidDataException($"Unknown hash spill key marker {hasKey}."),
+                };
+                var values = VdbeSpillRecordCodec.ReadValues(
+                    file,
+                    ref position,
+                    _columnCount,
+                    _options.Metrics,
+                    context.CancellationToken);
+                var rowIds = new long?[_rowIdCount];
+                for (var rowIdIndex = 0; rowIdIndex < rowIds.Length; rowIdIndex++)
+                {
+                    var hasRowId = VdbeSpillRecordCodec.ReadByte(file, ref position, _options.Metrics);
+                    rowIds[rowIdIndex] = hasRowId switch
+                    {
+                        0 => null,
+                        1 => VdbeSpillRecordCodec.ReadInt64(file, ref position, _options.Metrics),
+                        _ => throw new InvalidDataException($"Unknown hash spill rowid marker {hasRowId}."),
+                    };
+                }
+                VdbeSpillRecordCodec.RequireRecordEnd(position, recordEnd);
+                yield return new BuildEntry(
+                    new VdbeJoinRow(values, rowIds),
+                    key,
+                    ordinal,
+                    RetainedBytes: 0);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+
+            List<Exception>? cleanupFailures = null;
+            foreach (var partition in _partitions)
+            {
+                if (partition is null)
+                    continue;
+                try
+                {
+                    partition.File.Dispose();
+                }
+                catch (Exception exception)
+                {
+                    (cleanupFailures ??= []).Add(exception);
+                }
+            }
+
+            try
+            {
+                _buildOrder?.Dispose();
+            }
+            catch (Exception exception)
+            {
+                (cleanupFailures ??= []).Add(exception);
+            }
+
+            try
+            {
+                _matched?.Dispose();
+            }
+            catch (Exception exception)
+            {
+                (cleanupFailures ??= []).Add(exception);
+            }
+
+            if (cleanupFailures is [var cleanupFailure])
+                ExceptionDispatchInfo.Capture(cleanupFailure).Throw();
+            if (cleanupFailures is { Count: > 1 })
+                throw new AggregateException(cleanupFailures);
+        }
+
+        private static Partition CreatePartition(VdbeExecutionOptions options, int index)
+        {
+            var file = VdbeTemporaryFile.Create(options, $"hash-p{index:D3}");
+            try
+            {
+                var position = VdbeSpillRecordCodec.InitializeFile(
+                    file.File,
+                    VdbeSpillFileKind.HashPartition,
+                    options.Metrics);
+                return new Partition(file, position);
+            }
+            catch (Exception primaryFailure)
+            {
+                try
+                {
+                    file.Dispose();
+                }
+                catch (Exception cleanupFailure)
+                {
+                    throw new AggregateException(primaryFailure, cleanupFailure);
+                }
+                ExceptionDispatchInfo.Capture(primaryFailure).Throw();
+                throw;
+            }
+        }
+
+        private sealed class Partition(VdbeTemporaryFile file, long position)
+        {
+            public VdbeTemporaryFile File { get; } = file;
+
+            public long Position { get; set; } = position;
+
+            public int Count { get; set; }
+        }
+    }
+}

--- a/src/Ahtola.Core/Execution/VdbeHashJoinRuntime.cs
+++ b/src/Ahtola.Core/Execution/VdbeHashJoinRuntime.cs
@@ -7,7 +7,7 @@ internal sealed class VdbeJoinExecutionContext(
     VdbeExecutionOptions options,
     VdbeExecutionMemory memory)
 {
-    private List<IDisposable>? _pendingCleanup;
+    private readonly VdbePendingCleanupRegistry _pendingCleanup = new();
 
     public VdbeExecutionOptions Options { get; } = options;
 
@@ -28,11 +28,8 @@ internal sealed class VdbeJoinExecutionContext(
         CleanupFailure = CleanupFailure is null
             ? exception
             : new AggregateException(CleanupFailure, exception);
-        if (retryable is not null
-            && !(_pendingCleanup?.Contains(retryable) ?? false))
-        {
-            (_pendingCleanup ??= []).Add(retryable);
-        }
+        if (retryable is not null)
+            _pendingCleanup.Register(retryable);
     }
 
     public Exception? TakeCleanupFailure()
@@ -42,32 +39,13 @@ internal sealed class VdbeJoinExecutionContext(
         return failure;
     }
 
-    public bool HasPendingCleanup => _pendingCleanup is { Count: > 0 };
+    public bool HasPendingCleanup => _pendingCleanup.HasPending;
 
-    public void RetryPendingCleanup()
-    {
-        if (_pendingCleanup is not { Count: > 0 } pending)
-            return;
+    public void RegisterPendingCleanup(IDisposable cleanup) => _pendingCleanup.Register(cleanup);
 
-        List<Exception>? failures = null;
-        for (var index = pending.Count - 1; index >= 0; index--)
-        {
-            try
-            {
-                pending[index].Dispose();
-                pending.RemoveAt(index);
-            }
-            catch (Exception exception)
-            {
-                (failures ??= []).Add(exception);
-            }
-        }
+    public void UnregisterPendingCleanup(IDisposable cleanup) => _pendingCleanup.Unregister(cleanup);
 
-        if (failures is [var failure])
-            ExceptionDispatchInfo.Capture(failure).Throw();
-        if (failures is { Count: > 1 })
-            throw new AggregateException(failures);
-    }
+    public void RetryPendingCleanup() => _pendingCleanup.Retry();
 
     public static VdbeJoinExecutionContext CreateDefault()
     {
@@ -176,11 +154,23 @@ internal static class VdbeHashJoinRuntime
         LoadedPartition? loadedPartition = null;
         var unloadablePartition = -1;
         var trackUnmatchedBuild = buildIsRight && plan.Kind is VdbeJoinKind.Right or VdbeJoinKind.Full;
-        HashBuildBuffer? buffered = HashBuildBuffer.TryCreate(context.Memory, trackUnmatchedBuild);
+        var spillInfrastructureBytes = VdbeManagedFootprint.EstimateHashSpillInfrastructure(
+            context.Options.TemporaryDirectory,
+            PartitionCount,
+            trackUnmatchedBuild);
+        VdbeMemoryReservation? spillInfrastructureReservation = null;
+        HashBuildBuffer? buffered = null;
         var emitted = 0;
 
         try
         {
+            if (context.Options.AllowTemporaryFileSpill)
+            {
+                spillInfrastructureReservation = VdbeMemoryReservation.TryCreate(
+                    context.Memory,
+                    spillInfrastructureBytes);
+            }
+            buffered = HashBuildBuffer.TryCreate(context.Memory, trackUnmatchedBuild);
             long ordinal = 0;
             foreach (var row in buildNode.Enumerate(maximumRows: null, context))
             {
@@ -209,11 +199,15 @@ internal static class VdbeHashJoinRuntime
 
                 if (spill is null)
                 {
-                    spill = new HashSpill(
-                        context.Options,
+                    spillInfrastructureReservation ??= VdbeMemoryReservation.Create(
+                        context.Memory,
+                        spillInfrastructureBytes);
+                    spill = HashSpill.Create(
+                        context,
                         buildNode.ColumnCount,
                         buildNode.SourceCount,
-                        trackUnmatchedBuild);
+                        trackUnmatchedBuild,
+                        ref spillInfrastructureReservation);
                     if (buffered is not null)
                     {
                         foreach (var retained in buffered.Entries)
@@ -240,7 +234,7 @@ internal static class VdbeHashJoinRuntime
                 spill.CompleteBuild(context);
 
             bool[]? matched = trackUnmatchedBuild && spill is null
-                ? buffered!.CreateMatchedMap()
+                ? buffered?.CreateMatchedMap() ?? []
                 : null;
             foreach (var probe in probeNode.Enumerate(maximumRows: null, context))
             {
@@ -252,7 +246,7 @@ internal static class VdbeHashJoinRuntime
                 {
                     if (spill is null)
                     {
-                        if (buffered!.TryGetCandidates(key, out var candidateIndices))
+                        if (buffered?.TryGetCandidates(key, out var candidateIndices) == true)
                         {
                             foreach (var buildIndex in candidateIndices)
                             {
@@ -348,7 +342,9 @@ internal static class VdbeHashJoinRuntime
                 var nullProbe = NullRow(probeNode);
                 if (spill is null)
                 {
-                    for (var index = 0; index < buffered!.Count; index++)
+                    if (buffered is null)
+                        yield break;
+                    for (var index = 0; index < buffered.Count; index++)
                     {
                         context.ThrowIfCancellationRequested();
                         if (matched![index])
@@ -404,6 +400,7 @@ internal static class VdbeHashJoinRuntime
             {
                 context.RecordCleanupFailure(exception, spill);
             }
+            spillInfrastructureReservation?.Dispose();
         }
     }
 
@@ -688,49 +685,65 @@ internal static class VdbeHashJoinRuntime
         private readonly VdbeExecutionOptions _options;
         private readonly int _columnCount;
         private readonly int _rowIdCount;
-        private readonly Partition[] _partitions;
-        private readonly VdbeTemporaryFile? _buildOrder;
-        private readonly VdbeTemporaryFile? _matched;
+        private readonly Partition?[] _partitions;
+        private readonly VdbeMemoryReservation _infrastructureReservation;
+        private VdbeTemporaryFile? _buildOrder;
+        private VdbeTemporaryFile? _matched;
         private long _buildOrderPosition;
         private bool _disposed;
 
-        public HashSpill(
+        private HashSpill(
             VdbeExecutionOptions options,
             int columnCount,
             int rowIdCount,
-            bool trackUnmatchedBuild)
+            VdbeMemoryReservation infrastructureReservation)
         {
             _options = options;
             _columnCount = columnCount;
             _rowIdCount = rowIdCount;
+            _infrastructureReservation = infrastructureReservation;
             _partitions = new Partition[PartitionCount];
+        }
+
+        public static HashSpill Create(
+            VdbeJoinExecutionContext context,
+            int columnCount,
+            int rowIdCount,
+            bool trackUnmatchedBuild,
+            ref VdbeMemoryReservation? infrastructureReservation)
+        {
+            var reservation = infrastructureReservation
+                ?? throw new InvalidOperationException("Hash spill infrastructure was not reserved.");
+            HashSpill spill;
             try
             {
-                for (var index = 0; index < _partitions.Length; index++)
-                {
-                    _partitions[index] = CreatePartition(options, index);
-                    options.Metrics.HashPartitionCreated();
-                }
+                spill = new HashSpill(
+                    context.Options,
+                    columnCount,
+                    rowIdCount,
+                    reservation);
+            }
+            catch
+            {
+                reservation.Dispose();
+                infrastructureReservation = null;
+                throw;
+            }
 
-                if (trackUnmatchedBuild)
-                {
-                    _buildOrder = VdbeTemporaryFile.Create(options, "hash-build-order");
-                    _buildOrderPosition = VdbeSpillRecordCodec.InitializeFile(
-                        _buildOrder.File,
-                        VdbeSpillFileKind.HashBuildOrder,
-                        options.Metrics);
-                    _matched = VdbeTemporaryFile.Create(options, "hash-matches");
-                    VdbeSpillRecordCodec.InitializeFile(
-                        _matched.File,
-                        VdbeSpillFileKind.HashMatchMap,
-                        options.Metrics);
-                }
+            context.RegisterPendingCleanup(spill);
+            infrastructureReservation = null;
+            try
+            {
+                spill.Initialize(trackUnmatchedBuild);
+                context.UnregisterPendingCleanup(spill);
+                return spill;
             }
             catch (Exception primaryFailure)
             {
                 try
                 {
-                    Dispose();
+                    spill.Dispose();
+                    context.UnregisterPendingCleanup(spill);
                 }
                 catch (Exception cleanupFailure)
                 {
@@ -741,10 +754,39 @@ internal static class VdbeHashJoinRuntime
             }
         }
 
+        private void Initialize(bool trackUnmatchedBuild)
+        {
+            for (var index = 0; index < _partitions.Length; index++)
+            {
+                var partition = new Partition();
+                _partitions[index] = partition;
+                partition.SetFile(VdbeTemporaryFile.Create(_options, $"hash-p{index:D3}"));
+                partition.Position = VdbeSpillRecordCodec.InitializeFile(
+                    partition.File.File,
+                    VdbeSpillFileKind.HashPartition,
+                    _options.Metrics);
+                _options.Metrics.HashPartitionCreated();
+            }
+
+            if (!trackUnmatchedBuild)
+                return;
+
+            _buildOrder = VdbeTemporaryFile.Create(_options, "hash-build-order");
+            _buildOrderPosition = VdbeSpillRecordCodec.InitializeFile(
+                _buildOrder.File,
+                VdbeSpillFileKind.HashBuildOrder,
+                _options.Metrics);
+            _matched = VdbeTemporaryFile.Create(_options, "hash-matches");
+            VdbeSpillRecordCodec.InitializeFile(
+                _matched.File,
+                VdbeSpillFileKind.HashMatchMap,
+                _options.Metrics);
+        }
+
         public void WriteBuild(BuildEntry entry, VdbeJoinExecutionContext context)
         {
             context.ThrowIfCancellationRequested();
-            var partition = _partitions[entry.Key is null ? 0 : GetPartition(entry.Key)];
+            var partition = _partitions[entry.Key is null ? 0 : GetPartition(entry.Key)]!;
             var position = partition.Position;
             WriteEntry(partition.File.File, ref position, entry, context);
             partition.Position = position;
@@ -758,7 +800,7 @@ internal static class VdbeHashJoinRuntime
         {
             context.ThrowIfCancellationRequested();
             foreach (var partition in _partitions)
-                partition.File.File.FlushToDisk();
+                partition!.File.File.FlushToDisk();
             _buildOrder?.File.FlushToDisk();
         }
 
@@ -766,7 +808,7 @@ internal static class VdbeHashJoinRuntime
             int partitionIndex,
             VdbeJoinExecutionContext context)
         {
-            var partition = _partitions[partitionIndex];
+            var partition = _partitions[partitionIndex]!;
             _options.Metrics.HashPartitionScanned();
             VdbeSpillRecordCodec.ValidateFile(
                 partition.File.File,
@@ -790,7 +832,7 @@ internal static class VdbeHashJoinRuntime
             try
             {
                 buckets = new Dictionary<string, List<BuildEntry>>(StringComparer.Ordinal);
-                var partition = _partitions[partitionIndex];
+                var partition = _partitions[partitionIndex]!;
                 _options.Metrics.HashPartitionScanned();
                 VdbeSpillRecordCodec.ValidateFile(
                     partition.File.File,
@@ -892,7 +934,7 @@ internal static class VdbeHashJoinRuntime
                 _options.Metrics);
             return ReadEntries(
                 _buildOrder.File,
-                _partitions.Sum(static partition => partition.Count),
+                _partitions.Sum(static partition => partition!.Count),
                 context);
         }
 
@@ -1013,13 +1055,18 @@ internal static class VdbeHashJoinRuntime
                 var key = hasKey switch
                 {
                     0 => null,
-                    1 => VdbeSpillRecordCodec.ReadString(file, ref position, _options.Metrics),
+                    1 => VdbeSpillRecordCodec.ReadString(
+                        file,
+                        ref position,
+                        recordEnd,
+                        _options.Metrics),
                     _ => throw new InvalidDataException($"Unknown hash spill key marker {hasKey}."),
                 };
                 var values = VdbeSpillRecordCodec.ReadValues(
                     file,
                     ref position,
                     _columnCount,
+                    recordEnd,
                     _options.Metrics,
                     context.CancellationToken);
                 var rowIds = new long?[_rowIdCount];
@@ -1061,7 +1108,7 @@ internal static class VdbeHashJoinRuntime
                     continue;
                 try
                 {
-                    partition.File.Dispose();
+                    partition.Dispose();
                 }
                 catch (Exception exception)
                 {
@@ -1088,46 +1135,30 @@ internal static class VdbeHashJoinRuntime
             }
 
             if (cleanupFailures is null)
+            {
+                _infrastructureReservation.Dispose();
                 _disposed = true;
+            }
             if (cleanupFailures is [var cleanupFailure])
                 ExceptionDispatchInfo.Capture(cleanupFailure).Throw();
             if (cleanupFailures is { Count: > 1 })
                 throw new AggregateException(cleanupFailures);
         }
 
-        private static Partition CreatePartition(VdbeExecutionOptions options, int index)
+        private sealed class Partition : IDisposable
         {
-            var file = VdbeTemporaryFile.Create(options, $"hash-p{index:D3}");
-            try
-            {
-                var position = VdbeSpillRecordCodec.InitializeFile(
-                    file.File,
-                    VdbeSpillFileKind.HashPartition,
-                    options.Metrics);
-                return new Partition(file, position);
-            }
-            catch (Exception primaryFailure)
-            {
-                try
-                {
-                    file.Dispose();
-                }
-                catch (Exception cleanupFailure)
-                {
-                    throw new AggregateException(primaryFailure, cleanupFailure);
-                }
-                ExceptionDispatchInfo.Capture(primaryFailure).Throw();
-                throw;
-            }
-        }
+            private VdbeTemporaryFile? _file;
 
-        private sealed class Partition(VdbeTemporaryFile file, long position)
-        {
-            public VdbeTemporaryFile File { get; } = file;
+            public VdbeTemporaryFile File =>
+                _file ?? throw new InvalidOperationException("Hash spill partition is not initialized.");
 
-            public long Position { get; set; } = position;
+            public long Position { get; set; }
 
             public int Count { get; set; }
+
+            public void SetFile(VdbeTemporaryFile file) => _file = file;
+
+            public void Dispose() => _file?.Dispose();
         }
     }
 }

--- a/src/Ahtola.Core/Execution/VdbeProgram.cs
+++ b/src/Ahtola.Core/Execution/VdbeProgram.cs
@@ -900,6 +900,14 @@ public abstract class VdbeJoinPlanNode
     /// output before the first row is consumed.
     /// </summary>
     internal abstract IEnumerable<VdbeJoinRow> Enumerate(int? maximumRows);
+
+    internal virtual IEnumerable<VdbeJoinRow> Enumerate(
+        int? maximumRows,
+        VdbeJoinExecutionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return Enumerate(maximumRows);
+    }
 }
 
 /// <summary>A base-table leaf in a materializing join plan.</summary>
@@ -921,6 +929,11 @@ public sealed class VdbeJoinScanPlan : VdbeJoinPlanNode
     internal override IReadOnlyList<VdbeJoinRow> Materialize(int? maximumRows) => Enumerate(maximumRows).ToList();
 
     internal override IEnumerable<VdbeJoinRow> Enumerate(int? maximumRows)
+        => Enumerate(maximumRows, VdbeJoinExecutionContext.CreateDefault());
+
+    internal override IEnumerable<VdbeJoinRow> Enumerate(
+        int? maximumRows,
+        VdbeJoinExecutionContext context)
     {
         if (Source.RowIds is not null && Source.RowIds.Count != Source.Rows.Count)
         {
@@ -933,6 +946,7 @@ public sealed class VdbeJoinScanPlan : VdbeJoinPlanNode
             : Source.Rows.Count;
         for (var index = 0; index < count; index++)
         {
+            context.ThrowIfCancellationRequested();
             var values = Source.Rows[index];
             if (values.Length != ColumnCount)
             {
@@ -1193,26 +1207,35 @@ public sealed class VdbeJoinOperatorPlan : VdbeJoinPlanNode
     internal override IReadOnlyList<VdbeJoinRow> Materialize(int? maximumRows) => Enumerate(maximumRows).ToList();
 
     internal override IEnumerable<VdbeJoinRow> Enumerate(int? maximumRows)
+        => Enumerate(maximumRows, VdbeJoinExecutionContext.CreateDefault());
+
+    internal override IEnumerable<VdbeJoinRow> Enumerate(
+        int? maximumRows,
+        VdbeJoinExecutionContext context)
     {
         if (Right is VdbeJoinIndexScanPlan indexSeek)
-            return EnumerateIndexSeekRight(indexSeek, maximumRows);
+            return EnumerateIndexSeekRight(indexSeek, maximumRows, context);
+
+        if (EquiProbe is not null)
+            return VdbeHashJoinRuntime.Enumerate(this, maximumRows, context);
 
         // Default: materialize right once; stream left (OOM-safe for large outer × small inner).
         // INNER equijoin may flip to hash-build left when stats say left is smaller.
         if (!HashBuildRight)
-            return EnumerateHashBuildLeft(maximumRows);
-        return EnumerateHashBuildRight(maximumRows);
+            return EnumerateHashBuildLeft(maximumRows, context);
+        return EnumerateHashBuildRight(maximumRows, context);
     }
 
     private IEnumerable<VdbeJoinRow> EnumerateIndexSeekRight(
         VdbeJoinIndexScanPlan indexSeek,
-        int? maximumRows)
+        int? maximumRows,
+        VdbeJoinExecutionContext context)
     {
         if (Kind is not (VdbeJoinKind.Inner or VdbeJoinKind.Left))
             throw new InvalidOperationException("An index-seek right input requires an INNER or LEFT join.");
 
         var emitted = 0;
-        foreach (var left in Left.Enumerate(maximumRows: null))
+        foreach (var left in Left.Enumerate(maximumRows: null, context))
         {
             var matched = false;
             foreach (var right in indexSeek.Seek(left))
@@ -1238,9 +1261,11 @@ public sealed class VdbeJoinOperatorPlan : VdbeJoinPlanNode
         }
     }
 
-    private IEnumerable<VdbeJoinRow> EnumerateHashBuildRight(int? maximumRows)
+    private IEnumerable<VdbeJoinRow> EnumerateHashBuildRight(
+        int? maximumRows,
+        VdbeJoinExecutionContext context)
     {
-        var rightRows = Right.Enumerate(maximumRows: null).ToList();
+        var rightRows = Right.Enumerate(maximumRows: null, context).ToList();
         var rightMatched = Kind is VdbeJoinKind.Right or VdbeJoinKind.Full
             ? new bool[rightRows.Count]
             : null;
@@ -1266,8 +1291,9 @@ public sealed class VdbeJoinOperatorPlan : VdbeJoinPlanNode
             }
         }
 
-        foreach (var left in Left.Enumerate(maximumRows: null))
+        foreach (var left in Left.Enumerate(maximumRows: null, context))
         {
+            context.ThrowIfCancellationRequested();
             var matched = false;
             IEnumerable<int> candidateIndices;
             if (buckets is not null && EquiProbe is not null)
@@ -1321,11 +1347,13 @@ public sealed class VdbeJoinOperatorPlan : VdbeJoinPlanNode
         }
     }
 
-    private IEnumerable<VdbeJoinRow> EnumerateHashBuildLeft(int? maximumRows)
+    private IEnumerable<VdbeJoinRow> EnumerateHashBuildLeft(
+        int? maximumRows,
+        VdbeJoinExecutionContext context)
     {
         // INNER only: materialize left, stream right, probe left buckets. Output column order
         // stays left||right via Combine.
-        var leftRows = Left.Enumerate(maximumRows: null).ToList();
+        var leftRows = Left.Enumerate(maximumRows: null, context).ToList();
         var emitted = 0;
         Dictionary<string, List<int>>? buckets = null;
         if (EquiProbe is not null && leftRows.Count > 0)
@@ -1346,8 +1374,9 @@ public sealed class VdbeJoinOperatorPlan : VdbeJoinPlanNode
             }
         }
 
-        foreach (var right in Right.Enumerate(maximumRows: null))
+        foreach (var right in Right.Enumerate(maximumRows: null, context))
         {
+            context.ThrowIfCancellationRequested();
             IEnumerable<int> candidateIndices;
             if (buckets is not null && EquiProbe is not null)
             {
@@ -1445,13 +1474,17 @@ public sealed class VdbeJoinPlan
     /// row is consumed; the group-key ordinal map is built as rows arrive.
     /// </summary>
     internal IEnumerable<SqlValue[]> Enumerate()
+        => Enumerate(VdbeJoinExecutionContext.CreateDefault());
+
+    internal IEnumerable<SqlValue[]> Enumerate(VdbeJoinExecutionContext context)
     {
         var groupOrdinals = GroupKey is null
             ? null
             : new Dictionary<string, long>(StringComparer.Ordinal);
 
-        foreach (var raw in Root.Enumerate(MaximumRows))
+        foreach (var raw in Root.Enumerate(MaximumRows, context))
         {
+            context.ThrowIfCancellationRequested();
             if (Filter is not null && !Filter(raw))
                 continue;
 
@@ -1660,9 +1693,11 @@ public sealed class VdbeSubprogram
 
     internal ResumableStatement CreateRuntime(
         VdbeParameterBinding? parameterBinding,
-        VdbeExecutionOptions executionOptions)
+        VdbeExecutionOptions executionOptions,
+        VdbeExecutionMemory executionMemory)
     {
         ArgumentNullException.ThrowIfNull(executionOptions);
+        ArgumentNullException.ThrowIfNull(executionMemory);
         lock (_syncRoot)
         {
             var program = _program ?? throw new InvalidOperationException(
@@ -1675,7 +1710,8 @@ public sealed class VdbeSubprogram
                 parameterBinding,
                 sharedTransaction: null,
                 virtualTableBindings: null,
-                executionOptions: executionOptions);
+                executionOptions: executionOptions,
+                executionMemory: executionMemory);
         }
     }
 }

--- a/src/Ahtola.Core/Execution/VdbeSpillStore.cs
+++ b/src/Ahtola.Core/Execution/VdbeSpillStore.cs
@@ -325,6 +325,19 @@ internal static class VdbeSpillRecordCodec
         return bytes[0];
     }
 
+    public static bool ReadBoolean(
+        IFile file,
+        ref long position,
+        VdbeExecutionMetrics metrics,
+        string kind) =>
+        ReadByte(file, ref position, metrics) switch
+        {
+            0 => false,
+            1 => true,
+            var value => throw new InvalidDataException(
+                $"Unknown execution spill {kind} marker {value}."),
+        };
+
     private static void WriteValue(
         IFile file,
         ref long position,
@@ -423,7 +436,7 @@ internal static class VdbeSpillRecordCodec
         var length = ReadLength(file, ref position, recordEnd, metrics, "blob");
         var bytes = new byte[length];
         ReadExact(file, ref position, bytes, metrics);
-        return SqlValue.Blob(bytes);
+        return SqlValue.BlobOwned(bytes);
     }
 
     private static int ReadLength(

--- a/src/Ahtola.Core/Execution/VdbeSpillStore.cs
+++ b/src/Ahtola.Core/Execution/VdbeSpillStore.cs
@@ -1,0 +1,445 @@
+using System.Buffers.Binary;
+using System.Text;
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Core.Execution;
+
+internal enum VdbeSpillFileKind : byte
+{
+    SorterRun = 1,
+    HashPartition = 2,
+    HashBuildOrder = 3,
+    HashMatchMap = 4,
+}
+
+internal sealed class VdbeTemporaryFile : IDisposable
+{
+    private readonly IFileSystem _fileSystem;
+    private readonly VdbeExecutionMetrics _metrics;
+    private bool _disposed;
+
+    private VdbeTemporaryFile(
+        IFileSystem fileSystem,
+        VdbeExecutionMetrics metrics,
+        string path,
+        IFile file)
+    {
+        _fileSystem = fileSystem;
+        _metrics = metrics;
+        Path = path;
+        File = file;
+        metrics.SpillFileOpened();
+    }
+
+    public string Path { get; }
+
+    public IFile File { get; }
+
+    public static VdbeTemporaryFile Create(VdbeExecutionOptions options, string purpose)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrEmpty(purpose);
+        for (var attempt = 0; attempt < 16; attempt++)
+        {
+            var path = System.IO.Path.Combine(
+                options.TemporaryDirectory,
+                $"ahtola-{purpose}-{Guid.NewGuid():N}.spill");
+            try
+            {
+                var fileSystem = options.TemporaryFileSystem;
+                var file = fileSystem is ITemporaryFileSystem temporaryFileSystem
+                    ? temporaryFileSystem.OpenTemporaryFile(path)
+                    : fileSystem.OpenFile(path, FileOpenMode.CreateNew);
+                return new VdbeTemporaryFile(fileSystem, options.Metrics, path, file);
+            }
+            catch (IOException) when (options.TemporaryFileSystem.FileExists(path))
+            {
+            }
+        }
+
+        throw new IOException($"Unable to allocate a unique temporary {purpose} file.");
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        Exception? failure = null;
+        try
+        {
+            File.Dispose();
+        }
+        catch (Exception exception)
+        {
+            failure = exception;
+        }
+
+        var deleted = false;
+        // Make one best-effort retry so a surfaced transient cleanup error does not also
+        // strand its artifact. The first failure is still reported to the statement.
+        for (var attempt = 0; attempt < 2 && !deleted; attempt++)
+        {
+            try
+            {
+                _fileSystem.DeleteFile(Path);
+                deleted = true;
+            }
+            catch (Exception exception)
+            {
+                failure = failure is null ? exception : new AggregateException(failure, exception);
+            }
+        }
+
+        if (deleted)
+        {
+            _metrics.SpillFileClosed();
+            _disposed = true;
+        }
+
+        if (failure is not null)
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(failure).Throw();
+    }
+}
+
+internal static class VdbeSpillRecordCodec
+{
+    private static ReadOnlySpan<byte> Magic => "AHTSPILL"u8;
+    private const byte FormatVersion = 1;
+    public const int FileHeaderSize = 10;
+    private const int RecordLengthSize = 5;
+    private const long RowObjectOverhead = 32;
+    private const long ValueSlotOverhead = 16;
+    private const long KeyObjectOverhead = 24;
+
+    public static long InitializeFile(
+        IFile file,
+        VdbeSpillFileKind kind,
+        VdbeExecutionMetrics metrics)
+    {
+        Span<byte> header = stackalloc byte[FileHeaderSize];
+        Magic.CopyTo(header);
+        header[8] = FormatVersion;
+        header[9] = (byte)kind;
+        var position = 0L;
+        Write(file, ref position, header, metrics);
+        return position;
+    }
+
+    public static void ValidateFile(
+        IFile file,
+        VdbeSpillFileKind expectedKind,
+        VdbeExecutionMetrics metrics)
+    {
+        Span<byte> header = stackalloc byte[FileHeaderSize];
+        var position = 0L;
+        ReadExact(file, ref position, header, metrics);
+        if (!header[..8].SequenceEqual(Magic))
+            throw new InvalidDataException("Execution spill file has an invalid magic value.");
+        if (header[8] != FormatVersion)
+            throw new InvalidDataException($"Unsupported execution spill format version {header[8]}.");
+        if (header[9] != (byte)expectedKind)
+            throw new InvalidDataException($"Execution spill operator kind {header[9]} does not match {expectedKind}.");
+    }
+
+    public static long BeginRecord(ref long position)
+    {
+        var start = position;
+        position = checked(position + RecordLengthSize);
+        return start;
+    }
+
+    public static void CompleteRecord(
+        IFile file,
+        long recordStart,
+        long recordEnd,
+        VdbeExecutionMetrics metrics)
+    {
+        var payloadLength = checked(recordEnd - recordStart - RecordLengthSize);
+        if (payloadLength < 0 || payloadLength > uint.MaxValue)
+            throw new InvalidDataException("Execution spill record length is invalid.");
+
+        Span<byte> encoded = stackalloc byte[RecordLengthSize];
+        var remaining = (uint)payloadLength;
+        for (var index = 0; index < RecordLengthSize; index++)
+        {
+            encoded[index] = (byte)(remaining & 0x7F);
+            remaining >>= 7;
+            if (index < RecordLengthSize - 1)
+                encoded[index] |= 0x80;
+        }
+
+        var headerPosition = recordStart;
+        Write(file, ref headerPosition, encoded, metrics);
+    }
+
+    public static long ReadRecordEnd(
+        IFile file,
+        ref long position,
+        VdbeExecutionMetrics metrics)
+    {
+        Span<byte> encoded = stackalloc byte[RecordLengthSize];
+        ReadExact(file, ref position, encoded, metrics);
+        uint length = 0;
+        for (var index = 0; index < RecordLengthSize; index++)
+        {
+            var current = encoded[index];
+            var continuation = (current & 0x80) != 0;
+            if (continuation != (index < RecordLengthSize - 1))
+                throw new InvalidDataException("Execution spill record has a malformed length varint.");
+            if (index == RecordLengthSize - 1 && (current & 0x70) != 0)
+                throw new InvalidDataException("Execution spill record length exceeds the supported range.");
+            length |= (uint)(current & 0x7F) << (index * 7);
+        }
+
+        var end = checked(position + length);
+        if (end > file.Length)
+            throw new EndOfStreamException("Execution spill stream ended inside a record.");
+        return end;
+    }
+
+    public static void RequireRecordEnd(long position, long recordEnd)
+    {
+        if (position != recordEnd)
+            throw new InvalidDataException("Execution spill record has unexpected trailing or missing data.");
+    }
+
+    public static long EstimateRetainedBytes(IReadOnlyList<SqlValue> values, string? key = null, int rowIdCount = 0)
+    {
+        long total = checked(RowObjectOverhead + (values.Count * ValueSlotOverhead) + (rowIdCount * sizeof(long)));
+        if (key is not null)
+            total = checked(total + KeyObjectOverhead + (key.Length * sizeof(char)));
+        foreach (var value in values)
+            total = checked(total + EstimateValuePayloadBytes(value));
+        return total;
+    }
+
+    public static long EstimateValuePayloadBytes(SqlValue value) => value.Kind switch
+    {
+        SqlValueKind.Null => 1,
+        SqlValueKind.Integer or SqlValueKind.Real => 9,
+        SqlValueKind.Text => checked(5L + Encoding.UTF8.GetByteCount(value.AsText())),
+        SqlValueKind.Blob => checked(5L + value.AsBlobSpan().Length),
+        _ => throw new InvalidOperationException($"Unknown SQL value kind {value.Kind}."),
+    };
+
+    public static void WriteValues(
+        IFile file,
+        ref long position,
+        IReadOnlyList<SqlValue> values,
+        VdbeExecutionMetrics metrics)
+    {
+        foreach (var value in values)
+            WriteValue(file, ref position, value, metrics);
+    }
+
+    public static SqlValue[] ReadValues(
+        IFile file,
+        ref long position,
+        int count,
+        VdbeExecutionMetrics metrics,
+        CancellationToken cancellationToken)
+    {
+        var values = new SqlValue[count];
+        for (var index = 0; index < count; index++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            values[index] = ReadValue(file, ref position, metrics);
+        }
+        return values;
+    }
+
+    public static void WriteString(
+        IFile file,
+        ref long position,
+        string value,
+        VdbeExecutionMetrics metrics)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        WriteInt32(file, ref position, bytes.Length, metrics);
+        Write(file, ref position, bytes, metrics);
+    }
+
+    public static string ReadString(
+        IFile file,
+        ref long position,
+        VdbeExecutionMetrics metrics)
+    {
+        var length = ReadLength(file, ref position, metrics, "text");
+        var bytes = new byte[length];
+        ReadExact(file, ref position, bytes, metrics);
+        return Encoding.UTF8.GetString(bytes);
+    }
+
+    public static void WriteInt32(
+        IFile file,
+        ref long position,
+        int value,
+        VdbeExecutionMetrics metrics)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(int)];
+        BinaryPrimitives.WriteInt32LittleEndian(bytes, value);
+        Write(file, ref position, bytes, metrics);
+    }
+
+    public static int ReadInt32(IFile file, ref long position, VdbeExecutionMetrics metrics)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(int)];
+        ReadExact(file, ref position, bytes, metrics);
+        return BinaryPrimitives.ReadInt32LittleEndian(bytes);
+    }
+
+    public static void WriteInt64(
+        IFile file,
+        ref long position,
+        long value,
+        VdbeExecutionMetrics metrics)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(long)];
+        BinaryPrimitives.WriteInt64LittleEndian(bytes, value);
+        Write(file, ref position, bytes, metrics);
+    }
+
+    public static long ReadInt64(IFile file, ref long position, VdbeExecutionMetrics metrics)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(long)];
+        ReadExact(file, ref position, bytes, metrics);
+        return BinaryPrimitives.ReadInt64LittleEndian(bytes);
+    }
+
+    public static void WriteByte(
+        IFile file,
+        ref long position,
+        byte value,
+        VdbeExecutionMetrics metrics)
+    {
+        Span<byte> bytes = stackalloc byte[1] { value };
+        Write(file, ref position, bytes, metrics);
+    }
+
+    public static byte ReadByte(IFile file, ref long position, VdbeExecutionMetrics metrics)
+    {
+        Span<byte> bytes = stackalloc byte[1];
+        ReadExact(file, ref position, bytes, metrics);
+        return bytes[0];
+    }
+
+    private static void WriteValue(
+        IFile file,
+        ref long position,
+        SqlValue value,
+        VdbeExecutionMetrics metrics)
+    {
+        switch (value.Kind)
+        {
+            case SqlValueKind.Null:
+                WriteByte(file, ref position, 0x00, metrics);
+                break;
+            case SqlValueKind.Integer:
+                WriteByte(file, ref position, 0x01, metrics);
+                WriteInt64(file, ref position, value.AsInteger(), metrics);
+                break;
+            case SqlValueKind.Real:
+                WriteByte(file, ref position, 0x02, metrics);
+                Span<byte> real = stackalloc byte[sizeof(double)];
+                BinaryPrimitives.WriteDoubleLittleEndian(real, value.AsReal());
+                Write(file, ref position, real, metrics);
+                break;
+            case SqlValueKind.Text:
+                WriteByte(file, ref position, value.IsJson ? (byte)0x83 : (byte)0x03, metrics);
+                WriteString(file, ref position, value.AsText(), metrics);
+                break;
+            case SqlValueKind.Blob:
+                WriteByte(file, ref position, 0x04, metrics);
+                var blob = value.AsBlobSpan();
+                WriteInt32(file, ref position, blob.Length, metrics);
+                Write(file, ref position, blob, metrics);
+                break;
+            default:
+                throw new InvalidOperationException($"Unknown SQL value kind {value.Kind}.");
+        }
+    }
+
+    private static SqlValue ReadValue(IFile file, ref long position, VdbeExecutionMetrics metrics)
+    {
+        var kindByte = ReadByte(file, ref position, metrics);
+        var isJson = (kindByte & 0x80) != 0;
+        return (SqlValueKind)(kindByte & 0x0F) switch
+        {
+            SqlValueKind.Null when !isJson => SqlValue.Null,
+            SqlValueKind.Integer when !isJson => SqlValue.Integer(ReadInt64(file, ref position, metrics)),
+            SqlValueKind.Real when !isJson => ReadReal(file, ref position, metrics),
+            SqlValueKind.Text => ReadText(file, ref position, metrics, isJson),
+            SqlValueKind.Blob when !isJson => ReadBlob(file, ref position, metrics),
+            _ => throw new InvalidDataException($"Unknown spilled value tag 0x{kindByte:X2}."),
+        };
+    }
+
+    private static SqlValue ReadReal(IFile file, ref long position, VdbeExecutionMetrics metrics)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(double)];
+        ReadExact(file, ref position, bytes, metrics);
+        return SqlValue.Real(BinaryPrimitives.ReadDoubleLittleEndian(bytes));
+    }
+
+    private static SqlValue ReadText(
+        IFile file,
+        ref long position,
+        VdbeExecutionMetrics metrics,
+        bool isJson)
+    {
+        var text = ReadString(file, ref position, metrics);
+        return isJson ? SqlValue.JsonText(text) : SqlValue.Text(text);
+    }
+
+    private static SqlValue ReadBlob(IFile file, ref long position, VdbeExecutionMetrics metrics)
+    {
+        var length = ReadLength(file, ref position, metrics, "blob");
+        var bytes = new byte[length];
+        ReadExact(file, ref position, bytes, metrics);
+        return SqlValue.Blob(bytes);
+    }
+
+    private static int ReadLength(
+        IFile file,
+        ref long position,
+        VdbeExecutionMetrics metrics,
+        string kind)
+    {
+        var length = ReadInt32(file, ref position, metrics);
+        if (length < 0)
+            throw new InvalidDataException($"Execution spill {kind} length is negative.");
+        if (length > file.Length - position)
+            throw new EndOfStreamException($"Execution spill stream ended inside a {kind} payload.");
+        return length;
+    }
+
+    private static void Write(
+        IFile file,
+        ref long position,
+        ReadOnlySpan<byte> source,
+        VdbeExecutionMetrics metrics)
+    {
+        file.Write(position, source);
+        position = checked(position + source.Length);
+        metrics.AddSpillBytesWritten(source.Length);
+    }
+
+    private static void ReadExact(
+        IFile file,
+        ref long position,
+        Span<byte> destination,
+        VdbeExecutionMetrics metrics)
+    {
+        var total = 0;
+        while (total < destination.Length)
+        {
+            var read = file.Read(checked(position + total), destination[total..]);
+            if (read <= 0)
+                throw new EndOfStreamException("Execution spill stream ended mid-record.");
+            total += read;
+            metrics.AddSpillBytesRead(read);
+        }
+        position = checked(position + total);
+    }
+}

--- a/src/Ahtola.Core/Execution/VdbeSpillStore.cs
+++ b/src/Ahtola.Core/Execution/VdbeSpillStore.cs
@@ -236,6 +236,7 @@ internal static class VdbeSpillRecordCodec
         IFile file,
         ref long position,
         int count,
+        long recordEnd,
         VdbeExecutionMetrics metrics,
         CancellationToken cancellationToken)
     {
@@ -243,7 +244,7 @@ internal static class VdbeSpillRecordCodec
         for (var index = 0; index < count; index++)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            values[index] = ReadValue(file, ref position, metrics);
+            values[index] = ReadValue(file, ref position, recordEnd, metrics);
         }
         return values;
     }
@@ -262,9 +263,10 @@ internal static class VdbeSpillRecordCodec
     public static string ReadString(
         IFile file,
         ref long position,
+        long recordEnd,
         VdbeExecutionMetrics metrics)
     {
-        var length = ReadLength(file, ref position, metrics, "text");
+        var length = ReadLength(file, ref position, recordEnd, metrics, "text");
         var bytes = new byte[length];
         ReadExact(file, ref position, bytes, metrics);
         return Encoding.UTF8.GetString(bytes);
@@ -359,23 +361,43 @@ internal static class VdbeSpillRecordCodec
         }
     }
 
-    private static SqlValue ReadValue(IFile file, ref long position, VdbeExecutionMetrics metrics)
+    private static SqlValue ReadValue(
+        IFile file,
+        ref long position,
+        long recordEnd,
+        VdbeExecutionMetrics metrics)
     {
+        RequireRecordBytes(position, recordEnd, 1, "value tag");
         var kindByte = ReadByte(file, ref position, metrics);
         return kindByte switch
         {
             0x00 => SqlValue.Null,
-            0x01 => SqlValue.Integer(ReadInt64(file, ref position, metrics)),
-            0x02 => ReadReal(file, ref position, metrics),
-            0x03 => ReadText(file, ref position, metrics, isJson: false),
-            0x04 => ReadBlob(file, ref position, metrics),
-            0x83 => ReadText(file, ref position, metrics, isJson: true),
+            0x01 => ReadInteger(file, ref position, recordEnd, metrics),
+            0x02 => ReadReal(file, ref position, recordEnd, metrics),
+            0x03 => ReadText(file, ref position, recordEnd, metrics, isJson: false),
+            0x04 => ReadBlob(file, ref position, recordEnd, metrics),
+            0x83 => ReadText(file, ref position, recordEnd, metrics, isJson: true),
             _ => throw new InvalidDataException($"Unknown spilled value tag 0x{kindByte:X2}."),
         };
     }
 
-    private static SqlValue ReadReal(IFile file, ref long position, VdbeExecutionMetrics metrics)
+    private static SqlValue ReadInteger(
+        IFile file,
+        ref long position,
+        long recordEnd,
+        VdbeExecutionMetrics metrics)
     {
+        RequireRecordBytes(position, recordEnd, sizeof(long), "integer payload");
+        return SqlValue.Integer(ReadInt64(file, ref position, metrics));
+    }
+
+    private static SqlValue ReadReal(
+        IFile file,
+        ref long position,
+        long recordEnd,
+        VdbeExecutionMetrics metrics)
+    {
+        RequireRecordBytes(position, recordEnd, sizeof(double), "real payload");
         Span<byte> bytes = stackalloc byte[sizeof(double)];
         ReadExact(file, ref position, bytes, metrics);
         return SqlValue.Real(BinaryPrimitives.ReadDoubleLittleEndian(bytes));
@@ -384,16 +406,21 @@ internal static class VdbeSpillRecordCodec
     private static SqlValue ReadText(
         IFile file,
         ref long position,
+        long recordEnd,
         VdbeExecutionMetrics metrics,
         bool isJson)
     {
-        var text = ReadString(file, ref position, metrics);
+        var text = ReadString(file, ref position, recordEnd, metrics);
         return isJson ? SqlValue.JsonText(text) : SqlValue.Text(text);
     }
 
-    private static SqlValue ReadBlob(IFile file, ref long position, VdbeExecutionMetrics metrics)
+    private static SqlValue ReadBlob(
+        IFile file,
+        ref long position,
+        long recordEnd,
+        VdbeExecutionMetrics metrics)
     {
-        var length = ReadLength(file, ref position, metrics, "blob");
+        var length = ReadLength(file, ref position, recordEnd, metrics, "blob");
         var bytes = new byte[length];
         ReadExact(file, ref position, bytes, metrics);
         return SqlValue.Blob(bytes);
@@ -402,15 +429,33 @@ internal static class VdbeSpillRecordCodec
     private static int ReadLength(
         IFile file,
         ref long position,
+        long recordEnd,
         VdbeExecutionMetrics metrics,
         string kind)
     {
+        RequireRecordBytes(position, recordEnd, sizeof(int), $"{kind} length");
         var length = ReadInt32(file, ref position, metrics);
         if (length < 0)
             throw new InvalidDataException($"Execution spill {kind} length is negative.");
-        if (length > file.Length - position)
-            throw new EndOfStreamException($"Execution spill stream ended inside a {kind} payload.");
+        if (length > recordEnd - position)
+        {
+            throw new InvalidDataException(
+                $"Execution spill {kind} payload crosses its enclosing record boundary.");
+        }
         return length;
+    }
+
+    private static void RequireRecordBytes(
+        long position,
+        long recordEnd,
+        int byteCount,
+        string kind)
+    {
+        if (position < 0 || recordEnd < position || byteCount > recordEnd - position)
+        {
+            throw new InvalidDataException(
+                $"Execution spill {kind} crosses its enclosing record boundary.");
+        }
     }
 
     private static void Write(

--- a/src/Ahtola.Core/Execution/VdbeSpillStore.cs
+++ b/src/Ahtola.Core/Execution/VdbeSpillStore.cs
@@ -108,9 +108,6 @@ internal static class VdbeSpillRecordCodec
     private const byte FormatVersion = 1;
     public const int FileHeaderSize = 10;
     private const int RecordLengthSize = 5;
-    private const long RowObjectOverhead = 32;
-    private const long ValueSlotOverhead = 16;
-    private const long KeyObjectOverhead = 24;
 
     public static long InitializeFile(
         IFile file,
@@ -204,25 +201,6 @@ internal static class VdbeSpillRecordCodec
             throw new InvalidDataException("Execution spill record has unexpected trailing or missing data.");
     }
 
-    public static long EstimateRetainedBytes(IReadOnlyList<SqlValue> values, string? key = null, int rowIdCount = 0)
-    {
-        long total = checked(RowObjectOverhead + (values.Count * ValueSlotOverhead) + (rowIdCount * sizeof(long)));
-        if (key is not null)
-            total = checked(total + KeyObjectOverhead + (key.Length * sizeof(char)));
-        foreach (var value in values)
-            total = checked(total + EstimateValuePayloadBytes(value));
-        return total;
-    }
-
-    public static long EstimateValuePayloadBytes(SqlValue value) => value.Kind switch
-    {
-        SqlValueKind.Null => 1,
-        SqlValueKind.Integer or SqlValueKind.Real => 9,
-        SqlValueKind.Text => checked(5L + Encoding.UTF8.GetByteCount(value.AsText())),
-        SqlValueKind.Blob => checked(5L + value.AsBlobSpan().Length),
-        _ => throw new InvalidOperationException($"Unknown SQL value kind {value.Kind}."),
-    };
-
     public static void WriteValues(
         IFile file,
         ref long position,
@@ -232,6 +210,27 @@ internal static class VdbeSpillRecordCodec
         foreach (var value in values)
             WriteValue(file, ref position, value, metrics);
     }
+
+    public static long EstimateEncodedValuesLength(IReadOnlyList<SqlValue> values)
+    {
+        var total = 0L;
+        foreach (var value in values)
+        {
+            var valueLength = value.Kind switch
+            {
+                SqlValueKind.Null => 1L,
+                SqlValueKind.Integer or SqlValueKind.Real => 1L + sizeof(long),
+                SqlValueKind.Text => 1L + sizeof(int) + Encoding.UTF8.GetByteCount(value.AsText()),
+                SqlValueKind.Blob => 1L + sizeof(int) + value.AsBlobSpan().Length,
+                _ => throw new InvalidOperationException($"Unknown SQL value kind {value.Kind}."),
+            };
+            total = checked(total + valueLength);
+        }
+        return total;
+    }
+
+    public static long EstimateEncodedStringLength(string value) =>
+        checked((long)sizeof(int) + Encoding.UTF8.GetByteCount(value));
 
     public static SqlValue[] ReadValues(
         IFile file,
@@ -363,14 +362,14 @@ internal static class VdbeSpillRecordCodec
     private static SqlValue ReadValue(IFile file, ref long position, VdbeExecutionMetrics metrics)
     {
         var kindByte = ReadByte(file, ref position, metrics);
-        var isJson = (kindByte & 0x80) != 0;
-        return (SqlValueKind)(kindByte & 0x0F) switch
+        return kindByte switch
         {
-            SqlValueKind.Null when !isJson => SqlValue.Null,
-            SqlValueKind.Integer when !isJson => SqlValue.Integer(ReadInt64(file, ref position, metrics)),
-            SqlValueKind.Real when !isJson => ReadReal(file, ref position, metrics),
-            SqlValueKind.Text => ReadText(file, ref position, metrics, isJson),
-            SqlValueKind.Blob when !isJson => ReadBlob(file, ref position, metrics),
+            0x00 => SqlValue.Null,
+            0x01 => SqlValue.Integer(ReadInt64(file, ref position, metrics)),
+            0x02 => ReadReal(file, ref position, metrics),
+            0x03 => ReadText(file, ref position, metrics, isJson: false),
+            0x04 => ReadBlob(file, ref position, metrics),
+            0x83 => ReadText(file, ref position, metrics, isJson: true),
             _ => throw new InvalidDataException($"Unknown spilled value tag 0x{kindByte:X2}."),
         };
     }

--- a/src/Ahtola.Core/SqlValue.cs
+++ b/src/Ahtola.Core/SqlValue.cs
@@ -66,6 +66,12 @@ public readonly struct SqlValue : IEquatable<SqlValue>
     public static SqlValue Blob(ReadOnlySpan<byte> value)
         => new(SqlValueKind.Blob, default, default, null, value.ToArray(), false);
 
+    internal static SqlValue BlobOwned(byte[] value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        return new(SqlValueKind.Blob, default, default, null, value, false);
+    }
+
     internal bool IsJson => _isJson;
 
     internal SqlValue WithoutJsonSubtype()
@@ -93,15 +99,15 @@ public readonly struct SqlValue : IEquatable<SqlValue>
             ? _blob.ToArray()
             : throw InvalidKind(SqlValueKind.Blob);
 
-        /// <summary>Returns the owned blob bytes without allocating a defensive copy.</summary>
-        /// <remarks>
-        /// Internal hot-path readers (record encode, comparisons) must not mutate the returned
-        /// span. Public callers keep <see cref="AsBlob"/> so exposed buffers stay snapshot-isolated.
-        /// </remarks>
-        internal ReadOnlySpan<byte> AsBlobSpan()
-            => Kind == SqlValueKind.Blob
-                ? _blob.Span
-                : throw InvalidKind(SqlValueKind.Blob);
+    /// <summary>Returns the owned blob bytes without allocating a defensive copy.</summary>
+    /// <remarks>
+    /// Internal hot-path readers (record encode, comparisons) must not mutate the returned
+    /// span. Public callers keep <see cref="AsBlob"/> so exposed buffers stay snapshot-isolated.
+    /// </remarks>
+    internal ReadOnlySpan<byte> AsBlobSpan()
+        => Kind == SqlValueKind.Blob
+            ? _blob.Span
+            : throw InvalidKind(SqlValueKind.Blob);
 
     public bool Equals(SqlValue other)
     {

--- a/src/Ahtola.Tests/HashJoinSpillExecutionTests.cs
+++ b/src/Ahtola.Tests/HashJoinSpillExecutionTests.cs
@@ -247,6 +247,23 @@ public class HashJoinSpillExecutionTests
                     metrics,
                     CancellationToken.None));
         }
+
+        using var unknownBoolean = fileSystem.OpenFile(
+            "unknown-boolean.spill",
+            FileOpenMode.CreateNew);
+        var booleanPosition = VdbeSpillRecordCodec.InitializeFile(
+            unknownBoolean,
+            VdbeSpillFileKind.HashMatchMap,
+            metrics);
+        VdbeSpillRecordCodec.WriteByte(unknownBoolean, ref booleanPosition, 2, metrics);
+        booleanPosition = VdbeSpillRecordCodec.FileHeaderSize;
+
+        Assert.Throws<InvalidDataException>(
+            () => VdbeSpillRecordCodec.ReadBoolean(
+                    unknownBoolean,
+                    ref booleanPosition,
+                    metrics,
+                    "hash match-map"));
     }
 
     [TestCase(0x03)]

--- a/src/Ahtola.Tests/HashJoinSpillExecutionTests.cs
+++ b/src/Ahtola.Tests/HashJoinSpillExecutionTests.cs
@@ -1,0 +1,441 @@
+using AwesomeAssertions;
+using Ahtola.Core;
+using Ahtola.Core.Execution;
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Tests;
+
+public class HashJoinSpillExecutionTests
+{
+    [Test]
+    public void EquiJoinSpillsWithinBudgetAndCleansEveryTemporaryFile()
+    {
+        const long budget = 1024;
+        var fileSystem = new TrackingFileSystem();
+        var metrics = new VdbeExecutionMetrics();
+        var right = Enumerable.Range(0, 200)
+            .Select(static value => Row(value, $"r{value:D3}"))
+            .ToArray();
+        var left = Enumerable.Range(0, 200)
+            .Reverse()
+            .Select(static value => Row(value, $"l{value:D3}"))
+            .ToArray();
+        var program = JoinProgram(left, right, VdbeJoinKind.Inner);
+        var options = Options(fileSystem, metrics, budget);
+
+        using (var statement = ResumableStatement.CreateWithExecutionOptions(program, options))
+        {
+            var rows = Drain(statement);
+            rows.Should().HaveCount(200);
+            rows.Select(static row => row[0].AsInteger())
+                .Should().Equal(Enumerable.Range(0, 200).Reverse().Select(static value => (long)value));
+            metrics.CurrentRetainedBytes.Should().Be(0);
+            metrics.CurrentRetainedRows.Should().Be(0);
+        }
+
+        metrics.PeakRetainedBytes.Should().BeLessThanOrEqualTo(budget);
+        metrics.PeakRetainedRows.Should().BeGreaterThan(0);
+        metrics.HashPartitionsCreated.Should().Be(16);
+        metrics.HashPartitionScans.Should().BeGreaterThan(0);
+        metrics.SpillBytesWritten.Should().BeGreaterThan(0);
+        metrics.SpillBytesRead.Should().BeGreaterThan(0);
+        metrics.ActiveSpillFiles.Should().Be(0);
+        fileSystem.Deleted.Should().BeEquivalentTo(fileSystem.Created);
+        fileSystem.Created.Should().OnlyContain(path => !fileSystem.FileExists(path));
+    }
+
+    [Test]
+    public void SpilledFullJoinPreservesDuplicatesNullsAndUnmatchedBuildOrder()
+    {
+        var metrics = new VdbeExecutionMetrics();
+        var left =
+            new[] { Row(1, "l1"), Row(2, "l2"), Row(4, "l4"), Row(null, "ln") };
+        var right =
+            new[] { Row(2, "r2a"), Row(3, "r3"), Row(2, "r2b"), Row(null, "rn") };
+        var program = JoinProgram(left, right, VdbeJoinKind.Full);
+        var options = Options(new InMemoryFileSystem(), metrics, memoryLimitBytes: 160);
+
+        using var statement = ResumableStatement.CreateWithExecutionOptions(program, options);
+
+        Drain(statement).Select(Labels).Should().Equal(
+            ("l1", null),
+            ("l2", "r2a"),
+            ("l2", "r2b"),
+            ("l4", null),
+            ("ln", null),
+            (null, "r3"),
+            (null, "rn"));
+        metrics.HashPartitionsCreated.Should().Be(16);
+        metrics.HashPartitionLoads.Should().BeGreaterThan(0);
+        metrics.HashPartitionFallbackScans.Should().BeGreaterThan(0);
+        metrics.CurrentRetainedBytes.Should().Be(0);
+        metrics.ActiveSpillFiles.Should().Be(0);
+    }
+
+    [Test]
+    public void SpilledBuildLeftInnerJoinKeepsProbeThenBuildInsertionOrder()
+    {
+        var metrics = new VdbeExecutionMetrics();
+        var left = new[] { Row(2, "l2a"), Row(1, "l1"), Row(2, "l2b") };
+        var right = new[] { Row(1, "r1"), Row(2, "r2") };
+        var program = JoinProgram(
+            left,
+            right,
+            VdbeJoinKind.Inner,
+            hashBuildRight: false);
+        var options = Options(new InMemoryFileSystem(), metrics, memoryLimitBytes: 128);
+
+        using var statement = ResumableStatement.CreateWithExecutionOptions(program, options);
+
+        Drain(statement).Select(Labels).Should().Equal(
+            ("l1", "r1"),
+            ("l2a", "r2"),
+            ("l2b", "r2"));
+        metrics.HashPartitionsCreated.Should().Be(16);
+        metrics.PeakRetainedBytes.Should().BeLessThanOrEqualTo(128);
+    }
+
+    [Test]
+    public void DisabledSpillFailsAtBudgetWithoutCreatingHeapBackedFiles()
+    {
+        var fileSystem = new TrackingFileSystem();
+        var metrics = new VdbeExecutionMetrics();
+        var program = JoinProgram(
+            [Row(1, "left")],
+            Enumerable.Range(0, 20).Select(static value => Row(value, new string('x', 32))).ToArray(),
+            VdbeJoinKind.Inner);
+        var options = new VdbeExecutionOptions(
+            fileSystem,
+            sorterMemoryLimitBytes: 128,
+            temporaryDirectory: "hash-memory-only",
+            allowTemporaryFileSpill: false,
+            metrics: metrics);
+        using var statement = ResumableStatement.CreateWithExecutionOptions(program, options);
+
+        Assert.Throws<VdbeMemoryLimitExceededException>(() => statement.StepResumable());
+
+        statement.State.Should().Be(ResumableStatementState.Faulted);
+        metrics.CurrentRetainedBytes.Should().Be(0);
+        metrics.CurrentRetainedRows.Should().Be(0);
+        metrics.SpillFilesCreated.Should().Be(0);
+        fileSystem.Created.Should().BeEmpty();
+    }
+
+    [Test]
+    public void CancellationFaultsJoinAndReleasesSpillAndReservations()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var fileSystem = new TrackingFileSystem();
+        var metrics = new VdbeExecutionMetrics();
+        var program = JoinProgram(
+            [Row(1, "left")],
+            Enumerable.Range(0, 40).Select(static value => Row(value, $"r{value}")).ToArray(),
+            VdbeJoinKind.Inner,
+            condition: (_, _, _) =>
+            {
+                cancellation.Cancel();
+                return true;
+            });
+        var options = Options(fileSystem, metrics, memoryLimitBytes: 128);
+        using var statement = ResumableStatement.CreateWithExecutionOptions(program, options);
+
+        Assert.Throws<OperationCanceledException>(() => statement.StepResumable(cancellation.Token));
+
+        statement.State.Should().Be(ResumableStatementState.Faulted);
+        metrics.CurrentRetainedBytes.Should().Be(0);
+        metrics.CurrentRetainedRows.Should().Be(0);
+        metrics.ActiveSpillFiles.Should().Be(0);
+
+        fileSystem.Deleted.Should().BeEquivalentTo(fileSystem.Created);
+    }
+
+    [TestCase(FileSystemOperation.Write, 17)]
+    [TestCase(FileSystemOperation.Read, 1)]
+    public void SpillIoFailureFaultsJoinAndCleansFiles(
+        FileSystemOperation operation,
+        long occurrence)
+    {
+        var faults = new DeterministicFaultInjector();
+        var fileSystem = new TrackingFileSystem(new InMemoryFileSystem(faults));
+        var metrics = new VdbeExecutionMetrics();
+        var right = Enumerable.Range(0, 40).Select(static value => Row(value, $"r{value}")).ToArray();
+        var program = JoinProgram([Row(1, "left")], right, VdbeJoinKind.Inner);
+        var options = Options(fileSystem, metrics, memoryLimitBytes: 128);
+        faults.FailOnOccurrence(operation, occurrence);
+        using var statement = ResumableStatement.CreateWithExecutionOptions(program, options);
+
+        Assert.Throws<IOException>(() => statement.StepResumable());
+
+        statement.State.Should().Be(ResumableStatementState.Faulted);
+        metrics.CurrentRetainedBytes.Should().Be(0);
+        metrics.CurrentRetainedRows.Should().Be(0);
+        metrics.ActiveSpillFiles.Should().Be(0);
+
+        faults.ClearScheduled();
+        statement.Reset();
+        Drain(statement).Should().ContainSingle();
+
+        metrics.CurrentRetainedBytes.Should().Be(0);
+        metrics.ActiveSpillFiles.Should().Be(0);
+        fileSystem.Deleted.Should().BeEquivalentTo(fileSystem.Created);
+    }
+
+    [Test]
+    public void IdenticalInputsProduceIdenticalPartitionBytes()
+    {
+        var first = CaptureSpillPayloads();
+        var second = CaptureSpillPayloads();
+
+        first.Should().HaveSameCount(second);
+        for (var index = 0; index < first.Count; index++)
+            first[index].Should().Equal(second[index]);
+    }
+
+    [Test]
+    public void SharedCodecRejectsTruncatedRecordsAndUnknownValueTags()
+    {
+        var metrics = new VdbeExecutionMetrics();
+        var fileSystem = new InMemoryFileSystem();
+        using (var truncated = fileSystem.OpenFile("truncated.spill", FileOpenMode.CreateNew))
+        {
+            var position = VdbeSpillRecordCodec.InitializeFile(
+                truncated,
+                VdbeSpillFileKind.SorterRun,
+                metrics);
+            var start = VdbeSpillRecordCodec.BeginRecord(ref position);
+            VdbeSpillRecordCodec.WriteValues(
+                truncated,
+                ref position,
+                [SqlValue.Text("payload")],
+                metrics);
+            VdbeSpillRecordCodec.CompleteRecord(truncated, start, position, metrics);
+            truncated.SetLength(truncated.Length - 1);
+
+            position = VdbeSpillRecordCodec.FileHeaderSize;
+            Assert.Throws<EndOfStreamException>(
+                () => VdbeSpillRecordCodec.ReadRecordEnd(truncated, ref position, metrics));
+        }
+
+        using var unknownTag = fileSystem.OpenFile("unknown-tag.spill", FileOpenMode.CreateNew);
+        var unknownPosition = VdbeSpillRecordCodec.InitializeFile(
+            unknownTag,
+            VdbeSpillFileKind.SorterRun,
+            metrics);
+        var unknownStart = VdbeSpillRecordCodec.BeginRecord(ref unknownPosition);
+        VdbeSpillRecordCodec.WriteByte(unknownTag, ref unknownPosition, 0x7F, metrics);
+        VdbeSpillRecordCodec.CompleteRecord(unknownTag, unknownStart, unknownPosition, metrics);
+        unknownPosition = VdbeSpillRecordCodec.FileHeaderSize;
+        VdbeSpillRecordCodec.ReadRecordEnd(unknownTag, ref unknownPosition, metrics);
+
+        Assert.Throws<InvalidDataException>(
+            () => VdbeSpillRecordCodec.ReadValues(
+                unknownTag,
+                ref unknownPosition,
+                count: 1,
+                metrics,
+                CancellationToken.None));
+    }
+
+    [Test]
+    public void PredicateFailureRemainsPrimaryWhenCleanupAlsoFails()
+    {
+        var primary = new InvalidOperationException("predicate failed");
+        var faults = new DeterministicFaultInjector();
+        var fileSystem = new TrackingFileSystem(new InMemoryFileSystem(faults));
+        var metrics = new VdbeExecutionMetrics();
+        var program = JoinProgram(
+            [Row(1, "left")],
+            Enumerable.Range(0, 40).Select(static value => Row(value, $"r{value}")).ToArray(),
+            VdbeJoinKind.Inner,
+            condition: (_, _, _) => throw primary);
+        var options = Options(fileSystem, metrics, memoryLimitBytes: 128);
+        faults.FailNext(FileSystemOperation.Delete, "cleanup failed");
+        using var statement = ResumableStatement.CreateWithExecutionOptions(program, options);
+
+        var failure = Assert.Throws<AggregateException>(() => statement.StepResumable());
+
+        failure!.InnerExceptions[0].Should().BeSameAs(primary);
+        failure.InnerExceptions.Should().Contain(exception =>
+            exception is IOException && exception.Message == "cleanup failed");
+        statement.State.Should().Be(ResumableStatementState.Faulted);
+        metrics.CurrentRetainedBytes.Should().Be(0);
+        metrics.ActiveSpillFiles.Should().Be(0);
+        fileSystem.Created.Should().OnlyContain(path => !fileSystem.FileExists(path));
+    }
+
+    [Test]
+    public void NestedSubprogramSharesTheParentExecutionBudget()
+    {
+        const long budget = 192;
+        var metrics = new VdbeExecutionMetrics();
+        var fileSystem = new TrackingFileSystem();
+        var child = new VdbeSubprogram(JoinProgram(
+            [Row(1, "left")],
+            Enumerable.Range(0, 20).Select(static value => Row(value, $"r{value}")).ToArray(),
+            VdbeJoinKind.Inner));
+        VdbeRowComparer comparer = (_, _) => 0;
+        VdbeInstruction[] parentInstructions =
+        [
+            new OpenSorterInstruction(new Sorter(0), comparer, 1),
+            new LoadConstantInstruction(new Register(0), SqlValue.Text(new string('x', 64))),
+            new SorterInsertInstruction(new Sorter(0), new RegisterRange(new Register(0), 1)),
+            new ProgramInstruction([], child),
+            new CloseSorterInstruction(new Sorter(0)),
+            new HaltInstruction(),
+        ];
+        var parent = new VdbeProgram(
+            registerCount: 1,
+            cursorCount: 0,
+            parentInstructions,
+            sorterCount: 1);
+        using var statement = ResumableStatement.CreateWithExecutionOptions(
+            parent,
+            Options(fileSystem, metrics, budget));
+
+        statement.StepResumable().Should().Be(ResumableStatementStepResult.Done);
+
+        metrics.PeakRetainedBytes.Should().BeLessThanOrEqualTo(budget);
+        metrics.CurrentRetainedBytes.Should().Be(0);
+        metrics.HashPartitionsCreated.Should().Be(16);
+        metrics.ActiveSpillFiles.Should().Be(0);
+    }
+
+    private static VdbeExecutionOptions Options(
+        IFileSystem fileSystem,
+        VdbeExecutionMetrics metrics,
+        long memoryLimitBytes) =>
+        new(
+            fileSystem,
+            sorterMemoryLimitBytes: memoryLimitBytes,
+            temporaryDirectory: "hash-spill-tests",
+            metrics: metrics);
+
+    private static VdbeProgram JoinProgram(
+        IReadOnlyList<SqlValue[]> left,
+        IReadOnlyList<SqlValue[]> right,
+        VdbeJoinKind kind,
+        bool hashBuildRight = true,
+        VdbeJoinCondition? condition = null)
+    {
+        var equiProbe = new VdbeJoinEquiProbe(Key, Key);
+        var root = new VdbeJoinOperatorPlan(
+            new VdbeJoinScanPlan("left", 2, new VdbeCursorSource(left)),
+            new VdbeJoinScanPlan("right", 2, new VdbeCursorSource(right)),
+            kind,
+            condition,
+            equiProbe,
+            hashBuildRight);
+        var plan = new VdbeJoinPlan(root, $"{kind} spill test");
+        VdbeInstruction[] instructions =
+        [
+            new OpenJoinCursorInstruction(new Cursor(0), plan),
+            new RewindCursorInstruction(new Cursor(0), new ProgramCounter(8)),
+            new ColumnInstruction(new Cursor(0), 0, new Register(0)),
+            new ColumnInstruction(new Cursor(0), 1, new Register(1)),
+            new ColumnInstruction(new Cursor(0), 2, new Register(2)),
+            new ColumnInstruction(new Cursor(0), 3, new Register(3)),
+            new ResultRowInstruction(new RegisterRange(new Register(0), 4)),
+            new NextInstruction(new Cursor(0), new ProgramCounter(2)),
+            new CloseCursorInstruction(new Cursor(0)),
+            new HaltInstruction(),
+        ];
+        return new VdbeProgram(registerCount: 4, cursorCount: 1, instructions);
+    }
+
+    private static string? Key(VdbeJoinRow row) =>
+        row.Values[0].Kind == SqlValueKind.Null
+            ? null
+            : "N" + row.Values[0].AsInteger();
+
+    private static SqlValue[] Row(long? key, string label) =>
+        [key.HasValue ? SqlValue.Integer(key.Value) : SqlValue.Null, SqlValue.Text(label)];
+
+    private static (string? Left, string? Right) Labels(SqlValue[] row) =>
+        (TextOrNull(row[1]), TextOrNull(row[3]));
+
+    private static string? TextOrNull(SqlValue value) =>
+        value.Kind == SqlValueKind.Null ? null : value.AsText();
+
+    private static List<SqlValue[]> Drain(ResumableStatement statement)
+    {
+        var rows = new List<SqlValue[]>();
+        while (true)
+        {
+            var result = statement.StepResumable();
+            if (result == ResumableStatementStepResult.Done)
+                return rows;
+            result.Should().Be(ResumableStatementStepResult.Row);
+            rows.Add([.. statement.CurrentRow!]);
+        }
+    }
+
+    private static IReadOnlyList<byte[]> CaptureSpillPayloads()
+    {
+        var fileSystem = new TrackingFileSystem(captureDeletedPayloads: true);
+        var metrics = new VdbeExecutionMetrics();
+        var program = JoinProgram(
+            Enumerable.Range(0, 12).Select(static value => Row(value, $"l{value}")).ToArray(),
+            Enumerable.Range(0, 40).Select(static value => Row(value % 12, $"r{value}")).ToArray(),
+            VdbeJoinKind.Inner);
+        using var statement = ResumableStatement.CreateWithExecutionOptions(
+            program,
+            Options(fileSystem, metrics, memoryLimitBytes: 128));
+
+        Drain(statement);
+        return fileSystem.DeletedPayloads;
+    }
+
+    private sealed class TrackingFileSystem : IFileSystem
+    {
+        private readonly IFileSystem _inner;
+        private readonly bool _captureDeletedPayloads;
+
+        public TrackingFileSystem(
+            IFileSystem? inner = null,
+            bool captureDeletedPayloads = false)
+        {
+            _inner = inner ?? new InMemoryFileSystem();
+            _captureDeletedPayloads = captureDeletedPayloads;
+        }
+
+        public List<string> Created { get; } = [];
+
+        public List<string> Deleted { get; } = [];
+
+        public List<byte[]> DeletedPayloads { get; } = [];
+
+        public bool FileExists(string path) => _inner.FileExists(path);
+
+        public IFile OpenFile(string path, FileOpenMode mode, bool readOnly = false)
+        {
+            var file = _inner.OpenFile(path, mode, readOnly);
+            if (mode == FileOpenMode.CreateNew)
+                Created.Add(path);
+            return file;
+        }
+
+        public void DeleteFile(string path)
+        {
+            if (_captureDeletedPayloads && _inner.FileExists(path))
+                DeletedPayloads.Add(ReadAll(path));
+            Deleted.Add(path);
+            _inner.DeleteFile(path);
+        }
+
+        private byte[] ReadAll(string path)
+        {
+            using var file = _inner.OpenFile(path, FileOpenMode.OpenExisting, readOnly: true);
+            var bytes = new byte[checked((int)file.Length)];
+            var read = 0;
+            while (read < bytes.Length)
+            {
+                var count = file.Read(read, bytes.AsSpan(read));
+                if (count <= 0)
+                    throw new EndOfStreamException($"Temporary file '{path}' ended while being captured.");
+                read += count;
+            }
+
+            return bytes;
+        }
+    }
+}

--- a/src/Ahtola.Tests/HashJoinSpillExecutionTests.cs
+++ b/src/Ahtola.Tests/HashJoinSpillExecutionTests.cs
@@ -53,7 +53,7 @@ public class HashJoinSpillExecutionTests
         var right =
             new[] { Row(2, "r2a"), Row(3, "r3"), Row(2, "r2b"), Row(null, "rn") };
         var program = JoinProgram(left, right, VdbeJoinKind.Full);
-        var options = Options(new InMemoryFileSystem(), metrics, memoryLimitBytes: 160);
+        var options = Options(new InMemoryFileSystem(), metrics, memoryLimitBytes: 1024);
 
         using var statement = ResumableStatement.CreateWithExecutionOptions(program, options);
 
@@ -83,7 +83,7 @@ public class HashJoinSpillExecutionTests
             right,
             VdbeJoinKind.Inner,
             hashBuildRight: false);
-        var options = Options(new InMemoryFileSystem(), metrics, memoryLimitBytes: 128);
+        var options = Options(new InMemoryFileSystem(), metrics, memoryLimitBytes: 1024);
 
         using var statement = ResumableStatement.CreateWithExecutionOptions(program, options);
 
@@ -92,7 +92,7 @@ public class HashJoinSpillExecutionTests
             ("l2a", "r2"),
             ("l2b", "r2"));
         metrics.HashPartitionsCreated.Should().Be(16);
-        metrics.PeakRetainedBytes.Should().BeLessThanOrEqualTo(128);
+        metrics.PeakRetainedBytes.Should().BeLessThanOrEqualTo(1024);
     }
 
     [Test]
@@ -136,7 +136,7 @@ public class HashJoinSpillExecutionTests
                 cancellation.Cancel();
                 return true;
             });
-        var options = Options(fileSystem, metrics, memoryLimitBytes: 128);
+        var options = Options(fileSystem, metrics, memoryLimitBytes: 1024);
         using var statement = ResumableStatement.CreateWithExecutionOptions(program, options);
 
         Assert.Throws<OperationCanceledException>(() => statement.StepResumable(cancellation.Token));
@@ -160,7 +160,7 @@ public class HashJoinSpillExecutionTests
         var metrics = new VdbeExecutionMetrics();
         var right = Enumerable.Range(0, 40).Select(static value => Row(value, $"r{value}")).ToArray();
         var program = JoinProgram([Row(1, "left")], right, VdbeJoinKind.Inner);
-        var options = Options(fileSystem, metrics, memoryLimitBytes: 128);
+        var options = Options(fileSystem, metrics, memoryLimitBytes: 1024);
         faults.FailOnOccurrence(operation, occurrence);
         using var statement = ResumableStatement.CreateWithExecutionOptions(program, options);
 
@@ -216,24 +216,33 @@ public class HashJoinSpillExecutionTests
                 () => VdbeSpillRecordCodec.ReadRecordEnd(truncated, ref position, metrics));
         }
 
-        using var unknownTag = fileSystem.OpenFile("unknown-tag.spill", FileOpenMode.CreateNew);
-        var unknownPosition = VdbeSpillRecordCodec.InitializeFile(
-            unknownTag,
-            VdbeSpillFileKind.SorterRun,
-            metrics);
-        var unknownStart = VdbeSpillRecordCodec.BeginRecord(ref unknownPosition);
-        VdbeSpillRecordCodec.WriteByte(unknownTag, ref unknownPosition, 0x7F, metrics);
-        VdbeSpillRecordCodec.CompleteRecord(unknownTag, unknownStart, unknownPosition, metrics);
-        unknownPosition = VdbeSpillRecordCodec.FileHeaderSize;
-        VdbeSpillRecordCodec.ReadRecordEnd(unknownTag, ref unknownPosition, metrics);
-
-        Assert.Throws<InvalidDataException>(
-            () => VdbeSpillRecordCodec.ReadValues(
+        foreach (var reservedTag in new byte[] { 0x05, 0x13, 0x80, 0x84, 0x93, 0xFF })
+        {
+            using var unknownTag = fileSystem.OpenFile(
+                $"unknown-tag-{reservedTag:X2}.spill",
+                FileOpenMode.CreateNew);
+            var unknownPosition = VdbeSpillRecordCodec.InitializeFile(
                 unknownTag,
-                ref unknownPosition,
-                count: 1,
-                metrics,
-                CancellationToken.None));
+                VdbeSpillFileKind.SorterRun,
+                metrics);
+            var unknownStart = VdbeSpillRecordCodec.BeginRecord(ref unknownPosition);
+            VdbeSpillRecordCodec.WriteByte(unknownTag, ref unknownPosition, reservedTag, metrics);
+            VdbeSpillRecordCodec.CompleteRecord(
+                unknownTag,
+                unknownStart,
+                unknownPosition,
+                metrics);
+            unknownPosition = VdbeSpillRecordCodec.FileHeaderSize;
+            VdbeSpillRecordCodec.ReadRecordEnd(unknownTag, ref unknownPosition, metrics);
+
+            Assert.Throws<InvalidDataException>(
+                () => VdbeSpillRecordCodec.ReadValues(
+                    unknownTag,
+                    ref unknownPosition,
+                    count: 1,
+                    metrics,
+                    CancellationToken.None));
+        }
     }
 
     [Test]
@@ -248,7 +257,7 @@ public class HashJoinSpillExecutionTests
             Enumerable.Range(0, 40).Select(static value => Row(value, $"r{value}")).ToArray(),
             VdbeJoinKind.Inner,
             condition: (_, _, _) => throw primary);
-        var options = Options(fileSystem, metrics, memoryLimitBytes: 128);
+        var options = Options(fileSystem, metrics, memoryLimitBytes: 1024);
         faults.FailNext(FileSystemOperation.Delete, "cleanup failed");
         using var statement = ResumableStatement.CreateWithExecutionOptions(program, options);
 
@@ -266,7 +275,7 @@ public class HashJoinSpillExecutionTests
     [Test]
     public void NestedSubprogramSharesTheParentExecutionBudget()
     {
-        const long budget = 192;
+        const long budget = 1024;
         var metrics = new VdbeExecutionMetrics();
         var fileSystem = new TrackingFileSystem();
         var child = new VdbeSubprogram(JoinProgram(
@@ -298,6 +307,60 @@ public class HashJoinSpillExecutionTests
         metrics.CurrentRetainedBytes.Should().Be(0);
         metrics.HashPartitionsCreated.Should().Be(16);
         metrics.ActiveSpillFiles.Should().Be(0);
+    }
+
+    [Test]
+    public void OversizedSkewBuildRecordFailsBeforeItCanBeRetainedOrSpilled()
+    {
+        const long budget = 2048;
+        var metrics = new VdbeExecutionMetrics();
+        var fileSystem = new TrackingFileSystem();
+        var right = Enumerable.Range(0, 8)
+            .Select(static value => Row(1, $"small-{value}"))
+            .Append(Row(1, new string('x', 4096)))
+            .ToArray();
+        using var statement = ResumableStatement.CreateWithExecutionOptions(
+            JoinProgram([Row(1, "left")], right, VdbeJoinKind.Inner),
+            Options(fileSystem, metrics, budget));
+
+        var failure = Assert.Throws<VdbeMemoryLimitExceededException>(
+            () => statement.StepResumable());
+
+        failure!.LimitBytes.Should().Be(budget);
+        failure.RequestedBytes.Should().BeGreaterThan(budget);
+        metrics.PeakRetainedBytes.Should().BeLessThanOrEqualTo(budget);
+        metrics.CurrentRetainedBytes.Should().Be(0);
+        metrics.ActiveSpillFiles.Should().Be(0);
+        fileSystem.Created.Should().OnlyContain(path => !fileSystem.FileExists(path));
+    }
+
+    [Test]
+    public void DeleteFailureLeavesHashCleanupRetryableForReset()
+    {
+        var faults = new DeterministicFaultInjector();
+        var backing = new InMemoryFileSystem(faults);
+        var fileSystem = new TrackingFileSystem(backing);
+        var metrics = new VdbeExecutionMetrics();
+        var right = Enumerable.Range(0, 40)
+            .Select(static value => Row(value, $"r{value}"))
+            .ToArray();
+        using var statement = ResumableStatement.CreateWithExecutionOptions(
+            JoinProgram([Row(-1, "left")], right, VdbeJoinKind.Inner),
+            Options(fileSystem, metrics, memoryLimitBytes: 1024));
+        for (var occurrence = 1; occurrence <= 34; occurrence++)
+            faults.FailOnOccurrence(FileSystemOperation.Delete, occurrence);
+
+        Assert.Catch<Exception>(() => Drain(statement));
+
+        metrics.ActiveSpillFiles.Should().Be(1);
+        fileSystem.Created.Where(backing.FileExists).Should().ContainSingle();
+
+        faults.ClearScheduled();
+        statement.Reset();
+
+        metrics.ActiveSpillFiles.Should().Be(0);
+        metrics.CurrentRetainedBytes.Should().Be(0);
+        fileSystem.Created.Should().OnlyContain(path => !backing.FileExists(path));
     }
 
     private static VdbeExecutionOptions Options(
@@ -379,7 +442,7 @@ public class HashJoinSpillExecutionTests
             VdbeJoinKind.Inner);
         using var statement = ResumableStatement.CreateWithExecutionOptions(
             program,
-            Options(fileSystem, metrics, memoryLimitBytes: 128));
+            Options(fileSystem, metrics, memoryLimitBytes: 1024));
 
         Drain(statement);
         return fileSystem.DeletedPayloads;

--- a/src/Ahtola.Tests/HashJoinSpillExecutionTests.cs
+++ b/src/Ahtola.Tests/HashJoinSpillExecutionTests.cs
@@ -10,7 +10,7 @@ public class HashJoinSpillExecutionTests
     [Test]
     public void EquiJoinSpillsWithinBudgetAndCleansEveryTemporaryFile()
     {
-        const long budget = 1024;
+        const long budget = 8192;
         var fileSystem = new TrackingFileSystem();
         var metrics = new VdbeExecutionMetrics();
         var right = Enumerable.Range(0, 200)
@@ -53,7 +53,7 @@ public class HashJoinSpillExecutionTests
         var right =
             new[] { Row(2, "r2a"), Row(3, "r3"), Row(2, "r2b"), Row(null, "rn") };
         var program = JoinProgram(left, right, VdbeJoinKind.Full);
-        var options = Options(new InMemoryFileSystem(), metrics, memoryLimitBytes: 1024);
+        var options = Options(new InMemoryFileSystem(), metrics, memoryLimitBytes: 8192);
 
         using var statement = ResumableStatement.CreateWithExecutionOptions(program, options);
 
@@ -83,7 +83,7 @@ public class HashJoinSpillExecutionTests
             right,
             VdbeJoinKind.Inner,
             hashBuildRight: false);
-        var options = Options(new InMemoryFileSystem(), metrics, memoryLimitBytes: 1024);
+        var options = Options(new InMemoryFileSystem(), metrics, memoryLimitBytes: 8192);
 
         using var statement = ResumableStatement.CreateWithExecutionOptions(program, options);
 
@@ -92,7 +92,7 @@ public class HashJoinSpillExecutionTests
             ("l2a", "r2"),
             ("l2b", "r2"));
         metrics.HashPartitionsCreated.Should().Be(16);
-        metrics.PeakRetainedBytes.Should().BeLessThanOrEqualTo(1024);
+        metrics.PeakRetainedBytes.Should().BeLessThanOrEqualTo(8192);
     }
 
     [Test]
@@ -136,7 +136,7 @@ public class HashJoinSpillExecutionTests
                 cancellation.Cancel();
                 return true;
             });
-        var options = Options(fileSystem, metrics, memoryLimitBytes: 1024);
+        var options = Options(fileSystem, metrics, memoryLimitBytes: 8192);
         using var statement = ResumableStatement.CreateWithExecutionOptions(program, options);
 
         Assert.Throws<OperationCanceledException>(() => statement.StepResumable(cancellation.Token));
@@ -160,7 +160,7 @@ public class HashJoinSpillExecutionTests
         var metrics = new VdbeExecutionMetrics();
         var right = Enumerable.Range(0, 40).Select(static value => Row(value, $"r{value}")).ToArray();
         var program = JoinProgram([Row(1, "left")], right, VdbeJoinKind.Inner);
-        var options = Options(fileSystem, metrics, memoryLimitBytes: 1024);
+        var options = Options(fileSystem, metrics, memoryLimitBytes: 8192);
         faults.FailOnOccurrence(operation, occurrence);
         using var statement = ResumableStatement.CreateWithExecutionOptions(program, options);
 
@@ -233,16 +233,54 @@ public class HashJoinSpillExecutionTests
                 unknownPosition,
                 metrics);
             unknownPosition = VdbeSpillRecordCodec.FileHeaderSize;
-            VdbeSpillRecordCodec.ReadRecordEnd(unknownTag, ref unknownPosition, metrics);
+            var recordEnd = VdbeSpillRecordCodec.ReadRecordEnd(
+                unknownTag,
+                ref unknownPosition,
+                metrics);
 
             Assert.Throws<InvalidDataException>(
                 () => VdbeSpillRecordCodec.ReadValues(
                     unknownTag,
                     ref unknownPosition,
                     count: 1,
+                    recordEnd,
                     metrics,
                     CancellationToken.None));
         }
+    }
+
+    [TestCase(0x03)]
+    [TestCase(0x04)]
+    public void SharedCodecRejectsPayloadThatCrossesItsRecordBoundary(byte valueTag)
+    {
+        const int payloadLength = 64 * 1024;
+        var metrics = new VdbeExecutionMetrics();
+        var fileSystem = new InMemoryFileSystem();
+        using var file = fileSystem.OpenFile(
+            $"cross-record-{valueTag:X2}.spill",
+            FileOpenMode.CreateNew);
+        var position = VdbeSpillRecordCodec.InitializeFile(
+            file,
+            VdbeSpillFileKind.SorterRun,
+            metrics);
+        var recordStart = VdbeSpillRecordCodec.BeginRecord(ref position);
+        VdbeSpillRecordCodec.WriteByte(file, ref position, valueTag, metrics);
+        VdbeSpillRecordCodec.WriteInt32(file, ref position, payloadLength, metrics);
+        VdbeSpillRecordCodec.CompleteRecord(file, recordStart, position, metrics);
+        file.SetLength(checked(position + payloadLength));
+
+        position = VdbeSpillRecordCodec.FileHeaderSize;
+        var recordEnd = VdbeSpillRecordCodec.ReadRecordEnd(file, ref position, metrics);
+
+        Assert.Throws<InvalidDataException>(
+            () => VdbeSpillRecordCodec.ReadValues(
+                file,
+                ref position,
+                count: 1,
+                recordEnd,
+                metrics,
+                CancellationToken.None));
+        position.Should().Be(recordEnd);
     }
 
     [Test]
@@ -257,7 +295,7 @@ public class HashJoinSpillExecutionTests
             Enumerable.Range(0, 40).Select(static value => Row(value, $"r{value}")).ToArray(),
             VdbeJoinKind.Inner,
             condition: (_, _, _) => throw primary);
-        var options = Options(fileSystem, metrics, memoryLimitBytes: 1024);
+        var options = Options(fileSystem, metrics, memoryLimitBytes: 8192);
         faults.FailNext(FileSystemOperation.Delete, "cleanup failed");
         using var statement = ResumableStatement.CreateWithExecutionOptions(program, options);
 
@@ -275,7 +313,7 @@ public class HashJoinSpillExecutionTests
     [Test]
     public void NestedSubprogramSharesTheParentExecutionBudget()
     {
-        const long budget = 1024;
+        const long budget = 8192;
         var metrics = new VdbeExecutionMetrics();
         var fileSystem = new TrackingFileSystem();
         var child = new VdbeSubprogram(JoinProgram(
@@ -312,7 +350,7 @@ public class HashJoinSpillExecutionTests
     [Test]
     public void OversizedSkewBuildRecordFailsBeforeItCanBeRetainedOrSpilled()
     {
-        const long budget = 2048;
+        const long budget = 8192;
         var metrics = new VdbeExecutionMetrics();
         var fileSystem = new TrackingFileSystem();
         var right = Enumerable.Range(0, 8)
@@ -335,6 +373,119 @@ public class HashJoinSpillExecutionTests
     }
 
     [Test]
+    public void HashSpillRejectsBudgetBelowFixedInfrastructureBeforeCreatingFiles()
+    {
+        const string temporaryDirectory = "hash-spill-tests";
+        var infrastructureBytes = VdbeManagedFootprint.EstimateHashSpillInfrastructure(
+            temporaryDirectory,
+            partitionCount: 16,
+            trackUnmatchedBuild: false);
+        var budget = infrastructureBytes - 1;
+        var fileSystem = new TrackingFileSystem();
+        var metrics = new VdbeExecutionMetrics();
+        using var statement = ResumableStatement.CreateWithExecutionOptions(
+            JoinProgram(
+                [Row(-1, "left")],
+                Enumerable.Range(0, 100).Select(static value => Row(value, $"r{value}")).ToArray(),
+                VdbeJoinKind.Inner),
+            Options(fileSystem, metrics, budget));
+
+        var failure = Assert.Throws<VdbeMemoryLimitExceededException>(
+            () => statement.StepResumable());
+
+        failure!.LimitBytes.Should().Be(budget);
+        failure.RequestedBytes.Should().Be(infrastructureBytes);
+        metrics.SpillFilesCreated.Should().Be(0);
+        metrics.CurrentRetainedBytes.Should().Be(0);
+        fileSystem.Created.Should().BeEmpty();
+    }
+
+    [Test]
+    public void EmptyHashBuildSucceedsWhenInfrastructureReservationUsesTheWholeBudget()
+    {
+        const string temporaryDirectory = "hash-spill-tests";
+        var budget = VdbeManagedFootprint.EstimateHashSpillInfrastructure(
+            temporaryDirectory,
+            partitionCount: 16,
+            trackUnmatchedBuild: false);
+        var fileSystem = new TrackingFileSystem();
+        var metrics = new VdbeExecutionMetrics();
+        using var statement = ResumableStatement.CreateWithExecutionOptions(
+            JoinProgram([Row(1, "left")], [], VdbeJoinKind.Inner),
+            Options(fileSystem, metrics, budget));
+
+        Drain(statement).Should().BeEmpty();
+
+        metrics.PeakRetainedBytes.Should().Be(budget);
+        metrics.CurrentRetainedBytes.Should().Be(0);
+        metrics.SpillFilesCreated.Should().Be(0);
+        fileSystem.Created.Should().BeEmpty();
+    }
+
+    [TestCase(VdbeJoinKind.Right, 0)]
+    [TestCase(VdbeJoinKind.Full, 1)]
+    public void EmptyUnmatchedHashBuildSucceedsWhenInfrastructureUsesTheWholeBudget(
+        VdbeJoinKind kind,
+        int expectedRowCount)
+    {
+        const string temporaryDirectory = "hash-spill-tests";
+        var budget = VdbeManagedFootprint.EstimateHashSpillInfrastructure(
+            temporaryDirectory,
+            partitionCount: 16,
+            trackUnmatchedBuild: true);
+        var fileSystem = new TrackingFileSystem();
+        var metrics = new VdbeExecutionMetrics();
+        using var statement = ResumableStatement.CreateWithExecutionOptions(
+            JoinProgram([Row(1, "left")], [], kind),
+            Options(fileSystem, metrics, budget));
+
+        var rows = Drain(statement);
+
+        rows.Should().HaveCount(expectedRowCount);
+        if (kind == VdbeJoinKind.Full)
+            Labels(rows[0]).Should().Be(("left", null));
+        metrics.PeakRetainedBytes.Should().Be(budget);
+        metrics.CurrentRetainedBytes.Should().Be(0);
+        metrics.SpillFilesCreated.Should().Be(0);
+        fileSystem.Created.Should().BeEmpty();
+    }
+
+    [Test]
+    public void HashConstructionDeleteFailureRemainsRetryableForReset()
+    {
+        var faults = new DeterministicFaultInjector();
+        var backing = new InMemoryFileSystem(faults);
+        var fileSystem = new TrackingFileSystem(backing);
+        var metrics = new VdbeExecutionMetrics();
+        faults.FailOnOccurrence(
+            FileSystemOperation.Write,
+            occurrence: 3,
+            message: "construction failed");
+        for (var occurrence = 1; occurrence <= 64; occurrence++)
+            faults.FailOnOccurrence(FileSystemOperation.Delete, occurrence);
+        using var statement = ResumableStatement.CreateWithExecutionOptions(
+            JoinProgram(
+                [Row(1, "left")],
+                Enumerable.Range(0, 40).Select(static value => Row(value, $"r{value}")).ToArray(),
+                VdbeJoinKind.Inner),
+            Options(fileSystem, metrics, memoryLimitBytes: 8192));
+
+        Assert.Catch<Exception>(() => statement.StepResumable());
+
+        metrics.ActiveSpillFiles.Should().BeGreaterThan(0);
+        metrics.CurrentRetainedBytes.Should().BeGreaterThan(0);
+        fileSystem.Created.Where(backing.FileExists).Should().NotBeEmpty();
+
+        faults.ClearScheduled();
+        statement.Reset();
+
+        metrics.ActiveSpillFiles.Should().Be(0);
+        metrics.CurrentRetainedBytes.Should().Be(0);
+        fileSystem.Created.Should().OnlyContain(path => !backing.FileExists(path));
+        Drain(statement).Should().ContainSingle();
+    }
+
+    [Test]
     public void DeleteFailureLeavesHashCleanupRetryableForReset()
     {
         var faults = new DeterministicFaultInjector();
@@ -346,7 +497,7 @@ public class HashJoinSpillExecutionTests
             .ToArray();
         using var statement = ResumableStatement.CreateWithExecutionOptions(
             JoinProgram([Row(-1, "left")], right, VdbeJoinKind.Inner),
-            Options(fileSystem, metrics, memoryLimitBytes: 1024));
+            Options(fileSystem, metrics, memoryLimitBytes: 8192));
         for (var occurrence = 1; occurrence <= 34; occurrence++)
             faults.FailOnOccurrence(FileSystemOperation.Delete, occurrence);
 
@@ -442,7 +593,7 @@ public class HashJoinSpillExecutionTests
             VdbeJoinKind.Inner);
         using var statement = ResumableStatement.CreateWithExecutionOptions(
             program,
-            Options(fileSystem, metrics, memoryLimitBytes: 1024));
+            Options(fileSystem, metrics, memoryLimitBytes: 8192));
 
         Drain(statement);
         return fileSystem.DeletedPayloads;

--- a/src/Ahtola.Tests/SorterOpcodeExecutionTests.cs
+++ b/src/Ahtola.Tests/SorterOpcodeExecutionTests.cs
@@ -423,6 +423,67 @@ public class SorterOpcodeExecutionTests
     }
 
     [Test]
+    public void SorterSpillUsesExactAvailableInfrastructureBudget()
+    {
+        const string temporaryDirectory = "sorter-exact-infrastructure";
+        var infrastructureBytes =
+            VdbeManagedFootprint.EstimateSorterSpillInfrastructure(temporaryDirectory);
+        var metrics = new VdbeExecutionMetrics();
+        var fileSystem = new TrackingFileSystem();
+        var options = new VdbeExecutionOptions(
+            fileSystem,
+            sorterMemoryLimitBytes: infrastructureBytes,
+            temporaryDirectory: temporaryDirectory,
+            metrics: metrics);
+        using var statement = ResumableStatement.CreateWithExecutionOptions(
+            SingleColumnValueSpillInsertsThenHaltProgram(
+                comparer: (_, _) => 0,
+                bufferRowCapacity: 1,
+                SqlValue.Text(new string('x', 200))),
+            options);
+
+        statement.StepResumable().Should().Be(ResumableStatementStepResult.Done);
+
+        metrics.PeakRetainedBytes.Should().Be(infrastructureBytes);
+        metrics.CurrentRetainedBytes.Should().Be(0);
+        metrics.ActiveSpillFiles.Should().Be(0);
+        fileSystem.Created.Should().ContainSingle();
+        fileSystem.Deleted.Should().BeEquivalentTo(fileSystem.Created);
+    }
+
+    [Test]
+    public void SorterSpillBelowInfrastructureBudgetFailsBeforeCreatingFile()
+    {
+        const string temporaryDirectory = "sorter-below-infrastructure";
+        var infrastructureBytes =
+            VdbeManagedFootprint.EstimateSorterSpillInfrastructure(temporaryDirectory);
+        var bufferedBytes = EstimateSingleIntegerBufferBytes();
+        var metrics = new VdbeExecutionMetrics();
+        var fileSystem = new TrackingFileSystem();
+        var options = new VdbeExecutionOptions(
+            fileSystem,
+            sorterMemoryLimitBytes: checked(bufferedBytes + infrastructureBytes - 1),
+            temporaryDirectory: temporaryDirectory,
+            metrics: metrics);
+        var statement = ResumableStatement.CreateWithExecutionOptions(
+            SingleColumnSpillInsertsThenHaltProgram(
+                AscendingFirstColumn,
+                bufferRowCapacity: 1,
+                2,
+                1),
+            options);
+
+        var exception = Assert.Throws<VdbeMemoryLimitExceededException>(
+            () => statement.StepResumable());
+        exception.RequestedBytes.Should().Be(infrastructureBytes);
+        fileSystem.Created.Should().BeEmpty();
+
+        statement.Dispose();
+        metrics.CurrentRetainedBytes.Should().Be(0);
+        metrics.CurrentRetainedRows.Should().Be(0);
+    }
+
+    [Test]
     public void SpillWriteFailureDeletesTheAllocatedIFileSystemRunOnDispose()
     {
         var faults = new DeterministicFaultInjector();
@@ -453,6 +514,7 @@ public class SorterOpcodeExecutionTests
     [Test]
     public void SpillConstructionDeleteFailureRemainsRetryableForReset()
     {
+        const string temporaryDirectory = "sorter-construction-cleanup";
         var faults = new DeterministicFaultInjector();
         var backing = new InMemoryFileSystem(faults);
         var fileSystem = new TrackingFileSystem(backing);
@@ -466,7 +528,7 @@ public class SorterOpcodeExecutionTests
         var options = new VdbeExecutionOptions(
             fileSystem,
             sorterMemoryLimitBytes: 2048,
-            temporaryDirectory: "sorter-construction-cleanup",
+            temporaryDirectory: temporaryDirectory,
             metrics: metrics);
         using var statement = ResumableStatement.CreateWithExecutionOptions(
             SingleColumnSpillSorterProgram(
@@ -481,6 +543,11 @@ public class SorterOpcodeExecutionTests
         metrics.ActiveSpillFiles.Should().Be(1);
         metrics.CurrentRetainedBytes.Should().BeGreaterThan(0);
         fileSystem.Created.Where(backing.FileExists).Should().ContainSingle();
+
+        Assert.Catch<Exception>(() => statement.Reset());
+        metrics.CurrentRetainedBytes.Should().Be(
+            VdbeManagedFootprint.EstimateSorterSpillInfrastructure(temporaryDirectory));
+        metrics.ActiveSpillFiles.Should().Be(1);
 
         faults.ClearScheduled();
         statement.Reset();
@@ -503,7 +570,7 @@ public class SorterOpcodeExecutionTests
         };
         var options = new VdbeExecutionOptions(
             fileSystem,
-            sorterMemoryLimitBytes: 1024,
+            sorterMemoryLimitBytes: 2048,
             temporaryDirectory: "sorter-cancellation");
         var statement = ResumableStatement.CreateWithExecutionOptions(
             SingleColumnSpillSorterProgram(comparer, 2, 3, 2, 1),
@@ -671,6 +738,59 @@ public class SorterOpcodeExecutionTests
         instructions.Add(new HaltInstruction());
 
         return new VdbeProgram(registerCount: 1, cursorCount: 0, instructions, sorterCount: 1);
+    }
+
+    private static VdbeProgram SingleColumnSpillInsertsThenHaltProgram(
+        VdbeRowComparer comparer,
+        int bufferRowCapacity,
+        params long[] values)
+    {
+        var instructions = new List<VdbeInstruction>
+        {
+            new OpenSorterInstruction(new Sorter(0), comparer, 1, bufferRowCapacity),
+        };
+        foreach (var value in values)
+        {
+            instructions.Add(new LoadConstantInstruction(new Register(0), SqlValue.Integer(value)));
+            instructions.Add(new SorterInsertInstruction(new Sorter(0), new RegisterRange(new Register(0), 1)));
+        }
+        instructions.Add(new HaltInstruction());
+        return new VdbeProgram(registerCount: 1, cursorCount: 0, instructions, sorterCount: 1);
+    }
+
+    private static VdbeProgram SingleColumnValueSpillInsertsThenHaltProgram(
+        VdbeRowComparer comparer,
+        int bufferRowCapacity,
+        params SqlValue[] values)
+    {
+        var instructions = new List<VdbeInstruction>
+        {
+            new OpenSorterInstruction(new Sorter(0), comparer, 1, bufferRowCapacity),
+        };
+        foreach (var value in values)
+        {
+            instructions.Add(new LoadConstantInstruction(new Register(0), value));
+            instructions.Add(new SorterInsertInstruction(new Sorter(0), new RegisterRange(new Register(0), 1)));
+        }
+        instructions.Add(new HaltInstruction());
+        return new VdbeProgram(registerCount: 1, cursorCount: 0, instructions, sorterCount: 1);
+    }
+
+    private static long EstimateSingleIntegerBufferBytes()
+    {
+        SqlValue[] row = [SqlValue.Integer(1)];
+        var rowBytes = Math.Max(
+            VdbeManagedFootprint.EstimateSorterRow(row),
+            VdbeManagedFootprint.EstimateSorterRowFromEncodedLength(
+                VdbeSpillRecordCodec.EstimateEncodedValuesLength(row),
+                row.Length));
+        var capacity = VdbeManagedFootprint.GetListCapacityForCount(
+            currentCapacity: 0,
+            requiredCount: 1);
+        return checked(
+            rowBytes
+            + VdbeManagedFootprint.EstimateReferenceListStorage(capacity)
+            + VdbeManagedFootprint.EstimateSortWorkspace(1));
     }
 
     // Two-column variant for stability checks: the first column is the sort key, the

--- a/src/Ahtola.Tests/SorterOpcodeExecutionTests.cs
+++ b/src/Ahtola.Tests/SorterOpcodeExecutionTests.cs
@@ -306,6 +306,41 @@ public class SorterOpcodeExecutionTests
     }
 
     [Test]
+    public void SizeTieredConsolidationKeepsManyRunRewriteGrowthLogarithmic()
+    {
+        const int runCount = 256;
+        const long encodedIntegerRecordBytes = 14;
+        const int maximumWritesPerRecord = 10;
+        var metrics = new VdbeExecutionMetrics();
+        var options = new VdbeExecutionOptions(
+            new InMemoryFileSystem(),
+            sorterMemoryLimitBytes: 4096,
+            temporaryDirectory: "sorter-size-tiers",
+            sorterMergeFanIn: 2,
+            metrics: metrics);
+        var values = Enumerable.Range(1, runCount)
+            .Reverse()
+            .Select(static value => (long)value)
+            .ToArray();
+        var program = SingleColumnSpillSorterProgram(
+            AscendingFirstColumn,
+            bufferRowCapacity: 1,
+            values);
+        using var statement = ResumableStatement.CreateWithExecutionOptions(program, options);
+
+        DrainRows(statement)
+            .Select(row => row[0].AsInteger())
+            .Should()
+            .Equal(Enumerable.Range(1, runCount).Select(static value => (long)value));
+
+        metrics.SorterRunsWritten.Should().BeLessThanOrEqualTo((2L * runCount) - 1);
+        metrics.SpillBytesWritten.Should().BeLessThanOrEqualTo(
+            VdbeSpillRecordCodec.FileHeaderSize
+            + (runCount * encodedIntegerRecordBytes * maximumWritesPerRecord));
+        metrics.CurrentRetainedBytes.Should().Be(0);
+    }
+
+    [Test]
     public void LargeTextAndBlobRowsRemainWithinManagedMergeBudget()
     {
         const long budget = 12_000;
@@ -413,6 +448,47 @@ public class SorterOpcodeExecutionTests
         fileSystem.Created.Should().NotBeEmpty();
         fileSystem.Deleted.Should().BeEquivalentTo(fileSystem.Created);
         fileSystem.Created.Should().OnlyContain(path => !fileSystem.FileExists(path));
+    }
+
+    [Test]
+    public void SpillConstructionDeleteFailureRemainsRetryableForReset()
+    {
+        var faults = new DeterministicFaultInjector();
+        var backing = new InMemoryFileSystem(faults);
+        var fileSystem = new TrackingFileSystem(backing);
+        var metrics = new VdbeExecutionMetrics();
+        faults.FailOnOccurrence(
+            FileSystemOperation.Write,
+            occurrence: 1,
+            message: "construction failed");
+        for (var occurrence = 1; occurrence <= 32; occurrence++)
+            faults.FailOnOccurrence(FileSystemOperation.Delete, occurrence);
+        var options = new VdbeExecutionOptions(
+            fileSystem,
+            sorterMemoryLimitBytes: 2048,
+            temporaryDirectory: "sorter-construction-cleanup",
+            metrics: metrics);
+        using var statement = ResumableStatement.CreateWithExecutionOptions(
+            SingleColumnSpillSorterProgram(
+                AscendingFirstColumn,
+                bufferRowCapacity: 1,
+                2,
+                1),
+            options);
+
+        Assert.Catch<Exception>(() => statement.StepResumable());
+
+        metrics.ActiveSpillFiles.Should().Be(1);
+        metrics.CurrentRetainedBytes.Should().BeGreaterThan(0);
+        fileSystem.Created.Where(backing.FileExists).Should().ContainSingle();
+
+        faults.ClearScheduled();
+        statement.Reset();
+
+        metrics.ActiveSpillFiles.Should().Be(0);
+        metrics.CurrentRetainedBytes.Should().Be(0);
+        fileSystem.Created.Should().OnlyContain(path => !backing.FileExists(path));
+        DrainRows(statement).Select(row => row[0].AsInteger()).Should().Equal(1, 2);
     }
 
     [Test]

--- a/src/Ahtola.Tests/SorterOpcodeExecutionTests.cs
+++ b/src/Ahtola.Tests/SorterOpcodeExecutionTests.cs
@@ -343,7 +343,7 @@ public class SorterOpcodeExecutionTests
     [Test]
     public void LargeTextAndBlobRowsRemainWithinManagedMergeBudget()
     {
-        const long budget = 12_000;
+        const long budget = 32_768;
         var metrics = new VdbeExecutionMetrics();
         var options = new VdbeExecutionOptions(
             new InMemoryFileSystem(),
@@ -366,6 +366,80 @@ public class SorterOpcodeExecutionTests
         rows[1][0].AsBlob().ToArray().Should().Equal(blob);
         metrics.PeakRetainedBytes.Should().BeLessThanOrEqualTo(budget);
         metrics.CurrentRetainedBytes.Should().Be(0);
+    }
+
+    [Test]
+    public void EncodedRowFootprintIncludesUtf8DecoderScratch()
+    {
+        var row = new[] { SqlValue.Text(new string('x', 4096)) };
+        var encodedLength = VdbeSpillRecordCodec.EstimateEncodedValuesLength(row);
+        var retainedBytes = VdbeManagedFootprint.EstimateSorterRow(row);
+        var decodedPeakBytes = VdbeManagedFootprint.EstimateSorterRowFromEncodedLength(
+            encodedLength,
+            row.Length);
+
+        decodedPeakBytes.Should().BeGreaterThanOrEqualTo(
+            retainedBytes + VdbeManagedFootprint.EstimateUtf8Scratch(4096));
+    }
+
+    [Test]
+    public void ContainerReplacementAccountsForOverlappingBackingStores()
+    {
+        var oldBytes = VdbeManagedFootprint.EstimateReferenceListStorage(4);
+        var replacementBytes = VdbeManagedFootprint.EstimateReferenceListStorage(8);
+        var metrics = new VdbeExecutionMetrics();
+        var memory = new VdbeExecutionMemory(oldBytes + replacementBytes, metrics);
+        memory.RetainOrThrow(oldBytes, rows: 0);
+
+        var reservation =
+            VdbeManagedFootprint.EstimateContainerReplacement(oldBytes, replacementBytes);
+        memory.RetainOrThrow(reservation, rows: 0);
+        metrics.PeakRetainedBytes.Should().Be(oldBytes + replacementBytes);
+
+        memory.Release(oldBytes, rows: 0);
+        metrics.CurrentRetainedBytes.Should().Be(replacementBytes);
+        memory.Release(replacementBytes, rows: 0);
+        metrics.CurrentRetainedBytes.Should().Be(0);
+    }
+
+    [Test]
+    public void DirectSpillReservesRowBeforeAllocatingInfrastructure()
+    {
+        const string temporaryDirectory = "sorter-direct-reservation";
+        var spillBytes =
+            VdbeManagedFootprint.EstimateSorterSpillInfrastructure(temporaryDirectory);
+        var value = SqlValue.Text(new string('x', 150));
+        var row = new[] { value };
+        var rowBytes = Math.Max(
+            VdbeManagedFootprint.EstimateSorterRow(row),
+            VdbeManagedFootprint.EstimateSorterRowFromEncodedLength(
+                VdbeSpillRecordCodec.EstimateEncodedValuesLength(row),
+                row.Length));
+        rowBytes.Should().BeLessThan(spillBytes);
+        checked(
+                rowBytes
+                + VdbeManagedFootprint.EstimateReferenceListStorage(4)
+                + VdbeManagedFootprint.EstimateSortWorkspace(1))
+            .Should().BeGreaterThan(spillBytes);
+        var fileSystem = new TrackingFileSystem();
+        var metrics = new VdbeExecutionMetrics();
+        var options = new VdbeExecutionOptions(
+            fileSystem,
+            sorterMemoryLimitBytes: spillBytes,
+            temporaryDirectory: temporaryDirectory,
+            metrics: metrics);
+        using var statement = ResumableStatement.CreateWithExecutionOptions(
+            SingleColumnValueSpillSorterProgram(
+                AscendingFirstColumn,
+                bufferRowCapacity: 1,
+                value),
+            options);
+
+        Assert.Throws<VdbeMemoryLimitExceededException>(() => statement.StepResumable());
+
+        metrics.PeakRetainedBytes.Should().BeLessThanOrEqualTo(spillBytes);
+        metrics.ActiveSpillFiles.Should().Be(0);
+        fileSystem.Created.Should().BeEmpty();
     }
 
     [Test]
@@ -428,23 +502,26 @@ public class SorterOpcodeExecutionTests
         const string temporaryDirectory = "sorter-exact-infrastructure";
         var infrastructureBytes =
             VdbeManagedFootprint.EstimateSorterSpillInfrastructure(temporaryDirectory);
+        var bufferedBytes = EstimateSingleIntegerBufferBytes();
+        var budget = checked(bufferedBytes + infrastructureBytes);
         var metrics = new VdbeExecutionMetrics();
         var fileSystem = new TrackingFileSystem();
         var options = new VdbeExecutionOptions(
             fileSystem,
-            sorterMemoryLimitBytes: infrastructureBytes,
+            sorterMemoryLimitBytes: budget,
             temporaryDirectory: temporaryDirectory,
             metrics: metrics);
         using var statement = ResumableStatement.CreateWithExecutionOptions(
-            SingleColumnValueSpillInsertsThenHaltProgram(
-                comparer: (_, _) => 0,
+            SingleColumnSpillInsertsThenHaltProgram(
+                AscendingFirstColumn,
                 bufferRowCapacity: 1,
-                SqlValue.Text(new string('x', 200))),
+                2,
+                1),
             options);
 
         statement.StepResumable().Should().Be(ResumableStatementStepResult.Done);
 
-        metrics.PeakRetainedBytes.Should().Be(infrastructureBytes);
+        metrics.PeakRetainedBytes.Should().Be(budget);
         metrics.CurrentRetainedBytes.Should().Be(0);
         metrics.ActiveSpillFiles.Should().Be(0);
         fileSystem.Created.Should().ContainSingle();
@@ -509,6 +586,34 @@ public class SorterOpcodeExecutionTests
         fileSystem.Created.Should().NotBeEmpty();
         fileSystem.Deleted.Should().BeEquivalentTo(fileSystem.Created);
         fileSystem.Created.Should().OnlyContain(path => !fileSystem.FileExists(path));
+    }
+
+    [Test]
+    public void SpillOpenFailureReleasesInfrastructureAndAllowsRetry()
+    {
+        var faults = new DeterministicFaultInjector();
+        var backing = new InMemoryFileSystem(faults);
+        var fileSystem = new TrackingFileSystem(backing);
+        var metrics = new VdbeExecutionMetrics();
+        faults.FailNext(FileSystemOperation.Open);
+        var options = new VdbeExecutionOptions(
+            fileSystem,
+            sorterMemoryLimitBytes: 4096,
+            temporaryDirectory: "sorter-open-retry",
+            metrics: metrics);
+        using var statement = ResumableStatement.CreateWithExecutionOptions(
+            SingleColumnSpillSorterProgram(AscendingFirstColumn, 1, 2, 1),
+            options);
+
+        Assert.Throws<IOException>(() => statement.StepResumable());
+        metrics.CurrentRetainedBytes.Should().BeGreaterThan(0);
+        metrics.ActiveSpillFiles.Should().Be(0);
+
+        faults.ClearScheduled();
+        DrainRows(statement).Select(row => row[0].AsInteger()).Should().Equal(1, 2);
+
+        metrics.CurrentRetainedBytes.Should().Be(0);
+        metrics.ActiveSpillFiles.Should().Be(0);
     }
 
     [Test]

--- a/src/Ahtola.Tests/SorterOpcodeExecutionTests.cs
+++ b/src/Ahtola.Tests/SorterOpcodeExecutionTests.cs
@@ -319,9 +319,9 @@ public class SorterOpcodeExecutionTests
         DrainRows(statement).Select(row => row[0].AsInteger()).Should().Equal(1, 2);
         statement.Dispose();
 
-        fileSystem.Created.Should().HaveCount(1);
+        fileSystem.Created.Should().NotBeEmpty();
         fileSystem.Deleted.Should().BeEquivalentTo(fileSystem.Created);
-        fileSystem.FileExists(fileSystem.Created[0]).Should().BeFalse();
+        fileSystem.Created.Should().OnlyContain(path => !fileSystem.FileExists(path));
     }
 
     [Test]

--- a/src/Ahtola.Tests/SorterOpcodeExecutionTests.cs
+++ b/src/Ahtola.Tests/SorterOpcodeExecutionTests.cs
@@ -270,9 +270,14 @@ public class SorterOpcodeExecutionTests
         var fileSystem = new TrackingFileSystem();
         var options = new VdbeExecutionOptions(
             fileSystem,
-            sorterMemoryLimitBytes: 1,
+            sorterMemoryLimitBytes: 2048,
             temporaryDirectory: "sorter-byte-budget");
-        var program = SingleColumnSorterProgram(AscendingFirstColumn, 3, 1, 2);
+        var program = SingleColumnSpillSorterProgram(
+            AscendingFirstColumn,
+            bufferRowCapacity: 1,
+            3,
+            1,
+            2);
 
         using (var statement = ResumableStatement.CreateWithExecutionOptions(program, options))
         {
@@ -289,7 +294,7 @@ public class SorterOpcodeExecutionTests
     {
         var options = new VdbeExecutionOptions(
             new InMemoryFileSystem(),
-            sorterMemoryLimitBytes: 1024,
+            sorterMemoryLimitBytes: 2048,
             temporaryDirectory: "sorter-fan-in",
             sorterMergeFanIn: 2);
         var values = Enumerable.Range(1, 40).Select(static value => (long)(41 - value)).ToArray();
@@ -301,6 +306,88 @@ public class SorterOpcodeExecutionTests
     }
 
     [Test]
+    public void LargeTextAndBlobRowsRemainWithinManagedMergeBudget()
+    {
+        const long budget = 12_000;
+        var metrics = new VdbeExecutionMetrics();
+        var options = new VdbeExecutionOptions(
+            new InMemoryFileSystem(),
+            sorterMemoryLimitBytes: budget,
+            temporaryDirectory: "sorter-large-values",
+            metrics: metrics);
+        VdbeRowComparer preserveInsertionOrder = (_, _) => 0;
+        var text = new string('x', 2048);
+        var blob = Enumerable.Range(0, 2048).Select(static value => (byte)value).ToArray();
+        var program = SingleColumnValueSpillSorterProgram(
+            preserveInsertionOrder,
+            bufferRowCapacity: 1,
+            SqlValue.Text(text),
+            SqlValue.Blob(blob));
+
+        using var statement = ResumableStatement.CreateWithExecutionOptions(program, options);
+
+        var rows = DrainRows(statement);
+        rows[0][0].AsText().Should().Be(text);
+        rows[1][0].AsBlob().ToArray().Should().Equal(blob);
+        metrics.PeakRetainedBytes.Should().BeLessThanOrEqualTo(budget);
+        metrics.CurrentRetainedBytes.Should().Be(0);
+    }
+
+    [Test]
+    public void MergeFanInShrinksToFitEveryLargeRunHead()
+    {
+        const long budget = 8192;
+        var metrics = new VdbeExecutionMetrics();
+        var options = new VdbeExecutionOptions(
+            new InMemoryFileSystem(),
+            sorterMemoryLimitBytes: budget,
+            temporaryDirectory: "sorter-accounted-heads",
+            sorterMergeFanIn: 32,
+            metrics: metrics);
+        VdbeRowComparer comparer = (left, right) =>
+            string.CompareOrdinal(left[0].AsText(), right[0].AsText());
+        var values = Enumerable.Range(1, 20)
+            .Reverse()
+            .Select(static value => SqlValue.Text($"{value:D3}-{new string('x', 512)}"))
+            .ToArray();
+        var program = SingleColumnValueSpillSorterProgram(
+            comparer,
+            bufferRowCapacity: 1,
+            values);
+
+        using var statement = ResumableStatement.CreateWithExecutionOptions(program, options);
+
+        DrainRows(statement)
+            .Select(static row => row[0].AsText()[..3])
+            .Should()
+            .Equal(Enumerable.Range(1, 20).Select(static value => value.ToString("D3")));
+        metrics.SorterRunsWritten.Should().BeGreaterThan(values.Length);
+        metrics.PeakRetainedBytes.Should().BeLessThanOrEqualTo(budget);
+        metrics.CurrentRetainedBytes.Should().Be(0);
+    }
+
+    [Test]
+    public void FailedMergeInfrastructureReservationDoesNotReleasePhantomBytes()
+    {
+        var metrics = new VdbeExecutionMetrics();
+        var options = new VdbeExecutionOptions(
+            new InMemoryFileSystem(),
+            sorterMemoryLimitBytes: 200,
+            temporaryDirectory: "sorter-merge-reservation",
+            metrics: metrics);
+        var statement = ResumableStatement.CreateWithExecutionOptions(
+            SingleColumnSorterProgram(AscendingFirstColumn, 1),
+            options);
+
+        Assert.Throws<VdbeMemoryLimitExceededException>(() => statement.StepResumable());
+        statement.Dispose();
+
+        metrics.CurrentRetainedBytes.Should().Be(0);
+        metrics.CurrentRetainedRows.Should().Be(0);
+        metrics.ActiveSpillFiles.Should().Be(0);
+    }
+
+    [Test]
     public void SpillWriteFailureDeletesTheAllocatedIFileSystemRunOnDispose()
     {
         var faults = new DeterministicFaultInjector();
@@ -309,9 +396,13 @@ public class SorterOpcodeExecutionTests
         faults.FailNextAfter(FileSystemOperation.Open, FileSystemOperation.Write);
         var options = new VdbeExecutionOptions(
             fileSystem,
-            sorterMemoryLimitBytes: 1,
+            sorterMemoryLimitBytes: 2048,
             temporaryDirectory: "sorter-write-fault");
-        var program = SingleColumnSorterProgram(AscendingFirstColumn, 2, 1);
+        var program = SingleColumnSpillSorterProgram(
+            AscendingFirstColumn,
+            bufferRowCapacity: 1,
+            2,
+            1);
         var statement = ResumableStatement.CreateWithExecutionOptions(program, options);
 
         Assert.Throws<IOException>(() => statement.StepResumable());
@@ -358,10 +449,15 @@ public class SorterOpcodeExecutionTests
         faults.FailNext(FileSystemOperation.Read);
         var options = new VdbeExecutionOptions(
             fileSystem,
-            sorterMemoryLimitBytes: 1,
+            sorterMemoryLimitBytes: 2048,
             temporaryDirectory: "sorter-read-fault");
         var statement = ResumableStatement.CreateWithExecutionOptions(
-            SingleColumnSorterProgram(AscendingFirstColumn, 3, 1, 2),
+            SingleColumnSpillSorterProgram(
+                AscendingFirstColumn,
+                bufferRowCapacity: 1,
+                3,
+                1,
+                2),
             options);
 
         Assert.Throws<IOException>(() => statement.StepResumable());
@@ -573,6 +669,33 @@ public class SorterOpcodeExecutionTests
         instructions.Add(new CloseSorterInstruction(new Sorter(0)));
         instructions.Add(new HaltInstruction());
 
+        return new VdbeProgram(registerCount: 1, cursorCount: 0, instructions, sorterCount: 1);
+    }
+
+    private static VdbeProgram SingleColumnValueSpillSorterProgram(
+        VdbeRowComparer comparer,
+        int bufferRowCapacity,
+        params SqlValue[] values)
+    {
+        var instructions = new List<VdbeInstruction>
+        {
+            new OpenSorterInstruction(new Sorter(0), comparer, 1, bufferRowCapacity),
+        };
+        foreach (var value in values)
+        {
+            instructions.Add(new LoadConstantInstruction(new Register(0), value));
+            instructions.Add(new SorterInsertInstruction(new Sorter(0), new RegisterRange(new Register(0), 1)));
+        }
+
+        var sortAddress = instructions.Count;
+        var drainLoop = sortAddress + 1;
+        var drainDone = drainLoop + 3;
+        instructions.Add(new SorterSortInstruction(new Sorter(0), new ProgramCounter(drainDone)));
+        instructions.Add(new SorterDataInstruction(new Sorter(0), new RegisterRange(new Register(0), 1)));
+        instructions.Add(new ResultRowInstruction(new RegisterRange(new Register(0), 1)));
+        instructions.Add(new SorterNextInstruction(new Sorter(0), new ProgramCounter(drainLoop)));
+        instructions.Add(new CloseSorterInstruction(new Sorter(0)));
+        instructions.Add(new HaltInstruction());
         return new VdbeProgram(registerCount: 1, cursorCount: 0, instructions, sorterCount: 1);
     }
 


### PR DESCRIPTION
## Summary

- add a hard statement-local retained-memory governor, public execution high-water/spill metrics, and share the governor with nested VDBE subprograms
- spill compiled equijoin build state into deterministic, versioned, little-endian managed records using stable FNV-1a partitioning
- preserve probe/build insertion order, duplicates, NULL behavior, hidden rowids, and LEFT/RIGHT/FULL unmatched-row order with a build-order spool and disk-backed match map
- load one hash partition when it fits the remaining budget and fall back to bounded record scans for skewed partitions
- extract shared spill-file ownership and `SqlValue` framing, then migrate external sorter runs to it
- make `temp_store=MEMORY` fail at the finite `cache_size`-derived budget rather than moving retained rows into a heap-backed temp filesystem
- fault joins after cancellation/I/O/predicate failures, preserve primary exceptions over cleanup failures, and clean temporary artifacts on normal, reset, dispose, cancellation, and injected fault paths

## Coverage

- forced-spill build-right INNER/FULL and build-left INNER semantics
- duplicates, NULL keys, outer null extension, output order, partition load and skew fallback
- deterministic byte-for-byte spill payloads and malformed/truncated record rejection
- peak/current retained row and byte metrics under large inputs
- spill-disabled memory failure, cancellation, read/write/delete faults, reset after fault, nested subprogram budget sharing, and artifact cleanup
- existing sorter stability, merge, cancellation, fault, and SQL-routed compiled join suites

## Validation

- targeted bounded execution suite: 67 passed
- full guarded net10.0 managed suite: 6,403 passed, 0 failed
- `pwsh ./build.ps1 build`
- `pwsh ./build.ps1 validate-project-closure`
- `pwsh ./build.ps1 validate-trim`
- changed C# files pass `dotnet format --verify-no-changes`

The repository-wide `build.ps1 format-check` still reports the existing whitespace baseline in unchanged files (for example `Compilation/JoinProgramBuilder.cs`); this PR does not expand scope to reformat those files.

## Residual limits

This PR deliberately does not claim a fully bounded engine working set. Base-table residency, non-equijoin build sides, DISTINCT/compound sets, recursive worktables, buffered windows, ephemeral tables, and opaque aggregate contexts remain heap-resident. Hash spill currently uses 16 deterministic partitions with a bounded skew fallback; adaptive repartitioning is a follow-up optimization, not a correctness dependency.