### PR TITLE
Deepen managed FTS5 compatibility

### DIFF
--- a/docs/managed-vtab-fts-rtree-integration.md
+++ b/docs/managed-vtab-fts-rtree-integration.md
@@ -58,8 +58,12 @@ The managed `fts5` module accepts bare identifier columns with optional
 tables require SQLite's shadow-table/trigger contracts and are not represented
 by Ahtola's private payload.
 
-MATCH supports the bounded managed term, phrase, prefix, boolean, column
-filter, initial-token anchor, and NEAR grammar. Both `table MATCH ?` and
+MATCH supports bounded FTS5 term, phrase, quoted-phrase prefix, binary
+`NOT`, column-filter, initial-token anchor, and `NEAR(term ..., distance)`
+grammar. Implicit `AND` binds more tightly than binary `NOT`, and a
+`column MATCH ?` restriction intersects every explicit column filter in the
+query. BLOB content is decoded as UTF-8 for indexing and auxiliary rendering
+while the stored SQL value remains a BLOB. Both `table MATCH ?` and
 `column MATCH ?` are planner constraints. MATCH cursors expose the hidden
 `rank` column, use SQLite's negative BM25 convention (lower is better), return
 default scans in rank order, and consume a complete `ORDER BY rank ASC|DESC`.

--- a/docs/managed-vtab-fts-rtree-integration.md
+++ b/docs/managed-vtab-fts-rtree-integration.md
@@ -2,7 +2,7 @@
 
 ## Upstream reference
 
-Turso `v0.7.2` parses `CREATE VIRTUAL TABLE` into `CreateVirtualTable`
+The pinned Turso `v0.8.0-pre.7` source parses `CREATE VIRTUAL TABLE` into `CreateVirtualTable`
 (`turso-src/sqlite/parser/src/ast.rs`) and routes module instances through
 `VirtualTable` (`turso-src/core/vtab.rs`). Its planner calls `best_index` with
 constraints and ordering, then sends the plan and bound arguments to cursor
@@ -12,17 +12,18 @@ is implemented with Tantivy. The pinned source has no R-Tree module.
 
 The managed implementation follows the lifecycle shape without copying the
 native extension ABI or Tantivy dependency. Turso's index-method FTS remains a
-separate, possible future alignment path; this module is not an FTS5-parity
-claim.
+separate implementation path. Ahtola reuses its own pure-managed posting,
+query, ranking, and offset machinery for the SQL-compatible FTS5 slice below;
+it does not reuse Tantivy or claim Tantivy's storage representation.
 
 ## Implemented modules
 
 `ManagedVirtualTableModuleRegistry` statically registers direct singleton
 instances of these NativeAOT-safe modules:
 
-| Module | Accepted declaration | Initial scope |
+| Module | Accepted declaration | Scope |
 | --- | --- | --- |
-| `fts5` | One or more identifier column names | Managed token/posting index with term, phrase, prefix, AND/OR/NOT queries through the virtual-table cursor contract |
+| `fts5` | One or more identifier columns, optional `UNINDEXED`, and the options listed below | Content-owning managed FTS5 with bounded MATCH, rank/BM25, highlighting/snippets, and `optimize`/`rebuild` |
 | `rtree` | `id, min0, max0, ...` | Finite floating-point bounds and equality/range cursor constraints |
 | `rtree_i32` | `id, min0, max0, ...` | Integer-only coordinates and equality/range cursor constraints |
 
@@ -32,12 +33,60 @@ The modules use the canonical `ManagedVirtualTableModule`,
 registry's static constructor, uses no reflection or assembly scanning, and
 directly roots every module implementation for trimming and NativeAOT.
 
-`ManagedFtsTokenizer`, `ManagedFtsQueryParser`, and `ManagedFtsIndex` provide
-the FTS module's reusable tokenization, query parsing, and posting store.
+`ManagedFtsTokenization`, `ManagedFtsQueryLanguage`,
+`ManagedFtsSearchIndex`, and `ManagedFtsFunctions` provide the FTS module's
+reusable tokenization, bounded query parsing, scored posting store, and exact
+source-offset rendering.
 `ManagedRTreeBounds` and `ManagedRTreeIndex` provide inclusive
 N-dimensional bounds and deterministic spatial storage. The module adapters
 own virtual-table schema validation, `VUpdate` argument conversion, and
 transaction snapshots; the reusable components do not own catalog state.
+
+## Content-owning FTS5 SQL surface
+
+The managed `fts5` module accepts bare identifier columns with optional
+`UNINDEXED`, plus this fail-closed option subset:
+
+| Option | Accepted values | Managed behavior |
+| --- | --- | --- |
+| `tokenize` | `unicode61`, `ascii`, `trigram` | Selects the matching statically rooted managed tokenizer. Tokenizer modifiers and `porter` are rejected. |
+| `prefix` | One to 16 distinct integer lengths from 1 through 999 | Validated and retained in the declaration. Prefix MATCH uses the managed posting dictionary's bounded live-term expansion; no separate SQLite prefix shadow index is synthesized. |
+| `detail` | `full`, `column`, `none` | Controls retained positional/column detail. Phrase/NEAR and column-filter queries fail when the selected detail cannot answer them. |
+| `columnsize` | `0`, `1` | Accepted with SQLite-visible ranking semantics. Ahtola derives token lengths from its content rows instead of creating a `%_docsize` shadow table. |
+
+`content` and `content_rowid` are rejected. Contentless and external-content
+tables require SQLite's shadow-table/trigger contracts and are not represented
+by Ahtola's private payload.
+
+MATCH supports the bounded managed term, phrase, prefix, boolean, column
+filter, initial-token anchor, and NEAR grammar. Both `table MATCH ?` and
+`column MATCH ?` are planner constraints. MATCH cursors expose the hidden
+`rank` column, use SQLite's negative BM25 convention (lower is better), return
+default scans in rank order, and consume a complete `ORDER BY rank ASC|DESC`.
+A full scan exposes `rank` as NULL.
+
+These source-bound auxiliary functions are available on an FTS5 row:
+
+- `bm25(table [, weight...])`
+- `highlight(table, column, before, after)`
+- `snippet(table, column, before, after, ellipsis, tokens)`, including column
+  `-1` for automatic selection
+
+The first argument is resolved from the cursor binding carried by the row,
+including through joins and correlated outer-row chains. It is not inferred
+from a same-named ordinary column. Application-registered scalar callbacks
+still shadow these built-ins. BM25 uses SQLite's IDF floor, total-document
+length normalization, negative score convention, and per-column term weights.
+The default score is covered by stock-SQLite oracle tests; weighted
+phrase/NEAR scoring remains a deterministic approximation because the managed
+candidate currently retains aggregate phrase frequency rather than
+per-column phrase frequency.
+
+`INSERT INTO table VALUES (...)` targets visible columns only. Explicit
+`rowid`, `_rowid_`, and `oid` inserts and updates map to VUpdate's new-rowid
+slot unless a real declared column shadows that alias. Content-owning tables accept
+`INSERT INTO table(table) VALUES('optimize')` and `... VALUES('rebuild')`.
+Other commands, rank configuration, and `delete-all` fail closed.
 
 ## Durable managed catalog contract
 
@@ -67,8 +116,8 @@ other engines must not be expected to query or maintain these tables.
 SQL `INSERT`, `UPDATE`, and `DELETE` use the canonical foundation. The
 foundation extracts source-local conjunctive predicates and ordering, passes
 the selected `SqlValue` arguments to `Filter`, and honors
-`ManagedVirtualTableConstraintUsage.Omit`. FTS `MATCH` and R-Tree
-equality/range plans are therefore available through ordinary SQL, while DML
+`ManagedVirtualTableConstraintUsage.Omit`. FTS `MATCH`/rank ordering and R-Tree equality/range plans are therefore
+available through ordinary SQL, while DML
 uses the VUpdate old-rowid/new-rowid/declared-column layout under
 begin/sync/commit/rollback.
 
@@ -80,18 +129,18 @@ well as schema state for `CREATE`, `DROP`, and `RENAME`.
 
 ## Remaining product limitations
 
-- `fts5` is a small managed query/tokenizer subset, not FTS5 compatibility:
-  tokenizer options, external/contentless tables, auxiliary functions,
-  ranking, snippets, and FTS5-specific command syntax are unsupported.
-  For ranked full-text search over an ordinary table, use the `fts` **index
-  method** instead — see [docs/managed-index-methods.md](managed-index-methods.md),
-  which ships tokenizer options, BM25 ranking, highlighting and snippets.
+- FTS5 shadow tables, `%_data`/`%_idx`/`%_content`/`%_docsize` file layouts,
+  external/contentless tables, custom tokenizers, `fts5vocab`, rank
+  configuration, and the complete stock FTS5 query grammar remain
+  unsupported. The managed payload is not portable FTS5 storage.
+- The ordinary-table `fts` **index method** remains a separate Ahtola surface;
+  see [docs/managed-index-methods.md](managed-index-methods.md). It must not be
+  confused with the `CREATE VIRTUAL TABLE ... USING fts5` contract here.
 - `rtree` does not expose SQLite's full R-Tree auxiliary/geometry callback
-  surface. `rtree_i32` accepts only signed 32-bit integer coordinates.
+  surface or SQLite's outward-rounded float32 coordinate storage.
+  `rtree_i32` accepts only signed 32-bit integer coordinates.
 - The private payload is a managed catalog extension, not a portable FTS5/R-Tree
   file representation. Ahtola intentionally does not synthesize shadow tables.
-- The current generic DML path auto-assigns FTS rowids; explicitly naming
-  `rowid` in an `INSERT` column list is not supported yet.
 - Planner extraction is deliberately limited to source-local conjunctive
-  predicates. The modules do not consume ordering, so the engine remains
-  responsible for applying `ORDER BY`.
+  predicates. FTS5 consumes only a complete rank ordering; R-Tree and all
+  other ordering remain the engine's responsibility.

--- a/docs/managed-vtab-fts-rtree-integration.md
+++ b/docs/managed-vtab-fts-rtree-integration.md
@@ -60,7 +60,8 @@ by Ahtola's private payload.
 
 MATCH supports bounded FTS5 term, phrase, quoted-phrase prefix, binary
 `NOT`, column-filter, initial-token anchor, and `NEAR(phrase ..., distance)`
-grammar, including prefix and quoted-phrase operands within `NEAR`. Implicit
+grammar, including `+` phrase concatenation and independently prefixed phrase
+components within or outside `NEAR`. Implicit
 `AND` binds more tightly than binary `NOT`. Barewords use SQLite FTS5's
 restricted character set; reserved punctuation such as `.`, `/`, and `,`
 must be quoted. A

--- a/docs/managed-vtab-fts-rtree-integration.md
+++ b/docs/managed-vtab-fts-rtree-integration.md
@@ -61,7 +61,10 @@ by Ahtola's private payload.
 MATCH supports bounded FTS5 term, phrase, quoted-phrase prefix, binary
 `NOT`, column-filter, initial-token anchor, and `NEAR(phrase ..., distance)`
 grammar, including `+` phrase concatenation and independently prefixed phrase
-components within or outside `NEAR`. Implicit
+components within or outside `NEAR`. A tokenless concatenation atom after a
+term preserves SQLite's empty boundary by replacing that component's prefix
+state with the empty atom's trailing-`*` state instead of dropping the atom.
+Implicit
 `AND` binds more tightly than binary `NOT`. Barewords use SQLite FTS5's
 restricted character set; reserved punctuation such as `.`, `/`, and `,`
 must be quoted. A

--- a/docs/managed-vtab-fts-rtree-integration.md
+++ b/docs/managed-vtab-fts-rtree-integration.md
@@ -59,8 +59,11 @@ tables require SQLite's shadow-table/trigger contracts and are not represented
 by Ahtola's private payload.
 
 MATCH supports bounded FTS5 term, phrase, quoted-phrase prefix, binary
-`NOT`, column-filter, initial-token anchor, and `NEAR(term ..., distance)`
-grammar. Implicit `AND` binds more tightly than binary `NOT`, and a
+`NOT`, column-filter, initial-token anchor, and `NEAR(phrase ..., distance)`
+grammar, including prefix and quoted-phrase operands within `NEAR`. Implicit
+`AND` binds more tightly than binary `NOT`. Barewords use SQLite FTS5's
+restricted character set; reserved punctuation such as `.`, `/`, and `,`
+must be quoted. A
 `column MATCH ?` restriction intersects every explicit column filter in the
 query. BLOB content is decoded as UTF-8 for indexing and auxiliary rendering
 while the stored SQL value remains a BLOB. Both `table MATCH ?` and
@@ -81,10 +84,10 @@ including through joins and correlated outer-row chains. It is not inferred
 from a same-named ordinary column. Application-registered scalar callbacks
 still shadow these built-ins. BM25 uses SQLite's IDF floor, total-document
 length normalization, negative score convention, and per-column term weights.
-The default score is covered by stock-SQLite oracle tests; weighted
-phrase/NEAR scoring remains a deterministic approximation because the managed
-candidate currently retains aggregate phrase frequency rather than
-per-column phrase frequency.
+Terms and phrases retain per-column occurrence frequencies for weighting;
+each constituent phrase of a matching NEAR group contributes independently,
+matching stock SQLite's BM25 behavior. Default and weighted scores are covered
+by stock-SQLite oracle tests.
 
 `INSERT INTO table VALUES (...)` targets visible columns only. Explicit
 `rowid`, `_rowid_`, and `oid` inserts and updates map to VUpdate's new-rowid

--- a/src/Ahtola.Core/EmbeddedDatabase.Fts5Functions.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.Fts5Functions.cs
@@ -1,0 +1,122 @@
+using Ahtola.Core.Parsing;
+using Ahtola.Core.Search;
+
+namespace Ahtola.Core;
+
+public sealed partial class EmbeddedDatabase
+{
+    private static ManagedFts5SourceBinding ResolveFts5Source(
+        FunctionExpression function,
+        SourceRow? row)
+    {
+        if (row is null
+            || function.Arguments.Count == 0
+            || function.Arguments[0] is not ColumnExpression { BooleanKeyword: null } column)
+        {
+            throw new EmbeddedSqlException(
+                $"unable to use function {function.Name.ToLowerInvariant()} in the requested context");
+        }
+
+        var binding = column.Qualifier is { } qualifier
+            ? row.GetFts5SourceForQualifier(qualifier)
+            : row.GetFts5SourceForTable(column.UnqualifiedName ?? column.Name);
+        if (binding is null)
+        {
+            throw new EmbeddedSqlException(
+                $"unable to use function {function.Name.ToLowerInvariant()} in the requested context");
+        }
+
+        return binding;
+    }
+
+    private static SqlValue EvaluateFts5Bm25(
+        FunctionExpression function,
+        IReadOnlyList<SqlValue> arguments,
+        SourceRow? row)
+    {
+        if (arguments.Count == 0)
+            throw new EmbeddedSqlException("wrong number of arguments to function bm25()");
+
+        var binding = ResolveFts5Source(function, row);
+        if (arguments.Count == 1)
+            return SqlValue.Real(binding.Rank ?? 0.0);
+
+        var weights = new double[binding.Table.ColumnNames.Count];
+        Array.Fill(weights, 1.0);
+        for (var index = 1; index < arguments.Count && index <= weights.Length; index++)
+            weights[index - 1] = ReadFts5Double(arguments[index]);
+
+        return SqlValue.Real(binding.ScoreCache?.Score(binding.RowId, weights)
+            ?? binding.Table.Score(binding.Query, binding.RowId, weights));
+    }
+
+    private static SqlValue EvaluateFts5Highlight(
+        FunctionExpression function,
+        IReadOnlyList<SqlValue> arguments,
+        SourceRow? row)
+    {
+        RequireArgumentCount("highlight", arguments, 4);
+        var binding = ResolveFts5Source(function, row);
+        var column = ReadFts5ColumnIndex("highlight", arguments[1], binding.Table.ColumnNames.Count, allowAutomatic: false);
+        return ManagedFtsFunctions.HighlightFts5(
+            binding.Table.GetColumnValue(binding.RowId, column),
+            binding.Table.IsIndexedColumn(column) ? binding.Query : null,
+            binding.Table.ColumnNames[column],
+            ManagedFtsSearchIndex.ReadText(arguments[2]),
+            ManagedFtsSearchIndex.ReadText(arguments[3]),
+            binding.Table.Tokenizer);
+    }
+
+    private static SqlValue EvaluateFts5Snippet(
+        FunctionExpression function,
+        IReadOnlyList<SqlValue> arguments,
+        SourceRow? row)
+    {
+        RequireArgumentCount("snippet", arguments, 6);
+        var binding = ResolveFts5Source(function, row);
+        var column = ReadFts5ColumnIndex("snippet", arguments[1], binding.Table.ColumnNames.Count, allowAutomatic: true);
+        var requestedWindow = ReadFts5Integer(arguments[5]);
+        if (requestedWindow is < 1 or > 4096)
+            throw new EmbeddedSqlException("snippet() token count must be between 1 and 4096");
+        var window = (int)requestedWindow;
+        if (column < 0)
+            column = binding.Table.SelectSnippetColumn(binding.Query, binding.RowId, window);
+        return ManagedFtsFunctions.SnippetFts5(
+            binding.Table.GetColumnValue(binding.RowId, column),
+            binding.Table.IsIndexedColumn(column) ? binding.Query : null,
+            binding.Table.ColumnNames[column],
+            ManagedFtsSearchIndex.ReadText(arguments[2]),
+            ManagedFtsSearchIndex.ReadText(arguments[3]),
+            ManagedFtsSearchIndex.ReadText(arguments[4]),
+            window,
+            binding.Table.Tokenizer);
+    }
+
+    private static int ReadFts5ColumnIndex(
+        string function,
+        SqlValue value,
+        int columnCount,
+        bool allowAutomatic)
+    {
+        var column = ReadFts5Integer(value);
+        var minimum = allowAutomatic ? -1 : 0;
+        if (column < minimum || column >= columnCount)
+            throw new EmbeddedSqlException($"{function}() column index is out of range");
+
+        return checked((int)column);
+    }
+
+    private static double ReadFts5Double(SqlValue value)
+    {
+        var numeric = ApplyNumericAffinity(value);
+        return numeric.Kind == SqlValueKind.Integer ? numeric.AsInteger() : numeric.AsReal();
+    }
+
+    private static long ReadFts5Integer(SqlValue value)
+    {
+        var numeric = ApplyNumericAffinity(value);
+        return numeric.Kind == SqlValueKind.Integer
+            ? numeric.AsInteger()
+            : ToSqliteInteger(numeric.AsReal());
+    }
+}

--- a/src/Ahtola.Core/EmbeddedDatabase.Fts5Functions.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.Fts5Functions.cs
@@ -17,10 +17,7 @@ public sealed partial class EmbeddedDatabase
                 $"unable to use function {function.Name.ToLowerInvariant()} in the requested context");
         }
 
-        var binding = column.Qualifier is { } qualifier
-            ? row.GetFts5SourceForQualifier(qualifier)
-            : row.GetFts5SourceForTable(column.UnqualifiedName ?? column.Name);
-        if (binding is null)
+        if (!row.TryResolveFts5Source(column, out var binding) || binding is null)
         {
             throw new EmbeddedSqlException(
                 $"unable to use function {function.Name.ToLowerInvariant()} in the requested context");

--- a/src/Ahtola.Core/EmbeddedDatabase.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.cs
@@ -7934,18 +7934,28 @@ public sealed partial class EmbeddedDatabase : IDisposable
         }
 
         var schema = definition.Table.Schema;
-        var columns = statement.Columns ?? schema.Columns.Select(static column => column.Name).ToArray();
-        var assignments = ResolveVirtualTableColumns(schema, columns);
+        var columns = statement.Columns ?? schema.VisibleColumns.Select(static column => column.Name).ToArray();
+        var assignments = ResolveVirtualTableInsertColumns(schema, columns);
         var mutations = new List<IReadOnlyList<SqlValue>>(statement.Rows.Count);
         foreach (var row in statement.Rows)
         {
             if (row.Length != assignments.Length)
-                throw new EmbeddedSqlException($"table {statement.TableName} has {schema.Columns.Count} columns but {row.Length} values were supplied");
+            {
+                throw new EmbeddedSqlException(
+                    $"table {statement.TableName} has {columns.Length} columns but {row.Length} values were supplied");
+            }
 
             var values = Enumerable.Repeat(SqlValue.Null, schema.Columns.Count).ToArray();
+            long? newRowId = null;
             for (var index = 0; index < row.Length; index++)
-                values[assignments[index]] = Evaluate(row[index], parameters, null, context);
-            mutations.Add(BuildVirtualTableUpdateArguments(null, null, values));
+            {
+                var value = Evaluate(row[index], parameters, null, context);
+                if (assignments[index] < 0)
+                    newRowId = ManagedFts5Table.ReadRowId(value, "new rowid");
+                else
+                    values[assignments[index]] = value;
+            }
+            mutations.Add(BuildVirtualTableUpdateArguments(null, newRowId, values));
         }
 
         return ExecuteVirtualTableMutations(context.VirtualTables!, definition, mutations);
@@ -7978,7 +7988,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
             outerRow: null,
             statement.Where,
             []);
-        var assignments = ResolveVirtualTableColumns(
+        var assignments = ResolveVirtualTableInsertColumns(
             definition.Table.Schema,
             statement.Assignments.Select(static assignment => assignment.Column).ToArray());
         var mutations = new List<IReadOnlyList<SqlValue>>();
@@ -7996,9 +8006,29 @@ public sealed partial class EmbeddedDatabase : IDisposable
             }
 
             var values = row.Values.ToArray();
+            if (definition.Table is ManagedFts5Table)
+            {
+                for (var index = 0; index < definition.Table.Schema.Columns.Count; index++)
+                {
+                    if (definition.Table.Schema.Columns[index].IsHidden)
+                        values[index] = SqlValue.Null;
+                }
+            }
+            var newRowId = row.RowId;
             for (var index = 0; index < statement.Assignments.Count; index++)
-                values[assignments[index]] = Evaluate(statement.Assignments[index].Value, parameters, row, context);
-            mutations.Add(BuildVirtualTableUpdateArguments(row.RowId, row.RowId, values));
+            {
+                var value = Evaluate(statement.Assignments[index].Value, parameters, row, context);
+                if (assignments[index] < 0)
+                {
+                    newRowId = ManagedFts5Table.ReadRowId(value, "new rowid")
+                        ?? throw new EmbeddedSqlException("datatype mismatch");
+                }
+                else
+                {
+                    values[assignments[index]] = value;
+                }
+            }
+            mutations.Add(BuildVirtualTableUpdateArguments(row.RowId, newRowId, values));
         }
 
         return ExecuteVirtualTableMutations(context.VirtualTables!, definition, mutations);
@@ -8040,6 +8070,36 @@ public sealed partial class EmbeddedDatabase : IDisposable
             .Select(row => BuildVirtualTableUpdateArguments(row.RowId, null, row.Values))
             .ToArray();
         return ExecuteVirtualTableMutations(context.VirtualTables!, definition, mutations);
+    }
+
+    private static int[] ResolveVirtualTableInsertColumns(
+        ManagedVirtualTableSchema schema,
+        IReadOnlyList<string> names)
+    {
+        var indexes = new int[names.Count];
+        var seen = new HashSet<int>();
+        for (var index = 0; index < names.Count; index++)
+        {
+            var columnIndex = -1;
+            for (var candidate = 0; candidate < schema.Columns.Count; candidate++)
+            {
+                if (string.Equals(schema.Columns[candidate].Name, names[index], StringComparison.OrdinalIgnoreCase))
+                {
+                    columnIndex = candidate;
+                    break;
+                }
+            }
+
+            // A real schema column shadows rowid/_rowid_/oid, just as it does for ordinary tables.
+            if (columnIndex < 0 && EmbeddedTable.IsRowidAliasName(names[index]))
+                columnIndex = -2;
+            if (columnIndex == -1 || !seen.Add(columnIndex))
+                throw new EmbeddedSqlException($"no such column: {names[index]}");
+
+            indexes[index] = columnIndex;
+        }
+
+        return indexes;
     }
 
     private static int[] ResolveVirtualTableColumns(
@@ -24192,7 +24252,7 @@ out bool hasReturning)
                             group.Representative,
                             WithOuterAggregateScope(context, group.Rows))));
             }
-            if (statement.OrderBy.Count > 0)
+            if (statement.OrderBy.Count > 0 && !source.OrderByConsumed)
             {
                 var orderCollations = resolvedOrderBy
                     .Select(term => GetEffectiveCollation(term.Expression, context))
@@ -27878,7 +27938,10 @@ out bool hasReturning)
                     AmbiguousQualifiedColumns: ambiguousQualifiedColumns,
                     QualifiedMethodIndexSources: CombineMethodIndexSources(
                         GetMethodIndexSources(leftRow),
-                        GetMethodIndexSources(rightRow)));
+                        GetMethodIndexSources(rightRow)),
+                    QualifiedFts5Sources: CombineFts5Sources(
+                        GetFts5Sources(leftRow),
+                        GetFts5Sources(rightRow)));
                 if (source.Condition is not null
                     && !JoinConditionMatches(source, joinPairs, row, leftRow, rightRow, parameters, context))
                 {
@@ -27919,7 +27982,8 @@ out bool hasReturning)
                         GetMethodIndexSources(leftRow),
                         rowsForLeft.Rows.FirstOrDefault() is { } rightTemplate
                             ? GetMethodIndexSources(rightTemplate)
-                            : [])));
+                            : []),
+                    QualifiedFts5Sources: GetFts5Sources(leftRow)));
                 if (maximumRows is not null && rows.Count >= maximumRows.Value)
                     return CreateResult(rows);
             }
@@ -27957,7 +28021,8 @@ out bool hasReturning)
                         left.Rows.FirstOrDefault() is { } leftTemplate
                             ? GetMethodIndexSources(leftTemplate)
                             : [],
-                        GetMethodIndexSources(rightRow))));
+                        GetMethodIndexSources(rightRow)),
+                    QualifiedFts5Sources: GetFts5Sources(rightRow)));
                 if (maximumRows is not null && rows.Count >= maximumRows.Value)
                     return CreateResult(rows);
             }
@@ -28585,6 +28650,34 @@ out bool hasReturning)
     private static IReadOnlyDictionary<string, MethodIndexSourceBinding>? CombineMethodIndexSources(
         Dictionary<string, MethodIndexSourceBinding> left,
         Dictionary<string, MethodIndexSourceBinding> right)
+    {
+        if (left.Count == 0 && right.Count == 0)
+            return null;
+
+        foreach (var (qualifier, binding) in right)
+            left.TryAdd(qualifier, binding);
+
+        return left;
+    }
+
+    private static Dictionary<string, ManagedFts5SourceBinding> GetFts5Sources(SourceRow row)
+    {
+        var sources = new Dictionary<string, ManagedFts5SourceBinding>(StringComparer.OrdinalIgnoreCase);
+        if (row.QualifiedFts5Sources is not null)
+        {
+            foreach (var (qualifier, binding) in row.QualifiedFts5Sources)
+                sources.TryAdd(qualifier, binding);
+        }
+
+        if (row.Fts5Source is { } own && row.RowIdQualifier is { } qualifierName)
+            sources.TryAdd(qualifierName, own);
+
+        return sources;
+    }
+
+    private static IReadOnlyDictionary<string, ManagedFts5SourceBinding>? CombineFts5Sources(
+        Dictionary<string, ManagedFts5SourceBinding> left,
+        Dictionary<string, ManagedFts5SourceBinding> right)
     {
         if (left.Count == 0 && right.Count == 0)
             return null;
@@ -29469,11 +29562,24 @@ out bool hasReturning)
                 new Dictionary<string, long?>(StringComparer.OrdinalIgnoreCase)
                 {
                     [qualifier] = cursor.RowId,
-                }));
+                },
+                Fts5Source: cursor is IManagedFts5Cursor fts5Cursor
+                    ? fts5Cursor.CurrentBinding
+                    : null,
+                QualifiedFts5Sources: cursor is IManagedFts5Cursor qualifiedFts5Cursor
+                    ? new Dictionary<string, ManagedFts5SourceBinding>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        [qualifier] = qualifiedFts5Cursor.CurrentBinding,
+                    }
+                    : null));
             cursor.Next();
         }
 
-        return new SourceData(columns, rows, OmittedVirtualTablePredicates: omittedPredicates);
+        return new SourceData(
+            columns,
+            rows,
+            OmittedVirtualTablePredicates: omittedPredicates,
+            OrderByConsumed: plan.OrderByConsumed && plannerInput.OrderBy.Count == sourceOrderBy.Count);
     }
 
     private IReadOnlyList<SqlValue> BuildVirtualTableFilterArguments(
@@ -34575,6 +34681,9 @@ out bool hasReturning)
             "FTS_SNIPPET" => Search.ManagedFtsFunctions.Snippet(
                 arguments,
                 ResolveBoundFtsTokenizer(function, row, context)),
+            "BM25" => EvaluateFts5Bm25(function, arguments, row),
+            "HIGHLIGHT" => EvaluateFts5Highlight(function, arguments, row),
+            "SNIPPET" => EvaluateFts5Snippet(function, arguments, row),
             _ => throw new EmbeddedSqlException($"no such function: {function.Name}"),
         };
     }
@@ -51961,7 +52070,9 @@ internal sealed record SourceRow(
     IReadOnlyDictionary<string, EmbeddedColumn>? QualifiedColumnDefinitions = null,
     IReadOnlySet<string>? AmbiguousQualifiedColumns = null,
     MethodIndexSourceBinding? MethodIndexSource = null,
-    IReadOnlyDictionary<string, MethodIndexSourceBinding>? QualifiedMethodIndexSources = null)
+    IReadOnlyDictionary<string, MethodIndexSourceBinding>? QualifiedMethodIndexSources = null,
+    ManagedFts5SourceBinding? Fts5Source = null,
+    IReadOnlyDictionary<string, ManagedFts5SourceBinding>? QualifiedFts5Sources = null)
 {
     public SqlValue GetValue(string name)
         => GetValue(name, allowQualifiedLookup: true);
@@ -51989,6 +52100,47 @@ internal sealed record SourceRow(
             && string.Equals(owner, qualifier, StringComparison.OrdinalIgnoreCase)
                 ? own
                 : Parent?.GetMethodIndexSourceForQualifier(qualifier);
+    }
+
+    public ManagedFts5SourceBinding? GetFts5SourceForQualifier(string qualifier)
+    {
+        if (QualifiedFts5Sources is { } qualified && qualified.TryGetValue(qualifier, out var bound))
+            return bound;
+
+        return Fts5Source is { } own
+            && RowIdQualifier is { } owner
+            && string.Equals(owner, qualifier, StringComparison.OrdinalIgnoreCase)
+                ? own
+                : Parent?.GetFts5SourceForQualifier(qualifier);
+    }
+
+    public ManagedFts5SourceBinding? GetFts5SourceForTable(string tableName)
+    {
+        ManagedFts5SourceBinding? resolved = null;
+        if (QualifiedFts5Sources is not null)
+        {
+            foreach (var binding in QualifiedFts5Sources.Values)
+            {
+                if (!string.Equals(binding.Table.TableName, tableName, StringComparison.OrdinalIgnoreCase))
+                    continue;
+                if (resolved is not null
+                    && (!ReferenceEquals(resolved.Table, binding.Table) || resolved.RowId != binding.RowId))
+                {
+                    return null;
+                }
+
+                resolved = binding;
+            }
+        }
+
+        if (resolved is null
+            && Fts5Source is { } own
+            && string.Equals(own.Table.TableName, tableName, StringComparison.OrdinalIgnoreCase))
+        {
+            resolved = own;
+        }
+
+        return resolved ?? Parent?.GetFts5SourceForTable(tableName);
     }
 
     /// <summary>
@@ -52323,7 +52475,8 @@ internal sealed record SourceData(
     IReadOnlyList<SourceRow> Rows,
     IReadOnlyList<string?>? Collations = null,
     IReadOnlyList<EmbeddedColumn?>? ColumnDefinitions = null,
-    IReadOnlyList<Expression>? OmittedVirtualTablePredicates = null);
+    IReadOnlyList<Expression>? OmittedVirtualTablePredicates = null,
+    bool OrderByConsumed = false);
 
 internal sealed class LazyReadOnlyList<T>(IEnumerable<T> source) : IReadOnlyList<T>
 {

--- a/src/Ahtola.Core/EmbeddedDatabase.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.cs
@@ -52116,6 +52116,51 @@ internal sealed record SourceRow(
 
     public ManagedFts5SourceBinding? GetFts5SourceForTable(string tableName)
     {
+        var resolved = GetLocalFts5SourceForTable(tableName);
+        return resolved ?? Parent?.GetFts5SourceForTable(tableName);
+    }
+
+    public bool TryResolveFts5Source(
+        ColumnExpression column,
+        out ManagedFts5SourceBinding? binding)
+    {
+        if (column.Qualifier is { } qualifier)
+        {
+            if (AmbiguousQualifiedColumns?.Contains(column.Name) == true)
+                ThrowAmbiguousColumn(column.Name);
+            if (QualifiedColumns?.ContainsKey(column.Name) == true)
+            {
+                binding = GetLocalFts5SourceForQualifier(qualifier);
+                return true;
+            }
+        }
+        else if (FindUnqualifiedColumnIndex(column.Name) is not null)
+        {
+            binding = GetLocalFts5SourceForTable(column.Name);
+            return true;
+        }
+
+        if (Parent is not null)
+            return Parent.TryResolveFts5Source(column, out binding);
+
+        binding = null;
+        return false;
+    }
+
+    private ManagedFts5SourceBinding? GetLocalFts5SourceForQualifier(string qualifier)
+    {
+        if (QualifiedFts5Sources is { } qualified && qualified.TryGetValue(qualifier, out var bound))
+            return bound;
+
+        return Fts5Source is { } own
+            && RowIdQualifier is { } owner
+            && string.Equals(owner, qualifier, StringComparison.OrdinalIgnoreCase)
+                ? own
+                : null;
+    }
+
+    private ManagedFts5SourceBinding? GetLocalFts5SourceForTable(string tableName)
+    {
         ManagedFts5SourceBinding? resolved = null;
         if (QualifiedFts5Sources is not null)
         {
@@ -52140,7 +52185,7 @@ internal sealed record SourceRow(
             resolved = own;
         }
 
-        return resolved ?? Parent?.GetFts5SourceForTable(tableName);
+        return resolved;
     }
 
     /// <summary>

--- a/src/Ahtola.Core/ManagedSearchVirtualTables.cs
+++ b/src/Ahtola.Core/ManagedSearchVirtualTables.cs
@@ -613,7 +613,8 @@ internal sealed class ManagedFts5Table : ManagedVirtualTable
         var query = ManagedFtsQueryLanguage.Parse(
             value.AsText(),
             _definition.Tokenizer,
-            name => ResolveColumnIndex(name) is not null);
+            name => ResolveColumnIndex(name) is not null,
+            ManagedFtsQuerySyntax.SqliteFts5);
         return columnIndex == TableColumnIndex
             ? query
             : ApplyDefaultColumn(query, _columnNames[columnIndex]);
@@ -622,9 +623,10 @@ internal sealed class ManagedFts5Table : ManagedVirtualTable
     private static ManagedFtsNode ApplyDefaultColumn(ManagedFtsNode node, string column)
         => node switch
         {
-            ManagedFtsTermNode term => term.Column is null ? term with { Column = column } : term,
-            ManagedFtsPhraseNode phrase => phrase.Column is null ? phrase with { Column = column } : phrase,
-            ManagedFtsNearNode near => near.Column is null ? near with { Column = column } : near,
+            ManagedFtsNoMatchNode noMatch => noMatch,
+            ManagedFtsTermNode term => ApplyDefaultColumn(term, column),
+            ManagedFtsPhraseNode phrase => ApplyDefaultColumn(phrase, column),
+            ManagedFtsNearNode near => ApplyDefaultColumn(near, column),
             ManagedFtsAndNode and => new ManagedFtsAndNode(
                 ApplyDefaultColumn(and.Left, column),
                 ApplyDefaultColumn(and.Right, column)),
@@ -634,6 +636,24 @@ internal sealed class ManagedFts5Table : ManagedVirtualTable
             ManagedFtsNotNode not => new ManagedFtsNotNode(ApplyDefaultColumn(not.Operand, column)),
             _ => throw new ArgumentOutOfRangeException(nameof(node)),
         };
+
+    private static ManagedFtsNode ApplyDefaultColumn(ManagedFtsTermNode term, string column)
+        => term.Column is null
+            ? term with { Column = column }
+            : ColumnsEqual(term.Column, column) ? term : new ManagedFtsNoMatchNode();
+
+    private static ManagedFtsNode ApplyDefaultColumn(ManagedFtsPhraseNode phrase, string column)
+        => phrase.Column is null
+            ? phrase with { Column = column }
+            : ColumnsEqual(phrase.Column, column) ? phrase : new ManagedFtsNoMatchNode();
+
+    private static ManagedFtsNode ApplyDefaultColumn(ManagedFtsNearNode near, string column)
+        => near.Column is null
+            ? near with { Column = column }
+            : ColumnsEqual(near.Column, column) ? near : new ManagedFtsNoMatchNode();
+
+    private static bool ColumnsEqual(string left, string right)
+        => string.Equals(left, right, StringComparison.OrdinalIgnoreCase);
 
     private sealed class Cursor(ManagedFts5Table table)
         : ManagedVirtualTableCursor, IManagedFts5Cursor

--- a/src/Ahtola.Core/ManagedSearchVirtualTables.cs
+++ b/src/Ahtola.Core/ManagedSearchVirtualTables.cs
@@ -11,41 +11,170 @@ internal sealed class ManagedFts5Module : ManagedVirtualTableModule
     public override string Name => "fts5";
 
     public override ManagedVirtualTable Create(ManagedVirtualTableCreateContext context)
-        => new ManagedFts5Table(context.TableName, ParseColumnNames(context));
+        => new ManagedFts5Table(context.TableName, ParseDefinition(context));
 
     public override ManagedVirtualTable Create(
         ManagedVirtualTableCreateContext context,
         ManagedVirtualTablePersistencePayload payload)
     {
-        var table = new ManagedFts5Table(context.TableName, ParseColumnNames(context));
+        var table = new ManagedFts5Table(context.TableName, ParseDefinition(context));
         table.RestorePersistencePayload(payload);
         return table;
     }
 
-    private static IReadOnlyList<string> ParseColumnNames(ManagedVirtualTableCreateContext context)
+    private static ManagedFts5Definition ParseDefinition(ManagedVirtualTableCreateContext context)
     {
         if (context.Arguments.Count == 0)
             throw new EmbeddedSqlException("fts5 requires at least one column");
 
-        var columns = new List<string>(context.Arguments.Count);
+        var columns = new List<ManagedFts5Column>(context.Arguments.Count);
+        var tokenizer = ManagedFtsTokenizerOptions.Default;
+        var detail = ManagedFtsDetailLevel.Full;
+        var columnSize = true;
+        var prefixLengths = Array.Empty<int>();
+        var options = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var argument in context.Arguments)
         {
-            var column = argument.Trim();
-            if (column.Length == 0 || column.Contains('=') || !IsIdentifier(column))
+            var trimmed = argument.Trim();
+            var separator = trimmed.IndexOf('=');
+            if (separator >= 0)
+            {
+                var name = trimmed[..separator].Trim();
+                var value = Unquote(trimmed[(separator + 1)..].Trim());
+                if (!options.Add(name))
+                    throw new EmbeddedSqlException($"duplicate fts5 option: {name}");
+
+                switch (name.ToLowerInvariant())
+                {
+                    case "tokenize":
+                        tokenizer = ParseTokenizer(value);
+                        break;
+                    case "prefix":
+                        prefixLengths = ParsePrefixLengths(value);
+                        break;
+                    case "detail":
+                        detail = value.ToLowerInvariant() switch
+                        {
+                            "full" => ManagedFtsDetailLevel.Full,
+                            "column" => ManagedFtsDetailLevel.Columns,
+                            "none" => ManagedFtsDetailLevel.None,
+                            _ => throw new EmbeddedSqlException($"unsupported fts5 detail option: {value}"),
+                        };
+                        break;
+                    case "columnsize":
+                        columnSize = value switch
+                        {
+                            "0" => false,
+                            "1" => true,
+                            _ => throw new EmbeddedSqlException("fts5 columnsize must be 0 or 1"),
+                        };
+                        break;
+                    case "content":
+                    case "content_rowid":
+                        throw new EmbeddedSqlException(
+                            "managed fts5 does not support contentless or external-content tables");
+                    default:
+                        throw new EmbeddedSqlException($"unsupported fts5 option: {name}");
+                }
+
+                continue;
+            }
+
+            var parts = trimmed.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+            var unindexed = parts.Length == 2
+                && string.Equals(parts[1], "UNINDEXED", StringComparison.OrdinalIgnoreCase);
+            if (parts.Length == 0
+                || parts.Length > 2
+                || parts.Length == 2 && !unindexed
+                || !IsIdentifier(parts[0]))
+            {
                 throw new EmbeddedSqlException($"unsupported fts5 module argument: {argument}");
-            if (columns.Contains(column, StringComparer.OrdinalIgnoreCase))
+            }
+
+            var column = parts[0];
+            if (columns.Any(candidate => string.Equals(candidate.Name, column, StringComparison.OrdinalIgnoreCase)))
                 throw new EmbeddedSqlException($"duplicate fts5 column name: {column}");
 
-            columns.Add(column);
+            columns.Add(new ManagedFts5Column(column, unindexed));
         }
 
-        return columns;
+        if (columns.Count == 0)
+            throw new EmbeddedSqlException("fts5 requires at least one column");
+        if (columns.Count > Indexing.ManagedIndexMethodLimits.MaxIndexedColumns)
+        {
+            throw new EmbeddedSqlException(
+                $"managed fts5 supports at most {Indexing.ManagedIndexMethodLimits.MaxIndexedColumns} columns");
+        }
+
+        return new ManagedFts5Definition(columns, tokenizer, detail, columnSize, prefixLengths);
+    }
+
+    private static ManagedFtsTokenizerOptions ParseTokenizer(string value)
+    {
+        var parts = value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length != 1)
+            throw new EmbeddedSqlException("managed fts5 tokenizer modifiers are not supported");
+
+        return parts[0].ToLowerInvariant() switch
+        {
+            "unicode61" => ManagedFtsTokenizerOptions.Default,
+            "ascii" => new ManagedFtsTokenizerOptions(ManagedFtsTokenizerKind.Ascii),
+            "trigram" => new ManagedFtsTokenizerOptions(ManagedFtsTokenizerKind.Trigram),
+            "porter" => throw new EmbeddedSqlException("managed fts5 does not support the porter tokenizer"),
+            _ => throw new EmbeddedSqlException($"unsupported fts5 tokenizer: {parts[0]}"),
+        };
+    }
+
+    private static int[] ParsePrefixLengths(string value)
+    {
+        var parts = value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0 || parts.Length > ManagedFtsTokenizerOptions.MaximumGram)
+            throw new EmbeddedSqlException("fts5 prefix requires between 1 and 16 prefix lengths");
+
+        var result = new int[parts.Length];
+        var seen = new HashSet<int>();
+        for (var index = 0; index < parts.Length; index++)
+        {
+            if (!int.TryParse(parts[index], NumberStyles.None, CultureInfo.InvariantCulture, out var length)
+                || length is < 1 or > 999
+                || !seen.Add(length))
+            {
+                throw new EmbeddedSqlException($"invalid fts5 prefix length: {parts[index]}");
+            }
+
+            result[index] = length;
+        }
+
+        return result;
+    }
+
+    private static string Unquote(string value)
+    {
+        if (value.Length < 2)
+            return value;
+
+        var quote = value[0];
+        if ((quote is '\'' or '"' or '`') && value[^1] == quote)
+            return value[1..^1].Replace(new string(quote, 2), quote.ToString(), StringComparison.Ordinal);
+        if (quote == '[' && value[^1] == ']')
+            return value[1..^1].Replace("]]", "]", StringComparison.Ordinal);
+
+        return value;
     }
 
     private static bool IsIdentifier(string value)
         => value.All(static character => char.IsLetterOrDigit(character) || character == '_')
             && !char.IsDigit(value[0]);
 }
+
+internal sealed record ManagedFts5Column(string Name, bool Unindexed);
+
+internal sealed record ManagedFts5Definition(
+    IReadOnlyList<ManagedFts5Column> Columns,
+    ManagedFtsTokenizerOptions Tokenizer,
+    ManagedFtsDetailLevel Detail,
+    bool ColumnSize,
+    IReadOnlyList<int> PrefixLengths);
 
 internal sealed class ManagedRTreeModule : ManagedRTreeModuleBase
 {
@@ -103,30 +232,72 @@ internal sealed class ManagedFts5Table : ManagedVirtualTable
     private const int MatchPlan = 1;
     private const int PersistenceVersion = 1;
 
+    private readonly ManagedFts5Definition _definition;
     private readonly string[] _columnNames;
     private string _tableName;
     private ManagedVirtualTableSchema _schema;
     private readonly Dictionary<long, SqlValue[]> _rows = [];
-    private readonly ManagedFtsIndex _index = new();
+    private readonly ManagedFtsSearchIndex _index;
     private Dictionary<long, SqlValue[]>? _transactionSnapshot;
     private long? _transactionNextRowId;
     private long _nextRowId = 1;
 
-    public ManagedFts5Table(string tableName, IReadOnlyList<string> columnNames)
+    public ManagedFts5Table(string tableName, ManagedFts5Definition definition)
     {
-        _columnNames = [.. columnNames];
-        if (_columnNames.Contains(tableName, StringComparer.OrdinalIgnoreCase))
-            throw new EmbeddedSqlException("an fts5 column cannot have the same name as its table");
+        _definition = definition;
+        _columnNames = definition.Columns.Select(static column => column.Name).ToArray();
+        ValidateTableName(tableName);
+
+        var weights = new double[_columnNames.Length];
+        Array.Fill(weights, 1.0);
+        _index = new ManagedFtsSearchIndex(
+            _columnNames.Length,
+            definition.Tokenizer,
+            weights,
+            definition.Detail,
+            // SQLite computes token counts on demand when columnsize=0. Ahtola has no docsize
+            // shadow table, so retaining derived lengths preserves the observable BM25 result.
+            columnSize: true,
+            scoringProfile: ManagedFtsScoringProfile.SqliteFts5)
+        {
+            ColumnIndexResolver = ResolveColumnIndex,
+        };
 
         _tableName = tableName;
         _schema = CreateSchema(tableName);
     }
 
+    internal string TableName => _tableName;
+
+    internal IReadOnlyList<string> ColumnNames => _columnNames;
+
+    internal ManagedFtsTokenizerOptions Tokenizer => _definition.Tokenizer;
+
+    internal bool IsIndexedColumn(int columnIndex) => !_definition.Columns[columnIndex].Unindexed;
+
+    private void ValidateTableName(string tableName)
+    {
+        if (string.Equals(tableName, "rank", StringComparison.OrdinalIgnoreCase)
+            || _columnNames.Contains(tableName, StringComparer.OrdinalIgnoreCase))
+        {
+            throw new EmbeddedSqlException("an fts5 column cannot have the same name as its table");
+        }
+        if (_columnNames.Contains("rank", StringComparer.OrdinalIgnoreCase))
+            throw new EmbeddedSqlException("an fts5 column cannot be named rank");
+        if (_columnNames.Contains("rowid", StringComparer.OrdinalIgnoreCase))
+            throw new EmbeddedSqlException("reserved fts5 column name: rowid");
+    }
+
+    private int TableColumnIndex => _columnNames.Length;
+
+    private int RankColumnIndex => _columnNames.Length + 1;
+
     private ManagedVirtualTableSchema CreateSchema(string tableName)
         => new(
             _columnNames
                 .Select(static name => new ManagedVirtualTableColumn(name, ManagedVirtualTableAffinity.Text))
-                .Append(new ManagedVirtualTableColumn(tableName, ManagedVirtualTableAffinity.Text, IsHidden: true)));
+                .Append(new ManagedVirtualTableColumn(tableName, ManagedVirtualTableAffinity.Text, IsHidden: true))
+                .Append(new ManagedVirtualTableColumn("rank", ManagedVirtualTableAffinity.Real, IsHidden: true)));
 
     public override ManagedVirtualTableSchema Schema => _schema;
 
@@ -135,27 +306,42 @@ internal sealed class ManagedFts5Table : ManagedVirtualTable
         IReadOnlyList<ManagedVirtualTableOrderBy> orderBy)
     {
         var usages = new ManagedVirtualTableConstraintUsage[constraints.Count];
+        var matchedColumns = new List<int>();
+        var argumentIndex = 1;
         for (var index = 0; index < usages.Length; index++)
         {
-            if (constraints[index].Usable
-                && constraints[index].Operator == ManagedVirtualTableConstraintOperator.Match)
+            var constraint = constraints[index];
+            if (constraint.Usable
+                && constraint.Operator == ManagedVirtualTableConstraintOperator.Match
+                && constraint.ColumnIndex >= 0
+                && constraint.ColumnIndex <= TableColumnIndex)
             {
-                usages[index] = new ManagedVirtualTableConstraintUsage(1, Omit: true);
-                return new ManagedVirtualTablePlan(
-                    usages,
-                    indexNumber: MatchPlan,
-                    indexString: "fts5-match",
-                    estimatedCost: 10,
-                    estimatedRows: Math.Max(1, _rows.Count / 4));
+                usages[index] = new ManagedVirtualTableConstraintUsage(argumentIndex++, Omit: true);
+                matchedColumns.Add(constraint.ColumnIndex);
+                continue;
             }
 
             usages[index] = ManagedVirtualTableConstraintUsage.Unused;
         }
 
+        if (matchedColumns.Count != 0)
+        {
+            var rankOrder = orderBy.Count == 1 && orderBy[0].ColumnIndex == RankColumnIndex
+                ? orderBy[0].Descending ? "desc" : "asc"
+                : "none";
+            return new ManagedVirtualTablePlan(
+                usages,
+                indexNumber: MatchPlan,
+                indexString: string.Join(',', matchedColumns) + "|" + rankOrder,
+                orderByConsumed: rankOrder != "none",
+                estimatedCost: 10,
+                estimatedRows: Math.Max(1, _rows.Count / 4));
+        }
+
         return new ManagedVirtualTablePlan(usages, estimatedCost: Math.Max(1, _rows.Count), estimatedRows: _rows.Count);
     }
 
-    public override ManagedVirtualTableCursor Open() => new Cursor(_rows, _index);
+    public override ManagedVirtualTableCursor Open() => new Cursor(this);
 
     public override long? Update(IReadOnlyList<SqlValue> arguments)
     {
@@ -168,15 +354,81 @@ internal sealed class ManagedFts5Table : ManagedVirtualTable
             return null;
         }
 
-        var rowId = newRowId ?? oldRowId ?? _nextRowId++;
+        var tableArgument = arguments[TableColumnIndex + 2];
+        var rankArgument = arguments[RankColumnIndex + 2];
+        if (tableArgument.Kind != SqlValueKind.Null)
+            return ExecuteCommand(arguments, oldRowId, newRowId, tableArgument, rankArgument);
+        if (rankArgument.Kind != SqlValueKind.Null)
+            throw new EmbeddedSqlException("managed fts5 does not support rank configuration");
+
+        var rowId = newRowId ?? oldRowId ?? AllocateRowId();
+        if (oldRowId is null && newRowId is not null && _rows.ContainsKey(rowId))
+            throw new EmbeddedSqlException($"constraint failed: rowid {rowId} already exists");
+        if (oldRowId is { } replaced
+            && replaced != rowId
+            && _rows.ContainsKey(rowId))
+        {
+            throw new EmbeddedSqlException($"constraint failed: rowid {rowId} already exists");
+        }
         if (oldRowId is { } previous && previous != rowId)
             Remove(previous);
 
         var values = arguments.Skip(2).Take(_columnNames.Length).ToArray();
         _rows[rowId] = values;
-        _index.Upsert(rowId, values.Select(ToText).ToArray());
-        _nextRowId = Math.Max(_nextRowId, checked(rowId + 1));
+        UpsertIndex(rowId, values);
+        _nextRowId = Math.Max(_nextRowId, rowId == long.MaxValue ? long.MaxValue : rowId + 1);
         return rowId;
+    }
+
+    private long AllocateRowId()
+    {
+        if (_rows.Count == 0)
+            return 1;
+
+        var maximum = _rows.Keys.Max();
+        if (maximum < long.MaxValue)
+            return Math.Max(1, maximum + 1);
+
+        for (var attempt = 0; attempt < 100; attempt++)
+        {
+            var candidate = Random.Shared.NextInt64(1, long.MaxValue);
+            if (!_rows.ContainsKey(candidate))
+                return candidate;
+        }
+
+        throw new EmbeddedSqlException("database or disk is full");
+    }
+
+    private long? ExecuteCommand(
+        IReadOnlyList<SqlValue> arguments,
+        long? oldRowId,
+        long? newRowId,
+        SqlValue tableArgument,
+        SqlValue rankArgument)
+    {
+        if (oldRowId is not null
+            || newRowId is not null
+            || tableArgument.Kind != SqlValueKind.Text
+            || rankArgument.Kind != SqlValueKind.Null
+            || arguments.Skip(2).Take(_columnNames.Length).Any(static value => value.Kind != SqlValueKind.Null))
+        {
+            throw new EmbeddedSqlException("invalid managed fts5 command row");
+        }
+
+        switch (tableArgument.AsText().ToLowerInvariant())
+        {
+            case "optimize":
+                _index.Compact();
+                return null;
+            case "rebuild":
+                RebuildIndex();
+                return null;
+            case "delete-all":
+                throw new EmbeddedSqlException(
+                    "'delete-all' may only be used with a contentless or external content fts5 table");
+            default:
+                throw new EmbeddedSqlException($"unsupported managed fts5 command: {tableArgument.AsText()}");
+        }
     }
 
     public override void Begin()
@@ -229,6 +481,7 @@ internal sealed class ManagedFts5Table : ManagedVirtualTable
         if (string.IsNullOrWhiteSpace(newName))
             throw new EmbeddedSqlException("virtual table name cannot be empty");
 
+        ValidateTableName(newName);
         _tableName = newName;
         _schema = CreateSchema(_tableName);
     }
@@ -258,7 +511,7 @@ internal sealed class ManagedFts5Table : ManagedVirtualTable
                 values[column] = ManagedVirtualTablePayloadValues.Read(ref reader);
             if (!rows.TryAdd(rowId, values))
                 throw new EmbeddedSqlException("fts5 persistence payload contains duplicate rowids");
-            if (rowId >= nextRowId)
+            if (rowId >= nextRowId && rowId != long.MaxValue)
                 throw new EmbeddedSqlException("fts5 persistence payload has an invalid next rowid");
         }
         reader.RequireEnd();
@@ -280,36 +533,127 @@ internal sealed class ManagedFts5Table : ManagedVirtualTable
     {
         _index.Clear();
         foreach (var (rowId, values) in _rows)
-            _index.Upsert(rowId, values.Select(ToText).ToArray());
+            UpsertIndex(rowId, values);
     }
 
     private static Dictionary<long, SqlValue[]> CloneRows(IReadOnlyDictionary<long, SqlValue[]> source)
         => source.ToDictionary(static entry => entry.Key, static entry => entry.Value.ToArray());
 
-    private static string? ToText(SqlValue value)
-        => value.Kind switch
+    private void UpsertIndex(long rowId, SqlValue[] values)
+    {
+        var indexedValues = values.ToArray();
+        for (var index = 0; index < _definition.Columns.Count; index++)
         {
-            SqlValueKind.Null => null,
-            SqlValueKind.Text => value.AsText(),
-            SqlValueKind.Integer => value.AsInteger().ToString(CultureInfo.InvariantCulture),
-            SqlValueKind.Real => value.AsReal().ToString("R", CultureInfo.InvariantCulture),
-            SqlValueKind.Blob => System.Text.Encoding.UTF8.GetString(value.AsBlob().Span),
-            _ => throw new ArgumentOutOfRangeException(nameof(value)),
+            if (_definition.Columns[index].Unindexed)
+                indexedValues[index] = SqlValue.Null;
+        }
+
+        _index.Upsert(rowId, values, indexedValues);
+    }
+
+    private int? ResolveColumnIndex(string name)
+    {
+        for (var index = 0; index < _columnNames.Length; index++)
+        {
+            if (string.Equals(_columnNames[index], name, StringComparison.OrdinalIgnoreCase))
+                return index;
+        }
+
+        return null;
+    }
+
+    internal SqlValue GetColumnValue(long rowId, int columnIndex)
+    {
+        if (columnIndex < 0 || columnIndex >= _columnNames.Length)
+            throw new EmbeddedSqlException($"fts5 column index {columnIndex} is out of range");
+        return _rows[rowId][columnIndex];
+    }
+
+    internal double Score(ManagedFtsNode? query, long rowId, IReadOnlyList<double>? weights = null)
+        => query is null ? 0.0 : -_index.Score(query, rowId, weights);
+
+    internal IReadOnlyList<ManagedFtsHit> Search(
+        ManagedFtsNode query,
+        IReadOnlyList<double> weights)
+        => _index.Search(query, weights);
+
+    internal int SelectSnippetColumn(ManagedFtsNode? query, long rowId, int window)
+    {
+        if (query is null)
+            return 0;
+
+        var bestColumn = 0;
+        var bestMatches = -1;
+        for (var column = 0; column < _columnNames.Length; column++)
+        {
+            if (!IsIndexedColumn(column))
+                continue;
+
+            var matches = ManagedFtsFunctions.ScoreFts5Snippet(
+                _rows[rowId][column],
+                query,
+                _columnNames[column],
+                window,
+                _definition.Tokenizer);
+            if (matches > bestMatches)
+            {
+                bestColumn = column;
+                bestMatches = matches;
+            }
+        }
+
+        return bestColumn;
+    }
+
+    private ManagedFtsNode ParseQuery(SqlValue value, int columnIndex)
+    {
+        if (value.Kind != SqlValueKind.Text)
+            throw new EmbeddedSqlException("fts5 MATCH requires a text query");
+
+        var query = ManagedFtsQueryLanguage.Parse(
+            value.AsText(),
+            _definition.Tokenizer,
+            name => ResolveColumnIndex(name) is not null);
+        return columnIndex == TableColumnIndex
+            ? query
+            : ApplyDefaultColumn(query, _columnNames[columnIndex]);
+    }
+
+    private static ManagedFtsNode ApplyDefaultColumn(ManagedFtsNode node, string column)
+        => node switch
+        {
+            ManagedFtsTermNode term => term.Column is null ? term with { Column = column } : term,
+            ManagedFtsPhraseNode phrase => phrase.Column is null ? phrase with { Column = column } : phrase,
+            ManagedFtsNearNode near => near.Column is null ? near with { Column = column } : near,
+            ManagedFtsAndNode and => new ManagedFtsAndNode(
+                ApplyDefaultColumn(and.Left, column),
+                ApplyDefaultColumn(and.Right, column)),
+            ManagedFtsOrNode or => new ManagedFtsOrNode(
+                ApplyDefaultColumn(or.Left, column),
+                ApplyDefaultColumn(or.Right, column)),
+            ManagedFtsNotNode not => new ManagedFtsNotNode(ApplyDefaultColumn(not.Operand, column)),
+            _ => throw new ArgumentOutOfRangeException(nameof(node)),
         };
 
-    private sealed class Cursor(
-        IReadOnlyDictionary<long, SqlValue[]> rows,
-        ManagedFtsIndex index) : ManagedVirtualTableCursor
+    private sealed class Cursor(ManagedFts5Table table)
+        : ManagedVirtualTableCursor, IManagedFts5Cursor
     {
-        private IReadOnlyList<KeyValuePair<long, SqlValue[]>> _matches = [];
+        private IReadOnlyList<Match> _matches = [];
         private int _position;
+        private ManagedFts5ScoreCache? _scoreCache;
 
         public override bool Filter(ManagedVirtualTablePlan plan, IReadOnlyList<SqlValue> arguments)
         {
             _matches = plan.IndexNumber == MatchPlan
-                ? MatchRows(arguments)
-                : rows.OrderBy(static entry => entry.Key).ToArray();
+                ? MatchRows(plan, arguments)
+                : table._rows
+                    .OrderBy(static entry => entry.Key)
+                    .Select(static entry => new Match(entry.Key, entry.Value, null, null))
+                    .ToArray();
             _position = 0;
+            _scoreCache = _matches.FirstOrDefault()?.Query is { } query
+                ? new ManagedFts5ScoreCache(table, query)
+                : null;
             return _matches.Count != 0;
         }
 
@@ -318,21 +662,59 @@ internal sealed class ManagedFts5Table : ManagedVirtualTable
         public override bool Eof => _position >= _matches.Count;
 
         public override SqlValue Column(int columnIndex)
-            => columnIndex == _matches[_position].Value.Length
-                ? SqlValue.Null
-                : _matches[_position].Value[columnIndex];
-
-        public override long RowId => _matches[_position].Key;
-
-        private IReadOnlyList<KeyValuePair<long, SqlValue[]>> MatchRows(IReadOnlyList<SqlValue> arguments)
         {
-            if (arguments.Count != 1 || arguments[0].Kind != SqlValueKind.Text)
-                throw new EmbeddedSqlException("fts5 MATCH requires one text query");
+            if (columnIndex < 0 || columnIndex >= table.Schema.Columns.Count)
+                throw new ArgumentOutOfRangeException(nameof(columnIndex));
+            if (columnIndex < table._columnNames.Length)
+                return _matches[_position].Values[columnIndex];
+            if (columnIndex == table.TableColumnIndex)
+                return SqlValue.Integer(_matches[_position].Query is null ? 1 : 2);
 
-            return index.Search(ManagedFtsQueryParser.Parse(arguments[0].AsText()))
-                .Select(match => new KeyValuePair<long, SqlValue[]>(match.RowId, rows[match.RowId]))
+            return _matches[_position].Rank is { } rank ? SqlValue.Real(rank) : SqlValue.Null;
+        }
+
+        public override long RowId => _matches[_position].RowId;
+
+        public ManagedFts5SourceBinding CurrentBinding
+            => new(table, RowId, _matches[_position].Query, _matches[_position].Rank, _scoreCache);
+
+        private IReadOnlyList<Match> MatchRows(
+            ManagedVirtualTablePlan plan,
+            IReadOnlyList<SqlValue> arguments)
+        {
+            var encoded = plan.IndexString?.Split('|') ?? [];
+            if (encoded.Length != 2)
+                throw new EmbeddedSqlException("invalid fts5 filter plan");
+            var columns = encoded[0]
+                .Split(',', StringSplitOptions.RemoveEmptyEntries)
+                .Select(value => int.Parse(value, CultureInfo.InvariantCulture))
+                .ToArray();
+            var descending = encoded[1] == "desc";
+            if (arguments.Count != columns.Length)
+                throw new EmbeddedSqlException("fts5 filter argument count does not match the selected plan");
+
+            ManagedFtsNode? query = null;
+            for (var index = 0; index < arguments.Count; index++)
+            {
+                var parsed = table.ParseQuery(arguments[index], columns[index]);
+                query = query is null ? parsed : new ManagedFtsAndNode(query, parsed);
+            }
+
+            var hits = table._index.Search(query!);
+            if (descending)
+            {
+                hits = hits
+                    .OrderBy(static hit => hit.Score)
+                    .ThenBy(static hit => hit.RowId)
+                    .ToArray();
+            }
+
+            return hits
+                .Select(hit => new Match(hit.RowId, table._rows[hit.RowId], -hit.Score, query))
                 .ToArray();
         }
+
+        private sealed record Match(long RowId, SqlValue[] Values, double? Rank, ManagedFtsNode? Query);
     }
 
     internal static void ValidateUpdateArguments(IReadOnlyList<SqlValue> arguments, int columnCount)
@@ -346,8 +728,72 @@ internal sealed class ManagedFts5Table : ManagedVirtualTable
         {
             SqlValueKind.Null => null,
             SqlValueKind.Integer => value.AsInteger(),
+            SqlValueKind.Real when TryReadIntegralReal(value.AsReal(), out var realRowId) => realRowId,
+            SqlValueKind.Text when TryReadIntegralText(value.AsText(), out var textRowId) => textRowId,
             _ => throw new EmbeddedSqlException($"{name} must be an integer or NULL"),
         };
+
+    private static bool TryReadIntegralText(string text, out long rowId)
+    {
+        var trimmed = EmbeddedTable.TrimAsciiWhitespace(text);
+        if (long.TryParse(trimmed, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out rowId))
+            return true;
+        if (double.TryParse(trimmed, NumberStyles.Float, CultureInfo.InvariantCulture, out var real))
+            return TryReadIntegralReal(real, out rowId);
+
+        rowId = 0;
+        return false;
+    }
+
+    private static bool TryReadIntegralReal(double real, out long rowId)
+    {
+        const double MaximumExclusive = 9_223_372_036_854_775_808.0;
+        if (double.IsFinite(real)
+            && real > long.MinValue
+            && real < MaximumExclusive
+            && real == Math.Truncate(real))
+        {
+            rowId = (long)real;
+            return true;
+        }
+
+        rowId = 0;
+        return false;
+    }
+}
+
+internal interface IManagedFts5Cursor
+{
+    ManagedFts5SourceBinding CurrentBinding { get; }
+}
+
+internal sealed record ManagedFts5SourceBinding(
+    ManagedFts5Table Table,
+    long RowId,
+    ManagedFtsNode? Query,
+    double? Rank,
+    ManagedFts5ScoreCache? ScoreCache);
+
+internal sealed class ManagedFts5ScoreCache(
+    ManagedFts5Table table,
+    ManagedFtsNode query)
+{
+    private readonly List<(double[] Weights, IReadOnlyDictionary<long, double> Scores)> _weightedScores = [];
+
+    public double Score(long rowId, IReadOnlyList<double> weights)
+    {
+        foreach (var cached in _weightedScores)
+        {
+            if (cached.Weights.SequenceEqual(weights))
+                return cached.Scores.TryGetValue(rowId, out var score) ? score : 0.0;
+        }
+
+        var copiedWeights = weights.ToArray();
+        var scores = table.Search(query, copiedWeights)
+            .ToDictionary(static hit => hit.RowId, static hit => -hit.Score);
+        _weightedScores.Add((copiedWeights, scores));
+        return scores.TryGetValue(rowId, out var resolved) ? resolved : 0.0;
+    }
 }
 
 internal sealed class ManagedRTreeTable : ManagedVirtualTable
@@ -426,6 +872,12 @@ internal sealed class ManagedRTreeTable : ManagedVirtualTable
         var rowId = newRowId ?? suppliedId ?? oldRowId ?? _nextRowId++;
         if (suppliedId is not null && suppliedId != rowId)
             throw new EmbeddedSqlException("rtree id must match rowid");
+        if (oldRowId is { } replaced
+            && replaced != rowId
+            && _rows.ContainsKey(rowId))
+        {
+            throw new EmbeddedSqlException($"constraint failed: rowid {rowId} already exists");
+        }
         if (oldRowId is { } previous && previous != rowId)
             Remove(previous);
 

--- a/src/Ahtola.Core/Search/ManagedFtsFunctions.cs
+++ b/src/Ahtola.Core/Search/ManagedFtsFunctions.cs
@@ -432,7 +432,8 @@ internal static class ManagedFtsFunctions
                 }
                 return;
             case ManagedFtsPhraseNode phrase:
-                if (phrase.IsPrefix && ++prefixTerms > ManagedFtsLimits.MaxHighlightPrefixTerms)
+                prefixTerms += phrase.Terms.Count(static term => term.IsPrefix);
+                if (prefixTerms > ManagedFtsLimits.MaxHighlightPrefixTerms)
                 {
                     throw new EmbeddedSqlException(
                         $"fts highlight query uses more than {ManagedFtsLimits.MaxHighlightPrefixTerms} prefix terms");
@@ -443,7 +444,8 @@ internal static class ManagedFtsFunctions
             case ManagedFtsNearNode near:
                 foreach (var phrase in near.Phrases)
                 {
-                    if (phrase.IsPrefix && ++prefixTerms > ManagedFtsLimits.MaxHighlightPrefixTerms)
+                    prefixTerms += phrase.Terms.Count(static term => term.IsPrefix);
+                    if (prefixTerms > ManagedFtsLimits.MaxHighlightPrefixTerms)
                     {
                         throw new EmbeddedSqlException(
                             $"fts highlight query uses more than {ManagedFtsLimits.MaxHighlightPrefixTerms} prefix terms");
@@ -477,7 +479,7 @@ internal static class ManagedFtsFunctions
 
         foreach (var match in FindPhraseMatches(
                      lookup,
-                     new ManagedFtsNearPhrase(phrase.Terms, phrase.IsPrefix),
+                     new ManagedFtsNearPhrase(phrase.Terms),
                      phrase.AnchoredAtStart))
         {
             AddMatchSpan(destination, match.Span.Start, match.Span.End);
@@ -493,9 +495,10 @@ internal static class ManagedFtsFunctions
             return [];
 
         var matches = new List<PhraseMatch>();
-        var firstOccurrences = phrase.Terms.Count == 1 && phrase.IsPrefix
-            ? lookup.GetPrefix(phrase.Terms[0])
-            : lookup.Get(phrase.Terms[0]);
+        var firstTerm = phrase.Terms[0];
+        var firstOccurrences = firstTerm.IsPrefix
+            ? lookup.GetPrefix(firstTerm.Text)
+            : lookup.Get(firstTerm.Text);
         foreach (var first in firstOccurrences)
         {
             if (anchoredAtStart && first.Position != 0)
@@ -506,9 +509,10 @@ internal static class ManagedFtsFunctions
             for (var index = 1; index < phrase.Terms.Count; index++)
             {
                 var position = first.Position + index;
-                var found = phrase.IsPrefix && index == phrase.Terms.Count - 1
-                    ? lookup.TryGetPrefixAtPosition(phrase.Terms[index], position, out var token)
-                    : lookup.TryGetAtPosition(phrase.Terms[index], position, out token);
+                var phraseTerm = phrase.Terms[index];
+                var found = phraseTerm.IsPrefix
+                    ? lookup.TryGetPrefixAtPosition(phraseTerm.Text, position, out var token)
+                    : lookup.TryGetAtPosition(phraseTerm.Text, position, out token);
                 if (!found)
                 {
                     matched = false;

--- a/src/Ahtola.Core/Search/ManagedFtsFunctions.cs
+++ b/src/Ahtola.Core/Search/ManagedFtsFunctions.cs
@@ -411,6 +411,8 @@ internal static class ManagedFtsFunctions
     {
         switch (node)
         {
+            case ManagedFtsNoMatchNode:
+                return;
             case ManagedFtsTermNode term:
                 if (!AppliesToColumn(term.Column, columnName))
                     return;
@@ -430,6 +432,11 @@ internal static class ManagedFtsFunctions
                 }
                 return;
             case ManagedFtsPhraseNode phrase:
+                if (phrase.IsPrefix && ++prefixTerms > ManagedFtsLimits.MaxHighlightPrefixTerms)
+                {
+                    throw new EmbeddedSqlException(
+                        $"fts highlight query uses more than {ManagedFtsLimits.MaxHighlightPrefixTerms} prefix terms");
+                }
                 if (AppliesToColumn(phrase.Column, columnName))
                     CollectPhraseSpans(lookup, phrase, destination);
                 return;
@@ -469,7 +476,11 @@ internal static class ManagedFtsFunctions
             var matched = true;
             for (var index = 1; index < phrase.Terms.Count; index++)
             {
-                if (!lookup.TryGetAtPosition(phrase.Terms[index], first.Position + index, out var token))
+                var position = first.Position + index;
+                var found = phrase.IsPrefix && index == phrase.Terms.Count - 1
+                    ? lookup.TryGetPrefixAtPosition(phrase.Terms[index], position, out var token)
+                    : lookup.TryGetAtPosition(phrase.Terms[index], position, out token);
+                if (!found)
                 {
                     matched = false;
                     break;
@@ -491,6 +502,9 @@ internal static class ManagedFtsFunctions
         if (near.Terms.Count == 0)
             return;
 
+        var distance = near.SqliteDistance
+            ? checked(near.Distance + 1)
+            : near.Distance;
         foreach (var anchor in lookup.Get(near.Terms[0]))
         {
             var occurrences = new ManagedFtsToken[near.Terms.Count];
@@ -500,8 +514,8 @@ internal static class ManagedFtsFunctions
             {
                 if (!lookup.TryGetInRange(
                         near.Terms[index],
-                        Math.Max(0, anchor.Position - near.Distance),
-                        anchor.Position + near.Distance,
+                        Math.Max(0, anchor.Position - distance),
+                        anchor.Position + distance,
                         out occurrences[index]))
                 {
                     matched = false;
@@ -535,11 +549,13 @@ internal static class ManagedFtsFunctions
     private sealed class Fts5TokenLookup
     {
         private readonly Dictionary<string, List<ManagedFtsToken>> _byTerm = new(StringComparer.Ordinal);
+        private readonly Dictionary<int, ManagedFtsToken> _byPosition = [];
 
         public Fts5TokenLookup(IReadOnlyList<ManagedFtsToken> tokens)
         {
             foreach (var token in tokens)
             {
+                _byPosition.TryAdd(token.Position, token);
                 if (!_byTerm.TryGetValue(token.Text, out var occurrences))
                 {
                     occurrences = [];
@@ -596,6 +612,18 @@ internal static class ManagedFtsFunctions
             if (low < occurrences.Count && occurrences[low].Position == position)
             {
                 token = occurrences[low];
+                return true;
+            }
+
+            token = null!;
+            return false;
+        }
+
+        public bool TryGetPrefixAtPosition(string prefix, int position, out ManagedFtsToken token)
+        {
+            if (_byPosition.TryGetValue(position, out token!)
+                && token.Text.StartsWith(prefix, StringComparison.Ordinal))
+            {
                 return true;
             }
 

--- a/src/Ahtola.Core/Search/ManagedFtsFunctions.cs
+++ b/src/Ahtola.Core/Search/ManagedFtsFunctions.cs
@@ -441,6 +441,14 @@ internal static class ManagedFtsFunctions
                     CollectPhraseSpans(lookup, phrase, destination);
                 return;
             case ManagedFtsNearNode near:
+                foreach (var phrase in near.Phrases)
+                {
+                    if (phrase.IsPrefix && ++prefixTerms > ManagedFtsLimits.MaxHighlightPrefixTerms)
+                    {
+                        throw new EmbeddedSqlException(
+                            $"fts highlight query uses more than {ManagedFtsLimits.MaxHighlightPrefixTerms} prefix terms");
+                    }
+                }
                 if (AppliesToColumn(near.Column, columnName))
                     CollectNearSpans(lookup, near, destination);
                 return;
@@ -467,9 +475,30 @@ internal static class ManagedFtsFunctions
         if (phrase.Terms.Count == 0)
             return;
 
-        foreach (var first in lookup.Get(phrase.Terms[0]))
+        foreach (var match in FindPhraseMatches(
+                     lookup,
+                     new ManagedFtsNearPhrase(phrase.Terms, phrase.IsPrefix),
+                     phrase.AnchoredAtStart))
         {
-            if (phrase.AnchoredAtStart && first.Position != 0)
+            AddMatchSpan(destination, match.Span.Start, match.Span.End);
+        }
+    }
+
+    private static List<PhraseMatch> FindPhraseMatches(
+        Fts5TokenLookup lookup,
+        ManagedFtsNearPhrase phrase,
+        bool anchoredAtStart)
+    {
+        if (phrase.Terms.Count == 0)
+            return [];
+
+        var matches = new List<PhraseMatch>();
+        var firstOccurrences = phrase.Terms.Count == 1 && phrase.IsPrefix
+            ? lookup.GetPrefix(phrase.Terms[0])
+            : lookup.Get(phrase.Terms[0]);
+        foreach (var first in firstOccurrences)
+        {
+            if (anchoredAtStart && first.Position != 0)
                 continue;
 
             var end = first.Offset + first.Length;
@@ -490,8 +519,15 @@ internal static class ManagedFtsFunctions
             }
 
             if (matched)
-                AddMatchSpan(destination, first.Offset, end);
+            {
+                matches.Add(new PhraseMatch(
+                    first.Position,
+                    checked(first.Position + phrase.Terms.Count - 1),
+                    new MatchSpan(first.Offset, end)));
+            }
         }
+
+        return matches;
     }
 
     private static void CollectNearSpans(
@@ -499,36 +535,146 @@ internal static class ManagedFtsFunctions
         ManagedFtsNearNode near,
         List<MatchSpan> destination)
     {
-        if (near.Terms.Count == 0)
+        if (near.Phrases.Count == 0)
             return;
 
-        var distance = near.SqliteDistance
-            ? checked(near.Distance + 1)
-            : near.Distance;
-        foreach (var anchor in lookup.Get(near.Terms[0]))
+        var phraseMatches = near.Phrases
+            .Select(phrase => FindPhraseMatches(lookup, phrase, anchoredAtStart: false))
+            .ToArray();
+        if (phraseMatches.Any(static matches => matches.Count == 0))
+            return;
+
+        if (!near.SqliteDistance)
         {
-            var occurrences = new ManagedFtsToken[near.Terms.Count];
-            occurrences[0] = anchor;
-            var matched = true;
-            for (var index = 1; index < near.Terms.Count; index++)
+            foreach (var anchor in phraseMatches[0])
             {
-                if (!lookup.TryGetInRange(
-                        near.Terms[index],
-                        Math.Max(0, anchor.Position - distance),
-                        anchor.Position + distance,
-                        out occurrences[index]))
+                var occurrences = new PhraseMatch[near.Phrases.Count];
+                occurrences[0] = anchor;
+                var matched = true;
+                for (var index = 1; index < phraseMatches.Length; index++)
                 {
-                    matched = false;
-                    break;
+                    var found = phraseMatches[index].FirstOrDefault(
+                        candidate => Math.Abs(candidate.EndPosition - anchor.EndPosition) <= near.Distance);
+                    if (found == default)
+                    {
+                        matched = false;
+                        break;
+                    }
+
+                    occurrences[index] = found;
                 }
+
+                if (!matched)
+                    continue;
+                foreach (var occurrence in occurrences)
+                    AddMatchSpan(destination, occurrence.Span.Start, occurrence.Span.End);
             }
 
-            if (!matched)
+            return;
+        }
+
+        var maximumStarts = phraseMatches
+            .SelectMany(static matches => matches)
+            .Select(static match => match.StartPosition)
+            .Distinct()
+            .Order()
+            .ToArray();
+        var participatingRanges = Enumerable
+            .Range(0, phraseMatches.Length)
+            .Select(static _ => new List<PhraseMatchRange>())
+            .ToArray();
+        foreach (var maximumStart in maximumStarts)
+        {
+            var ranges = new PhraseMatchRange[phraseMatches.Length];
+            var matches = true;
+            for (var phraseIndex = 0; phraseIndex < phraseMatches.Length; phraseIndex++)
+            {
+                var minimumStart = Math.Max(
+                    0L,
+                    (long)maximumStart - near.Distance - near.Phrases[phraseIndex].Terms.Count);
+                var first = LowerBoundByStart(phraseMatches[phraseIndex], minimumStart);
+                var end = UpperBoundByStart(phraseMatches[phraseIndex], maximumStart);
+                if (first == end)
+                {
+                    matches = false;
+                    break;
+                }
+
+                ranges[phraseIndex] = new PhraseMatchRange(first, end);
+            }
+
+            if (!matches)
                 continue;
-            foreach (var token in occurrences)
-                AddMatchSpan(destination, token.Offset, token.Offset + token.Length);
+
+            for (var phraseIndex = 0; phraseIndex < phraseMatches.Length; phraseIndex++)
+                AddPhraseMatchRange(participatingRanges[phraseIndex], ranges[phraseIndex]);
+        }
+
+        for (var phraseIndex = 0; phraseIndex < phraseMatches.Length; phraseIndex++)
+        {
+            foreach (var range in participatingRanges[phraseIndex])
+            {
+                for (var index = range.Start; index < range.End; index++)
+                {
+                    var match = phraseMatches[phraseIndex][index];
+                    AddMatchSpan(destination, match.Span.Start, match.Span.End);
+                }
+            }
         }
     }
+
+    private static int LowerBoundByStart(IReadOnlyList<PhraseMatch> matches, long target)
+    {
+        var low = 0;
+        var high = matches.Count;
+        while (low < high)
+        {
+            var middle = low + ((high - low) >> 1);
+            if (matches[middle].StartPosition < target)
+                low = middle + 1;
+            else
+                high = middle;
+        }
+
+        return low;
+    }
+
+    private static int UpperBoundByStart(IReadOnlyList<PhraseMatch> matches, int target)
+    {
+        var low = 0;
+        var high = matches.Count;
+        while (low < high)
+        {
+            var middle = low + ((high - low) >> 1);
+            if (matches[middle].StartPosition <= target)
+                low = middle + 1;
+            else
+                high = middle;
+        }
+
+        return low;
+    }
+
+    private static void AddPhraseMatchRange(
+        List<PhraseMatchRange> ranges,
+        PhraseMatchRange next)
+    {
+        if (ranges.Count == 0 || next.Start > ranges[^1].End)
+        {
+            ranges.Add(next);
+            return;
+        }
+
+        var previous = ranges[^1];
+        ranges[^1] = new PhraseMatchRange(previous.Start, Math.Max(previous.End, next.End));
+    }
+
+    private readonly record struct PhraseMatch(
+        int StartPosition,
+        int EndPosition,
+        MatchSpan Span);
+
+    private readonly record struct PhraseMatchRange(int Start, int End);
 
     private static void AddMatchSpan(List<MatchSpan> destination, int start, int end)
     {
@@ -590,6 +736,13 @@ internal static class ManagedFtsFunctions
         public IReadOnlyList<ManagedFtsToken> Get(string term)
             => _byTerm.TryGetValue(term, out var occurrences) ? occurrences : [];
 
+        public IReadOnlyList<ManagedFtsToken> GetPrefix(string prefix)
+            => _byPosition.Values
+                .Where(token => token.Text.StartsWith(prefix, StringComparison.Ordinal))
+                .OrderBy(static token => token.Position)
+                .ThenBy(static token => token.Offset)
+                .ToArray();
+
         public bool TryGetAtPosition(string term, int position, out ManagedFtsToken token)
         {
             if (!_byTerm.TryGetValue(term, out var occurrences))
@@ -631,34 +784,6 @@ internal static class ManagedFtsFunctions
             return false;
         }
 
-        public bool TryGetInRange(string term, int minimum, int maximum, out ManagedFtsToken token)
-        {
-            if (!_byTerm.TryGetValue(term, out var occurrences))
-            {
-                token = null!;
-                return false;
-            }
-
-            var low = 0;
-            var high = occurrences.Count;
-            while (low < high)
-            {
-                var middle = low + ((high - low) >> 1);
-                if (occurrences[middle].Position < minimum)
-                    low = middle + 1;
-                else
-                    high = middle;
-            }
-
-            if (low < occurrences.Count && occurrences[low].Position <= maximum)
-            {
-                token = occurrences[low];
-                return true;
-            }
-
-            token = null!;
-            return false;
-        }
     }
 
     private static ManagedFtsSearchIndex BuildSingleDocumentIndex(

--- a/src/Ahtola.Core/Search/ManagedFtsFunctions.cs
+++ b/src/Ahtola.Core/Search/ManagedFtsFunctions.cs
@@ -95,6 +95,31 @@ internal static class ManagedFtsFunctions
         return SqlValue.Text(builder.ToString());
     }
 
+    internal static SqlValue HighlightFts5(
+        SqlValue value,
+        ManagedFtsNode? query,
+        string columnName,
+        string before,
+        string after,
+        ManagedFtsTokenizerOptions tokenizer)
+    {
+        if (value.Kind == SqlValueKind.Null)
+            return SqlValue.Null;
+
+        var text = ManagedFtsSearchIndex.ReadText(value);
+        if (query is null)
+            return SqlValue.Text(text);
+
+        var tokens = ManagedFtsTokenization.Tokenize(text, tokenizer);
+        var spans = CollectMatchedSpans(tokens, query, columnName);
+        if (spans.Count == 0)
+            return SqlValue.Text(text);
+
+        var builder = new StringBuilder(text.Length + (spans.Count * (before.Length + after.Length)));
+        AppendRange(builder, text, 0, text.Length, spans, before, after);
+        return SqlValue.Text(builder.ToString());
+    }
+
     /// <summary>
     /// <c>fts_snippet(text, query, before, after, ellipsis, tokens)</c>: the densest window of
     /// <c>tokens</c> tokens containing query matches, with matches wrapped.
@@ -125,7 +150,7 @@ internal static class ManagedFtsFunctions
         var spans = CollectMatchedSpans(tokens, query, options);
         var matchedPositions = MarkMatchedTokenPositions(tokens, spans);
 
-        var start = SelectWindowStart(tokens, window, matchedPositions);
+        var start = SelectWindow(tokens, window, matchedPositions).Start;
         var end = Math.Min(start + window, tokens.Count);
 
         // Clip to the source span the window covers. When the window reaches an edge of the
@@ -144,6 +169,58 @@ internal static class ManagedFtsFunctions
             builder.Append(ellipsis);
 
         return SqlValue.Text(builder.ToString());
+    }
+
+    internal static SqlValue SnippetFts5(
+        SqlValue value,
+        ManagedFtsNode? query,
+        string columnName,
+        string before,
+        string after,
+        string ellipsis,
+        int window,
+        ManagedFtsTokenizerOptions tokenizer)
+    {
+        if (value.Kind == SqlValueKind.Null)
+            return SqlValue.Null;
+        if (window <= 0 || window > 4096)
+            throw new EmbeddedSqlException("snippet() token count must be between 1 and 4096");
+
+        var text = ManagedFtsSearchIndex.ReadText(value);
+        var tokens = ManagedFtsTokenization.Tokenize(text, tokenizer);
+        if (tokens.Count == 0 || query is null)
+            return SqlValue.Text(text);
+
+        var spans = CollectMatchedSpans(tokens, query, columnName);
+        var matchedPositions = MarkMatchedTokenPositions(tokens, spans);
+        var start = SelectWindow(tokens, window, matchedPositions).Start;
+        var end = Math.Min(start + window, tokens.Count);
+        var rangeStart = start == 0 ? 0 : tokens[start].Offset;
+        var rangeEnd = end >= tokens.Count ? text.Length : MaxEnd(tokens, start, end);
+
+        var builder = new StringBuilder();
+        if (rangeStart > 0)
+            builder.Append(ellipsis);
+        AppendRange(builder, text, rangeStart, rangeEnd, spans, before, after);
+        if (rangeEnd < text.Length)
+            builder.Append(ellipsis);
+        return SqlValue.Text(builder.ToString());
+    }
+
+    internal static int ScoreFts5Snippet(
+        SqlValue value,
+        ManagedFtsNode query,
+        string columnName,
+        int window,
+        ManagedFtsTokenizerOptions tokenizer)
+    {
+        if (value.Kind == SqlValueKind.Null)
+            return 0;
+
+        var text = ManagedFtsSearchIndex.ReadText(value);
+        var tokens = ManagedFtsTokenization.Tokenize(text, tokenizer);
+        var spans = CollectMatchedSpans(tokens, query, columnName);
+        return SelectWindow(tokens, window, MarkMatchedTokenPositions(tokens, spans)).Count;
     }
 
     /// <summary>
@@ -242,20 +319,23 @@ internal static class ManagedFtsFunctions
     /// so the whole scan is linear in the token count instead of recounting the window at every
     /// start. Ties still resolve to the earliest window, exactly as the recount did.
     /// </remarks>
-    private static int SelectWindowStart(
+    private static (int Start, int Count) SelectWindow(
         IReadOnlyList<ManagedFtsToken> tokens,
         int window,
         HashSet<int> matchedPositions)
     {
-        if (matchedPositions.Count == 0 || tokens.Count <= window)
-            return 0;
+        if (matchedPositions.Count == 0 || tokens.Count == 0)
+            return (0, 0);
 
         var count = 0;
-        for (var index = 0; index < window; index++)
+        var initialEnd = Math.Min(window, tokens.Count);
+        for (var index = 0; index < initialEnd; index++)
         {
             if (matchedPositions.Contains(tokens[index].Position))
                 count++;
         }
+        if (tokens.Count <= window)
+            return (0, count);
 
         var bestStart = 0;
         var bestCount = count;
@@ -273,7 +353,7 @@ internal static class ManagedFtsFunctions
             }
         }
 
-        return bestStart;
+        return (bestStart, bestCount);
     }
 
     /// <summary>A merged source span covered by at least one matching token.</summary>
@@ -285,44 +365,18 @@ internal static class ManagedFtsFunctions
         ManagedFtsTokenizerOptions options)
     {
         var node = ManagedFtsQueryLanguage.Parse(query, options, static _ => true);
-        var wanted = new List<(string Text, bool IsPrefix)>();
-        CollectPositiveTerms(node, wanted);
+        return CollectMatchedSpans(tokens, node, columnName: null);
+    }
 
-        // Exact terms resolve in constant time per token; only prefix terms need a scan, and the
-        // parser's own term budget plus this bound keep that scan a small constant.
-        var exact = new HashSet<string>(StringComparer.Ordinal);
-        var prefixes = new List<string>();
-        foreach (var (text, isPrefix) in wanted)
-        {
-            if (!isPrefix)
-            {
-                exact.Add(text);
-                continue;
-            }
-
-            if (prefixes.Count == ManagedFtsLimits.MaxHighlightPrefixTerms)
-            {
-                throw new EmbeddedSqlException(
-                    $"fts highlight query uses more than {ManagedFtsLimits.MaxHighlightPrefixTerms} prefix terms");
-            }
-
-            prefixes.Add(text);
-        }
-
+    private static List<MatchSpan> CollectMatchedSpans(
+        IReadOnlyList<ManagedFtsToken> tokens,
+        ManagedFtsNode node,
+        string? columnName)
+    {
         var matched = new List<MatchSpan>();
-        foreach (var token in tokens)
-        {
-            if (!exact.Contains(token.Text) && !StartsWithAny(token.Text, prefixes))
-                continue;
-
-            if (matched.Count == ManagedFtsLimits.MaxHighlightSpans)
-            {
-                throw new EmbeddedSqlException(
-                    $"fts highlight matched more than {ManagedFtsLimits.MaxHighlightSpans} spans in one value");
-            }
-
-            matched.Add(new MatchSpan(token.Offset, token.Offset + token.Length));
-        }
+        var lookup = new Fts5TokenLookup(tokens);
+        var prefixTerms = 0;
+        CollectMatchedSpans(tokens, lookup, node, columnName, matched, ref prefixTerms);
 
         if (matched.Count <= 1)
             return matched;
@@ -347,45 +401,235 @@ internal static class ManagedFtsFunctions
         return merged;
     }
 
-    private static bool StartsWithAny(string text, List<string> prefixes)
-    {
-        foreach (var prefix in prefixes)
-        {
-            if (text.StartsWith(prefix, StringComparison.Ordinal))
-                return true;
-        }
-
-        return false;
-    }
-
-    private static void CollectPositiveTerms(ManagedFtsNode node, List<(string Text, bool IsPrefix)> destination)
+    private static void CollectMatchedSpans(
+        IReadOnlyList<ManagedFtsToken> tokens,
+        Fts5TokenLookup lookup,
+        ManagedFtsNode node,
+        string? columnName,
+        List<MatchSpan> destination,
+        ref int prefixTerms)
     {
         switch (node)
         {
             case ManagedFtsTermNode term:
-                destination.Add((term.Text, term.IsPrefix));
+                if (!AppliesToColumn(term.Column, columnName))
+                    return;
+                if (term.IsPrefix && ++prefixTerms > ManagedFtsLimits.MaxHighlightPrefixTerms)
+                {
+                    throw new EmbeddedSqlException(
+                        $"fts highlight query uses more than {ManagedFtsLimits.MaxHighlightPrefixTerms} prefix terms");
+                }
+
+                var occurrences = term.IsPrefix
+                    ? tokens.Where(token => token.Text.StartsWith(term.Text, StringComparison.Ordinal))
+                    : lookup.Get(term.Text);
+                foreach (var token in occurrences)
+                {
+                    if (!term.AnchoredAtStart || token.Position == 0)
+                        AddMatchSpan(destination, token.Offset, token.Offset + token.Length);
+                }
                 return;
             case ManagedFtsPhraseNode phrase:
-                foreach (var term in phrase.Terms)
-                    destination.Add((term, false));
+                if (AppliesToColumn(phrase.Column, columnName))
+                    CollectPhraseSpans(lookup, phrase, destination);
                 return;
             case ManagedFtsNearNode near:
-                foreach (var term in near.Terms)
-                    destination.Add((term, false));
+                if (AppliesToColumn(near.Column, columnName))
+                    CollectNearSpans(lookup, near, destination);
                 return;
             case ManagedFtsAndNode and:
-                CollectPositiveTerms(and.Left, destination);
-                CollectPositiveTerms(and.Right, destination);
+                CollectMatchedSpans(tokens, lookup, and.Left, columnName, destination, ref prefixTerms);
+                CollectMatchedSpans(tokens, lookup, and.Right, columnName, destination, ref prefixTerms);
                 return;
             case ManagedFtsOrNode or:
-                CollectPositiveTerms(or.Left, destination);
-                CollectPositiveTerms(or.Right, destination);
+                CollectMatchedSpans(tokens, lookup, or.Left, columnName, destination, ref prefixTerms);
+                CollectMatchedSpans(tokens, lookup, or.Right, columnName, destination, ref prefixTerms);
                 return;
             case ManagedFtsNotNode:
-                // A negated branch never contributes highlighted text.
                 return;
             default:
                 throw new ArgumentOutOfRangeException(nameof(node));
+        }
+    }
+
+    private static void CollectPhraseSpans(
+        Fts5TokenLookup lookup,
+        ManagedFtsPhraseNode phrase,
+        List<MatchSpan> destination)
+    {
+        if (phrase.Terms.Count == 0)
+            return;
+
+        foreach (var first in lookup.Get(phrase.Terms[0]))
+        {
+            if (phrase.AnchoredAtStart && first.Position != 0)
+                continue;
+
+            var end = first.Offset + first.Length;
+            var matched = true;
+            for (var index = 1; index < phrase.Terms.Count; index++)
+            {
+                if (!lookup.TryGetAtPosition(phrase.Terms[index], first.Position + index, out var token))
+                {
+                    matched = false;
+                    break;
+                }
+
+                end = Math.Max(end, token.Offset + token.Length);
+            }
+
+            if (matched)
+                AddMatchSpan(destination, first.Offset, end);
+        }
+    }
+
+    private static void CollectNearSpans(
+        Fts5TokenLookup lookup,
+        ManagedFtsNearNode near,
+        List<MatchSpan> destination)
+    {
+        if (near.Terms.Count == 0)
+            return;
+
+        foreach (var anchor in lookup.Get(near.Terms[0]))
+        {
+            var occurrences = new ManagedFtsToken[near.Terms.Count];
+            occurrences[0] = anchor;
+            var matched = true;
+            for (var index = 1; index < near.Terms.Count; index++)
+            {
+                if (!lookup.TryGetInRange(
+                        near.Terms[index],
+                        Math.Max(0, anchor.Position - near.Distance),
+                        anchor.Position + near.Distance,
+                        out occurrences[index]))
+                {
+                    matched = false;
+                    break;
+                }
+            }
+
+            if (!matched)
+                continue;
+            foreach (var token in occurrences)
+                AddMatchSpan(destination, token.Offset, token.Offset + token.Length);
+        }
+    }
+
+    private static void AddMatchSpan(List<MatchSpan> destination, int start, int end)
+    {
+        if (destination.Count == ManagedFtsLimits.MaxHighlightSpans)
+        {
+            throw new EmbeddedSqlException(
+                $"fts highlight matched more than {ManagedFtsLimits.MaxHighlightSpans} spans in one value");
+        }
+
+        destination.Add(new MatchSpan(start, end));
+    }
+
+    private static bool AppliesToColumn(string? constrainedColumn, string? requestedColumn)
+        => requestedColumn is null
+            || constrainedColumn is null
+            || string.Equals(constrainedColumn, requestedColumn, StringComparison.OrdinalIgnoreCase);
+
+    private sealed class Fts5TokenLookup
+    {
+        private readonly Dictionary<string, List<ManagedFtsToken>> _byTerm = new(StringComparer.Ordinal);
+
+        public Fts5TokenLookup(IReadOnlyList<ManagedFtsToken> tokens)
+        {
+            foreach (var token in tokens)
+            {
+                if (!_byTerm.TryGetValue(token.Text, out var occurrences))
+                {
+                    occurrences = [];
+                    _byTerm.Add(token.Text, occurrences);
+                }
+
+                occurrences.Add(token);
+            }
+
+            foreach (var occurrences in _byTerm.Values)
+            {
+                var ordered = true;
+                for (var index = 1; index < occurrences.Count; index++)
+                {
+                    if (occurrences[index - 1].Position > occurrences[index].Position)
+                    {
+                        ordered = false;
+                        break;
+                    }
+                }
+
+                if (!ordered)
+                {
+                    occurrences.Sort(static (left, right)
+                        => left.Position == right.Position
+                            ? left.Offset.CompareTo(right.Offset)
+                            : left.Position.CompareTo(right.Position));
+                }
+            }
+        }
+
+        public IReadOnlyList<ManagedFtsToken> Get(string term)
+            => _byTerm.TryGetValue(term, out var occurrences) ? occurrences : [];
+
+        public bool TryGetAtPosition(string term, int position, out ManagedFtsToken token)
+        {
+            if (!_byTerm.TryGetValue(term, out var occurrences))
+            {
+                token = null!;
+                return false;
+            }
+
+            var low = 0;
+            var high = occurrences.Count;
+            while (low < high)
+            {
+                var middle = low + ((high - low) >> 1);
+                if (occurrences[middle].Position < position)
+                    low = middle + 1;
+                else
+                    high = middle;
+            }
+
+            if (low < occurrences.Count && occurrences[low].Position == position)
+            {
+                token = occurrences[low];
+                return true;
+            }
+
+            token = null!;
+            return false;
+        }
+
+        public bool TryGetInRange(string term, int minimum, int maximum, out ManagedFtsToken token)
+        {
+            if (!_byTerm.TryGetValue(term, out var occurrences))
+            {
+                token = null!;
+                return false;
+            }
+
+            var low = 0;
+            var high = occurrences.Count;
+            while (low < high)
+            {
+                var middle = low + ((high - low) >> 1);
+                if (occurrences[middle].Position < minimum)
+                    low = middle + 1;
+                else
+                    high = middle;
+            }
+
+            if (low < occurrences.Count && occurrences[low].Position <= maximum)
+            {
+                token = occurrences[low];
+                return true;
+            }
+
+            token = null!;
+            return false;
         }
     }
 

--- a/src/Ahtola.Core/Search/ManagedFtsQueryLanguage.cs
+++ b/src/Ahtola.Core/Search/ManagedFtsQueryLanguage.cs
@@ -47,17 +47,20 @@ internal abstract record ManagedFtsNode;
 
 internal sealed record ManagedFtsNoMatchNode : ManagedFtsNode;
 
+internal sealed record ManagedFtsOmittedNode : ManagedFtsNode;
+
 internal sealed record ManagedFtsTermNode(string Text, bool IsPrefix, string? Column, bool AnchoredAtStart)
     : ManagedFtsNode;
 
+internal sealed record ManagedFtsPhraseTerm(string Text, bool IsPrefix);
+
 internal sealed record ManagedFtsPhraseNode(
-    IReadOnlyList<string> Terms,
-    bool IsPrefix,
+    IReadOnlyList<ManagedFtsPhraseTerm> Terms,
     string? Column,
     bool AnchoredAtStart)
     : ManagedFtsNode;
 
-internal sealed record ManagedFtsNearPhrase(IReadOnlyList<string> Terms, bool IsPrefix);
+internal sealed record ManagedFtsNearPhrase(IReadOnlyList<ManagedFtsPhraseTerm> Terms);
 
 internal sealed record ManagedFtsNearNode(
     IReadOnlyList<ManagedFtsNearPhrase> Phrases,
@@ -114,7 +117,7 @@ internal sealed class ManagedFtsQueryLanguage
         var parser = new ManagedFtsQueryLanguage(query, options, isKnownColumn, syntax);
         var node = parser.ParseOr();
         parser.ExpectEnd();
-        return node;
+        return NormalizeOmitted(node);
     }
 
     private ManagedFtsNode ParseOr()
@@ -125,11 +128,16 @@ internal sealed class ManagedFtsQueryLanguage
             : ParseManagedAnd();
         while (TryReadKeyword("OR"))
         {
+            var right = _syntax == ManagedFtsQuerySyntax.SqliteFts5
+                ? ParseFts5ExplicitAnd()
+                : ParseManagedAnd();
             expression = new ManagedFtsOrNode(
-                expression,
                 _syntax == ManagedFtsQuerySyntax.SqliteFts5
-                    ? ParseFts5ExplicitAnd()
-                    : ParseManagedAnd());
+                    ? NormalizeOmitted(expression)
+                    : expression,
+                _syntax == ManagedFtsQuerySyntax.SqliteFts5
+                    ? NormalizeOmitted(right)
+                    : right);
         }
 
         return expression;
@@ -169,7 +177,11 @@ internal sealed class ManagedFtsQueryLanguage
         using var _ = Descend();
         var expression = ParseFts5Not();
         while (TryReadKeyword("AND"))
-            expression = new ManagedFtsAndNode(expression, ParseFts5Not());
+        {
+            expression = new ManagedFtsAndNode(
+                NormalizeOmitted(expression),
+                NormalizeOmitted(ParseFts5Not()));
+        }
 
         return expression;
     }
@@ -181,8 +193,8 @@ internal sealed class ManagedFtsQueryLanguage
         while (TryReadKeyword("NOT"))
         {
             expression = new ManagedFtsAndNode(
-                expression,
-                new ManagedFtsNotNode(ParseFts5ImplicitAnd()));
+                NormalizeOmitted(expression),
+                new ManagedFtsNotNode(NormalizeOmitted(ParseFts5ImplicitAnd())));
         }
 
         return expression;
@@ -193,7 +205,15 @@ internal sealed class ManagedFtsQueryLanguage
         using var _ = Descend();
         var expression = ParsePrimary();
         while (IsFts5ImplicitOperandStart())
-            expression = new ManagedFtsAndNode(expression, ParsePrimary());
+        {
+            var right = ParsePrimary();
+            expression = expression switch
+            {
+                ManagedFtsOmittedNode => right,
+                _ when right is ManagedFtsOmittedNode => expression,
+                _ => new ManagedFtsAndNode(expression, right),
+            };
+        }
 
         return expression;
     }
@@ -223,12 +243,13 @@ internal sealed class ManagedFtsQueryLanguage
             return ParseNear(column);
 
         var anchored = TryRead('^');
+        if (_syntax == ManagedFtsQuerySyntax.SqliteFts5)
+            return ParseFts5Phrase(column, anchored);
+
         if (TryRead('"'))
             return ParsePhrase(column, anchored);
 
-        var term = _syntax == ManagedFtsQuerySyntax.SqliteFts5
-            ? ReadFts5Bareword()
-            : ReadWord();
+        var term = ReadWord();
         if (term.Length == 0)
             throw Error("Expected an FTS term.");
 
@@ -289,7 +310,10 @@ internal sealed class ManagedFtsQueryLanguage
             terms[index] = tokens[index];
         }
 
-        return new ManagedFtsPhraseNode(terms, IsPrefix: false, column, anchored);
+        return new ManagedFtsPhraseNode(
+            terms.Select(static term => new ManagedFtsPhraseTerm(term, IsPrefix: false)).ToArray(),
+            column,
+            anchored);
     }
 
     private ManagedFtsNode ParseNear(string? column)
@@ -351,7 +375,10 @@ internal sealed class ManagedFtsQueryLanguage
             throw Error("NEAR requires at least two terms.");
 
         return new ManagedFtsNearNode(
-            terms.Select(static term => new ManagedFtsNearPhrase([term], IsPrefix: false)).ToArray(),
+            terms
+                .Select(static term => new ManagedFtsNearPhrase(
+                    [new ManagedFtsPhraseTerm(term, IsPrefix: false)]))
+                .ToArray(),
             distance,
             column);
     }
@@ -363,6 +390,7 @@ internal sealed class ManagedFtsQueryLanguage
 
         var distance = 10;
         var phrases = new List<ManagedFtsNearPhrase>();
+        var operandCount = 0;
         while (true)
         {
             SkipWhitespace();
@@ -388,20 +416,57 @@ internal sealed class ManagedFtsQueryLanguage
                 break;
             }
 
-            phrases.Add(ParseFts5NearPhrase());
+            var phrase = ParseFts5NearPhrase();
+            operandCount++;
+            if (phrase.Terms.Count != 0)
+                phrases.Add(phrase);
         }
 
+        if (operandCount == 0)
+            throw Error("NEAR requires at least one phrase.");
         if (phrases.Count == 0)
-            throw Error("NEAR requires at least one term.");
+            return new ManagedFtsOmittedNode();
 
         return new ManagedFtsNearNode(phrases, distance, column, SqliteDistance: true);
     }
 
     private ManagedFtsNearPhrase ParseFts5NearPhrase()
     {
-        var phraseText = TryRead('"') ? ReadQuotedText() : ReadFts5Bareword();
-        if (phraseText.Length == 0)
-            throw Error("Expected an FTS phrase inside NEAR.");
+        var terms = ParseFts5PhraseAtom();
+        while (TryRead('+'))
+            terms.AddRange(ParseFts5PhraseAtom());
+
+        return new ManagedFtsNearPhrase(terms);
+    }
+
+    private ManagedFtsNode ParseFts5Phrase(string? column, bool anchored)
+    {
+        var terms = ParseFts5PhraseAtom();
+        while (TryRead('+'))
+            terms.AddRange(ParseFts5PhraseAtom());
+
+        return terms.Count switch
+        {
+            0 => new ManagedFtsOmittedNode(),
+            1 => new ManagedFtsTermNode(terms[0].Text, terms[0].IsPrefix, column, anchored),
+            _ => new ManagedFtsPhraseNode(terms, column, anchored),
+        };
+    }
+
+    private List<ManagedFtsPhraseTerm> ParseFts5PhraseAtom()
+    {
+        var quoted = TryRead('"');
+        if (!quoted
+            && (IsKeywordAtOffset("AND")
+                || IsKeywordAtOffset("OR")
+                || IsKeywordAtOffset("NOT")))
+        {
+            throw Error("Expected an FTS phrase.");
+        }
+
+        var phraseText = quoted ? ReadQuotedText() : ReadFts5Bareword();
+        if (!quoted && phraseText.Length == 0)
+            throw Error("Expected an FTS phrase.");
 
         var prefix = TryRead('*') && !_options.IsGramTokenizer;
         if (TryRead('*'))
@@ -409,22 +474,18 @@ internal sealed class ManagedFtsQueryLanguage
 
         var tokens = ManagedFtsTokenization.TokenizeQueryText(phraseText, _options);
         if (tokens.Count == 0)
+            return [];
+
+        var terms = new List<ManagedFtsPhraseTerm>(tokens.Count);
+        for (var index = 0; index < tokens.Count; index++)
         {
             CountTerm();
-            return new ManagedFtsNearPhrase(
-                [ManagedFtsTokenization.NormalizeTerm(phraseText, _options)],
-                prefix);
+            terms.Add(new ManagedFtsPhraseTerm(
+                tokens[index],
+                prefix && index == tokens.Count - 1));
         }
 
-        var terms = new string[tokens.Count];
-        var index = 0;
-        foreach (var token in tokens)
-        {
-            CountTerm();
-            terms[index++] = token;
-        }
-
-        return new ManagedFtsNearPhrase(terms, prefix);
+        return terms;
     }
 
     private ManagedFtsNode ParsePhrase(string? column, bool anchored)
@@ -452,7 +513,14 @@ internal sealed class ManagedFtsQueryLanguage
             terms[index] = tokens[index];
         }
 
-        return new ManagedFtsPhraseNode(terms, prefix, column, anchored);
+        return new ManagedFtsPhraseNode(
+            terms
+                .Select((term, index) => new ManagedFtsPhraseTerm(
+                    term,
+                    prefix && index == terms.Length - 1))
+                .ToArray(),
+            column,
+            anchored);
     }
 
     private string? TryReadColumnPrefix()
@@ -588,6 +656,9 @@ internal sealed class ManagedFtsQueryLanguage
         => _syntax == ManagedFtsQuerySyntax.SqliteFts5
             ? IsFts5BarewordCharacter(value)
             : IsWordChar(value);
+
+    private static ManagedFtsNode NormalizeOmitted(ManagedFtsNode node)
+        => node is ManagedFtsOmittedNode ? new ManagedFtsNoMatchNode() : node;
 
     /// <summary>
     /// The characters that can continue a bare term. This must agree with <see cref="ReadWord"/>

--- a/src/Ahtola.Core/Search/ManagedFtsQueryLanguage.cs
+++ b/src/Ahtola.Core/Search/ManagedFtsQueryLanguage.cs
@@ -31,20 +31,37 @@ internal static class ManagedFtsLimits
     public const int MaxHighlightPrefixTerms = 64;
 }
 
+/// <summary>Selects the query grammar exposed by the managed search surface.</summary>
+internal enum ManagedFtsQuerySyntax
+{
+    Managed,
+    SqliteFts5,
+}
+
 /// <summary>The extended managed FTS query grammar used by method indexes and managed FTS5.</summary>
 /// <remarks>
 /// A superset of <see cref="ManagedFtsQueryParser"/>. The additions are column filters
-/// (<c>col:term</c>), initial-token anchors (<c>^term</c>) and <c>NEAR/n(a b)</c>.
+/// (<c>col:term</c>), initial-token anchors (<c>^term</c>) and bounded proximity groups.
 /// </remarks>
 internal abstract record ManagedFtsNode;
+
+internal sealed record ManagedFtsNoMatchNode : ManagedFtsNode;
 
 internal sealed record ManagedFtsTermNode(string Text, bool IsPrefix, string? Column, bool AnchoredAtStart)
     : ManagedFtsNode;
 
-internal sealed record ManagedFtsPhraseNode(IReadOnlyList<string> Terms, string? Column, bool AnchoredAtStart)
+internal sealed record ManagedFtsPhraseNode(
+    IReadOnlyList<string> Terms,
+    bool IsPrefix,
+    string? Column,
+    bool AnchoredAtStart)
     : ManagedFtsNode;
 
-internal sealed record ManagedFtsNearNode(IReadOnlyList<string> Terms, int Distance, string? Column)
+internal sealed record ManagedFtsNearNode(
+    IReadOnlyList<string> Terms,
+    int Distance,
+    string? Column,
+    bool SqliteDistance = false)
     : ManagedFtsNode;
 
 internal sealed record ManagedFtsAndNode(ManagedFtsNode Left, ManagedFtsNode Right) : ManagedFtsNode;
@@ -63,6 +80,7 @@ internal sealed class ManagedFtsQueryLanguage
     private readonly string _text;
     private readonly ManagedFtsTokenizerOptions _options;
     private readonly Func<string, bool> _isKnownColumn;
+    private readonly ManagedFtsQuerySyntax _syntax;
     private int _offset;
     private int _depth;
     private int _termCount;
@@ -70,17 +88,20 @@ internal sealed class ManagedFtsQueryLanguage
     private ManagedFtsQueryLanguage(
         string text,
         ManagedFtsTokenizerOptions options,
-        Func<string, bool> isKnownColumn)
+        Func<string, bool> isKnownColumn,
+        ManagedFtsQuerySyntax syntax)
     {
         _text = text;
         _options = options;
         _isKnownColumn = isKnownColumn;
+        _syntax = syntax;
     }
 
     public static ManagedFtsNode Parse(
         string query,
         ManagedFtsTokenizerOptions options,
-        Func<string, bool> isKnownColumn)
+        Func<string, bool> isKnownColumn,
+        ManagedFtsQuerySyntax syntax = ManagedFtsQuerySyntax.Managed)
     {
         ArgumentNullException.ThrowIfNull(query);
         ArgumentNullException.ThrowIfNull(options);
@@ -88,7 +109,7 @@ internal sealed class ManagedFtsQueryLanguage
         if (query.AsSpan().Trim().Length == 0)
             throw new EmbeddedSqlException("fts query is empty");
 
-        var parser = new ManagedFtsQueryLanguage(query, options, isKnownColumn);
+        var parser = new ManagedFtsQueryLanguage(query, options, isKnownColumn, syntax);
         var node = parser.ParseOr();
         parser.ExpectEnd();
         return node;
@@ -97,46 +118,95 @@ internal sealed class ManagedFtsQueryLanguage
     private ManagedFtsNode ParseOr()
     {
         using var _ = Descend();
-        var expression = ParseAnd();
+        var expression = _syntax == ManagedFtsQuerySyntax.SqliteFts5
+            ? ParseFts5ExplicitAnd()
+            : ParseManagedAnd();
         while (TryReadKeyword("OR"))
-            expression = new ManagedFtsOrNode(expression, ParseAnd());
+        {
+            expression = new ManagedFtsOrNode(
+                expression,
+                _syntax == ManagedFtsQuerySyntax.SqliteFts5
+                    ? ParseFts5ExplicitAnd()
+                    : ParseManagedAnd());
+        }
 
         return expression;
     }
 
-    private ManagedFtsNode ParseAnd()
+    private ManagedFtsNode ParseManagedAnd()
     {
         using var _ = Descend();
-        var expression = ParseUnary();
+        var expression = ParseManagedUnary();
         while (true)
         {
             if (TryReadKeyword("AND"))
             {
-                expression = new ManagedFtsAndNode(expression, ParseUnary());
+                expression = new ManagedFtsAndNode(expression, ParseManagedUnary());
                 continue;
             }
 
             if (!IsOperandStart())
                 return expression;
 
-            expression = new ManagedFtsAndNode(expression, ParseUnary());
+            expression = new ManagedFtsAndNode(expression, ParseManagedUnary());
         }
     }
 
-    private ManagedFtsNode ParseUnary()
+    private ManagedFtsNode ParseManagedUnary()
     {
         using var _ = Descend();
         SkipWhitespace();
         if (TryReadKeyword("NOT") || TryRead('-'))
-            return new ManagedFtsNotNode(ParseUnary());
+            return new ManagedFtsNotNode(ParseManagedUnary());
 
         return ParsePrimary();
+    }
+
+    private ManagedFtsNode ParseFts5ExplicitAnd()
+    {
+        using var _ = Descend();
+        var expression = ParseFts5Not();
+        while (TryReadKeyword("AND"))
+            expression = new ManagedFtsAndNode(expression, ParseFts5Not());
+
+        return expression;
+    }
+
+    private ManagedFtsNode ParseFts5Not()
+    {
+        using var _ = Descend();
+        var expression = ParseFts5ImplicitAnd();
+        while (TryReadKeyword("NOT"))
+        {
+            expression = new ManagedFtsAndNode(
+                expression,
+                new ManagedFtsNotNode(ParseFts5ImplicitAnd()));
+        }
+
+        return expression;
+    }
+
+    private ManagedFtsNode ParseFts5ImplicitAnd()
+    {
+        using var _ = Descend();
+        var expression = ParsePrimary();
+        while (IsFts5ImplicitOperandStart())
+            expression = new ManagedFtsAndNode(expression, ParsePrimary());
+
+        return expression;
     }
 
     private ManagedFtsNode ParsePrimary()
     {
         using var _ = Descend();
         SkipWhitespace();
+        if (_syntax == ManagedFtsQuerySyntax.SqliteFts5
+            && (IsKeywordAtOffset("AND")
+                || IsKeywordAtOffset("OR")
+                || IsKeywordAtOffset("NOT")))
+        {
+            throw Error("Expected an FTS term.");
+        }
         if (TryRead('('))
         {
             var expression = ParseOr();
@@ -214,12 +284,19 @@ internal sealed class ManagedFtsQueryLanguage
             terms[index] = tokens[index];
         }
 
-        return new ManagedFtsPhraseNode(terms, column, anchored);
+        return new ManagedFtsPhraseNode(terms, IsPrefix: false, column, anchored);
     }
 
     private ManagedFtsNode ParseNear(string? column)
     {
         _offset += "NEAR".Length;
+        return _syntax == ManagedFtsQuerySyntax.SqliteFts5
+            ? ParseFts5Near(column)
+            : ParseManagedNear(column);
+    }
+
+    private ManagedFtsNode ParseManagedNear(string? column)
+    {
         var distance = 10;
         if (TryRead('/'))
         {
@@ -271,6 +348,67 @@ internal sealed class ManagedFtsQueryLanguage
         return new ManagedFtsNearNode(terms, distance, column);
     }
 
+    private ManagedFtsNode ParseFts5Near(string? column)
+    {
+        if (!TryRead('('))
+            throw Error("Expected '(' after NEAR.");
+
+        var distance = 10;
+        var terms = new List<string>();
+        while (true)
+        {
+            SkipWhitespace();
+            if (TryRead(')'))
+                break;
+            if (TryRead(','))
+            {
+                var digits = ReadDigits();
+                if (digits.Length == 0
+                    || !int.TryParse(
+                        digits,
+                        System.Globalization.NumberStyles.None,
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        out distance)
+                    || distance < 0
+                    || distance > ManagedFtsLimits.MaxNearDistance)
+                {
+                    throw Error($"NEAR distance must be between 0 and {ManagedFtsLimits.MaxNearDistance}.");
+                }
+                if (!TryRead(')'))
+                    throw Error("Expected ')' after NEAR distance.");
+                break;
+            }
+
+            var word = ReadNearWord();
+            if (word.Length == 0)
+                throw Error("Expected an FTS term inside NEAR.");
+
+            AddNearTokens(terms, word);
+        }
+
+        if (terms.Count == 0)
+            throw Error("NEAR requires at least one term.");
+
+        return new ManagedFtsNearNode(terms, distance, column, SqliteDistance: true);
+    }
+
+    private void AddNearTokens(List<string> terms, string word)
+    {
+        var tokens = ManagedFtsTokenization.TokenizeQueryText(word, _options);
+        if (tokens.Count == 0)
+        {
+            CountTerm();
+            terms.Add(ManagedFtsTokenization.NormalizeTerm(word, _options));
+            return;
+        }
+
+        foreach (var token in tokens)
+        {
+            CountTerm();
+            terms.Add(token);
+        }
+    }
+
     private ManagedFtsNode ParsePhrase(string? column, bool anchored)
     {
         var start = _offset;
@@ -283,7 +421,8 @@ internal sealed class ManagedFtsQueryLanguage
         var phraseText = _text[start.._offset];
         _offset++;
 
-        if (TryRead('*'))
+        var prefix = TryRead('*');
+        if (prefix && _syntax != ManagedFtsQuerySyntax.SqliteFts5)
             throw Error("A prefix wildcard is valid only after an unquoted FTS term.");
 
         var tokens = ManagedFtsTokenization.TokenizeQueryText(phraseText, _options);
@@ -293,7 +432,7 @@ internal sealed class ManagedFtsQueryLanguage
         if (tokens.Count == 1)
         {
             CountTerm();
-            return new ManagedFtsTermNode(tokens[0], IsPrefix: false, column, anchored);
+            return new ManagedFtsTermNode(tokens[0], prefix, column, anchored);
         }
 
         var terms = new string[tokens.Count];
@@ -303,7 +442,7 @@ internal sealed class ManagedFtsQueryLanguage
             terms[index] = tokens[index];
         }
 
-        return new ManagedFtsPhraseNode(terms, column, anchored);
+        return new ManagedFtsPhraseNode(terms, prefix, column, anchored);
     }
 
     private string? TryReadColumnPrefix()
@@ -333,6 +472,17 @@ internal sealed class ManagedFtsQueryLanguage
         return !IsKeywordAtOffset("OR");
     }
 
+    private bool IsFts5ImplicitOperandStart()
+    {
+        SkipWhitespace();
+        if (_offset >= _text.Length || _text[_offset] == ')')
+            return false;
+
+        return !IsKeywordAtOffset("AND")
+            && !IsKeywordAtOffset("OR")
+            && !IsKeywordAtOffset("NOT");
+    }
+
     private string ReadWord()
     {
         SkipWhitespace();
@@ -340,6 +490,20 @@ internal sealed class ManagedFtsQueryLanguage
         while (_offset < _text.Length
             && !char.IsWhiteSpace(_text[_offset])
             && _text[_offset] is not ('(' or ')' or '"' or '*' or '-' or ':' or '^'))
+        {
+            _offset++;
+        }
+
+        return _text[start.._offset];
+    }
+
+    private string ReadNearWord()
+    {
+        SkipWhitespace();
+        var start = _offset;
+        while (_offset < _text.Length
+            && !char.IsWhiteSpace(_text[_offset])
+            && _text[_offset] is not ('(' or ')' or '"' or '*' or '-' or ':' or '^' or ','))
         {
             _offset++;
         }

--- a/src/Ahtola.Core/Search/ManagedFtsQueryLanguage.cs
+++ b/src/Ahtola.Core/Search/ManagedFtsQueryLanguage.cs
@@ -57,8 +57,10 @@ internal sealed record ManagedFtsPhraseNode(
     bool AnchoredAtStart)
     : ManagedFtsNode;
 
+internal sealed record ManagedFtsNearPhrase(IReadOnlyList<string> Terms, bool IsPrefix);
+
 internal sealed record ManagedFtsNearNode(
-    IReadOnlyList<string> Terms,
+    IReadOnlyList<ManagedFtsNearPhrase> Phrases,
     int Distance,
     string? Column,
     bool SqliteDistance = false)
@@ -216,14 +218,17 @@ internal sealed class ManagedFtsQueryLanguage
         }
 
         var column = TryReadColumnPrefix();
-        if (IsKeywordAtOffset("NEAR"))
+        if (IsKeywordAtOffset("NEAR")
+            && (_syntax != ManagedFtsQuerySyntax.SqliteFts5 || IsFts5NearAtOffset()))
             return ParseNear(column);
 
         var anchored = TryRead('^');
         if (TryRead('"'))
             return ParsePhrase(column, anchored);
 
-        var term = ReadWord();
+        var term = _syntax == ManagedFtsQuerySyntax.SqliteFts5
+            ? ReadFts5Bareword()
+            : ReadWord();
         if (term.Length == 0)
             throw Error("Expected an FTS term.");
 
@@ -345,7 +350,10 @@ internal sealed class ManagedFtsQueryLanguage
         if (terms.Count < 2)
             throw Error("NEAR requires at least two terms.");
 
-        return new ManagedFtsNearNode(terms, distance, column);
+        return new ManagedFtsNearNode(
+            terms.Select(static term => new ManagedFtsNearPhrase([term], IsPrefix: false)).ToArray(),
+            distance,
+            column);
     }
 
     private ManagedFtsNode ParseFts5Near(string? column)
@@ -354,7 +362,7 @@ internal sealed class ManagedFtsQueryLanguage
             throw Error("Expected '(' after NEAR.");
 
         var distance = 10;
-        var terms = new List<string>();
+        var phrases = new List<ManagedFtsNearPhrase>();
         while (true)
         {
             SkipWhitespace();
@@ -362,6 +370,7 @@ internal sealed class ManagedFtsQueryLanguage
                 break;
             if (TryRead(','))
             {
+                SkipWhitespace();
                 var digits = ReadDigits();
                 if (digits.Length == 0
                     || !int.TryParse(
@@ -379,47 +388,48 @@ internal sealed class ManagedFtsQueryLanguage
                 break;
             }
 
-            var word = ReadNearWord();
-            if (word.Length == 0)
-                throw Error("Expected an FTS term inside NEAR.");
-
-            AddNearTokens(terms, word);
+            phrases.Add(ParseFts5NearPhrase());
         }
 
-        if (terms.Count == 0)
+        if (phrases.Count == 0)
             throw Error("NEAR requires at least one term.");
 
-        return new ManagedFtsNearNode(terms, distance, column, SqliteDistance: true);
+        return new ManagedFtsNearNode(phrases, distance, column, SqliteDistance: true);
     }
 
-    private void AddNearTokens(List<string> terms, string word)
+    private ManagedFtsNearPhrase ParseFts5NearPhrase()
     {
-        var tokens = ManagedFtsTokenization.TokenizeQueryText(word, _options);
+        var phraseText = TryRead('"') ? ReadQuotedText() : ReadFts5Bareword();
+        if (phraseText.Length == 0)
+            throw Error("Expected an FTS phrase inside NEAR.");
+
+        var prefix = TryRead('*') && !_options.IsGramTokenizer;
+        if (TryRead('*'))
+            throw Error("An FTS prefix term can contain only one trailing '*'.");
+
+        var tokens = ManagedFtsTokenization.TokenizeQueryText(phraseText, _options);
         if (tokens.Count == 0)
         {
             CountTerm();
-            terms.Add(ManagedFtsTokenization.NormalizeTerm(word, _options));
-            return;
+            return new ManagedFtsNearPhrase(
+                [ManagedFtsTokenization.NormalizeTerm(phraseText, _options)],
+                prefix);
         }
 
+        var terms = new string[tokens.Count];
+        var index = 0;
         foreach (var token in tokens)
         {
             CountTerm();
-            terms.Add(token);
+            terms[index++] = token;
         }
+
+        return new ManagedFtsNearPhrase(terms, prefix);
     }
 
     private ManagedFtsNode ParsePhrase(string? column, bool anchored)
     {
-        var start = _offset;
-        while (_offset < _text.Length && _text[_offset] != '"')
-            _offset++;
-
-        if (_offset == _text.Length)
-            throw Error("Unterminated FTS phrase.");
-
-        var phraseText = _text[start.._offset];
-        _offset++;
+        var phraseText = ReadQuotedText();
 
         var prefix = TryRead('*');
         if (prefix && _syntax != ManagedFtsQuerySyntax.SqliteFts5)
@@ -497,18 +507,43 @@ internal sealed class ManagedFtsQueryLanguage
         return _text[start.._offset];
     }
 
-    private string ReadNearWord()
+    private string ReadFts5Bareword()
     {
         SkipWhitespace();
         var start = _offset;
-        while (_offset < _text.Length
-            && !char.IsWhiteSpace(_text[_offset])
-            && _text[_offset] is not ('(' or ')' or '"' or '*' or '-' or ':' or '^' or ','))
-        {
+        while (_offset < _text.Length && IsFts5BarewordCharacter(_text[_offset]))
             _offset++;
-        }
 
         return _text[start.._offset];
+    }
+
+    private string ReadQuotedText()
+    {
+        var start = _offset;
+        while (_offset < _text.Length)
+        {
+            if (_text[_offset] != '"')
+            {
+                _offset++;
+                continue;
+            }
+
+            if (_syntax == ManagedFtsQuerySyntax.SqliteFts5
+                && _offset + 1 < _text.Length
+                && _text[_offset + 1] == '"')
+            {
+                _offset += 2;
+                continue;
+            }
+
+            var phraseText = _text[start.._offset];
+            if (_syntax == ManagedFtsQuerySyntax.SqliteFts5)
+                phraseText = phraseText.Replace("\"\"", "\"", StringComparison.Ordinal);
+            _offset++;
+            return phraseText;
+        }
+
+        throw Error("Unterminated FTS phrase.");
     }
 
     private string ReadDigits()
@@ -532,9 +567,27 @@ internal sealed class ManagedFtsQueryLanguage
 
     private bool IsKeywordAtOffset(string keyword)
         => _offset + keyword.Length <= _text.Length
-            && _text.AsSpan(_offset, keyword.Length).Equals(keyword, StringComparison.OrdinalIgnoreCase)
+            && _text.AsSpan(_offset, keyword.Length).Equals(
+                keyword,
+                _syntax == ManagedFtsQuerySyntax.SqliteFts5
+                    ? StringComparison.Ordinal
+                    : StringComparison.OrdinalIgnoreCase)
             && (_offset + keyword.Length == _text.Length
-                || !IsWordChar(_text[_offset + keyword.Length]));
+                || !IsKeywordContinuation(_text[_offset + keyword.Length]));
+
+    private bool IsFts5NearAtOffset()
+    {
+        var next = _offset + "NEAR".Length;
+        while (next < _text.Length && char.IsWhiteSpace(_text[next]))
+            next++;
+
+        return next < _text.Length && _text[next] == '(';
+    }
+
+    private bool IsKeywordContinuation(char value)
+        => _syntax == ManagedFtsQuerySyntax.SqliteFts5
+            ? IsFts5BarewordCharacter(value)
+            : IsWordChar(value);
 
     /// <summary>
     /// The characters that can continue a bare term. This must agree with <see cref="ReadWord"/>
@@ -543,6 +596,12 @@ internal sealed class ManagedFtsQueryLanguage
     /// followed by <c>_A_TERM</c> instead of the single term the tokenizer will actually produce.
     /// </summary>
     private static bool IsWordChar(char value) => char.IsLetterOrDigit(value) || value == '_';
+
+    private static bool IsFts5BarewordCharacter(char value)
+        => char.IsAsciiLetterOrDigit(value)
+            || value == '_'
+            || value == '\u001A'
+            || value > '\u007F';
 
     private bool TryRead(char value)
     {

--- a/src/Ahtola.Core/Search/ManagedFtsQueryLanguage.cs
+++ b/src/Ahtola.Core/Search/ManagedFtsQueryLanguage.cs
@@ -418,32 +418,29 @@ internal sealed class ManagedFtsQueryLanguage
 
             var phrase = ParseFts5NearPhrase();
             operandCount++;
-            if (phrase.Terms.Count != 0)
-                phrases.Add(phrase);
+            if (phrase.Count != 0)
+                phrases.Add(new ManagedFtsNearPhrase(phrase));
         }
 
         if (operandCount == 0)
             throw Error("NEAR requires at least one phrase.");
         if (phrases.Count == 0)
             return new ManagedFtsOmittedNode();
+        if (phrases.Count == 1 && phrases[0].Terms.Count == 1)
+        {
+            var term = phrases[0].Terms[0];
+            return new ManagedFtsTermNode(term.Text, term.IsPrefix, column, AnchoredAtStart: false);
+        }
 
         return new ManagedFtsNearNode(phrases, distance, column, SqliteDistance: true);
     }
 
-    private ManagedFtsNearPhrase ParseFts5NearPhrase()
-    {
-        var terms = ParseFts5PhraseAtom();
-        while (TryRead('+'))
-            terms.AddRange(ParseFts5PhraseAtom());
-
-        return new ManagedFtsNearPhrase(terms);
-    }
+    private IReadOnlyList<ManagedFtsPhraseTerm> ParseFts5NearPhrase()
+        => ParseFts5ConcatenatedPhrase();
 
     private ManagedFtsNode ParseFts5Phrase(string? column, bool anchored)
     {
-        var terms = ParseFts5PhraseAtom();
-        while (TryRead('+'))
-            terms.AddRange(ParseFts5PhraseAtom());
+        var terms = ParseFts5ConcatenatedPhrase();
 
         return terms.Count switch
         {
@@ -453,7 +450,27 @@ internal sealed class ManagedFtsQueryLanguage
         };
     }
 
-    private List<ManagedFtsPhraseTerm> ParseFts5PhraseAtom()
+    private List<ManagedFtsPhraseTerm> ParseFts5ConcatenatedPhrase()
+    {
+        var firstAtom = ParseFts5PhraseAtom();
+        var terms = firstAtom.Terms;
+        while (TryRead('+'))
+        {
+            var atom = ParseFts5PhraseAtom();
+            if (atom.Terms.Count == 0 && terms.Count != 0)
+            {
+                terms[^1] = terms[^1] with { IsPrefix = atom.IsPrefix };
+            }
+            else
+            {
+                terms.AddRange(atom.Terms);
+            }
+        }
+
+        return terms;
+    }
+
+    private ParsedFts5PhraseAtom ParseFts5PhraseAtom()
     {
         var quoted = TryRead('"');
         if (!quoted
@@ -474,7 +491,7 @@ internal sealed class ManagedFtsQueryLanguage
 
         var tokens = ManagedFtsTokenization.TokenizeQueryText(phraseText, _options);
         if (tokens.Count == 0)
-            return [];
+            return new ParsedFts5PhraseAtom([], prefix);
 
         var terms = new List<ManagedFtsPhraseTerm>(tokens.Count);
         for (var index = 0; index < tokens.Count; index++)
@@ -485,8 +502,12 @@ internal sealed class ManagedFtsQueryLanguage
                 prefix && index == tokens.Count - 1));
         }
 
-        return terms;
+        return new ParsedFts5PhraseAtom(terms, prefix);
     }
+
+    private readonly record struct ParsedFts5PhraseAtom(
+        List<ManagedFtsPhraseTerm> Terms,
+        bool IsPrefix);
 
     private ManagedFtsNode ParsePhrase(string? column, bool anchored)
     {

--- a/src/Ahtola.Core/Search/ManagedFtsQueryLanguage.cs
+++ b/src/Ahtola.Core/Search/ManagedFtsQueryLanguage.cs
@@ -31,11 +31,10 @@ internal static class ManagedFtsLimits
     public const int MaxHighlightPrefixTerms = 64;
 }
 
-/// <summary>The extended managed FTS query grammar used by method indexes.</summary>
+/// <summary>The extended managed FTS query grammar used by method indexes and managed FTS5.</summary>
 /// <remarks>
-/// A superset of <see cref="ManagedFtsQueryParser"/>, which stays untouched for the shipped
-/// <c>fts5</c> virtual table. The additions are column filters (<c>col:term</c>), initial-token
-/// anchors (<c>^term</c>) and <c>NEAR/n(a b)</c>.
+/// A superset of <see cref="ManagedFtsQueryParser"/>. The additions are column filters
+/// (<c>col:term</c>), initial-token anchors (<c>^term</c>) and <c>NEAR/n(a b)</c>.
 /// </remarks>
 internal abstract record ManagedFtsNode;
 

--- a/src/Ahtola.Core/Search/ManagedFtsSearchIndex.cs
+++ b/src/Ahtola.Core/Search/ManagedFtsSearchIndex.cs
@@ -553,24 +553,14 @@ internal sealed class ManagedFtsSearchIndex
     {
         RequirePositions("phrase");
         var columnMask = ResolveColumnMask(phrase.Column);
-        if (phrase.IsPrefix)
-        {
-            return EvaluatePrefixPhrase(
-                phrase,
-                accumulator,
-                columnWeights,
-                columnMask,
-                includedRowFrequencies);
-        }
-
         var candidates = new List<ScoreCandidate>();
         var matches = new HashSet<long>();
-        foreach (var rowId in IntersectTerms(phrase.Terms))
+        var nearPhrase = new ManagedFtsNearPhrase(phrase.Terms);
+        foreach (var rowId in FindPhraseCandidates(nearPhrase))
         {
             var frequencies = CountPhraseByColumn(
                 rowId,
                 phrase.Terms,
-                isPrefix: false,
                 columnMask,
                 phrase.AnchoredAtStart);
             var candidate = CreateFrequencyCandidate(rowId, frequencies);
@@ -587,45 +577,6 @@ internal sealed class ManagedFtsSearchIndex
         return matches;
     }
 
-    private HashSet<long> EvaluatePrefixPhrase(
-        ManagedFtsPhraseNode phrase,
-        Dictionary<long, double>? accumulator,
-        IReadOnlyList<double> columnWeights,
-        uint columnMask,
-        IReadOnlyDictionary<long, int[]>? includedRowFrequencies)
-    {
-        var candidates = new List<ScoreCandidate>();
-        var matches = new HashSet<long>();
-        var nearPhrase = new ManagedFtsNearPhrase(phrase.Terms, IsPrefix: true);
-        foreach (var rowId in FindPhraseCandidates(nearPhrase))
-        {
-            var frequencies = CountPhraseByColumn(
-                rowId,
-                phrase.Terms,
-                isPrefix: true,
-                columnMask,
-                phrase.AnchoredAtStart);
-            var candidate = CreateFrequencyCandidate(rowId, frequencies);
-            if (candidate.Frequency == 0)
-                continue;
-
-            matches.Add(rowId);
-            candidates.Add(candidate);
-        }
-
-        if (accumulator is not null)
-        {
-            Accumulate(
-                accumulator,
-                candidates,
-                columnMask,
-                columnWeights,
-                includedRowFrequencies);
-        }
-
-        return matches;
-    }
-
     private HashSet<long> EvaluateNear(
         ManagedFtsNearNode near,
         Dictionary<long, double>? accumulator,
@@ -636,7 +587,10 @@ internal sealed class ManagedFtsSearchIndex
         if (near.SqliteDistance)
             return EvaluateSqliteNear(near, accumulator, columnWeights, columnMask);
 
-        var terms = near.Phrases.SelectMany(static phrase => phrase.Terms).ToArray();
+        var terms = near.Phrases
+            .SelectMany(static phrase => phrase.Terms)
+            .Select(static term => term.Text)
+            .ToArray();
         var candidates = new List<ScoreCandidate>();
         var matches = new HashSet<long>();
         foreach (var rowId in IntersectTerms(terms))
@@ -697,7 +651,6 @@ internal sealed class ManagedFtsSearchIndex
             EvaluatePhrase(
                 new ManagedFtsPhraseNode(
                     phrase.Terms,
-                    phrase.IsPrefix,
                     near.Column,
                     AnchoredAtStart: false),
                 accumulator,
@@ -791,14 +744,14 @@ internal sealed class ManagedFtsSearchIndex
         for (var index = 0; index < phrase.Terms.Count; index++)
         {
             var termRows = new HashSet<long>();
-            var isPrefix = phrase.IsPrefix && index == phrase.Terms.Count - 1;
-            var terms = isPrefix
+            var phraseTerm = phrase.Terms[index];
+            var terms = phraseTerm.IsPrefix
                 ? ExpandTerm(new ManagedFtsTermNode(
-                    phrase.Terms[index],
+                    phraseTerm.Text,
                     IsPrefix: true,
                     Column: null,
                     AnchoredAtStart: false))
-                : [phrase.Terms[index]];
+                : [phraseTerm.Text];
             foreach (var term in terms)
             {
                 if (!_postings.TryGetValue(term, out var list))
@@ -835,14 +788,14 @@ internal sealed class ManagedFtsSearchIndex
         var streams = new long[phrase.Terms.Count][];
         for (var index = 0; index < phrase.Terms.Count; index++)
         {
-            var isPrefix = phrase.IsPrefix && index == phrase.Terms.Count - 1;
-            if (isPrefix)
+            var phraseTerm = phrase.Terms[index];
+            if (phraseTerm.IsPrefix)
             {
-                streams[index] = GetPrefixPositions(phrase.Terms[index], rowId);
+                streams[index] = GetPrefixPositions(phraseTerm.Text, rowId);
                 if (streams[index].Length == 0)
                     return [];
             }
-            else if (TryGetPositions(phrase.Terms[index], rowId, out var positions))
+            else if (TryGetPositions(phraseTerm.Text, rowId, out var positions))
             {
                 streams[index] = positions;
             }
@@ -930,15 +883,14 @@ internal sealed class ManagedFtsSearchIndex
 
     private int[] CountPhraseByColumn(
         long rowId,
-        IReadOnlyList<string> terms,
-        bool isPrefix,
+        IReadOnlyList<ManagedFtsPhraseTerm> terms,
         uint columnMask,
         bool anchored)
     {
         var frequencies = new int[_columnCount];
         foreach (var occurrence in GetPhraseOccurrences(
                      rowId,
-                     new ManagedFtsNearPhrase(terms, isPrefix),
+                     new ManagedFtsNearPhrase(terms),
                      columnMask,
                      anchored))
         {

--- a/src/Ahtola.Core/Search/ManagedFtsSearchIndex.cs
+++ b/src/Ahtola.Core/Search/ManagedFtsSearchIndex.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text;
 
 namespace Ahtola.Core.Search;
 
@@ -372,6 +373,7 @@ internal sealed class ManagedFtsSearchIndex
         IReadOnlyList<double> columnWeights)
         => node switch
         {
+            ManagedFtsNoMatchNode => [],
             ManagedFtsTermNode term => EvaluateTerm(term, accumulator, columnWeights),
             ManagedFtsPhraseNode phrase => EvaluatePhrase(phrase, accumulator, columnWeights),
             ManagedFtsNearNode near => EvaluateNear(near, accumulator, columnWeights),
@@ -550,6 +552,9 @@ internal sealed class ManagedFtsSearchIndex
     {
         RequirePositions("phrase");
         var columnMask = ResolveColumnMask(phrase.Column);
+        if (phrase.IsPrefix)
+            return EvaluatePrefixPhrase(phrase, accumulator, columnWeights, columnMask);
+
         var candidates = new List<ScoreCandidate>();
         var matches = new HashSet<long>();
         foreach (var rowId in IntersectTerms(phrase.Terms))
@@ -568,6 +573,49 @@ internal sealed class ManagedFtsSearchIndex
         return matches;
     }
 
+    private HashSet<long> EvaluatePrefixPhrase(
+        ManagedFtsPhraseNode phrase,
+        Dictionary<long, double>? accumulator,
+        IReadOnlyList<double> columnWeights,
+        uint columnMask)
+    {
+        var frequencies = new Dictionary<long, int>();
+        var terms = phrase.Terms.ToArray();
+        var prefix = new ManagedFtsTermNode(
+            terms[^1],
+            IsPrefix: true,
+            phrase.Column,
+            AnchoredAtStart: false);
+        foreach (var expanded in ExpandTerm(prefix))
+        {
+            terms[^1] = expanded;
+            foreach (var rowId in IntersectTerms(terms))
+            {
+                var frequency = CountPhrase(rowId, terms, columnMask, phrase.AnchoredAtStart);
+                if (frequency == 0)
+                    continue;
+
+                frequencies[rowId] = frequencies.TryGetValue(rowId, out var existing)
+                    ? existing + frequency
+                    : frequency;
+            }
+        }
+
+        var matches = new HashSet<long>(frequencies.Keys);
+        if (accumulator is not null)
+        {
+            Accumulate(
+                accumulator,
+                frequencies
+                    .Select(entry => new ScoreCandidate(entry.Key, entry.Value, [], [], columnMask))
+                    .ToList(),
+                columnMask,
+                columnWeights);
+        }
+
+        return matches;
+    }
+
     private HashSet<long> EvaluateNear(
         ManagedFtsNearNode near,
         Dictionary<long, double>? accumulator,
@@ -579,7 +627,9 @@ internal sealed class ManagedFtsSearchIndex
         var matches = new HashSet<long>();
         foreach (var rowId in IntersectTerms(near.Terms))
         {
-            var frequency = CountNear(rowId, near.Terms, near.Distance, columnMask);
+            var frequency = near.SqliteDistance
+                ? CountSqliteNear(rowId, near.Terms, near.Distance, columnMask)
+                : CountNear(rowId, near.Terms, near.Distance, columnMask);
             if (frequency == 0)
                 continue;
 
@@ -720,6 +770,73 @@ internal sealed class ManagedFtsSearchIndex
 
             if (matched)
                 count++;
+        }
+
+        return count;
+    }
+
+    private int CountSqliteNear(long rowId, IReadOnlyList<string> terms, int distance, uint columnMask)
+    {
+        var termIndices = new Dictionary<string, int>(StringComparer.Ordinal);
+        var requirements = new List<int>();
+        var streams = new List<long[]>();
+        foreach (var term in terms)
+        {
+            if (termIndices.TryGetValue(term, out var existing))
+            {
+                requirements[existing]++;
+                continue;
+            }
+            if (!TryGetPositions(term, rowId, out var positions))
+                return 0;
+
+            termIndices.Add(term, streams.Count);
+            streams.Add(positions);
+            requirements.Add(1);
+        }
+
+        var maximumSpan = checked(distance + 1);
+        var count = 0;
+        for (var column = 0; column < _columnCount; column++)
+        {
+            if ((columnMask & (1u << column)) == 0)
+                continue;
+
+            var events = new List<NearEvent>();
+            for (var termIndex = 0; termIndex < streams.Count; termIndex++)
+            {
+                var positions = streams[termIndex];
+                var start = LowerBound(positions, EncodePosition(column, 0));
+                while (start < positions.Length && (int)(positions[start] >> 32) == column)
+                {
+                    events.Add(new NearEvent((int)(positions[start] & 0xFFFFFFFFL), termIndex));
+                    start++;
+                }
+            }
+
+            events.Sort(static (left, right)
+                => left.Position == right.Position
+                    ? left.TermIndex.CompareTo(right.TermIndex)
+                    : left.Position.CompareTo(right.Position));
+            var occurrences = new int[streams.Count];
+            var covered = 0;
+            var leftIndex = 0;
+            for (var rightIndex = 0; rightIndex < events.Count; rightIndex++)
+            {
+                var right = events[rightIndex];
+                if (++occurrences[right.TermIndex] == requirements[right.TermIndex])
+                    covered++;
+
+                while (covered == streams.Count)
+                {
+                    var left = events[leftIndex];
+                    if (right.Position - left.Position <= maximumSpan)
+                        count++;
+                    if (occurrences[left.TermIndex]-- == requirements[left.TermIndex])
+                        covered--;
+                    leftIndex++;
+                }
+            }
         }
 
         return count;
@@ -1142,7 +1259,7 @@ internal sealed class ManagedFtsSearchIndex
             SqlValueKind.Text => value.AsText(),
             SqlValueKind.Integer => value.AsInteger().ToString(CultureInfo.InvariantCulture),
             SqlValueKind.Real => value.AsReal().ToString("R", CultureInfo.InvariantCulture),
-            SqlValueKind.Blob => string.Empty,
+            SqlValueKind.Blob => Encoding.UTF8.GetString(value.AsBlob().Span),
             _ => string.Empty,
         };
 
@@ -1181,6 +1298,8 @@ internal sealed class ManagedFtsSearchIndex
         uint ColumnMask,
         long[] Positions,
         int[] ColumnFrequencies);
+
+    private readonly record struct NearEvent(int Position, int TermIndex);
 
     /// <summary>One document's contribution to a term's score, before BM25 is applied.</summary>
     private readonly record struct ScoreCandidate(

--- a/src/Ahtola.Core/Search/ManagedFtsSearchIndex.cs
+++ b/src/Ahtola.Core/Search/ManagedFtsSearchIndex.cs
@@ -548,27 +548,41 @@ internal sealed class ManagedFtsSearchIndex
     private HashSet<long> EvaluatePhrase(
         ManagedFtsPhraseNode phrase,
         Dictionary<long, double>? accumulator,
-        IReadOnlyList<double> columnWeights)
+        IReadOnlyList<double> columnWeights,
+        IReadOnlyDictionary<long, int[]>? includedRowFrequencies = null)
     {
         RequirePositions("phrase");
         var columnMask = ResolveColumnMask(phrase.Column);
         if (phrase.IsPrefix)
-            return EvaluatePrefixPhrase(phrase, accumulator, columnWeights, columnMask);
+        {
+            return EvaluatePrefixPhrase(
+                phrase,
+                accumulator,
+                columnWeights,
+                columnMask,
+                includedRowFrequencies);
+        }
 
         var candidates = new List<ScoreCandidate>();
         var matches = new HashSet<long>();
         foreach (var rowId in IntersectTerms(phrase.Terms))
         {
-            var frequency = CountPhrase(rowId, phrase.Terms, columnMask, phrase.AnchoredAtStart);
-            if (frequency == 0)
+            var frequencies = CountPhraseByColumn(
+                rowId,
+                phrase.Terms,
+                isPrefix: false,
+                columnMask,
+                phrase.AnchoredAtStart);
+            var candidate = CreateFrequencyCandidate(rowId, frequencies);
+            if (candidate.Frequency == 0)
                 continue;
 
             matches.Add(rowId);
-            candidates.Add(new ScoreCandidate(rowId, frequency, [], [], columnMask));
+            candidates.Add(candidate);
         }
 
         if (accumulator is not null)
-            Accumulate(accumulator, candidates, columnMask, columnWeights);
+            Accumulate(accumulator, candidates, columnMask, columnWeights, includedRowFrequencies);
 
         return matches;
     }
@@ -577,40 +591,36 @@ internal sealed class ManagedFtsSearchIndex
         ManagedFtsPhraseNode phrase,
         Dictionary<long, double>? accumulator,
         IReadOnlyList<double> columnWeights,
-        uint columnMask)
+        uint columnMask,
+        IReadOnlyDictionary<long, int[]>? includedRowFrequencies)
     {
-        var frequencies = new Dictionary<long, int>();
-        var terms = phrase.Terms.ToArray();
-        var prefix = new ManagedFtsTermNode(
-            terms[^1],
-            IsPrefix: true,
-            phrase.Column,
-            AnchoredAtStart: false);
-        foreach (var expanded in ExpandTerm(prefix))
+        var candidates = new List<ScoreCandidate>();
+        var matches = new HashSet<long>();
+        var nearPhrase = new ManagedFtsNearPhrase(phrase.Terms, IsPrefix: true);
+        foreach (var rowId in FindPhraseCandidates(nearPhrase))
         {
-            terms[^1] = expanded;
-            foreach (var rowId in IntersectTerms(terms))
-            {
-                var frequency = CountPhrase(rowId, terms, columnMask, phrase.AnchoredAtStart);
-                if (frequency == 0)
-                    continue;
+            var frequencies = CountPhraseByColumn(
+                rowId,
+                phrase.Terms,
+                isPrefix: true,
+                columnMask,
+                phrase.AnchoredAtStart);
+            var candidate = CreateFrequencyCandidate(rowId, frequencies);
+            if (candidate.Frequency == 0)
+                continue;
 
-                frequencies[rowId] = frequencies.TryGetValue(rowId, out var existing)
-                    ? existing + frequency
-                    : frequency;
-            }
+            matches.Add(rowId);
+            candidates.Add(candidate);
         }
 
-        var matches = new HashSet<long>(frequencies.Keys);
         if (accumulator is not null)
         {
             Accumulate(
                 accumulator,
-                frequencies
-                    .Select(entry => new ScoreCandidate(entry.Key, entry.Value, [], [], columnMask))
-                    .ToList(),
+                candidates,
                 columnMask,
-                columnWeights);
+                columnWeights,
+                includedRowFrequencies);
         }
 
         return matches;
@@ -623,13 +633,15 @@ internal sealed class ManagedFtsSearchIndex
     {
         RequirePositions("NEAR");
         var columnMask = ResolveColumnMask(near.Column);
+        if (near.SqliteDistance)
+            return EvaluateSqliteNear(near, accumulator, columnWeights, columnMask);
+
+        var terms = near.Phrases.SelectMany(static phrase => phrase.Terms).ToArray();
         var candidates = new List<ScoreCandidate>();
         var matches = new HashSet<long>();
-        foreach (var rowId in IntersectTerms(near.Terms))
+        foreach (var rowId in IntersectTerms(terms))
         {
-            var frequency = near.SqliteDistance
-                ? CountSqliteNear(rowId, near.Terms, near.Distance, columnMask)
-                : CountNear(rowId, near.Terms, near.Distance, columnMask);
+            var frequency = CountNear(rowId, terms, near.Distance, columnMask);
             if (frequency == 0)
                 continue;
 
@@ -639,6 +651,59 @@ internal sealed class ManagedFtsSearchIndex
 
         if (accumulator is not null)
             Accumulate(accumulator, candidates, columnMask, columnWeights);
+
+        return matches;
+    }
+
+    private HashSet<long> EvaluateSqliteNear(
+        ManagedFtsNearNode near,
+        Dictionary<long, double>? accumulator,
+        IReadOnlyList<double> columnWeights,
+        uint columnMask)
+    {
+        var matches = new HashSet<long>();
+        var matchedPhraseFrequencies = Enumerable
+            .Range(0, near.Phrases.Count)
+            .Select(static _ => new Dictionary<long, int[]>())
+            .ToArray();
+        foreach (var rowId in IntersectPhrases(near.Phrases))
+        {
+            var nearMatch = FindSqliteNearMatches(
+                rowId,
+                near.Phrases,
+                near.Distance,
+                columnMask);
+            var mask = GetFrequencyColumnMask(nearMatch.GroupFrequencies);
+            if (mask == 0)
+                continue;
+
+            matches.Add(rowId);
+            for (var phraseIndex = 0; phraseIndex < near.Phrases.Count; phraseIndex++)
+            {
+                matchedPhraseFrequencies[phraseIndex].Add(
+                    rowId,
+                    nearMatch.PhraseColumnFrequencies[phraseIndex]);
+            }
+        }
+
+        if (accumulator is null || matches.Count == 0)
+            return matches;
+
+        // SQLite FTS5 scores every phrase in a NEAR group independently. The proximity
+        // predicate only limits which rows and columns receive those phrase contributions.
+        for (var phraseIndex = 0; phraseIndex < near.Phrases.Count; phraseIndex++)
+        {
+            var phrase = near.Phrases[phraseIndex];
+            EvaluatePhrase(
+                new ManagedFtsPhraseNode(
+                    phrase.Terms,
+                    phrase.IsPrefix,
+                    near.Column,
+                    AnchoredAtStart: false),
+                accumulator,
+                columnWeights,
+                matchedPhraseFrequencies[phraseIndex]);
+        }
 
         return matches;
     }
@@ -702,24 +767,97 @@ internal sealed class ManagedFtsSearchIndex
         return candidates ?? [];
     }
 
-    private int CountPhrase(long rowId, IReadOnlyList<string> terms, uint columnMask, bool anchored)
+    private IEnumerable<long> IntersectPhrases(IReadOnlyList<ManagedFtsNearPhrase> phrases)
     {
-        var streams = new long[terms.Count][];
-        for (var index = 0; index < terms.Count; index++)
+        HashSet<long>? candidates = null;
+        foreach (var phrase in phrases)
         {
-            if (!TryGetPositions(terms[index], rowId, out var positions))
-                return 0;
+            var phraseCandidates = FindPhraseCandidates(phrase);
+            if (candidates is null)
+                candidates = phraseCandidates;
+            else
+                candidates.IntersectWith(phraseCandidates);
 
-            streams[index] = positions;
+            if (candidates.Count == 0)
+                return [];
         }
 
-        var count = 0;
+        return candidates ?? [];
+    }
+
+    private HashSet<long> FindPhraseCandidates(ManagedFtsNearPhrase phrase)
+    {
+        HashSet<long>? candidates = null;
+        for (var index = 0; index < phrase.Terms.Count; index++)
+        {
+            var termRows = new HashSet<long>();
+            var isPrefix = phrase.IsPrefix && index == phrase.Terms.Count - 1;
+            var terms = isPrefix
+                ? ExpandTerm(new ManagedFtsTermNode(
+                    phrase.Terms[index],
+                    IsPrefix: true,
+                    Column: null,
+                    AnchoredAtStart: false))
+                : [phrase.Terms[index]];
+            foreach (var term in terms)
+            {
+                if (!_postings.TryGetValue(term, out var list))
+                    continue;
+
+                foreach (var posting in list.Entries)
+                {
+                    if (IsLive(posting))
+                        termRows.Add(posting.RowId);
+                }
+            }
+
+            if (candidates is null)
+                candidates = termRows;
+            else
+                candidates.IntersectWith(termRows);
+
+            if (candidates.Count == 0)
+                return [];
+        }
+
+        return candidates ?? [];
+    }
+
+    private List<PhraseOccurrence> GetPhraseOccurrences(
+        long rowId,
+        ManagedFtsNearPhrase phrase,
+        uint columnMask,
+        bool anchored)
+    {
+        if (phrase.Terms.Count == 0)
+            return [];
+
+        var streams = new long[phrase.Terms.Count][];
+        for (var index = 0; index < phrase.Terms.Count; index++)
+        {
+            var isPrefix = phrase.IsPrefix && index == phrase.Terms.Count - 1;
+            if (isPrefix)
+            {
+                streams[index] = GetPrefixPositions(phrase.Terms[index], rowId);
+                if (streams[index].Length == 0)
+                    return [];
+            }
+            else if (TryGetPositions(phrase.Terms[index], rowId, out var positions))
+            {
+                streams[index] = positions;
+            }
+            else
+            {
+                return [];
+            }
+        }
+
+        var occurrences = new List<PhraseOccurrence>();
         foreach (var start in streams[0])
         {
             var column = (int)(start >> 32);
-            if ((columnMask & (1u << column)) == 0)
-                continue;
-            if (anchored && (start & 0xFFFFFFFFL) != 0)
+            var position = (int)(start & 0xFFFFFFFFL);
+            if ((columnMask & (1u << column)) == 0 || (anchored && position != 0))
                 continue;
 
             var matched = true;
@@ -733,10 +871,81 @@ internal sealed class ManagedFtsSearchIndex
             }
 
             if (matched)
-                count++;
+            {
+                occurrences.Add(new PhraseOccurrence(
+                    column,
+                    position,
+                    checked(position + streams.Length - 1)));
+            }
         }
 
-        return count;
+        return occurrences;
+    }
+
+    private long[] GetPrefixPositions(string prefix, long rowId)
+    {
+        var positions = new List<long>();
+        foreach (var expanded in ExpandTerm(new ManagedFtsTermNode(
+                     prefix,
+                     IsPrefix: true,
+                     Column: null,
+                     AnchoredAtStart: false)))
+        {
+            if (TryGetPositions(expanded, rowId, out var expandedPositions))
+                positions.AddRange(expandedPositions);
+        }
+
+        positions.Sort();
+        return positions.ToArray();
+    }
+
+    private ScoreCandidate CreateFrequencyCandidate(long rowId, IReadOnlyList<int> frequencies)
+    {
+        var columnMask = GetFrequencyColumnMask(frequencies);
+        var compact = new int[System.Numerics.BitOperations.PopCount(columnMask)];
+        var next = 0;
+        var total = 0;
+        for (var column = 0; column < _columnCount; column++)
+        {
+            var frequency = frequencies[column];
+            total += frequency;
+            if (frequency != 0)
+                compact[next++] = frequency;
+        }
+
+        return new ScoreCandidate(rowId, total, [], compact, columnMask);
+    }
+
+    private uint GetFrequencyColumnMask(IReadOnlyList<int> frequencies)
+    {
+        var mask = 0u;
+        for (var column = 0; column < _columnCount; column++)
+        {
+            if (frequencies[column] != 0)
+                mask |= 1u << column;
+        }
+
+        return mask;
+    }
+
+    private int[] CountPhraseByColumn(
+        long rowId,
+        IReadOnlyList<string> terms,
+        bool isPrefix,
+        uint columnMask,
+        bool anchored)
+    {
+        var frequencies = new int[_columnCount];
+        foreach (var occurrence in GetPhraseOccurrences(
+                     rowId,
+                     new ManagedFtsNearPhrase(terms, isPrefix),
+                     columnMask,
+                     anchored))
+        {
+            frequencies[occurrence.Column]++;
+        }
+
+        return frequencies;
     }
 
     private int CountNear(long rowId, IReadOnlyList<string> terms, int distance, uint columnMask)
@@ -775,71 +984,138 @@ internal sealed class ManagedFtsSearchIndex
         return count;
     }
 
-    private int CountSqliteNear(long rowId, IReadOnlyList<string> terms, int distance, uint columnMask)
+    private SqliteNearMatch FindSqliteNearMatches(
+        long rowId,
+        IReadOnlyList<ManagedFtsNearPhrase> phrases,
+        int distance,
+        uint columnMask)
     {
-        var termIndices = new Dictionary<string, int>(StringComparer.Ordinal);
-        var requirements = new List<int>();
-        var streams = new List<long[]>();
-        foreach (var term in terms)
+        var phraseOccurrences = new List<PhraseOccurrence>[phrases.Count];
+        for (var index = 0; index < phrases.Count; index++)
         {
-            if (termIndices.TryGetValue(term, out var existing))
-            {
-                requirements[existing]++;
-                continue;
-            }
-            if (!TryGetPositions(term, rowId, out var positions))
-                return 0;
-
-            termIndices.Add(term, streams.Count);
-            streams.Add(positions);
-            requirements.Add(1);
+            phraseOccurrences[index] = GetPhraseOccurrences(
+                rowId,
+                phrases[index],
+                columnMask,
+                anchored: false);
+            if (phraseOccurrences[index].Count == 0)
+                return new SqliteNearMatch(phrases.Count, _columnCount);
         }
 
-        var maximumSpan = checked(distance + 1);
-        var count = 0;
+        var result = new SqliteNearMatch(phrases.Count, _columnCount);
         for (var column = 0; column < _columnCount; column++)
         {
             if ((columnMask & (1u << column)) == 0)
                 continue;
 
-            var events = new List<NearEvent>();
-            for (var termIndex = 0; termIndex < streams.Count; termIndex++)
+            var columnOccurrences = new List<PhraseOccurrence>[phrases.Count];
+            var maximumStarts = new List<int>();
+            for (var phraseIndex = 0; phraseIndex < phraseOccurrences.Length; phraseIndex++)
             {
-                var positions = streams[termIndex];
-                var start = LowerBound(positions, EncodePosition(column, 0));
-                while (start < positions.Length && (int)(positions[start] >> 32) == column)
-                {
-                    events.Add(new NearEvent((int)(positions[start] & 0xFFFFFFFFL), termIndex));
-                    start++;
-                }
+                columnOccurrences[phraseIndex] = phraseOccurrences[phraseIndex]
+                    .Where(occurrence => occurrence.Column == column)
+                    .ToList();
+                if (columnOccurrences[phraseIndex].Count == 0)
+                    goto NextColumn;
+
+                maximumStarts.AddRange(
+                    columnOccurrences[phraseIndex].Select(static occurrence => occurrence.StartPosition));
             }
 
-            events.Sort(static (left, right)
-                => left.Position == right.Position
-                    ? left.TermIndex.CompareTo(right.TermIndex)
-                    : left.Position.CompareTo(right.Position));
-            var occurrences = new int[streams.Count];
-            var covered = 0;
-            var leftIndex = 0;
-            for (var rightIndex = 0; rightIndex < events.Count; rightIndex++)
+            maximumStarts.Sort();
+            var participatingRanges = Enumerable
+                .Range(0, phrases.Count)
+                .Select(static _ => new List<OccurrenceRange>())
+                .ToArray();
+            var previousMaximumStart = -1;
+            foreach (var maximumStart in maximumStarts)
             {
-                var right = events[rightIndex];
-                if (++occurrences[right.TermIndex] == requirements[right.TermIndex])
-                    covered++;
+                if (maximumStart == previousMaximumStart)
+                    continue;
+                previousMaximumStart = maximumStart;
 
-                while (covered == streams.Count)
+                var ranges = new OccurrenceRange[phrases.Count];
+                var matches = true;
+                for (var phraseIndex = 0; phraseIndex < phrases.Count; phraseIndex++)
                 {
-                    var left = events[leftIndex];
-                    if (right.Position - left.Position <= maximumSpan)
-                        count++;
-                    if (occurrences[left.TermIndex]-- == requirements[left.TermIndex])
-                        covered--;
-                    leftIndex++;
+                    var minimumStart = Math.Max(
+                        0L,
+                        (long)maximumStart - distance - phrases[phraseIndex].Terms.Count);
+                    var occurrences = columnOccurrences[phraseIndex];
+                    var first = LowerBoundByStart(occurrences, minimumStart);
+                    var end = UpperBoundByStart(occurrences, maximumStart);
+                    if (first == end)
+                    {
+                        matches = false;
+                        break;
+                    }
+
+                    ranges[phraseIndex] = new OccurrenceRange(first, end);
                 }
+
+                if (!matches)
+                    continue;
+
+                result.GroupFrequencies[column]++;
+                for (var phraseIndex = 0; phraseIndex < phrases.Count; phraseIndex++)
+                    AddOccurrenceRange(participatingRanges[phraseIndex], ranges[phraseIndex]);
             }
+
+            for (var phraseIndex = 0; phraseIndex < phrases.Count; phraseIndex++)
+            {
+                result.PhraseColumnFrequencies[phraseIndex][column] =
+                    participatingRanges[phraseIndex].Sum(static range => range.End - range.Start);
+            }
+
+        NextColumn:
+            continue;
         }
 
-        return count;
+        return result;
+    }
+
+    private static int LowerBoundByStart(IReadOnlyList<PhraseOccurrence> occurrences, long target)
+    {
+        var low = 0;
+        var high = occurrences.Count;
+        while (low < high)
+        {
+            var middle = low + ((high - low) >> 1);
+            if (occurrences[middle].StartPosition < target)
+                low = middle + 1;
+            else
+                high = middle;
+        }
+
+        return low;
+    }
+
+    private static int UpperBoundByStart(IReadOnlyList<PhraseOccurrence> occurrences, int target)
+    {
+        var low = 0;
+        var high = occurrences.Count;
+        while (low < high)
+        {
+            var middle = low + ((high - low) >> 1);
+            if (occurrences[middle].StartPosition <= target)
+                low = middle + 1;
+            else
+                high = middle;
+        }
+
+        return low;
+    }
+
+    private static void AddOccurrenceRange(List<OccurrenceRange> ranges, OccurrenceRange next)
+    {
+        if (ranges.Count == 0 || next.Start > ranges[^1].End)
+        {
+            ranges.Add(next);
+            return;
+        }
+
+        var previous = ranges[^1];
+        ranges[^1] = new OccurrenceRange(previous.Start, Math.Max(previous.End, next.End));
     }
 
     private static bool HasPositionWithin(long[] positions, int column, int anchorPosition, int distance)
@@ -944,7 +1220,8 @@ internal sealed class ManagedFtsSearchIndex
         Dictionary<long, double> accumulator,
         List<ScoreCandidate> candidates,
         uint columnMask,
-        IReadOnlyList<double> columnWeights)
+        IReadOnlyList<double> columnWeights,
+        IReadOnlyDictionary<long, int[]>? includedRowFrequencies = null)
     {
         if (candidates.Count == 0)
             return;
@@ -955,20 +1232,59 @@ internal sealed class ManagedFtsSearchIndex
                 0.000001,
                 Math.Log((documentCount - candidates.Count + 0.5) / (candidates.Count + 0.5)))
             : Math.Log(1.0 + ((documentCount - candidates.Count + 0.5) / (candidates.Count + 0.5)));
-        foreach (var candidate in candidates)
+        foreach (var originalCandidate in candidates)
         {
-            if (!_documents.TryGetValue(candidate.RowId, out var document))
+            if (!_documents.TryGetValue(originalCandidate.RowId, out var document))
                 continue;
+
+            var candidate = originalCandidate;
+            var effectiveColumnMask = columnMask;
+            if (includedRowFrequencies is not null)
+            {
+                if (!includedRowFrequencies.TryGetValue(candidate.RowId, out var frequencies))
+                    continue;
+
+                candidate = CreateFrequencyCandidate(candidate.RowId, frequencies);
+                effectiveColumnMask &= candidate.PostingColumnMask;
+                if (effectiveColumnMask == 0)
+                    continue;
+            }
 
             double score;
             if (_scoringProfile == ManagedFtsScoringProfile.SqliteFts5)
-                score = ScoreSqliteFts5(document, candidate, idf, columnMask, columnWeights);
+                score = ScoreSqliteFts5(
+                    document,
+                    candidate,
+                    idf,
+                    effectiveColumnMask,
+                    columnWeights);
             else if (candidate.Positions.Length != 0)
-                score = ScorePerColumn(document, candidate.Positions, idf, columnMask, columnWeights);
+            {
+                score = ScorePerColumn(
+                    document,
+                    candidate.Positions,
+                    idf,
+                    effectiveColumnMask,
+                    columnWeights);
+            }
             else if (candidate.ColumnFrequencies.Length != 0)
-                score = ScorePerColumnFrequencies(document, candidate, idf, columnMask, columnWeights);
+            {
+                score = ScorePerColumnFrequencies(
+                    document,
+                    candidate,
+                    idf,
+                    effectiveColumnMask,
+                    columnWeights);
+            }
             else
-                score = ScoreUniform(document, candidate.Frequency, idf, columnMask, columnWeights);
+            {
+                score = ScoreUniform(
+                    document,
+                    candidate.Frequency,
+                    idf,
+                    effectiveColumnMask,
+                    columnWeights);
+            }
 
             accumulator[candidate.RowId] = accumulator.TryGetValue(candidate.RowId, out var existing)
                 ? existing + score
@@ -1015,9 +1331,8 @@ internal sealed class ManagedFtsSearchIndex
         }
         else
         {
-            // Phrase/NEAR candidates currently carry aggregate frequency. All default FTS5
-            // weights are one, so this is exact for rank and bm25(table); a weighted phrase uses
-            // the greatest eligible weight as a deterministic approximation.
+            // detail=none has no column attribution. Preserve its aggregate-frequency behavior;
+            // phrase and NEAR candidates require detail=full and carry exact per-column counts.
             var weight = 0.0;
             for (var column = 0; column < _columnCount; column++)
             {
@@ -1299,7 +1614,19 @@ internal sealed class ManagedFtsSearchIndex
         long[] Positions,
         int[] ColumnFrequencies);
 
-    private readonly record struct NearEvent(int Position, int TermIndex);
+    private readonly record struct PhraseOccurrence(int Column, int StartPosition, int EndPosition);
+
+    private readonly record struct OccurrenceRange(int Start, int End);
+
+    private sealed class SqliteNearMatch(int phraseCount, int columnCount)
+    {
+        public int[] GroupFrequencies { get; } = new int[columnCount];
+
+        public int[][] PhraseColumnFrequencies { get; } = Enumerable
+            .Range(0, phraseCount)
+            .Select(_ => new int[columnCount])
+            .ToArray();
+    }
 
     /// <summary>One document's contribution to a term's score, before BM25 is applied.</summary>
     private readonly record struct ScoreCandidate(

--- a/src/Ahtola.Core/Search/ManagedFtsSearchIndex.cs
+++ b/src/Ahtola.Core/Search/ManagedFtsSearchIndex.cs
@@ -5,6 +5,12 @@ namespace Ahtola.Core.Search;
 /// <summary>One scored search hit. Ordering is score descending, then rowid ascending.</summary>
 internal readonly record struct ManagedFtsHit(long RowId, double Score);
 
+internal enum ManagedFtsScoringProfile
+{
+    Managed,
+    SqliteFts5,
+}
+
 /// <summary>
 /// The managed inverted index behind a <c>USING fts</c> method index: term dictionary, per-document
 /// postings with term frequency, column mask and token positions, deterministic Okapi BM25 scoring,
@@ -47,6 +53,7 @@ internal sealed class ManagedFtsSearchIndex
     private readonly double[] _columnWeights;
     private readonly ManagedFtsDetailLevel _detail;
     private readonly bool _columnSize;
+    private readonly ManagedFtsScoringProfile _scoringProfile;
     private readonly Dictionary<long, Document> _documents = [];
     private readonly Dictionary<string, PostingList> _postings = new(StringComparer.Ordinal);
     private readonly long[] _columnTokenTotals;
@@ -59,9 +66,11 @@ internal sealed class ManagedFtsSearchIndex
         ManagedFtsTokenizerOptions tokenizer,
         IReadOnlyList<double> columnWeights,
         ManagedFtsDetailLevel detail = ManagedFtsDetailLevel.Full,
-        bool columnSize = true)
+        bool columnSize = true,
+        ManagedFtsScoringProfile scoringProfile = ManagedFtsScoringProfile.Managed)
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(columnCount, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(columnCount, sizeof(uint) * 8);
         ArgumentNullException.ThrowIfNull(tokenizer);
         ArgumentNullException.ThrowIfNull(columnWeights);
         if (columnWeights.Count != columnCount)
@@ -72,6 +81,7 @@ internal sealed class ManagedFtsSearchIndex
         _columnWeights = columnWeights.ToArray();
         _detail = detail;
         _columnSize = columnSize;
+        _scoringProfile = scoringProfile;
         _columnTokenTotals = new long[columnCount];
     }
 
@@ -172,8 +182,11 @@ internal sealed class ManagedFtsSearchIndex
                 if (!perTerm.TryGetValue(token.Text, out var occurrence))
                 {
                     occurrence = new TermOccurrence();
-                    if (_detail == ManagedFtsDetailLevel.Columns)
+                    if (_detail == ManagedFtsDetailLevel.Columns
+                        || _scoringProfile == ManagedFtsScoringProfile.SqliteFts5)
+                    {
                         occurrence.ColumnFrequencies = new int[_columnCount];
+                    }
                     perTerm.Add(token.Text, occurrence);
                 }
 
@@ -181,8 +194,11 @@ internal sealed class ManagedFtsSearchIndex
                 occurrence.ColumnMask |= 1u << column;
                 if (_detail == ManagedFtsDetailLevel.Full)
                     occurrence.Positions.Add(EncodePosition(column, token.Position));
-                else if (_detail == ManagedFtsDetailLevel.Columns)
+                else if (_detail == ManagedFtsDetailLevel.Columns
+                    || _scoringProfile == ManagedFtsScoringProfile.SqliteFts5)
+                {
                     occurrence.ColumnFrequencies[column]++;
+                }
             }
         }
 
@@ -219,11 +235,13 @@ internal sealed class ManagedFtsSearchIndex
                 occurrence.Positions.Sort();
                 positions = occurrence.Positions.ToArray();
             }
-            else if (_detail == ManagedFtsDetailLevel.Columns)
+            else if (_detail == ManagedFtsDetailLevel.Columns
+                || _scoringProfile == ManagedFtsScoringProfile.SqliteFts5)
             {
                 // Compact to just the columns the term actually occurs in, ascending. This is the
-                // minimum metadata a column-filtered query and a per-column BM25 term weight need
-                // once positions are not recorded.
+                // minimum metadata a column-filtered query or SQLite-compatible per-column BM25
+                // weight needs once positions are not recorded. detail=none still refuses column
+                // filters; the derived frequencies are retained only for observable ranking.
                 columnFrequencies = new int[System.Numerics.BitOperations.PopCount(occurrence.ColumnMask)];
                 var next = 0;
                 for (var column = 0; column < _columnCount; column++)
@@ -290,10 +308,21 @@ internal sealed class ManagedFtsSearchIndex
 
     /// <summary>Evaluates a parsed query and returns hits ordered by score desc, rowid asc.</summary>
     public IReadOnlyList<ManagedFtsHit> Search(ManagedFtsNode query, int? limit = null)
+        => Search(query, _columnWeights, limit);
+
+    /// <summary>Evaluates a parsed query with call-specific BM25 column weights.</summary>
+    public IReadOnlyList<ManagedFtsHit> Search(
+        ManagedFtsNode query,
+        IReadOnlyList<double> columnWeights,
+        int? limit = null)
     {
         ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(columnWeights);
+        if (columnWeights.Count != _columnCount)
+            throw new ArgumentException("One weight per indexed column is required.", nameof(columnWeights));
+
         var accumulator = new Dictionary<long, double>();
-        var matches = Evaluate(query, accumulator);
+        var matches = Evaluate(query, accumulator, columnWeights);
         if (matches.Count > ManagedFtsLimits.MaxMatchRows)
             throw new EmbeddedSqlException($"fts query matches more than {ManagedFtsLimits.MaxMatchRows} rows");
 
@@ -316,28 +345,43 @@ internal sealed class ManagedFtsSearchIndex
     public bool Matches(ManagedFtsNode query, long rowId)
     {
         ArgumentNullException.ThrowIfNull(query);
-        return _documents.ContainsKey(rowId) && Evaluate(query, accumulator: null).Contains(rowId);
+        return _documents.ContainsKey(rowId)
+            && Evaluate(query, null, _columnWeights).Contains(rowId);
     }
 
     /// <summary>The BM25 score of one document for a query, or 0 when it does not match.</summary>
-    public double Score(ManagedFtsNode query, long rowId)
+    public double Score(
+        ManagedFtsNode query,
+        long rowId,
+        IReadOnlyList<double>? columnWeights = null)
     {
         ArgumentNullException.ThrowIfNull(query);
+        var weights = columnWeights ?? _columnWeights;
+        if (weights.Count != _columnCount)
+            throw new ArgumentException("One weight per indexed column is required.", nameof(columnWeights));
         var accumulator = new Dictionary<long, double>();
-        return Evaluate(query, accumulator).Contains(rowId) && accumulator.TryGetValue(rowId, out var score)
+        return Evaluate(query, accumulator, weights).Contains(rowId)
+            && accumulator.TryGetValue(rowId, out var score)
             ? score
             : 0.0;
     }
 
-    private HashSet<long> Evaluate(ManagedFtsNode node, Dictionary<long, double>? accumulator)
+    private HashSet<long> Evaluate(
+        ManagedFtsNode node,
+        Dictionary<long, double>? accumulator,
+        IReadOnlyList<double> columnWeights)
         => node switch
         {
-            ManagedFtsTermNode term => EvaluateTerm(term, accumulator),
-            ManagedFtsPhraseNode phrase => EvaluatePhrase(phrase, accumulator),
-            ManagedFtsNearNode near => EvaluateNear(near, accumulator),
-            ManagedFtsAndNode and => Intersect(Evaluate(and.Left, accumulator), Evaluate(and.Right, accumulator)),
-            ManagedFtsOrNode or => Union(Evaluate(or.Left, accumulator), Evaluate(or.Right, accumulator)),
-            ManagedFtsNotNode not => Exclude(EvaluateExclusion(not.Operand)),
+            ManagedFtsTermNode term => EvaluateTerm(term, accumulator, columnWeights),
+            ManagedFtsPhraseNode phrase => EvaluatePhrase(phrase, accumulator, columnWeights),
+            ManagedFtsNearNode near => EvaluateNear(near, accumulator, columnWeights),
+            ManagedFtsAndNode and => Intersect(
+                Evaluate(and.Left, accumulator, columnWeights),
+                Evaluate(and.Right, accumulator, columnWeights)),
+            ManagedFtsOrNode or => Union(
+                Evaluate(or.Left, accumulator, columnWeights),
+                Evaluate(or.Right, accumulator, columnWeights)),
+            ManagedFtsNotNode not => Exclude(EvaluateExclusion(not.Operand, columnWeights)),
             _ => throw new ArgumentOutOfRangeException(nameof(node)),
         };
 
@@ -351,12 +395,16 @@ internal sealed class ManagedFtsSearchIndex
     /// that survives through another branch — <c>(NOT b) OR x</c> and <c>a NOT (b NOT c)</c> both
     /// keep rows the negated branch scored — so the exclusion is evaluated in isolation instead.
     /// </remarks>
-    private HashSet<long> EvaluateExclusion(ManagedFtsNode node)
-        => Evaluate(node, new Dictionary<long, double>());
+    private HashSet<long> EvaluateExclusion(
+        ManagedFtsNode node,
+        IReadOnlyList<double> columnWeights)
+        => Evaluate(node, new Dictionary<long, double>(), columnWeights);
 
-    private HashSet<long> EvaluateTerm(ManagedFtsTermNode term, Dictionary<long, double>? accumulator)
+    private HashSet<long> EvaluateTerm(
+        ManagedFtsTermNode term,
+        Dictionary<long, double>? accumulator,
+        IReadOnlyList<double> columnWeights)
     {
-        var matches = new HashSet<long>();
         if (term.AnchoredAtStart)
         {
             // An anchored term asks "is this the first token of the column", which needs the token's
@@ -366,6 +414,10 @@ internal sealed class ManagedFtsSearchIndex
         }
 
         var columnMask = ResolveColumnMask(term.Column);
+        if (term.IsPrefix && _scoringProfile == ManagedFtsScoringProfile.SqliteFts5)
+            return EvaluateSqlitePrefixTerm(term, accumulator, columnWeights, columnMask);
+
+        var matches = new HashSet<long>();
         foreach (var expanded in ExpandTerm(term))
         {
             if (!_postings.TryGetValue(expanded, out var list))
@@ -386,20 +438,115 @@ internal sealed class ManagedFtsSearchIndex
                 candidates.Add(new ScoreCandidate(
                     posting.RowId,
                     frequency,
-                    posting.Positions,
+                    term.AnchoredAtStart
+                        ? posting.Positions
+                            .Where(encoded => (encoded & 0xFFFFFFFFL) == 0
+                                && (columnMask & (1u << (int)(encoded >> 32))) != 0)
+                            .ToArray()
+                        : posting.Positions,
                     posting.ColumnFrequencies,
                     posting.ColumnMask));
                 matches.Add(posting.RowId);
             }
 
             if (accumulator is not null)
-                Accumulate(accumulator, candidates, columnMask);
+                Accumulate(accumulator, candidates, columnMask, columnWeights);
         }
 
         return matches;
     }
 
-    private HashSet<long> EvaluatePhrase(ManagedFtsPhraseNode phrase, Dictionary<long, double>? accumulator)
+    private HashSet<long> EvaluateSqlitePrefixTerm(
+        ManagedFtsTermNode term,
+        Dictionary<long, double>? accumulator,
+        IReadOnlyList<double> columnWeights,
+        uint columnMask)
+    {
+        var aggregates = new Dictionary<long, PrefixScoreCandidate>();
+        foreach (var expanded in ExpandTerm(term))
+        {
+            if (!_postings.TryGetValue(expanded, out var list))
+                continue;
+
+            foreach (var posting in list.Entries)
+            {
+                if (!IsLive(posting) || (posting.ColumnMask & columnMask) == 0)
+                    continue;
+
+                var frequency = term.AnchoredAtStart
+                    ? CountAnchored(posting.Positions, columnMask)
+                    : CountInColumns(posting, columnMask);
+                if (frequency == 0)
+                    continue;
+
+                if (!aggregates.TryGetValue(posting.RowId, out var aggregate))
+                {
+                    aggregate = new PrefixScoreCandidate(_columnCount);
+                    aggregates.Add(posting.RowId, aggregate);
+                }
+
+                aggregate.Frequency += frequency;
+                aggregate.ColumnMask |= posting.ColumnMask & columnMask;
+                if (posting.Positions.Length != 0)
+                {
+                    foreach (var encoded in posting.Positions)
+                    {
+                        var bit = 1u << (int)(encoded >> 32);
+                        if ((columnMask & bit) != 0
+                            && (!term.AnchoredAtStart || (encoded & 0xFFFFFFFFL) == 0))
+                        {
+                            aggregate.Positions.Add(encoded);
+                        }
+                    }
+                }
+                else
+                {
+                    var next = 0;
+                    for (var column = 0; column < _columnCount; column++)
+                    {
+                        var bit = 1u << column;
+                        if ((posting.ColumnMask & bit) == 0)
+                            continue;
+                        if ((columnMask & bit) != 0)
+                            aggregate.ColumnFrequencies[column] += posting.ColumnFrequencies[next];
+                        next++;
+                    }
+                }
+            }
+        }
+
+        var matches = new HashSet<long>(aggregates.Keys);
+        if (accumulator is null || aggregates.Count == 0)
+            return matches;
+
+        var candidates = new List<ScoreCandidate>(aggregates.Count);
+        foreach (var (rowId, aggregate) in aggregates)
+        {
+            aggregate.Positions.Sort();
+            var compactFrequencies = new int[System.Numerics.BitOperations.PopCount(aggregate.ColumnMask)];
+            var next = 0;
+            for (var column = 0; column < _columnCount; column++)
+            {
+                if ((aggregate.ColumnMask & (1u << column)) != 0)
+                    compactFrequencies[next++] = aggregate.ColumnFrequencies[column];
+            }
+
+            candidates.Add(new ScoreCandidate(
+                rowId,
+                aggregate.Frequency,
+                aggregate.Positions.ToArray(),
+                aggregate.Positions.Count == 0 ? compactFrequencies : [],
+                aggregate.ColumnMask));
+        }
+
+        Accumulate(accumulator, candidates, columnMask, columnWeights);
+        return matches;
+    }
+
+    private HashSet<long> EvaluatePhrase(
+        ManagedFtsPhraseNode phrase,
+        Dictionary<long, double>? accumulator,
+        IReadOnlyList<double> columnWeights)
     {
         RequirePositions("phrase");
         var columnMask = ResolveColumnMask(phrase.Column);
@@ -416,12 +563,15 @@ internal sealed class ManagedFtsSearchIndex
         }
 
         if (accumulator is not null)
-            Accumulate(accumulator, candidates, columnMask);
+            Accumulate(accumulator, candidates, columnMask, columnWeights);
 
         return matches;
     }
 
-    private HashSet<long> EvaluateNear(ManagedFtsNearNode near, Dictionary<long, double>? accumulator)
+    private HashSet<long> EvaluateNear(
+        ManagedFtsNearNode near,
+        Dictionary<long, double>? accumulator,
+        IReadOnlyList<double> columnWeights)
     {
         RequirePositions("NEAR");
         var columnMask = ResolveColumnMask(near.Column);
@@ -438,7 +588,7 @@ internal sealed class ManagedFtsSearchIndex
         }
 
         if (accumulator is not null)
-            Accumulate(accumulator, candidates, columnMask);
+            Accumulate(accumulator, candidates, columnMask, columnWeights);
 
         return matches;
     }
@@ -676,30 +826,106 @@ internal sealed class ManagedFtsSearchIndex
     private void Accumulate(
         Dictionary<long, double> accumulator,
         List<ScoreCandidate> candidates,
-        uint columnMask)
+        uint columnMask,
+        IReadOnlyList<double> columnWeights)
     {
         if (candidates.Count == 0)
             return;
 
         var documentCount = _documents.Count;
-        var idf = Math.Log(1.0 + ((documentCount - candidates.Count + 0.5) / (candidates.Count + 0.5)));
+        var idf = _scoringProfile == ManagedFtsScoringProfile.SqliteFts5
+            ? Math.Max(
+                0.000001,
+                Math.Log((documentCount - candidates.Count + 0.5) / (candidates.Count + 0.5)))
+            : Math.Log(1.0 + ((documentCount - candidates.Count + 0.5) / (candidates.Count + 0.5)));
         foreach (var candidate in candidates)
         {
             if (!_documents.TryGetValue(candidate.RowId, out var document))
                 continue;
 
             double score;
-            if (candidate.Positions.Length != 0)
-                score = ScorePerColumn(document, candidate.Positions, idf, columnMask);
+            if (_scoringProfile == ManagedFtsScoringProfile.SqliteFts5)
+                score = ScoreSqliteFts5(document, candidate, idf, columnMask, columnWeights);
+            else if (candidate.Positions.Length != 0)
+                score = ScorePerColumn(document, candidate.Positions, idf, columnMask, columnWeights);
             else if (candidate.ColumnFrequencies.Length != 0)
-                score = ScorePerColumnFrequencies(document, candidate, idf, columnMask);
+                score = ScorePerColumnFrequencies(document, candidate, idf, columnMask, columnWeights);
             else
-                score = ScoreUniform(document, candidate.Frequency, idf, columnMask);
+                score = ScoreUniform(document, candidate.Frequency, idf, columnMask, columnWeights);
 
             accumulator[candidate.RowId] = accumulator.TryGetValue(candidate.RowId, out var existing)
                 ? existing + score
                 : score;
         }
+    }
+
+    private double ScoreSqliteFts5(
+        Document document,
+        in ScoreCandidate candidate,
+        double idf,
+        uint columnMask,
+        IReadOnlyList<double> columnWeights)
+    {
+        double weightedFrequency;
+        if (candidate.Positions.Length != 0)
+        {
+            Span<int> perColumn = stackalloc int[_columnCount];
+            foreach (var encoded in candidate.Positions)
+            {
+                var column = (int)(encoded >> 32);
+                if ((columnMask & (1u << column)) != 0)
+                    perColumn[column]++;
+            }
+
+            weightedFrequency = 0.0;
+            for (var column = 0; column < _columnCount; column++)
+                weightedFrequency += perColumn[column] * columnWeights[column];
+        }
+        else if (candidate.ColumnFrequencies.Length != 0)
+        {
+            weightedFrequency = 0.0;
+            var next = 0;
+            for (var column = 0; column < _columnCount; column++)
+            {
+                var bit = 1u << column;
+                if ((candidate.PostingColumnMask & bit) == 0)
+                    continue;
+
+                var frequency = candidate.ColumnFrequencies[next++];
+                if ((columnMask & bit) != 0)
+                    weightedFrequency += frequency * columnWeights[column];
+            }
+        }
+        else
+        {
+            // Phrase/NEAR candidates currently carry aggregate frequency. All default FTS5
+            // weights are one, so this is exact for rank and bm25(table); a weighted phrase uses
+            // the greatest eligible weight as a deterministic approximation.
+            var weight = 0.0;
+            for (var column = 0; column < _columnCount; column++)
+            {
+                if ((columnMask & (1u << column)) != 0)
+                    weight = Math.Max(weight, columnWeights[column]);
+            }
+
+            weightedFrequency = candidate.Frequency * weight;
+        }
+
+        if (weightedFrequency <= 0.0)
+            return 0.0;
+
+        var documentLength = document.ColumnLengths.Sum();
+        var totalTokens = 0L;
+        foreach (var total in _columnTokenTotals)
+            totalTokens += total;
+        var averageLength = _documents.Count == 0 ? 0.0 : (double)totalTokens / _documents.Count;
+        var normalization = averageLength <= 0.0
+            ? 1.0
+            : 1.0 - BM25B + (BM25B * documentLength / averageLength);
+        return idf
+            * weightedFrequency
+            * (BM25K1 + 1.0)
+            / (weightedFrequency + (BM25K1 * normalization));
     }
 
     /// <summary>
@@ -716,7 +942,8 @@ internal sealed class ManagedFtsSearchIndex
         Document document,
         in ScoreCandidate candidate,
         double idf,
-        uint columnMask)
+        uint columnMask,
+        IReadOnlyList<double> columnWeights)
     {
         var score = 0.0;
         var next = 0;
@@ -730,13 +957,18 @@ internal sealed class ManagedFtsSearchIndex
             if ((columnMask & bit) == 0 || frequency == 0)
                 continue;
 
-            score += _columnWeights[column] * idf * Saturate(frequency, document.ColumnLengths[column], column);
+            score += columnWeights[column] * idf * Saturate(frequency, document.ColumnLengths[column], column);
         }
 
         return score;
     }
 
-    private double ScorePerColumn(Document document, long[] positions, double idf, uint columnMask)
+    private double ScorePerColumn(
+        Document document,
+        long[] positions,
+        double idf,
+        uint columnMask,
+        IReadOnlyList<double> columnWeights)
     {
         Span<int> perColumn = stackalloc int[_columnCount];
         foreach (var encoded in positions)
@@ -752,13 +984,18 @@ internal sealed class ManagedFtsSearchIndex
             if (perColumn[column] == 0)
                 continue;
 
-            score += _columnWeights[column] * idf * Saturate(perColumn[column], document.ColumnLengths[column], column);
+            score += columnWeights[column] * idf * Saturate(perColumn[column], document.ColumnLengths[column], column);
         }
 
         return score;
     }
 
-    private double ScoreUniform(Document document, int frequency, double idf, uint columnMask)
+    private double ScoreUniform(
+        Document document,
+        int frequency,
+        double idf,
+        uint columnMask,
+        IReadOnlyList<double> columnWeights)
     {
         // Phrase and NEAR match a contiguous window, so their frequency is not attributable to a
         // single column stream. Attribute it to the heaviest selected column, which keeps the score
@@ -770,9 +1007,9 @@ internal sealed class ManagedFtsSearchIndex
             if ((columnMask & (1u << column)) == 0 || document.ColumnLengths[column] == 0)
                 continue;
 
-            if (bestColumn < 0 || _columnWeights[column] > bestWeight)
+            if (bestColumn < 0 || columnWeights[column] > bestWeight)
             {
-                bestWeight = _columnWeights[column];
+                bestWeight = columnWeights[column];
                 bestColumn = column;
             }
         }
@@ -952,6 +1189,14 @@ internal sealed class ManagedFtsSearchIndex
         long[] Positions,
         int[] ColumnFrequencies,
         uint PostingColumnMask);
+
+    private sealed class PrefixScoreCandidate(int columnCount)
+    {
+        public int Frequency;
+        public uint ColumnMask;
+        public List<long> Positions { get; } = [];
+        public int[] ColumnFrequencies { get; } = new int[columnCount];
+    }
 
     private sealed class PostingList
     {

--- a/src/Ahtola.Core/SqliteBuiltinFunctions.cs
+++ b/src/Ahtola.Core/SqliteBuiltinFunctions.cs
@@ -45,6 +45,8 @@ internal static class SqliteBuiltinFunctions
         "VECTOR_DISTANCE_JACCARD", "VECTOR_DISTANCE_DOT", "VECTOR_CONCAT", "VECTOR_SLICE",
         // Managed full-text index method surface (Ahtola.Core.Search.ManagedFtsFunctions).
         "FTS_MATCH", "FTS_SCORE", "FTS_HIGHLIGHT", "FTS_SNIPPET",
+        // SQLite FTS5 auxiliary functions. These require a row from an fts5 virtual table.
+        "BM25", "HIGHLIGHT", "SNIPPET",
     };
 
     private static readonly HashSet<string> WindowOnlyNames = new(StringComparer.Ordinal)
@@ -98,6 +100,9 @@ internal static class SqliteBuiltinFunctions
         // WHERE clauses, generated columns, CHECK constraints) must therefore reject it, exactly
         // the way SQLite rejects any function it did not mark SQLITE_DETERMINISTIC.
         "FTS_SCORE",
+        "BM25",
+        "HIGHLIGHT",
+        "SNIPPET",
     };
 
     public static bool Contains(string name)
@@ -163,13 +168,13 @@ internal static class SqliteBuiltinFunctions
         if (normalized is "REPLACE" or "IIF" or "IF" or "VECTOR_SLICE")
             return [3];
 
-        if (normalized is "FTS_HIGHLIGHT")
+        if (normalized is "FTS_HIGHLIGHT" or "HIGHLIGHT")
             return [4];
 
-        if (normalized is "FTS_SNIPPET")
+        if (normalized is "FTS_SNIPPET" or "SNIPPET")
             return [6];
 
-        if (normalized is "FTS_MATCH" or "FTS_SCORE")
+        if (normalized is "FTS_MATCH" or "FTS_SCORE" or "BM25")
             return [-1];
 
         if (normalized is "COALESCE" or "CHAR" or "CONCAT" or "CONCAT_WS" or "FORMAT"

--- a/src/Ahtola.Tests/ManagedFtsSearchEngineTests.cs
+++ b/src/Ahtola.Tests/ManagedFtsSearchEngineTests.cs
@@ -71,6 +71,16 @@ public sealed class ManagedFtsSearchEngineTests
     }
 
     [Test]
+    public void LegacyGrammarDoesNotAdoptFts5PhraseConcatenation()
+    {
+        var index = CreateIndex(1);
+        index.Upsert(1, [], [SqlValue.Text("one two")]);
+
+        RowIds(index, "one + two").Should().BeEmpty();
+        RowIds(index, "\"one two\"").Should().Equal(1);
+    }
+
+    [Test]
     public void RankingIsDeterministicWithRowidTieBreak()
     {
         var index = CreateIndex(1);

--- a/src/Ahtola.Tests/ManagedFtsSearchEngineTests.cs
+++ b/src/Ahtola.Tests/ManagedFtsSearchEngineTests.cs
@@ -60,6 +60,17 @@ public sealed class ManagedFtsSearchEngineTests
     }
 
     [Test]
+    public void LegacyDoubledQuotesRemainTwoImplicitlyAndedPhrases()
+    {
+        var index = CreateIndex(1);
+        index.Upsert(1, [], [SqlValue.Text("one x two")]);
+        index.Upsert(2, [], [SqlValue.Text("one two")]);
+
+        RowIds(index, "\"one\"\"two\"").Should().BeEquivalentTo(new[] { 1L, 2L });
+        RowIds(index, "\"one two\"").Should().Equal(2);
+    }
+
+    [Test]
     public void RankingIsDeterministicWithRowidTieBreak()
     {
         var index = CreateIndex(1);

--- a/src/Ahtola.Tests/ManagedSearchVirtualTableTests.cs
+++ b/src/Ahtola.Tests/ManagedSearchVirtualTableTests.cs
@@ -96,6 +96,7 @@ public sealed class ManagedSearchVirtualTableTests
             SqlValue.Text("Orchid"),
             SqlValue.Text("Purple flower"),
             SqlValue.Null,
+            SqlValue.Null,
         ]).Should().Be(7);
         table.Update(
         [
@@ -103,6 +104,7 @@ public sealed class ManagedSearchVirtualTableTests
             SqlValue.Integer(9),
             SqlValue.Text("Rose"),
             SqlValue.Text("Red flower"),
+            SqlValue.Null,
             SqlValue.Null,
         ]).Should().Be(9);
 
@@ -117,10 +119,12 @@ public sealed class ManagedSearchVirtualTableTests
         plan.ConstraintUsages.Should().Equal(new ManagedVirtualTableConstraintUsage(1, Omit: true));
         var matches = ReadRows(table, plan, [SqlValue.Text("orchid OR rose")]);
         matches.Should().HaveCount(2);
-        matches[0].Should().Equal(
-            SqlValue.Integer(7), SqlValue.Text("Orchid"), SqlValue.Text("Purple flower"), SqlValue.Null);
-        matches[1].Should().Equal(
-            SqlValue.Integer(9), SqlValue.Text("Rose"), SqlValue.Text("Red flower"), SqlValue.Null);
+        matches[0][..4].Should().Equal(
+            SqlValue.Integer(7), SqlValue.Text("Orchid"), SqlValue.Text("Purple flower"), SqlValue.Integer(2));
+        matches[0][4].AsReal().Should().BeLessThan(0);
+        matches[1][..4].Should().Equal(
+            SqlValue.Integer(9), SqlValue.Text("Rose"), SqlValue.Text("Red flower"), SqlValue.Integer(2));
+        matches[1][4].AsReal().Should().BeLessThan(0);
 
         table.Update(
         [
@@ -129,11 +133,13 @@ public sealed class ManagedSearchVirtualTableTests
             SqlValue.Null,
             SqlValue.Null,
             SqlValue.Null,
+            SqlValue.Null,
         ]).Should().BeNull();
         matches = ReadRows(table, plan, [SqlValue.Text("orchid OR rose")]);
         matches.Should().ContainSingle();
-        matches[0].Should().Equal(
-            SqlValue.Integer(9), SqlValue.Text("Rose"), SqlValue.Text("Red flower"), SqlValue.Null);
+        matches[0][..4].Should().Equal(
+            SqlValue.Integer(9), SqlValue.Text("Rose"), SqlValue.Text("Red flower"), SqlValue.Integer(2));
+        matches[0][4].AsReal().Should().BeLessThan(0);
 
         table.Begin();
         table.Update(
@@ -143,9 +149,264 @@ public sealed class ManagedSearchVirtualTableTests
             SqlValue.Text("Lily"),
             SqlValue.Text("White flower"),
             SqlValue.Null,
+            SqlValue.Null,
         ]);
         table.Rollback();
         ReadRows(table, plan, [SqlValue.Text("lily")]).Should().BeEmpty();
+    }
+
+    [Test]
+    public void Fts5OptionsRowidsRankingAndAuxiliariesMatchStockSqlite()
+    {
+        const string create = """
+            CREATE VIRTUAL TABLE documents USING fts5(
+                title UNINDEXED,
+                body,
+                tokenize='ascii',
+                prefix='2 3',
+                detail=full,
+                columnsize=0
+            );
+            """;
+        string[] setup =
+        [
+            create,
+            "INSERT INTO documents(rowid, title, body) VALUES (10, 'Alpha metadata', 'alpha beta');",
+            "INSERT INTO documents VALUES ('Second metadata', 'alpha alpha delta');",
+            "INSERT INTO documents(title, body) VALUES ('Third metadata', 'omega');",
+        ];
+
+        using var database = new EmbeddedDatabase();
+        using var managed = database.Connect();
+        using var stock = new MsData.SqliteConnection("Data Source=:memory:");
+        stock.Open();
+        foreach (var sql in setup)
+        {
+            Execute(managed, sql);
+            Execute(stock, sql);
+        }
+
+        const string prefixQuery = """
+            SELECT rowid, title, body
+            FROM documents
+            WHERE documents MATCH 'alp*'
+            ORDER BY rowid;
+            """;
+        ReadRowsAsStrings(managed, prefixQuery).Should().Equal(ReadRowsAsStrings(stock, prefixQuery));
+
+        const string columnQuery = """
+            SELECT rowid
+            FROM documents
+            WHERE body MATCH 'alpha'
+            ORDER BY rank;
+            """;
+        ReadRowsAsStrings(managed, columnQuery).Should().Equal(ReadRowsAsStrings(stock, columnQuery));
+        const string descendingRankQuery = """
+            SELECT rowid
+            FROM documents
+            WHERE documents MATCH 'alpha'
+            ORDER BY rank DESC;
+            """;
+        ReadRowsAsStrings(managed, descendingRankQuery).Should().Equal(ReadRowsAsStrings(stock, descendingRankQuery));
+        ReadRows(managed, "SELECT rowid FROM documents WHERE title MATCH 'alpha';").Should().BeEmpty();
+
+        const string auxiliaryQuery = """
+            SELECT rowid,
+                   highlight(documents, 1, '<b>', '</b>'),
+                   snippet(documents, 1, '[', ']', '...', 10)
+            FROM documents
+            WHERE documents MATCH 'alpha'
+            ORDER BY rowid;
+            """;
+        ReadRowsAsStrings(managed, auxiliaryQuery).Should().Equal(ReadRowsAsStrings(stock, auxiliaryQuery));
+
+        const string unindexedAuxiliaryQuery = """
+            SELECT highlight(documents, 0, '<b>', '</b>'),
+                   snippet(documents, -1, '[', ']', '...', 10)
+            FROM documents
+            WHERE documents MATCH 'alpha'
+            ORDER BY rowid;
+            """;
+        ReadRowsAsStrings(managed, unindexedAuxiliaryQuery)
+            .Should().Equal(ReadRowsAsStrings(stock, unindexedAuxiliaryQuery));
+
+        const string coercedAuxiliaryQuery = """
+            SELECT highlight(documents, '1', '<b>', '</b>'),
+                   snippet(documents, '-1', '[', ']', '...', '10'),
+                   bm25(documents, '2', '1') < 0
+            FROM documents
+            WHERE documents MATCH 'alpha'
+            ORDER BY rowid;
+            """;
+        ReadRowsAsStrings(managed, coercedAuxiliaryQuery)
+            .Should().Equal(ReadRowsAsStrings(stock, coercedAuxiliaryQuery));
+
+        var ranked = ReadRows(
+            managed,
+            "SELECT rank, bm25(documents), bm25(documents, 2.0, 1.0) "
+            + "FROM documents WHERE documents MATCH 'alpha' ORDER BY rank;");
+        ranked.Should().HaveCount(2);
+        foreach (var row in ranked)
+        {
+            row[0].AsReal().Should().BeLessThan(0);
+            row[1].AsReal().Should().Be(row[0].AsReal());
+            row[2].AsReal().Should().BeLessThan(0);
+        }
+        using (var stockRankCommand = stock.CreateCommand())
+        {
+            stockRankCommand.CommandText =
+                "SELECT rank FROM documents WHERE documents MATCH 'alpha' ORDER BY rowid;";
+            using var stockRankReader = stockRankCommand.ExecuteReader();
+            var managedRanks = ReadRows(
+                managed,
+                "SELECT rank FROM documents WHERE documents MATCH 'alpha' ORDER BY rowid;");
+            for (var index = 0; index < managedRanks.Count; index++)
+            {
+                stockRankReader.Read().Should().BeTrue();
+                managedRanks[index][0].AsReal().Should().BeApproximately(stockRankReader.GetDouble(0), 1e-12);
+            }
+            stockRankReader.Read().Should().BeFalse();
+        }
+
+        Execute(managed, "INSERT INTO documents(documents) VALUES('optimize');");
+        Execute(managed, "INSERT INTO documents(documents) VALUES('rebuild');");
+        ReadRowsAsStrings(managed, prefixQuery).Should().Equal(ReadRowsAsStrings(stock, prefixQuery));
+
+        string[] rowIdSetup =
+        [
+            "CREATE VIRTUAL TABLE rowids USING fts5(body);",
+            "INSERT INTO rowids(rowid, body) VALUES (10, 'discarded');",
+            "DELETE FROM rowids WHERE rowid = 10;",
+            "INSERT INTO rowids(body) VALUES ('reused');",
+        ];
+        foreach (var sql in rowIdSetup)
+        {
+            Execute(managed, sql);
+            Execute(stock, sql);
+        }
+        Execute(managed, "UPDATE rowids SET rowid = '5' WHERE rowid = 1;");
+        Execute(stock, "UPDATE rowids SET rowid = '5' WHERE rowid = 1;");
+        Execute(managed, "INSERT INTO rowids(rowid, body) VALUES (6.0, 'real rowid');");
+        Execute(stock, "INSERT INTO rowids(rowid, body) VALUES (6.0, 'real rowid');");
+        ReadRowsAsStrings(managed, "SELECT rowid FROM rowids ORDER BY rowid;")
+            .Should().Equal(ReadRowsAsStrings(stock, "SELECT rowid FROM rowids ORDER BY rowid;"));
+        Action fractionalRowId = () => Execute(
+            managed,
+            "INSERT INTO rowids(rowid, body) VALUES (6.5, 'fractional');");
+        fractionalRowId.Should().Throw<EmbeddedSqlException>().WithMessage("*integer*");
+
+        Execute(managed, "INSERT INTO documents(rowid, title, body) VALUES (30, 'Phrase', 'alpha x beta alpha beta');");
+        Execute(stock, "INSERT INTO documents(rowid, title, body) VALUES (30, 'Phrase', 'alpha x beta alpha beta');");
+        const string phraseAuxiliaryQuery = """
+            SELECT rowid, highlight(documents, 1, '[', ']'), snippet(documents, 1, '<', '>', '...', 10)
+            FROM documents
+            WHERE documents MATCH '"alpha beta"'
+            ORDER BY rowid;
+            """;
+        ReadRowsAsStrings(managed, phraseAuxiliaryQuery)
+            .Should().Equal(ReadRowsAsStrings(stock, phraseAuxiliaryQuery));
+
+        Execute(managed, "CREATE VIRTUAL TABLE snippet_choice USING fts5(a, b);");
+        Execute(stock, "CREATE VIRTUAL TABLE snippet_choice USING fts5(a, b);");
+        Execute(managed, "INSERT INTO snippet_choice VALUES ('alpha one two beta', 'beta alpha');");
+        Execute(stock, "INSERT INTO snippet_choice VALUES ('alpha one two beta', 'beta alpha');");
+        const string snippetChoiceQuery = """
+            SELECT snippet(snippet_choice, -1, '[', ']', '...', 2)
+            FROM snippet_choice
+            WHERE snippet_choice MATCH 'alpha beta';
+            """;
+        ReadRowsAsStrings(managed, snippetChoiceQuery)
+            .Should().Equal(ReadRowsAsStrings(stock, snippetChoiceQuery));
+
+        string[] prefixScoreSetup =
+        [
+            "CREATE VIRTUAL TABLE prefix_scores USING fts5(body);",
+            "INSERT INTO prefix_scores VALUES ('apple'), ('apply'), ('apple apply');",
+            "CREATE VIRTUAL TABLE detail_none USING fts5(a, b, detail=none);",
+            "INSERT INTO detail_none VALUES ('shared', ''), ('', 'shared');",
+        ];
+        foreach (var sql in prefixScoreSetup)
+        {
+            Execute(managed, sql);
+            Execute(stock, sql);
+        }
+
+        AssertScoresMatchStock(
+            managed,
+            stock,
+            "SELECT bm25(prefix_scores) FROM prefix_scores WHERE prefix_scores MATCH 'app*' ORDER BY rowid;");
+        AssertScoresMatchStock(
+            managed,
+            stock,
+            "SELECT bm25(detail_none, 10, 1) FROM detail_none WHERE detail_none MATCH 'shared' ORDER BY rowid;");
+    }
+
+    [Test]
+    public void Fts5AuxiliariesBindThroughJoinsAndMayBeShadowed()
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, "CREATE VIRTUAL TABLE documents USING fts5(title, body);");
+        Execute(connection, "CREATE TABLE tags(tag TEXT);");
+        Execute(connection, "INSERT INTO documents(rowid, title, body) VALUES (42, 'Orchid', 'purple orchid flower');");
+        Execute(connection, "INSERT INTO tags VALUES ('flora');");
+
+        ReadRows(
+                connection,
+                "SELECT highlight(documents, 1, '[', ']'), snippet(documents, -1, '<', '>', '...', 8) "
+                + "FROM documents JOIN tags ON tag = 'flora' WHERE documents MATCH 'orchid';")
+            .Should().ContainSingle()
+            .Which.Should().Equal(
+                SqlValue.Text("purple [orchid] flower"),
+                SqlValue.Text("<Orchid>"));
+
+        ReadRows(connection, "SELECT bm25(documents), highlight(documents, 1, '[', ']') FROM documents;")
+            .Should().ContainSingle()
+            .Which.Should().Equal(SqlValue.Real(0), SqlValue.Text("purple orchid flower"));
+
+        connection.RegisterScalarFunction("highlight", 4, static _ => SqlValue.Text("shadowed"));
+        ReadRows(
+                connection,
+                "SELECT highlight(documents, 1, '[', ']') FROM documents WHERE documents MATCH 'orchid';")
+            .Should().ContainSingle()
+            .Which.Should().Equal(SqlValue.Text("shadowed"));
+    }
+
+    [Test]
+    public void Fts5DeclarationsAndCommandsRejectUnsupportedPayloadsFailClosed()
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+
+        string[] declarations =
+        [
+            "CREATE VIRTUAL TABLE bad USING fts5(body, content='source');",
+            "CREATE VIRTUAL TABLE bad USING fts5(body, content_rowid='id');",
+            "CREATE VIRTUAL TABLE bad USING fts5(body, tokenize='porter unicode61');",
+            "CREATE VIRTUAL TABLE bad USING fts5(body, tokenize='porter');",
+            "CREATE VIRTUAL TABLE bad USING fts5(body, detail=offsets);",
+            "CREATE VIRTUAL TABLE bad USING fts5(body, columnsize=2);",
+            "CREATE VIRTUAL TABLE bad USING fts5(body, prefix='2 two');",
+            "CREATE VIRTUAL TABLE bad USING fts5(body, unknown=1);",
+            $"CREATE VIRTUAL TABLE bad USING fts5({string.Join(", ", Enumerable.Range(0, 33).Select(static index => $"c{index:D2}"))});",
+            "CREATE VIRTUAL TABLE bad USING fts5(rowid);",
+        ];
+        foreach (var declaration in declarations)
+        {
+            Action create = () => Execute(connection, declaration);
+            create.Should().Throw<EmbeddedSqlException>();
+        }
+
+        Execute(connection, "CREATE VIRTUAL TABLE documents USING fts5(body);");
+        Execute(connection, "INSERT INTO documents VALUES ('alpha');");
+        Action deleteAll = () => Execute(connection, "INSERT INTO documents(documents) VALUES('delete-all');");
+        deleteAll.Should().Throw<EmbeddedSqlException>().WithMessage("*contentless or external content*");
+        Action unknownCommand = () => Execute(connection, "INSERT INTO documents(documents) VALUES('merge=4');");
+        unknownCommand.Should().Throw<EmbeddedSqlException>().WithMessage("*unsupported managed fts5 command*");
+        Action duplicateRowId = () => Execute(
+            connection,
+            "INSERT INTO documents(rowid, body) VALUES (1, 'replacement');");
+        duplicateRowId.Should().Throw<EmbeddedSqlException>().WithMessage("*rowid 1 already exists*");
     }
 
     [Test]
@@ -244,6 +505,83 @@ public sealed class ManagedSearchVirtualTableTests
         {
             DeleteDatabase(sourcePath);
             DeleteDatabase(backupPath);
+        }
+    }
+
+    [Test]
+    public void OptionRichFts5RankingAuxiliariesAndCommandsSurviveReopenAndSavepointRollback()
+    {
+        var path = CreateDatabasePath("managed-fts5-options");
+        try
+        {
+            using (var database = EmbeddedDatabase.OpenFile(path))
+            using (var connection = database.Connect())
+            {
+                Execute(
+                    connection,
+                    """
+                    CREATE VIRTUAL TABLE documents USING fts5(
+                        title,
+                        body UNINDEXED,
+                        tokenize='ascii',
+                        prefix='2 3',
+                        detail=full,
+                        columnsize=0
+                    );
+                    """);
+                Execute(connection, "INSERT INTO documents(rowid, title, body) VALUES (10, 'Orchid orchid', 'private'), (20, 'Orchid', 'private');");
+                Execute(connection, "INSERT INTO documents(documents) VALUES ('optimize');");
+                Execute(connection, "CREATE VIRTUAL TABLE extreme_rowids USING fts5(body);");
+                Execute(connection, "INSERT INTO extreme_rowids(rowid, body) VALUES (9223372036854775807, 'maximum');");
+            }
+
+            using (var database = EmbeddedDatabase.OpenFile(path))
+            using (var connection = database.Connect())
+            {
+                ReadRowsAsStrings(
+                    connection,
+                    """
+                    SELECT rowid, rank < 0, bm25(documents) < 0,
+                           highlight(documents, 0, '[', ']'),
+                           snippet(documents, 0, '<b>', '</b>', '...', 8)
+                    FROM documents
+                    WHERE title MATCH 'orch*'
+                    ORDER BY rank;
+                    """)
+                    .Should().Equal(
+                        "10\u001F1\u001F1\u001F[Orchid] [orchid]\u001F<b>Orchid</b> <b>orchid</b>",
+                        "20\u001F1\u001F1\u001F[Orchid]\u001F<b>Orchid</b>");
+
+                Execute(connection, "SAVEPOINT fts_state;");
+                Execute(connection, "UPDATE documents SET title = 'Rose' WHERE rowid = 10;");
+                Execute(connection, "INSERT INTO documents(documents) VALUES ('rebuild');");
+                ReadRowsAsStrings(connection, "SELECT rowid FROM documents WHERE documents MATCH 'orch*' ORDER BY rank;")
+                    .Should().Equal("20");
+                Execute(connection, "ROLLBACK TO fts_state;");
+                Execute(connection, "RELEASE fts_state;");
+
+                ReadRowsAsStrings(connection, "SELECT rowid FROM documents WHERE documents MATCH 'orch*' ORDER BY rank;")
+                    .Should().Equal("10", "20");
+                Execute(connection, "INSERT INTO documents(documents) VALUES ('rebuild');");
+                Execute(connection, "INSERT INTO extreme_rowids(body) VALUES ('random fallback');");
+                var extremeRowIds = ReadRows(connection, "SELECT rowid FROM extreme_rowids ORDER BY rowid;");
+                extremeRowIds.Should().HaveCount(2);
+                extremeRowIds.Select(static row => row[0].AsInteger())
+                    .Should().Contain(long.MaxValue)
+                    .And.OnlyContain(static rowId => rowId > 0);
+            }
+
+            using (var database = EmbeddedDatabase.OpenFile(path))
+            using (var connection = database.Connect())
+            {
+                ReadRowsAsStrings(connection, "SELECT rowid FROM documents WHERE documents MATCH 'orch*' ORDER BY rank;")
+                    .Should().Equal("10", "20");
+                ReadRows(connection, "SELECT rowid FROM extreme_rowids;").Should().HaveCount(2);
+            }
+        }
+        finally
+        {
+            DeleteDatabase(path);
         }
     }
 
@@ -463,6 +801,69 @@ public sealed class ManagedSearchVirtualTableTests
         {
         }
     }
+
+    private static void Execute(MsData.SqliteConnection connection, string sql)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.ExecuteNonQuery();
+    }
+
+    private static IReadOnlyList<string> ReadRowsAsStrings(EmbeddedConnection connection, string sql)
+        => ReadRows(connection, sql)
+            .Select(row => string.Join('\u001F', row.Select(Format)))
+            .ToArray();
+
+    private static IReadOnlyList<string> ReadRowsAsStrings(MsData.SqliteConnection connection, string sql)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        using var reader = command.ExecuteReader();
+        var rows = new List<string>();
+        while (reader.Read())
+        {
+            var row = new string[reader.FieldCount];
+            for (var index = 0; index < row.Length; index++)
+            {
+                row[index] = reader.IsDBNull(index)
+                    ? "<NULL>"
+                    : Convert.ToString(reader.GetValue(index), System.Globalization.CultureInfo.InvariantCulture)!;
+            }
+
+            rows.Add(string.Join('\u001F', row));
+        }
+
+        return rows;
+    }
+
+    private static void AssertScoresMatchStock(
+        EmbeddedConnection managed,
+        MsData.SqliteConnection stock,
+        string sql)
+    {
+        var managedRows = ReadRows(managed, sql);
+        using var command = stock.CreateCommand();
+        command.CommandText = sql;
+        using var reader = command.ExecuteReader();
+        foreach (var row in managedRows)
+        {
+            reader.Read().Should().BeTrue();
+            row[0].AsReal().Should().BeApproximately(reader.GetDouble(0), 1e-12);
+        }
+
+        reader.Read().Should().BeFalse();
+    }
+
+    private static string Format(SqlValue value)
+        => value.Kind switch
+        {
+            SqlValueKind.Null => "<NULL>",
+            SqlValueKind.Integer => value.AsInteger().ToString(System.Globalization.CultureInfo.InvariantCulture),
+            SqlValueKind.Real => value.AsReal().ToString(System.Globalization.CultureInfo.InvariantCulture),
+            SqlValueKind.Text => value.AsText(),
+            SqlValueKind.Blob => Convert.ToHexString(value.AsBlob().Span),
+            _ => throw new ArgumentOutOfRangeException(nameof(value)),
+        };
 
     private static IReadOnlyList<SqlValue[]> ReadRows(EmbeddedConnection connection, string sql)
     {

--- a/src/Ahtola.Tests/ManagedSearchVirtualTableTests.cs
+++ b/src/Ahtola.Tests/ManagedSearchVirtualTableTests.cs
@@ -342,6 +342,96 @@ public sealed class ManagedSearchVirtualTableTests
     }
 
     [Test]
+    public void Fts5ReviewedQueryAndContentSemanticsMatchStockSqlite()
+    {
+        string[] setup =
+        [
+            "CREATE VIRTUAL TABLE documents USING fts5(a, b);",
+            "INSERT INTO documents(rowid, a, b) VALUES (1, 'one', 'one');",
+            "INSERT INTO documents(rowid, a, b) VALUES (2, 'one two', 'two');",
+            "INSERT INTO documents(rowid, a, b) VALUES (3, 'one three', 'three');",
+            "INSERT INTO documents(rowid, a, b) VALUES (4, 'one two three', 'two three');",
+            "INSERT INTO documents(rowid, a, b) VALUES (10, 'blob', x'636166C3A9206E6F6972');",
+            "CREATE TABLE no_shadow(marker TEXT);",
+            "INSERT INTO no_shadow VALUES ('x');",
+            "CREATE TABLE shadows(documents TEXT);",
+            "INSERT INTO shadows VALUES ('ordinary');",
+            "CREATE VIRTUAL TABLE near_docs USING fts5(body);",
+            "INSERT INTO near_docs(rowid, body) VALUES (1, 'one x two'), (2, 'one x x two'), (3, 'two x one');",
+            "CREATE VIRTUAL TABLE phrase_docs USING fts5(body);",
+            "INSERT INTO phrase_docs(rowid, body) VALUES (1, 'one two three'), (2, 'one two throw'), (3, 'one two thyme');",
+        ];
+
+        using var database = new EmbeddedDatabase();
+        using var managed = database.Connect();
+        using var stock = new MsData.SqliteConnection("Data Source=:memory:");
+        stock.Open();
+        foreach (var sql in setup)
+        {
+            Execute(managed, sql);
+            Execute(stock, sql);
+        }
+
+        string[] oracleQueries =
+        [
+            "SELECT rowid FROM documents WHERE b MATCH 'a:one' ORDER BY rowid;",
+            "SELECT rowid FROM documents WHERE b MATCH 'a:one OR two' ORDER BY rowid;",
+            "SELECT rowid FROM documents WHERE documents MATCH 'one NOT two three' ORDER BY rowid;",
+            """
+            SELECT rowid, typeof(b), highlight(documents, 1, '[', ']'),
+                   snippet(documents, 1, '<', '>', '...', 8)
+            FROM documents
+            WHERE documents MATCH 'café'
+            ORDER BY rowid;
+            """,
+            "SELECT rowid FROM near_docs WHERE near_docs MATCH 'NEAR(one two,1)' ORDER BY rowid;",
+            "SELECT rowid FROM near_docs WHERE near_docs MATCH 'NEAR(one x two,0)' ORDER BY rowid;",
+            "SELECT rowid FROM near_docs WHERE near_docs MATCH 'NEAR(one,1)' ORDER BY rowid;",
+            """
+            SELECT rowid, highlight(phrase_docs, 0, '[', ']')
+            FROM phrase_docs
+            WHERE phrase_docs MATCH '"one two thr"*'
+            ORDER BY rowid;
+            """,
+            """
+            SELECT (SELECT bm25(documents) FROM no_shadow),
+                   (SELECT highlight(documents, 0, '[', ']') FROM no_shadow),
+                   (SELECT snippet(documents, 0, '[', ']', '...', 5) FROM no_shadow)
+            FROM documents
+            WHERE documents MATCH 'one'
+            ORDER BY rowid;
+            """,
+        ];
+        foreach (var sql in oracleQueries)
+            ReadRowsAsStrings(managed, sql).Should().Equal(ReadRowsAsStrings(stock, sql), sql);
+
+        foreach (var auxiliary in new[]
+                 {
+                     "bm25(documents)",
+                     "highlight(documents, 0, '[', ']')",
+                     "snippet(documents, 0, '[', ']', '...', 5)",
+                 })
+        {
+            var sql = $"""
+                SELECT (SELECT {auxiliary} FROM shadows)
+                FROM documents
+                WHERE documents MATCH 'one';
+                """;
+            Action managedShadow = () => ReadRowsAsStrings(managed, sql);
+            Action stockShadow = () => ReadRowsAsStrings(stock, sql);
+            managedShadow.Should().Throw<EmbeddedSqlException>();
+            stockShadow.Should().Throw<MsData.SqliteException>();
+        }
+
+        const string legacyNear =
+            "SELECT rowid FROM near_docs WHERE near_docs MATCH 'NEAR/1(one two)';";
+        Action managedLegacyNear = () => ReadRowsAsStrings(managed, legacyNear);
+        Action stockLegacyNear = () => ReadRowsAsStrings(stock, legacyNear);
+        managedLegacyNear.Should().Throw<EmbeddedSqlException>();
+        stockLegacyNear.Should().Throw<MsData.SqliteException>();
+    }
+
+    [Test]
     public void Fts5AuxiliariesBindThroughJoinsAndMayBeShadowed()
     {
         using var database = new EmbeddedDatabase();

--- a/src/Ahtola.Tests/ManagedSearchVirtualTableTests.cs
+++ b/src/Ahtola.Tests/ManagedSearchVirtualTableTests.cs
@@ -357,9 +357,38 @@ public sealed class ManagedSearchVirtualTableTests
             "CREATE TABLE shadows(documents TEXT);",
             "INSERT INTO shadows VALUES ('ordinary');",
             "CREATE VIRTUAL TABLE near_docs USING fts5(body);",
-            "INSERT INTO near_docs(rowid, body) VALUES (1, 'one x two'), (2, 'one x x two'), (3, 'two x one');",
+            """
+            INSERT INTO near_docs(rowid, body) VALUES
+                (1, 'one x two'),
+                (2, 'one x x two'),
+                (3, 'two x one'),
+                (4, 'one two three'),
+                (5, 'one two throw'),
+                (6, 'one'),
+                (7, 'three one two');
+            """,
             "CREATE VIRTUAL TABLE phrase_docs USING fts5(body);",
             "INSERT INTO phrase_docs(rowid, body) VALUES (1, 'one two three'), (2, 'one two throw'), (3, 'one two thyme');",
+            "CREATE VIRTUAL TABLE near_scores USING fts5(a, b);",
+            """
+            INSERT INTO near_scores(rowid, a, b) VALUES
+                (1, 'one two three', ''),
+                (2, '', 'one two three'),
+                (3, 'one two x three', ''),
+                (4, '', 'one two x three'),
+                (5, 'filler', 'filler');
+            """,
+            "CREATE VIRTUAL TABLE near_edges USING fts5(body);",
+            """
+            INSERT INTO near_edges(rowid, body) VALUES
+                (1, 'a b c'),
+                (2, 'a b b'),
+                (3, 'one two three filler filler one two'),
+                (4, 'one two three filler filler filler filler'),
+                (5, 'or not near'),
+                (6, 'one three two'),
+                (7, 'one two three');
+            """,
         ];
 
         using var database = new EmbeddedDatabase();
@@ -387,6 +416,44 @@ public sealed class ManagedSearchVirtualTableTests
             "SELECT rowid FROM near_docs WHERE near_docs MATCH 'NEAR(one two,1)' ORDER BY rowid;",
             "SELECT rowid FROM near_docs WHERE near_docs MATCH 'NEAR(one x two,0)' ORDER BY rowid;",
             "SELECT rowid FROM near_docs WHERE near_docs MATCH 'NEAR(one,1)' ORDER BY rowid;",
+            "SELECT rowid FROM near_docs WHERE near_docs MATCH 'NEAR(one one,0)' ORDER BY rowid;",
+            """
+            SELECT rowid, highlight(near_docs, 0, '[', ']')
+            FROM near_docs
+            WHERE near_docs MATCH 'NEAR("one two" three,1)'
+            ORDER BY rowid;
+            """,
+            """
+            SELECT rowid, highlight(near_docs, 0, '[', ']')
+            FROM near_docs
+            WHERE near_docs MATCH 'NEAR(three "one two",0)'
+            ORDER BY rowid;
+            """,
+            """
+            SELECT rowid, highlight(near_docs, 0, '[', ']')
+            FROM near_docs
+            WHERE near_docs MATCH 'NEAR(one tw*,1)'
+            ORDER BY rowid;
+            """,
+            """
+            SELECT rowid, highlight(near_docs, 0, '[', ']')
+            FROM near_docs
+            WHERE near_docs MATCH 'NEAR("one tw"* three,1)'
+            ORDER BY rowid;
+            """,
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH 'NEAR(a c \"a b\",0)' ORDER BY rowid;",
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH 'NEAR(a c \"a b\",1)' ORDER BY rowid;",
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH 'NEAR(one two, 1)' ORDER BY rowid;",
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH 'NEAR(\"one\"\"two\" three,1)' ORDER BY rowid;",
+            """
+            SELECT rowid, highlight(near_edges, 0, '[', ']')
+            FROM near_edges
+            WHERE near_edges MATCH 'NEAR(a b,1)'
+            ORDER BY rowid;
+            """,
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH 'or' ORDER BY rowid;",
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH 'NEAR' ORDER BY rowid;",
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH 'OR\U0001F4A9' ORDER BY rowid;",
             """
             SELECT rowid, highlight(phrase_docs, 0, '[', ']')
             FROM phrase_docs
@@ -404,6 +471,53 @@ public sealed class ManagedSearchVirtualTableTests
         ];
         foreach (var sql in oracleQueries)
             ReadRowsAsStrings(managed, sql).Should().Equal(ReadRowsAsStrings(stock, sql), sql);
+
+        AssertScoresMatchStock(
+            managed,
+            stock,
+            """
+            SELECT bm25(near_scores)
+            FROM near_scores
+            WHERE near_scores MATCH 'NEAR("one two" three,1)'
+            ORDER BY rowid;
+            """);
+        AssertScoresMatchStock(
+            managed,
+            stock,
+            """
+            SELECT bm25(near_scores, 10, 1)
+            FROM near_scores
+            WHERE near_scores MATCH 'NEAR("one two" three,1)'
+            ORDER BY rowid;
+            """);
+        AssertScoresMatchStock(
+            managed,
+            stock,
+            """
+            SELECT bm25(near_docs)
+            FROM near_docs
+            WHERE near_docs MATCH 'NEAR(one one,0)'
+            ORDER BY rowid;
+            """);
+        AssertScoresMatchStock(
+            managed,
+            stock,
+            """
+            SELECT bm25(near_edges)
+            FROM near_edges
+            WHERE near_edges MATCH 'NEAR("one two" three,0)'
+            ORDER BY rowid;
+            """);
+
+        foreach (var invalidBareword in new[] { "foo.bar", "foo/bar", "foo,bar" })
+        {
+            var sql =
+                $"SELECT rowid FROM near_docs WHERE near_docs MATCH '{invalidBareword}';";
+            Action managedInvalid = () => ReadRowsAsStrings(managed, sql);
+            Action stockInvalid = () => ReadRowsAsStrings(stock, sql);
+            managedInvalid.Should().Throw<EmbeddedSqlException>();
+            stockInvalid.Should().Throw<MsData.SqliteException>();
+        }
 
         foreach (var auxiliary in new[]
                  {

--- a/src/Ahtola.Tests/ManagedSearchVirtualTableTests.cs
+++ b/src/Ahtola.Tests/ManagedSearchVirtualTableTests.cs
@@ -389,8 +389,13 @@ public sealed class ManagedSearchVirtualTableTests
                 (6, 'one three two'),
                 (7, 'one two three'),
                 (8, 'only two three'),
-                (9, 'one twin three');
+                (9, 'one twin three'),
+                (10, 'on two three');
             """,
+            "CREATE VIRTUAL TABLE near_detail_column USING fts5(body, detail=column);",
+            "INSERT INTO near_detail_column VALUES ('one two three');",
+            "CREATE VIRTUAL TABLE near_detail_none USING fts5(body, detail=none);",
+            "INSERT INTO near_detail_none VALUES ('one two three');",
         ];
 
         using var database = new EmbeddedDatabase();
@@ -468,6 +473,20 @@ public sealed class ManagedSearchVirtualTableTests
             "SELECT rowid FROM near_edges WHERE near_edges MATCH '\"!!!\" + one' ORDER BY rowid;",
             "SELECT rowid FROM near_edges WHERE near_edges MATCH '\"\" + one' ORDER BY rowid;",
             "SELECT rowid FROM near_edges WHERE near_edges MATCH 'NEAR(\"!!!\" + one two,1)' ORDER BY rowid;",
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH 'on* + \"\" + two' ORDER BY rowid;",
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH 'on* + \"!!!\" + two' ORDER BY rowid;",
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH 'on* + \"\"' ORDER BY rowid;",
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH 'one + tw* + \"\" + three' ORDER BY rowid;",
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH 'on* + \"\"* + two' ORDER BY rowid;",
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH 'on* + \"\" + \"\"* + two' ORDER BY rowid;",
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH 'on + \"\"* + two' ORDER BY rowid;",
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH 'one + \"\" + two' ORDER BY rowid;",
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH '\"\" + on* + two' ORDER BY rowid;",
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH 'NEAR(on* + \"\" + two three,1)' ORDER BY rowid;",
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH 'NEAR(on* + \"\"* + two three,1)' ORDER BY rowid;",
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH 'NEAR(on* + \"\" + \"\"* + two three,1)' ORDER BY rowid;",
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH 'NEAR(one + \"\" + two three,1)' ORDER BY rowid;",
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH 'NEAR(\"\" + on* + two three,1)' ORDER BY rowid;",
             "SELECT rowid FROM near_edges WHERE near_edges MATCH '\"!!!\" one' ORDER BY rowid;",
             "SELECT rowid FROM near_edges WHERE near_edges MATCH 'one \"!!!\"' ORDER BY rowid;",
             "SELECT rowid FROM near_edges WHERE near_edges MATCH '\"!!!\" AND one' ORDER BY rowid;",
@@ -480,6 +499,12 @@ public sealed class ManagedSearchVirtualTableTests
             "SELECT rowid FROM near_edges WHERE near_edges MATCH 'or' ORDER BY rowid;",
             "SELECT rowid FROM near_edges WHERE near_edges MATCH 'NEAR' ORDER BY rowid;",
             "SELECT rowid FROM near_edges WHERE near_edges MATCH 'OR\U0001F4A9' ORDER BY rowid;",
+            "SELECT rowid FROM near_detail_column WHERE near_detail_column MATCH 'NEAR(one,1)' ORDER BY rowid;",
+            "SELECT rowid FROM near_detail_column WHERE near_detail_column MATCH 'NEAR(on* + \"\",1)' ORDER BY rowid;",
+            "SELECT rowid FROM near_detail_column WHERE near_detail_column MATCH 'NEAR(on + \"\"*,1)' ORDER BY rowid;",
+            "SELECT rowid FROM near_detail_none WHERE near_detail_none MATCH 'NEAR(one,1)' ORDER BY rowid;",
+            "SELECT rowid FROM near_detail_none WHERE near_detail_none MATCH 'NEAR(on* + \"\",1)' ORDER BY rowid;",
+            "SELECT rowid FROM near_detail_none WHERE near_detail_none MATCH 'NEAR(on + \"\"*,1)' ORDER BY rowid;",
             """
             SELECT rowid, highlight(phrase_docs, 0, '[', ']')
             FROM phrase_docs
@@ -497,6 +522,19 @@ public sealed class ManagedSearchVirtualTableTests
         ];
         foreach (var sql in oracleQueries)
             ReadRowsAsStrings(managed, sql).Should().Equal(ReadRowsAsStrings(stock, sql), sql);
+
+        foreach (var positionalQuery in new[]
+        {
+            "on* + \"\" + two",
+            "NEAR(on* + \"\" + two,1)",
+        })
+        {
+            var sql = $"SELECT rowid FROM near_detail_column WHERE near_detail_column MATCH '{positionalQuery}';";
+            Action managedPositional = () => ReadRowsAsStrings(managed, sql);
+            Action stockPositional = () => ReadRowsAsStrings(stock, sql);
+            managedPositional.Should().Throw<EmbeddedSqlException>();
+            stockPositional.Should().Throw<MsData.SqliteException>();
+        }
 
         AssertScoresMatchStock(
             managed,

--- a/src/Ahtola.Tests/ManagedSearchVirtualTableTests.cs
+++ b/src/Ahtola.Tests/ManagedSearchVirtualTableTests.cs
@@ -387,7 +387,9 @@ public sealed class ManagedSearchVirtualTableTests
                 (4, 'one two three filler filler filler filler'),
                 (5, 'or not near'),
                 (6, 'one three two'),
-                (7, 'one two three');
+                (7, 'one two three'),
+                (8, 'only two three'),
+                (9, 'one twin three');
             """,
         ];
 
@@ -445,6 +447,30 @@ public sealed class ManagedSearchVirtualTableTests
             "SELECT rowid FROM near_edges WHERE near_edges MATCH 'NEAR(a c \"a b\",1)' ORDER BY rowid;",
             "SELECT rowid FROM near_edges WHERE near_edges MATCH 'NEAR(one two, 1)' ORDER BY rowid;",
             "SELECT rowid FROM near_edges WHERE near_edges MATCH 'NEAR(\"one\"\"two\" three,1)' ORDER BY rowid;",
+            """
+            SELECT rowid, highlight(near_edges, 0, '[', ']')
+            FROM near_edges
+            WHERE near_edges MATCH 'one + two'
+            ORDER BY rowid;
+            """,
+            """
+            SELECT rowid, highlight(near_edges, 0, '[', ']')
+            FROM near_edges
+            WHERE near_edges MATCH 'NEAR(one + tw* three,1)'
+            ORDER BY rowid;
+            """,
+            """
+            SELECT rowid, highlight(near_edges, 0, '[', ']')
+            FROM near_edges
+            WHERE near_edges MATCH 'NEAR(on* + two three,1)'
+            ORDER BY rowid;
+            """,
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH '\"!!!\" + one' ORDER BY rowid;",
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH '\"\" + one' ORDER BY rowid;",
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH 'NEAR(\"!!!\" + one two,1)' ORDER BY rowid;",
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH '\"!!!\" one' ORDER BY rowid;",
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH 'one \"!!!\"' ORDER BY rowid;",
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH '\"!!!\" AND one' ORDER BY rowid;",
             """
             SELECT rowid, highlight(near_edges, 0, '[', ']')
             FROM near_edges
@@ -513,6 +539,22 @@ public sealed class ManagedSearchVirtualTableTests
         {
             var sql =
                 $"SELECT rowid FROM near_docs WHERE near_docs MATCH '{invalidBareword}';";
+            Action managedInvalid = () => ReadRowsAsStrings(managed, sql);
+            Action stockInvalid = () => ReadRowsAsStrings(stock, sql);
+            managedInvalid.Should().Throw<EmbeddedSqlException>();
+            stockInvalid.Should().Throw<MsData.SqliteException>();
+        }
+
+        const string reservedConcatenation =
+            "SELECT rowid FROM near_edges WHERE near_edges MATCH 'one + OR';";
+        Action managedReserved = () => ReadRowsAsStrings(managed, reservedConcatenation);
+        Action stockReserved = () => ReadRowsAsStrings(stock, reservedConcatenation);
+        managedReserved.Should().Throw<EmbeddedSqlException>();
+        stockReserved.Should().Throw<MsData.SqliteException>();
+
+        foreach (var invalidNear in new[] { "NEAR()", "NEAR(,1)" })
+        {
+            var sql = $"SELECT rowid FROM near_edges WHERE near_edges MATCH '{invalidNear}';";
             Action managedInvalid = () => ReadRowsAsStrings(managed, sql);
             Action stockInvalid = () => ReadRowsAsStrings(stock, sql);
             managedInvalid.Should().Throw<EmbeddedSqlException>();


### PR DESCRIPTION
## Summary

- expand the content-owning managed `fts5` module with fail-closed parsing for `UNINDEXED`, `tokenize`, `prefix`, `detail`, and `columnsize`
- add table/column `MATCH`, hidden negative `rank`, consumed `ORDER BY rank`, SQLite-profile BM25 (including prefix and weighted detail-none parity), `highlight`, and density-based `snippet`
- carry FTS5 auxiliary bindings by source identity through joins, cache weighted result sets per cursor, and preserve application callback shadowing
- make virtual-table DML target visible columns by default, support SQLite-compatible rowid insert/update aliases and coercions, and add `optimize`/`rebuild`
- retain durable rows in the versioned rootpage-zero Ahtola payload and rebuild derived postings across reopen, rollback, savepoints, `VACUUM INTO`, and maintenance commands
- add stock SQLite differential/oracle coverage for options, rowids, ranking, BM25, prefix scoring, phrase highlighting, snippet selection, commands, joins, and fail-closed declarations

## Scope boundaries

This does **not** implement or claim SQLite FTS5 shadow-table/file-format interoperability. External/contentless tables, custom tokenizer modifiers/`porter`, `fts5vocab`, rank configuration, and the complete stock FTS5 query grammar remain unsupported. Weighted phrase/NEAR attribution remains a deterministic approximation because phrase candidates do not retain per-column phrase frequency. Prefix declarations use bounded managed term expansion rather than SQLite prefix shadow indexes.

R-Tree geometry callbacks and SQLite float32 outward-rounding parity remain follow-up work; `rtree`/`rtree_i32` persistence is unchanged.

No native, Rust, Tantivy, reflection-registration, or P/Invoke dependency was added, and neither `turso-src` nor the conformance corpus was modified.

## Validation

- `pwsh ./build.ps1 test` — 6,396 passed, 47 skipped
- targeted FTS5/virtual-table suites — 75 passed on each of `net8.0`, `net9.0`, and `net10.0`
- changed-file `dotnet format --verify-no-changes`