### PR TITLE
Fix managed replica pull and push publication races

### DIFF
--- a/src/Ahtola.Core/Storage/SqliteWalByteRangeLock.cs
+++ b/src/Ahtola.Core/Storage/SqliteWalByteRangeLock.cs
@@ -137,7 +137,14 @@ public sealed partial class SqliteWalByteRangeLock
     {
         ValidateRange(offset, length);
         ValidateMode(mode);
-        return TryAcquireCore(offset, length, mode, carrier: null, out lease, out _);
+        return TryAcquireCore(
+            offset,
+            length,
+            mode,
+            carrier: null,
+            writableLease: false,
+            out lease,
+            out _);
     }
 
     /// <summary>
@@ -185,7 +192,14 @@ public sealed partial class SqliteWalByteRangeLock
         long length,
         SqliteWalByteRangeLockMode mode,
         TimeSpan timeout)
-        => AcquireCore(offset, length, mode, timeout, CancellationToken.None, carrier: null);
+        => AcquireCore(
+            offset,
+            length,
+            mode,
+            timeout,
+            CancellationToken.None,
+            carrier: null,
+            writableLease: false);
 
     /// <summary>
     /// Acquires a lock, retrying until it is available, the requested timeout
@@ -200,7 +214,14 @@ public sealed partial class SqliteWalByteRangeLock
         SqliteWalByteRangeLockMode mode,
         TimeSpan timeout,
         CancellationToken cancellationToken)
-        => AcquireCore(offset, length, mode, timeout, cancellationToken, carrier: null);
+        => AcquireCore(
+            offset,
+            length,
+            mode,
+            timeout,
+            cancellationToken,
+            carrier: null,
+            writableLease: false);
 
     internal bool TryAcquireExclusive(
         ISqliteWalSharedMemoryLockCarrier carrier,
@@ -215,6 +236,7 @@ public sealed partial class SqliteWalByteRangeLock
             length,
             SqliteWalByteRangeLockMode.Exclusive,
             carrier,
+            writableLease: false,
             out lease,
             out _);
     }
@@ -233,8 +255,23 @@ public sealed partial class SqliteWalByteRangeLock
             SqliteWalByteRangeLockMode.Exclusive,
             timeout,
             cancellationToken,
-            carrier);
+            carrier,
+            writableLease: false);
     }
+
+    internal SqliteWalByteRangeLockLease AcquireExclusiveWritable(
+        long offset,
+        long length,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+        => AcquireCore(
+            offset,
+            length,
+            SqliteWalByteRangeLockMode.Exclusive,
+            timeout,
+            cancellationToken,
+            carrier: null,
+            writableLease: true);
 
     private SqliteWalByteRangeLockLease AcquireCore(
         long offset,
@@ -242,7 +279,8 @@ public sealed partial class SqliteWalByteRangeLock
         SqliteWalByteRangeLockMode mode,
         TimeSpan timeout,
         CancellationToken cancellationToken,
-        ISqliteWalSharedMemoryLockCarrier? carrier)
+        ISqliteWalSharedMemoryLockCarrier? carrier,
+        bool writableLease)
     {
         ValidateRange(offset, length);
         ValidateMode(mode);
@@ -254,7 +292,14 @@ public sealed partial class SqliteWalByteRangeLock
         while (true)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (TryAcquireCore(offset, length, mode, carrier, out var lease, out contention))
+            if (TryAcquireCore(
+                    offset,
+                    length,
+                    mode,
+                    carrier,
+                    writableLease,
+                    out var lease,
+                    out contention))
             {
                 return lease
                     ?? throw new InvalidOperationException(
@@ -279,11 +324,12 @@ public sealed partial class SqliteWalByteRangeLock
         long length,
         SqliteWalByteRangeLockMode mode,
         ISqliteWalSharedMemoryLockCarrier? carrier,
+        bool writableLease,
         out SqliteWalByteRangeLockLease? lease,
         out IOException? contention)
     {
         var handle = carrier is null
-            ? OpenLeaseHandle(mode)
+            ? OpenLeaseHandle(mode, writableLease)
             : carrier.DuplicateLockCarrierHandle();
         try
         {
@@ -312,11 +358,12 @@ public sealed partial class SqliteWalByteRangeLock
         }
     }
 
-    private SafeFileHandle OpenLeaseHandle(SqliteWalByteRangeLockMode mode)
+    private SafeFileHandle OpenLeaseHandle(SqliteWalByteRangeLockMode mode, bool writableLease)
         => File.OpenHandle(
             LockFilePath,
             FileMode.Open,
-            mode == SqliteWalByteRangeLockMode.Shared || OperatingSystem.IsWindows()
+            mode == SqliteWalByteRangeLockMode.Shared
+                || (OperatingSystem.IsWindows() && !writableLease)
                 ? FileAccess.Read
                 : FileAccess.ReadWrite,
             FileShare.ReadWrite | FileShare.Delete,
@@ -754,6 +801,18 @@ public sealed class SqliteWalByteRangeLockLease : IDisposable
 
     internal SqliteWalSharedMemoryCarrierIdentity CarrierIdentity { get; }
 
+    internal int Read(Span<byte> buffer, long fileOffset)
+        => RandomAccess.Read(GetHandle(), buffer, fileOffset);
+
+    internal void Write(ReadOnlySpan<byte> buffer, long fileOffset)
+        => RandomAccess.Write(GetHandle(), buffer, fileOffset);
+
+    internal void SetLength(long length)
+        => RandomAccess.SetLength(GetHandle(), length);
+
+    internal void FlushToDisk()
+        => RandomAccess.FlushToDisk(GetHandle());
+
     /// <inheritdoc />
     public void Dispose()
     {
@@ -772,6 +831,10 @@ public sealed class SqliteWalByteRangeLockLease : IDisposable
             handle.Dispose();
         }
     }
+
+    private SafeFileHandle GetHandle()
+        => Volatile.Read(ref _handle)
+           ?? throw new ObjectDisposedException(nameof(SqliteWalByteRangeLockLease));
 }
 
 /// <summary>Identifies one physical shared-memory carrier across independently opened handles.</summary>

--- a/src/Ahtola.Core/Storage/SqliteWalByteRangeLock.cs
+++ b/src/Ahtola.Core/Storage/SqliteWalByteRangeLock.cs
@@ -316,7 +316,9 @@ public sealed partial class SqliteWalByteRangeLock
         => File.OpenHandle(
             LockFilePath,
             FileMode.Open,
-            mode == SqliteWalByteRangeLockMode.Shared ? FileAccess.Read : FileAccess.ReadWrite,
+            mode == SqliteWalByteRangeLockMode.Shared || OperatingSystem.IsWindows()
+                ? FileAccess.Read
+                : FileAccess.ReadWrite,
             FileShare.ReadWrite | FileShare.Delete,
             FileOptions.None);
 

--- a/src/Ahtola.Data/ManagedReplicaApplyLock.cs
+++ b/src/Ahtola.Data/ManagedReplicaApplyLock.cs
@@ -344,8 +344,10 @@ internal static class ManagedReplicaJournalLock
 /// <remarks>
 /// The apply and journal leases remain short and are never held across network I/O. This separate
 /// lease spans watermark verification and SQL replay so two processes cannot both observe the same
-/// pre-batch watermark and replay one non-idempotent batch concurrently. It excludes only another
-/// push flight; local commands and unrelated apply work continue to use their existing leases.
+/// pre-batch watermark and replay one non-idempotent batch concurrently. Any operation that can
+/// publish pull metadata or replace the main file takes this lease before the apply lease. That
+/// push-to-apply order prevents a file replacement from changing the physical identity used for
+/// this carrier while an older push carrier is still held.
 /// </remarks>
 internal static class ManagedReplicaPushLock
 {

--- a/src/Ahtola.Data/ManagedReplicaApplyLock.cs
+++ b/src/Ahtola.Data/ManagedReplicaApplyLock.cs
@@ -583,14 +583,16 @@ internal static class ManagedReplicaApplyLock
         IDisposable? replacementLock,
         string backupPath,
         string destinationPath,
-        string displacedPath)
+        string displacedPath,
+        Action beforeLeaseRelease)
     {
         if (replacementLock is MainFileReplacementLease lease)
         {
-            lease.RollBack(backupPath, destinationPath, displacedPath);
+            lease.RollBack(backupPath, destinationPath, displacedPath, beforeLeaseRelease);
             return;
         }
 
+        beforeLeaseRelease();
         File.Replace(backupPath, destinationPath, displacedPath, ignoreMetadataErrors: false);
     }
 
@@ -631,22 +633,52 @@ internal static class ManagedReplicaApplyLock
             }
         }
 
-        internal void RollBack(string backupPath, string destinationPath, string displacedPath)
+        internal void RollBack(
+            string backupPath,
+            string destinationPath,
+            string displacedPath,
+            Action beforeLeaseRelease)
         {
-            if (OperatingSystem.IsWindows())
+            FileStream? replacementHandoffGuard = null;
+            if (OperatingSystem.IsWindows() && _replacementMainFileLease is null)
             {
-                ReleaseMainFileLease();
-                Interlocked.Exchange(ref _replacementMainFileLease, null)?.Dispose();
-                ManagedReplicaFaultInjection.Hit(
-                    ManagedReplicaDurableBoundary.MainFileRollbackLeasesReleased);
+                // Forward replacement may have failed while reacquiring the published inode.
+                // Reestablish exclusion before classifying and quarantining its sidecars.
+                _replacementMainFileLease = AcquireSqliteMainFileLease(destinationPath);
             }
-            File.Replace(backupPath, destinationPath, displacedPath, ignoreMetadataErrors: false);
-            if (OperatingSystem.IsWindows())
+            try
             {
-                // A writer may have entered either inode while ReplaceFile required their leases
-                // to be released. Reacquire both before rollback state or sidecars are reconciled.
-                _destinationMainFileLease = AcquireSqliteMainFileLease(destinationPath);
-                _replacementMainFileLease = AcquireSqliteMainFileLease(displacedPath);
+                if (OperatingSystem.IsWindows())
+                {
+                    // This read-only handle denies new write handles while permitting ReplaceFile.
+                    // It follows the replacement inode to the displaced path through the swap.
+                    replacementHandoffGuard = File.Open(
+                        destinationPath,
+                        FileMode.Open,
+                        FileAccess.Read,
+                        FileShare.Read | FileShare.Delete);
+                }
+                beforeLeaseRelease();
+                if (OperatingSystem.IsWindows())
+                {
+                    ReleaseMainFileLease();
+                    Interlocked.Exchange(ref _replacementMainFileLease, null)?.Dispose();
+                    ManagedReplicaFaultInjection.Hit(
+                        ManagedReplicaDurableBoundary.MainFileRollbackLeasesReleased);
+                }
+                File.Replace(backupPath, destinationPath, displacedPath, ignoreMetadataErrors: false);
+                if (OperatingSystem.IsWindows())
+                {
+                    ManagedReplicaFaultInjection.Hit(
+                        ManagedReplicaDurableBoundary.MainFileRollbackPublishedBeforeLease);
+                    _destinationMainFileLease = AcquireSqliteMainFileLease(destinationPath);
+                    _replacementMainFileLease = replacementHandoffGuard;
+                    replacementHandoffGuard = null;
+                }
+            }
+            finally
+            {
+                replacementHandoffGuard?.Dispose();
             }
         }
 

--- a/src/Ahtola.Data/ManagedReplicaApplyLock.cs
+++ b/src/Ahtola.Data/ManagedReplicaApplyLock.cs
@@ -641,6 +641,13 @@ internal static class ManagedReplicaApplyLock
                     ManagedReplicaDurableBoundary.MainFileRollbackLeasesReleased);
             }
             File.Replace(backupPath, destinationPath, displacedPath, ignoreMetadataErrors: false);
+            if (OperatingSystem.IsWindows())
+            {
+                // A writer may have entered either inode while ReplaceFile required their leases
+                // to be released. Reacquire both before rollback state or sidecars are reconciled.
+                _destinationMainFileLease = AcquireSqliteMainFileLease(destinationPath);
+                _replacementMainFileLease = AcquireSqliteMainFileLease(displacedPath);
+            }
         }
 
         public void Dispose()

--- a/src/Ahtola.Data/ManagedReplicaApplyLock.cs
+++ b/src/Ahtola.Data/ManagedReplicaApplyLock.cs
@@ -174,7 +174,7 @@ internal static class ManagedReplicaLockCarrier
         return pathCarrier;
     }
 
-    private static void EnsureCarrier(string carrierPath)
+    internal static void EnsureCarrier(string carrierPath)
     {
         Directory.CreateDirectory(Path.GetDirectoryName(carrierPath)!);
 
@@ -260,6 +260,184 @@ internal static class ManagedReplicaLockCarrier
 }
 
 /// <summary>
+/// Acquires only the physical-identity carrier for an existing database inode. Registrations make
+/// the carrier safely reclaimable: every holder and waiter registers under one directory guard
+/// before opening the carrier, and the last registration removes both files.
+/// </summary>
+internal sealed class ManagedReplicaPhysicalCarrierLease : IAsyncDisposable
+{
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> Gates =
+        new(StringComparer.Ordinal);
+    private static readonly ConcurrentDictionary<string, byte> ActiveRegistrations =
+        new(StringComparer.Ordinal);
+    private static readonly ConcurrentDictionary<string, object> RegistryGates =
+        new(StringComparer.Ordinal);
+
+    private SemaphoreSlim? _gate;
+    private SqliteWalByteRangeLockLease? _carrierLease;
+    private Registration? _registration;
+
+    private ManagedReplicaPhysicalCarrierLease(
+        SemaphoreSlim? gate,
+        SqliteWalByteRangeLockLease? carrierLease,
+        Registration? registration)
+    {
+        _gate = gate;
+        _carrierLease = carrierLease;
+        _registration = registration;
+    }
+
+    internal static async ValueTask<ManagedReplicaPhysicalCarrierLease> AcquireAsync(
+        string databasePath,
+        string kind,
+        CancellationToken cancellationToken)
+    {
+        while (ManagedReplicaLockCarrier.TryResolvePhysical(databasePath, kind) is { } carrierPath)
+        {
+            Registration? registration = null;
+            SemaphoreSlim? gate = null;
+            SqliteWalByteRangeLockLease? carrierLease = null;
+            var gateHeld = false;
+            try
+            {
+                registration = Registration.Create(carrierPath);
+                gate = Gates.GetOrAdd(carrierPath, static _ => new SemaphoreSlim(1, 1));
+                await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+                gateHeld = true;
+                carrierLease = new SqliteWalByteRangeLock(carrierPath).AcquireExclusive(
+                    offset: 0,
+                    length: 1,
+                    Timeout.InfiniteTimeSpan,
+                    cancellationToken);
+                if (string.Equals(
+                        ManagedReplicaLockCarrier.TryResolvePhysical(databasePath, kind),
+                        carrierPath,
+                        StringComparison.Ordinal))
+                {
+                    return new ManagedReplicaPhysicalCarrierLease(gate, carrierLease, registration);
+                }
+            }
+            catch
+            {
+                carrierLease?.Dispose();
+                if (gateHeld)
+                    gate!.Release();
+                registration?.Dispose();
+                throw;
+            }
+
+            carrierLease.Dispose();
+            gate.Release();
+            registration.Dispose();
+        }
+
+        return new ManagedReplicaPhysicalCarrierLease(null, null, null);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Interlocked.Exchange(ref _carrierLease, null)?.Dispose();
+        Interlocked.Exchange(ref _gate, null)?.Release();
+        Interlocked.Exchange(ref _registration, null)?.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    private sealed class Registration : IDisposable
+    {
+        private readonly string _carrierPath;
+        private readonly string _holderPath;
+        private SqliteWalByteRangeLockLease? _holderLease;
+
+        private Registration(
+            string carrierPath,
+            string holderPath,
+            SqliteWalByteRangeLockLease holderLease)
+        {
+            _carrierPath = carrierPath;
+            _holderPath = holderPath;
+            _holderLease = holderLease;
+        }
+
+        internal static Registration Create(string carrierPath)
+        {
+            var directory = Path.GetDirectoryName(carrierPath)!;
+            Directory.CreateDirectory(directory);
+            var registryPath = Path.Combine(directory, "physical-carrier-registry.lock");
+            ManagedReplicaLockCarrier.EnsureCarrier(registryPath);
+            lock (RegistryGates.GetOrAdd(registryPath, static _ => new object()))
+            {
+                using var registryLease = new SqliteWalByteRangeLock(registryPath).AcquireExclusive(
+                    offset: 0,
+                    length: 1,
+                    Timeout.InfiniteTimeSpan,
+                    CancellationToken.None);
+
+                CleanupStaleRegistrations(carrierPath);
+                ManagedReplicaLockCarrier.EnsureCarrier(carrierPath);
+                var holderPath = string.Concat(
+                    carrierPath,
+                    ".holder-",
+                    Environment.ProcessId.ToString(CultureInfo.InvariantCulture),
+                    "-",
+                    Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+                ManagedReplicaLockCarrier.EnsureCarrier(holderPath);
+                var holderLease = new SqliteWalByteRangeLock(holderPath).AcquireExclusive(
+                    offset: 0,
+                    length: 1,
+                    Timeout.InfiniteTimeSpan,
+                    CancellationToken.None);
+                ActiveRegistrations.TryAdd(holderPath, 0);
+                return new Registration(carrierPath, holderPath, holderLease);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _holderLease, null) is not { } holderLease)
+                return;
+
+            var directory = Path.GetDirectoryName(_carrierPath)!;
+            var registryPath = Path.Combine(directory, "physical-carrier-registry.lock");
+            lock (RegistryGates.GetOrAdd(registryPath, static _ => new object()))
+            {
+                using var registryLease = new SqliteWalByteRangeLock(registryPath).AcquireExclusive(
+                    offset: 0,
+                    length: 1,
+                    Timeout.InfiniteTimeSpan,
+                    CancellationToken.None);
+                ActiveRegistrations.TryRemove(_holderPath, out _);
+                holderLease.Dispose();
+                File.Delete(_holderPath);
+                CleanupStaleRegistrations(_carrierPath);
+                if (!EnumerateHolderPaths(_carrierPath).Any())
+                    File.Delete(_carrierPath);
+            }
+        }
+
+        private static void CleanupStaleRegistrations(string carrierPath)
+        {
+            foreach (var holderPath in EnumerateHolderPaths(carrierPath))
+            {
+                if (ActiveRegistrations.ContainsKey(holderPath))
+                    continue;
+                var marker = new SqliteWalByteRangeLock(holderPath);
+                if (!marker.TryAcquireExclusive(offset: 0, length: 1, out var staleLease))
+                    continue;
+                staleLease!.Dispose();
+                File.Delete(holderPath);
+            }
+        }
+
+        private static IEnumerable<string> EnumerateHolderPaths(string carrierPath)
+        {
+            var directory = Path.GetDirectoryName(carrierPath)!;
+            var pattern = Path.GetFileName(carrierPath) + ".holder-*";
+            return Directory.EnumerateFiles(directory, pattern, SearchOption.TopDirectoryOnly);
+        }
+    }
+}
+
+/// <summary>
 /// Narrow seam for the single exclusive lease that must be held across a managed embedded
 /// replica's apply sequence: from the moment WAL/journal sidecar state is validated, through
 /// checkpoint, main-file swap, and metadata publication (or rollback/cleanup on failure). Holding
@@ -305,7 +483,6 @@ internal static class ManagedReplicaApplyLock
     internal const string CarrierSuffix = ".ahtola-replica-apply-lock";
     private const long PendingByte = 0x4000_0000;
     private const long SQLiteExclusiveRangeLength = 512;
-    private static readonly TimeSpan ReplacementLockTimeout = TimeSpan.FromSeconds(30);
     private static IManagedReplicaApplyLockCoordinator _current = CrossProcessManagedReplicaApplyLockCoordinator.Instance;
 
     internal static IManagedReplicaApplyLockCoordinator Current
@@ -338,6 +515,8 @@ internal static class ManagedReplicaApplyLock
 
         IDisposable? destinationMainFileLease = null;
         IDisposable? replacementMainFileLease = null;
+        ManagedReplicaPhysicalCarrierLease? replacementPushCarrier = null;
+        ManagedReplicaPhysicalCarrierLease? replacementApplyCarrier = null;
         try
         {
             // The caller already owns the final path's stable push/apply carriers. Lock the two
@@ -347,6 +526,16 @@ internal static class ManagedReplicaApplyLock
             // while the old destination remains locked. The GUID staging path deliberately gets no
             // named carrier of its own; creating one per replacement would leak permanent files
             // into the shared carrier directory.
+            replacementPushCarrier = ManagedReplicaPhysicalCarrierLease.AcquireAsync(
+                    replacementPath,
+                    ManagedReplicaLockCarrier.PushKind,
+                    cancellationToken)
+                .AsTask().GetAwaiter().GetResult();
+            replacementApplyCarrier = ManagedReplicaPhysicalCarrierLease.AcquireAsync(
+                    replacementPath,
+                    ManagedReplicaLockCarrier.ApplyKind,
+                    cancellationToken)
+                .AsTask().GetAwaiter().GetResult();
             destinationMainFileLease = new SqliteWalByteRangeLock(path).AcquireExclusive(
                 PendingByte,
                 SQLiteExclusiveRangeLength,
@@ -360,12 +549,15 @@ internal static class ManagedReplicaApplyLock
             return new MainFileReplacementLease(
                 destinationMainFileLease,
                 replacementMainFileLease,
-                cancellationToken);
+                replacementPushCarrier,
+                replacementApplyCarrier);
         }
         catch
         {
             replacementMainFileLease?.Dispose();
             destinationMainFileLease?.Dispose();
+            replacementApplyCarrier?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            replacementPushCarrier?.DisposeAsync().AsTask().GetAwaiter().GetResult();
             throw;
         }
     }
@@ -404,10 +596,13 @@ internal static class ManagedReplicaApplyLock
     private sealed class MainFileReplacementLease(
         IDisposable destinationMainFileLease,
         IDisposable replacementMainFileLease,
-        CancellationToken cancellationToken) : IDisposable
+        ManagedReplicaPhysicalCarrierLease replacementPushCarrier,
+        ManagedReplicaPhysicalCarrierLease replacementApplyCarrier) : IDisposable
     {
         private IDisposable? _destinationMainFileLease = destinationMainFileLease;
         private IDisposable? _replacementMainFileLease = replacementMainFileLease;
+        private ManagedReplicaPhysicalCarrierLease? _replacementPushCarrier = replacementPushCarrier;
+        private ManagedReplicaPhysicalCarrierLease? _replacementApplyCarrier = replacementApplyCarrier;
 
         internal void ReleaseMainFileLease()
             => Interlocked.Exchange(ref _destinationMainFileLease, null)?.Dispose();
@@ -419,12 +614,20 @@ internal static class ManagedReplicaApplyLock
             Action replacementCompleted)
         {
             if (OperatingSystem.IsWindows())
+            {
                 Interlocked.Exchange(ref _replacementMainFileLease, null)?.Dispose();
+                ManagedReplicaFaultInjection.Hit(
+                    ManagedReplicaDurableBoundary.MainFileReplacementSourceLeaseReleased);
+            }
 
             File.Replace(replacementPath, destinationPath, backupPath, ignoreMetadataErrors: false);
             replacementCompleted();
             if (OperatingSystem.IsWindows())
+            {
+                ManagedReplicaFaultInjection.Hit(
+                    ManagedReplicaDurableBoundary.MainFileReplacementPublishedBeforeLease);
                 _replacementMainFileLease = AcquireSqliteMainFileLease(destinationPath);
+            }
         }
 
         internal void RollBack(string backupPath, string destinationPath)
@@ -433,6 +636,8 @@ internal static class ManagedReplicaApplyLock
             {
                 ReleaseMainFileLease();
                 Interlocked.Exchange(ref _replacementMainFileLease, null)?.Dispose();
+                ManagedReplicaFaultInjection.Hit(
+                    ManagedReplicaDurableBoundary.MainFileRollbackLeasesReleased);
             }
             File.Replace(backupPath, destinationPath, destinationBackupFileName: null, ignoreMetadataErrors: false);
         }
@@ -441,14 +646,18 @@ internal static class ManagedReplicaApplyLock
         {
             ReleaseMainFileLease();
             Interlocked.Exchange(ref _replacementMainFileLease, null)?.Dispose();
+            Interlocked.Exchange(ref _replacementApplyCarrier, null)
+                ?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            Interlocked.Exchange(ref _replacementPushCarrier, null)
+                ?.DisposeAsync().AsTask().GetAwaiter().GetResult();
         }
 
         private IDisposable AcquireSqliteMainFileLease(string path)
             => new SqliteWalByteRangeLock(path).AcquireExclusive(
                 PendingByte,
                 SQLiteExclusiveRangeLength,
-                ReplacementLockTimeout,
-                cancellationToken);
+                Timeout.InfiniteTimeSpan,
+                CancellationToken.None);
     }
 }
 
@@ -595,6 +804,7 @@ internal static class ManagedReplicaPushLock
     {
         var gates = new List<SemaphoreSlim>(2);
         var carrierLeases = new List<SqliteWalByteRangeLockLease>(2);
+        ManagedReplicaPhysicalCarrierLease? physicalLease = null;
         try
         {
             var stableCarrier = ManagedReplicaLockCarrier.EnsureStable(
@@ -609,38 +819,17 @@ internal static class ManagedReplicaPushLock
                 Timeout.InfiniteTimeSpan,
                 cancellationToken));
 
-            while (ManagedReplicaLockCarrier.EnsurePhysical(
-                       databasePath,
-                       ManagedReplicaLockCarrier.PushKind) is { } physicalCarrier)
-            {
-                var physicalGate = Gates.GetOrAdd(physicalCarrier, static _ => new SemaphoreSlim(1, 1));
-                await physicalGate.WaitAsync(cancellationToken).ConfigureAwait(false);
-                gates.Add(physicalGate);
-                var physicalLease = new SqliteWalByteRangeLock(physicalCarrier).AcquireExclusive(
-                    offset: 0,
-                    length: 1,
-                    Timeout.InfiniteTimeSpan,
-                    cancellationToken);
-                if (string.Equals(
-                        ManagedReplicaLockCarrier.TryResolvePhysical(
-                            databasePath,
-                            ManagedReplicaLockCarrier.PushKind),
-                        physicalCarrier,
-                        StringComparison.Ordinal))
-                {
-                    carrierLeases.Add(physicalLease);
-                    break;
-                }
-
-                physicalLease.Dispose();
-                gates.RemoveAt(gates.Count - 1);
-                physicalGate.Release();
-            }
-
-            return new Lease(gates, carrierLeases);
+            physicalLease = await ManagedReplicaPhysicalCarrierLease.AcquireAsync(
+                    databasePath,
+                    ManagedReplicaLockCarrier.PushKind,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return new Lease(gates, carrierLeases, physicalLease);
         }
         catch
         {
+            if (physicalLease is not null)
+                await physicalLease.DisposeAsync().ConfigureAwait(false);
             for (var index = carrierLeases.Count - 1; index >= 0; index--)
                 carrierLeases[index].Dispose();
             for (var index = gates.Count - 1; index >= 0; index--)
@@ -651,13 +840,17 @@ internal static class ManagedReplicaPushLock
 
     private sealed class Lease(
         IReadOnlyList<SemaphoreSlim> gates,
-        IReadOnlyList<SqliteWalByteRangeLockLease> carrierLeases) : IAsyncDisposable
+        IReadOnlyList<SqliteWalByteRangeLockLease> carrierLeases,
+        ManagedReplicaPhysicalCarrierLease physicalLease) : IAsyncDisposable
     {
         private IReadOnlyList<SemaphoreSlim>? _gates = gates;
         private IReadOnlyList<SqliteWalByteRangeLockLease>? _carrierLeases = carrierLeases;
+        private ManagedReplicaPhysicalCarrierLease? _physicalLease = physicalLease;
 
-        public ValueTask DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
+            if (Interlocked.Exchange(ref _physicalLease, null) is { } physical)
+                await physical.DisposeAsync().ConfigureAwait(false);
             if (Interlocked.Exchange(ref _carrierLeases, null) is { } leases)
             {
                 for (var index = leases.Count - 1; index >= 0; index--)
@@ -668,7 +861,6 @@ internal static class ManagedReplicaPushLock
                 for (var index = heldGates.Count - 1; index >= 0; index--)
                     heldGates[index].Release();
             }
-            return ValueTask.CompletedTask;
         }
     }
 }
@@ -683,6 +875,7 @@ internal sealed class CrossProcessManagedReplicaApplyLockCoordinator : IManagedR
     {
         var localLeases = new List<IAsyncDisposable>(2);
         var carrierLeases = new List<SqliteWalByteRangeLockLease>(2);
+        ManagedReplicaPhysicalCarrierLease? physicalLease = null;
         try
         {
             var stableCarrier = ManagedReplicaLockCarrier.EnsureStable(
@@ -697,39 +890,17 @@ internal sealed class CrossProcessManagedReplicaApplyLockCoordinator : IManagedR
                 Timeout.InfiniteTimeSpan,
                 cancellationToken));
 
-            while (ManagedReplicaLockCarrier.EnsurePhysical(
-                       path,
-                       ManagedReplicaLockCarrier.ApplyKind) is { } physicalCarrier)
-            {
-                var physicalLocalLease = await InProcessManagedReplicaApplyLockCoordinator
-                    .AcquireCarrierAsync(physicalCarrier, cancellationToken)
-                    .ConfigureAwait(false);
-                localLeases.Add(physicalLocalLease);
-                var physicalLease = new SqliteWalByteRangeLock(physicalCarrier).AcquireExclusive(
-                    offset: 0,
-                    length: 1,
-                    Timeout.InfiniteTimeSpan,
-                    cancellationToken);
-                if (string.Equals(
-                        ManagedReplicaLockCarrier.TryResolvePhysical(
-                            path,
-                            ManagedReplicaLockCarrier.ApplyKind),
-                        physicalCarrier,
-                        StringComparison.Ordinal))
-                {
-                    carrierLeases.Add(physicalLease);
-                    break;
-                }
-
-                physicalLease.Dispose();
-                localLeases.RemoveAt(localLeases.Count - 1);
-                await physicalLocalLease.DisposeAsync().ConfigureAwait(false);
-            }
-
-            return new Lease(localLeases, carrierLeases);
+            physicalLease = await ManagedReplicaPhysicalCarrierLease.AcquireAsync(
+                    path,
+                    ManagedReplicaLockCarrier.ApplyKind,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return new Lease(localLeases, carrierLeases, physicalLease);
         }
         catch
         {
+            if (physicalLease is not null)
+                await physicalLease.DisposeAsync().ConfigureAwait(false);
             for (var index = carrierLeases.Count - 1; index >= 0; index--)
                 carrierLeases[index].Dispose();
             for (var index = localLeases.Count - 1; index >= 0; index--)
@@ -740,13 +911,17 @@ internal sealed class CrossProcessManagedReplicaApplyLockCoordinator : IManagedR
 
     private sealed class Lease(
         IReadOnlyList<IAsyncDisposable> localLeases,
-        IReadOnlyList<SqliteWalByteRangeLockLease> carrierLeases) : IAsyncDisposable
+        IReadOnlyList<SqliteWalByteRangeLockLease> carrierLeases,
+        ManagedReplicaPhysicalCarrierLease physicalLease) : IAsyncDisposable
     {
         private IReadOnlyList<IAsyncDisposable>? _localLeases = localLeases;
         private IReadOnlyList<SqliteWalByteRangeLockLease>? _carrierLeases = carrierLeases;
+        private ManagedReplicaPhysicalCarrierLease? _physicalLease = physicalLease;
 
         public async ValueTask DisposeAsync()
         {
+            if (Interlocked.Exchange(ref _physicalLease, null) is { } physical)
+                await physical.DisposeAsync().ConfigureAwait(false);
             if (Interlocked.Exchange(ref _carrierLeases, null) is { } carrierLocks)
             {
                 for (var index = carrierLocks.Count - 1; index >= 0; index--)
@@ -791,7 +966,7 @@ internal sealed class InProcessManagedReplicaApplyLockCoordinator : IManagedRepl
                 path,
                 ManagedReplicaLockCarrier.ApplyKind);
             leases.Add(await AcquireCarrierAsync(stableCarrier, cancellationToken).ConfigureAwait(false));
-            while (ManagedReplicaLockCarrier.EnsurePhysical(
+            while (ManagedReplicaLockCarrier.TryResolvePhysical(
                        path,
                        ManagedReplicaLockCarrier.ApplyKind) is { } physicalCarrier)
             {

--- a/src/Ahtola.Data/ManagedReplicaApplyLock.cs
+++ b/src/Ahtola.Data/ManagedReplicaApplyLock.cs
@@ -305,6 +305,7 @@ internal static class ManagedReplicaApplyLock
     internal const string CarrierSuffix = ".ahtola-replica-apply-lock";
     private const long PendingByte = 0x4000_0000;
     private const long SQLiteExclusiveRangeLength = 512;
+    private static readonly TimeSpan ReplacementLockTimeout = TimeSpan.FromSeconds(30);
     private static IManagedReplicaApplyLockCoordinator _current = CrossProcessManagedReplicaApplyLockCoordinator.Instance;
 
     internal static IManagedReplicaApplyLockCoordinator Current
@@ -335,70 +336,119 @@ internal static class ManagedReplicaApplyLock
         if (!File.Exists(path))
             return null;
 
-        IAsyncDisposable? replacementPushLease = null;
-        IAsyncDisposable? replacementApplyLease = null;
-        IDisposable? mainFileLease = null;
+        IDisposable? destinationMainFileLease = null;
+        IDisposable? replacementMainFileLease = null;
         try
         {
-            // The replacement inode is still private at this point, so acquiring its push carrier
-            // after the old generation's apply carrier cannot deadlock with another participant.
-            // Retaining both replacement carriers across File.Replace guarantees that any alias
-            // which resolves the newly published inode queues behind this publication.
-            replacementPushLease = ManagedReplicaPushLock
-                .AcquireExclusiveAsync(replacementPath, cancellationToken)
-                .AsTask()
-                .GetAwaiter()
-                .GetResult();
-            replacementApplyLease = CrossProcessManagedReplicaApplyLockCoordinator.Instance
-                .AcquireExclusiveAsync(replacementPath, cancellationToken)
-                .AsTask()
-                .GetAwaiter()
-                .GetResult();
-            mainFileLease = new SqliteWalByteRangeLock(path).AcquireExclusive(
+            // The caller already owns the final path's stable push/apply carriers. Lock the two
+            // database inodes themselves as well. Unix retains both leases across rename. Windows
+            // cannot rename a byte-locked source, so replacement releases that private staging
+            // lease at the replace syscall and immediately reacquires it through the final path,
+            // while the old destination remains locked. The GUID staging path deliberately gets no
+            // named carrier of its own; creating one per replacement would leak permanent files
+            // into the shared carrier directory.
+            destinationMainFileLease = new SqliteWalByteRangeLock(path).AcquireExclusive(
+                PendingByte,
+                SQLiteExclusiveRangeLength,
+                Timeout.InfiniteTimeSpan,
+                cancellationToken);
+            replacementMainFileLease = new SqliteWalByteRangeLock(replacementPath).AcquireExclusive(
                 PendingByte,
                 SQLiteExclusiveRangeLength,
                 Timeout.InfiniteTimeSpan,
                 cancellationToken);
             return new MainFileReplacementLease(
-                mainFileLease,
-                replacementApplyLease,
-                replacementPushLease);
+                destinationMainFileLease,
+                replacementMainFileLease,
+                cancellationToken);
         }
         catch
         {
-            mainFileLease?.Dispose();
-            replacementApplyLease?.DisposeAsync().AsTask().GetAwaiter().GetResult();
-            replacementPushLease?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            replacementMainFileLease?.Dispose();
+            destinationMainFileLease?.Dispose();
             throw;
         }
     }
 
-    internal static void ReleaseMainFileLeaseForRollback(IDisposable? replacementLock)
+    internal static void ReplaceMainFile(
+        IDisposable? replacementLock,
+        string replacementPath,
+        string destinationPath,
+        string? backupPath,
+        Action replacementCompleted)
     {
         if (replacementLock is MainFileReplacementLease lease)
-            lease.ReleaseMainFileLease();
+        {
+            lease.Replace(replacementPath, destinationPath, backupPath, replacementCompleted);
+            return;
+        }
+
+        File.Replace(replacementPath, destinationPath, backupPath, ignoreMetadataErrors: false);
+        replacementCompleted();
+    }
+
+    internal static void RollBackMainFile(
+        IDisposable? replacementLock,
+        string backupPath,
+        string destinationPath)
+    {
+        if (replacementLock is MainFileReplacementLease lease)
+        {
+            lease.RollBack(backupPath, destinationPath);
+            return;
+        }
+
+        File.Replace(backupPath, destinationPath, destinationBackupFileName: null, ignoreMetadataErrors: false);
     }
 
     private sealed class MainFileReplacementLease(
-        IDisposable mainFileLease,
-        IAsyncDisposable replacementApplyLease,
-        IAsyncDisposable replacementPushLease) : IDisposable
+        IDisposable destinationMainFileLease,
+        IDisposable replacementMainFileLease,
+        CancellationToken cancellationToken) : IDisposable
     {
-        private IDisposable? _mainFileLease = mainFileLease;
-        private IAsyncDisposable? _replacementApplyLease = replacementApplyLease;
-        private IAsyncDisposable? _replacementPushLease = replacementPushLease;
+        private IDisposable? _destinationMainFileLease = destinationMainFileLease;
+        private IDisposable? _replacementMainFileLease = replacementMainFileLease;
 
         internal void ReleaseMainFileLease()
-            => Interlocked.Exchange(ref _mainFileLease, null)?.Dispose();
+            => Interlocked.Exchange(ref _destinationMainFileLease, null)?.Dispose();
+
+        internal void Replace(
+            string replacementPath,
+            string destinationPath,
+            string? backupPath,
+            Action replacementCompleted)
+        {
+            if (OperatingSystem.IsWindows())
+                Interlocked.Exchange(ref _replacementMainFileLease, null)?.Dispose();
+
+            File.Replace(replacementPath, destinationPath, backupPath, ignoreMetadataErrors: false);
+            replacementCompleted();
+            if (OperatingSystem.IsWindows())
+                _replacementMainFileLease = AcquireSqliteMainFileLease(destinationPath);
+        }
+
+        internal void RollBack(string backupPath, string destinationPath)
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                ReleaseMainFileLease();
+                Interlocked.Exchange(ref _replacementMainFileLease, null)?.Dispose();
+            }
+            File.Replace(backupPath, destinationPath, destinationBackupFileName: null, ignoreMetadataErrors: false);
+        }
 
         public void Dispose()
         {
             ReleaseMainFileLease();
-            Interlocked.Exchange(ref _replacementApplyLease, null)
-                ?.DisposeAsync().AsTask().GetAwaiter().GetResult();
-            Interlocked.Exchange(ref _replacementPushLease, null)
-                ?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            Interlocked.Exchange(ref _replacementMainFileLease, null)?.Dispose();
         }
+
+        private IDisposable AcquireSqliteMainFileLease(string path)
+            => new SqliteWalByteRangeLock(path).AcquireExclusive(
+                PendingByte,
+                SQLiteExclusiveRangeLength,
+                ReplacementLockTimeout,
+                cancellationToken);
     }
 }
 

--- a/src/Ahtola.Data/ManagedReplicaApplyLock.cs
+++ b/src/Ahtola.Data/ManagedReplicaApplyLock.cs
@@ -582,15 +582,16 @@ internal static class ManagedReplicaApplyLock
     internal static void RollBackMainFile(
         IDisposable? replacementLock,
         string backupPath,
-        string destinationPath)
+        string destinationPath,
+        string displacedPath)
     {
         if (replacementLock is MainFileReplacementLease lease)
         {
-            lease.RollBack(backupPath, destinationPath);
+            lease.RollBack(backupPath, destinationPath, displacedPath);
             return;
         }
 
-        File.Replace(backupPath, destinationPath, destinationBackupFileName: null, ignoreMetadataErrors: false);
+        File.Replace(backupPath, destinationPath, displacedPath, ignoreMetadataErrors: false);
     }
 
     private sealed class MainFileReplacementLease(
@@ -630,7 +631,7 @@ internal static class ManagedReplicaApplyLock
             }
         }
 
-        internal void RollBack(string backupPath, string destinationPath)
+        internal void RollBack(string backupPath, string destinationPath, string displacedPath)
         {
             if (OperatingSystem.IsWindows())
             {
@@ -639,7 +640,7 @@ internal static class ManagedReplicaApplyLock
                 ManagedReplicaFaultInjection.Hit(
                     ManagedReplicaDurableBoundary.MainFileRollbackLeasesReleased);
             }
-            File.Replace(backupPath, destinationPath, destinationBackupFileName: null, ignoreMetadataErrors: false);
+            File.Replace(backupPath, destinationPath, displacedPath, ignoreMetadataErrors: false);
         }
 
         public void Dispose()

--- a/src/Ahtola.Data/ManagedReplicaApplyLock.cs
+++ b/src/Ahtola.Data/ManagedReplicaApplyLock.cs
@@ -7,8 +7,8 @@ using Ahtola.Core.Storage;
 namespace Ahtola;
 
 /// <summary>
-/// Resolves the single operating-system lock carrier that every alias of one physical replica
-/// database must share.
+/// Resolves the operating-system lock carriers that every alias and every published generation of
+/// one replica database must share.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -20,11 +20,11 @@ namespace Ahtola;
 /// database.
 /// </para>
 /// <para>
-/// The carrier is instead named from the file's <em>physical</em> identity (volume/device plus
-/// file/inode id) inside one stable directory, so every alias resolves to the same carrier
-/// regardless of how it was spelled or which process resolved it. The directory is deliberately
-/// not a sibling of the database: two hard links to one file may live in different directories,
-/// and a per-directory carrier would split them again.
+/// Each lease holds two carriers: one named from the file's <em>physical</em> identity
+/// (volume/device plus file/inode id), which unifies hard-link aliases, and one named from the
+/// physical parent-directory identity plus file name, which remains stable when an atomic
+/// <see cref="File.Replace(string,string,string?,bool)"/> publishes a new inode at that path.
+/// Symbolic-link and junction aliases resolve their parent to the same physical directory.
 /// </para>
 /// <para>
 /// When a replica path does not exist yet (its very first bootstrap) there is no file identity to
@@ -58,19 +58,41 @@ internal static class ManagedReplicaLockCarrier
     /// </summary>
     internal static string Ensure(string databasePath, string kind)
     {
-        var carrierPath = Resolve(databasePath, kind);
-        Directory.CreateDirectory(Path.GetDirectoryName(carrierPath)!);
+        var carrierPaths = EnsureAll(databasePath, kind);
+        return carrierPaths[0];
+    }
 
-        // Opened and closed purely to create the carrier: the lease below takes its own handle.
-        using (File.Open(
-                   carrierPath,
-                   FileMode.OpenOrCreate,
-                   FileAccess.ReadWrite,
-                   FileShare.ReadWrite | FileShare.Delete))
-        {
-        }
+    internal static IReadOnlyList<string> EnsureAll(string databasePath, string kind)
+    {
+        var carrierPaths = ResolveAll(databasePath, kind);
+        foreach (var carrierPath in carrierPaths)
+            EnsureCarrier(carrierPath);
 
+        return carrierPaths;
+    }
+
+    internal static string EnsureStable(string databasePath, string kind)
+    {
+        var carrierPath = ResolveStable(databasePath, kind);
+        EnsureCarrier(carrierPath);
         return carrierPath;
+    }
+
+    internal static string? EnsurePhysical(string databasePath, string kind)
+    {
+        var carrierPath = TryResolvePhysical(databasePath, kind);
+        if (carrierPath is not null)
+            EnsureCarrier(carrierPath);
+        return carrierPath;
+    }
+
+    internal static string? TryResolvePhysical(string databasePath, string kind)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(databasePath);
+        var fullPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(databasePath));
+        return TryReadFileIdentity(fullPath) is { } fileIdentity
+            ? Compose(kind, 'f', fileIdentity, name: null)
+            : null;
     }
 
     /// <summary>
@@ -93,29 +115,76 @@ internal static class ManagedReplicaLockCarrier
         }
     }
 
+    internal static IReadOnlyList<string> TryResolveAll(string databasePath, string kind)
+    {
+        try
+        {
+            return ResolveAll(databasePath, kind);
+        }
+        catch (Exception exception) when (exception is IOException
+                                              or UnauthorizedAccessException
+                                              or PlatformNotSupportedException
+                                              or ArgumentException)
+        {
+            return [];
+        }
+    }
+
     private static string Resolve(string databasePath, string kind)
+        => ResolveAll(databasePath, kind)[0];
+
+    private static IReadOnlyList<string> ResolveAll(string databasePath, string kind)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(databasePath);
         var fullPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(databasePath));
+        var pathCarrier = ResolveStable(fullPath, kind);
+        var physicalCarrier = TryResolvePhysical(fullPath, kind);
+        if (physicalCarrier is null)
+            return [pathCarrier];
 
-        if (TryReadFileIdentity(fullPath) is { } fileIdentity)
-            return Compose(kind, 'f', fileIdentity, name: null);
+        return string.Equals(physicalCarrier, pathCarrier, StringComparison.Ordinal)
+            ? [physicalCarrier]
+            : [physicalCarrier, pathCarrier];
+    }
 
+    private static string ResolveStable(string databasePath, string kind)
+    {
+        var fullPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(databasePath));
         var parentDirectory = Path.GetDirectoryName(fullPath);
         var fileName = Path.GetFileName(fullPath);
         if (string.IsNullOrEmpty(parentDirectory) || string.IsNullOrEmpty(fileName))
             throw FailClosed(fullPath);
 
+        string pathCarrier;
         try
         {
             var parentIdentity = SqliteWalSharedMemoryCarrierIdentity.FromDirectoryPath(parentDirectory);
-            return Compose(kind, 'd', parentIdentity, OperatingSystem.IsWindows() ? fileName.ToUpperInvariant() : fileName);
+            pathCarrier = Compose(
+                kind,
+                'd',
+                parentIdentity,
+                OperatingSystem.IsWindows() ? fileName.ToUpperInvariant() : fileName);
         }
         catch (Exception exception) when (exception is DirectoryNotFoundException
                                               or FileNotFoundException
                                               or PlatformNotSupportedException)
         {
             throw FailClosed(fullPath, exception);
+        }
+        return pathCarrier;
+    }
+
+    private static void EnsureCarrier(string carrierPath)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(carrierPath)!);
+
+        // Opened and closed purely to create the carrier: the lease below takes its own handle.
+        using (File.Open(
+                   carrierPath,
+                   FileMode.OpenOrCreate,
+                   FileAccess.ReadWrite,
+                   FileShare.ReadWrite | FileShare.Delete))
+        {
         }
     }
 
@@ -257,6 +326,80 @@ internal static class ManagedReplicaApplyLock
                 Timeout.InfiniteTimeSpan,
                 cancellationToken)
             : null;
+
+    internal static IDisposable? AcquireMainFileReplacementLock(
+        string path,
+        string replacementPath,
+        CancellationToken cancellationToken)
+    {
+        if (!File.Exists(path))
+            return null;
+
+        IAsyncDisposable? replacementPushLease = null;
+        IAsyncDisposable? replacementApplyLease = null;
+        IDisposable? mainFileLease = null;
+        try
+        {
+            // The replacement inode is still private at this point, so acquiring its push carrier
+            // after the old generation's apply carrier cannot deadlock with another participant.
+            // Retaining both replacement carriers across File.Replace guarantees that any alias
+            // which resolves the newly published inode queues behind this publication.
+            replacementPushLease = ManagedReplicaPushLock
+                .AcquireExclusiveAsync(replacementPath, cancellationToken)
+                .AsTask()
+                .GetAwaiter()
+                .GetResult();
+            replacementApplyLease = CrossProcessManagedReplicaApplyLockCoordinator.Instance
+                .AcquireExclusiveAsync(replacementPath, cancellationToken)
+                .AsTask()
+                .GetAwaiter()
+                .GetResult();
+            mainFileLease = new SqliteWalByteRangeLock(path).AcquireExclusive(
+                PendingByte,
+                SQLiteExclusiveRangeLength,
+                Timeout.InfiniteTimeSpan,
+                cancellationToken);
+            return new MainFileReplacementLease(
+                mainFileLease,
+                replacementApplyLease,
+                replacementPushLease);
+        }
+        catch
+        {
+            mainFileLease?.Dispose();
+            replacementApplyLease?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            replacementPushLease?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            throw;
+        }
+    }
+
+    internal static void ReleaseMainFileLeaseForRollback(IDisposable? replacementLock)
+    {
+        if (replacementLock is MainFileReplacementLease lease)
+            lease.ReleaseMainFileLease();
+    }
+
+    private sealed class MainFileReplacementLease(
+        IDisposable mainFileLease,
+        IAsyncDisposable replacementApplyLease,
+        IAsyncDisposable replacementPushLease) : IDisposable
+    {
+        private IDisposable? _mainFileLease = mainFileLease;
+        private IAsyncDisposable? _replacementApplyLease = replacementApplyLease;
+        private IAsyncDisposable? _replacementPushLease = replacementPushLease;
+
+        internal void ReleaseMainFileLease()
+            => Interlocked.Exchange(ref _mainFileLease, null)?.Dispose();
+
+        public void Dispose()
+        {
+            ReleaseMainFileLease();
+            Interlocked.Exchange(ref _replacementApplyLease, null)
+                ?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            Interlocked.Exchange(ref _replacementPushLease, null)
+                ?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+    }
 }
 
 /// <summary>
@@ -301,39 +444,81 @@ internal static class ManagedReplicaJournalLock
         if (_override is { } factory)
             return factory(databasePath);
 
-        var carrierPath = ManagedReplicaLockCarrier.Ensure(databasePath, ManagedReplicaLockCarrier.JournalKind);
-
-        // The in-process gate is taken first so threads of this process queue on a cheap semaphore
-        // instead of spinning on the operating-system lock, and so a reentrant-looking second
-        // acquisition inside one process is a deadlock we own rather than an OS-level lock upgrade
-        // whose behaviour differs per platform.
-        var gate = Gates.GetOrAdd(carrierPath, static _ => new SemaphoreSlim(1, 1));
-        gate.Wait();
+        var gates = new List<SemaphoreSlim>(2);
+        var carrierLeases = new List<SqliteWalByteRangeLockLease>(2);
         try
         {
-            var lease = new SqliteWalByteRangeLock(carrierPath).AcquireExclusive(
+            var stableCarrier = ManagedReplicaLockCarrier.EnsureStable(
+                databasePath,
+                ManagedReplicaLockCarrier.JournalKind);
+            var stableGate = Gates.GetOrAdd(stableCarrier, static _ => new SemaphoreSlim(1, 1));
+            stableGate.Wait();
+            gates.Add(stableGate);
+            carrierLeases.Add(new SqliteWalByteRangeLock(stableCarrier).AcquireExclusive(
                 offset: 0,
                 length: 1,
                 Timeout.InfiniteTimeSpan,
-                CancellationToken.None);
-            return new Lease(gate, lease);
+                CancellationToken.None));
+
+            while (ManagedReplicaLockCarrier.EnsurePhysical(
+                       databasePath,
+                       ManagedReplicaLockCarrier.JournalKind) is { } physicalCarrier)
+            {
+                var physicalGate = Gates.GetOrAdd(physicalCarrier, static _ => new SemaphoreSlim(1, 1));
+                physicalGate.Wait();
+                gates.Add(physicalGate);
+                var physicalLease = new SqliteWalByteRangeLock(physicalCarrier).AcquireExclusive(
+                    offset: 0,
+                    length: 1,
+                    Timeout.InfiniteTimeSpan,
+                    CancellationToken.None);
+                if (string.Equals(
+                        ManagedReplicaLockCarrier.TryResolvePhysical(
+                            databasePath,
+                            ManagedReplicaLockCarrier.JournalKind),
+                        physicalCarrier,
+                        StringComparison.Ordinal))
+                {
+                    carrierLeases.Add(physicalLease);
+                    break;
+                }
+
+                physicalLease.Dispose();
+                gates.RemoveAt(gates.Count - 1);
+                physicalGate.Release();
+            }
+
+            return new Lease(gates, carrierLeases);
         }
         catch
         {
-            gate.Release();
+            for (var index = carrierLeases.Count - 1; index >= 0; index--)
+                carrierLeases[index].Dispose();
+            for (var index = gates.Count - 1; index >= 0; index--)
+                gates[index].Release();
             throw;
         }
     }
 
-    private sealed class Lease(SemaphoreSlim gate, IDisposable carrierLease) : IDisposable
+    private sealed class Lease(
+        IReadOnlyList<SemaphoreSlim> gates,
+        IReadOnlyList<SqliteWalByteRangeLockLease> carrierLeases) : IDisposable
     {
-        private SemaphoreSlim? _gate = gate;
-        private IDisposable? _carrierLease = carrierLease;
+        private IReadOnlyList<SemaphoreSlim>? _gates = gates;
+        private IReadOnlyList<SqliteWalByteRangeLockLease>? _carrierLeases = carrierLeases;
 
         public void Dispose()
         {
-            Interlocked.Exchange(ref _carrierLease, null)?.Dispose();
-            Interlocked.Exchange(ref _gate, null)?.Release();
+            if (Interlocked.Exchange(ref _carrierLeases, null) is { } leases)
+            {
+                for (var index = leases.Count - 1; index >= 0; index--)
+                    leases[index].Dispose();
+            }
+            if (Interlocked.Exchange(ref _gates, null) is { } heldGates)
+            {
+                for (var index = heldGates.Count - 1; index >= 0; index--)
+                    heldGates[index].Release();
+            }
         }
     }
 }
@@ -358,41 +543,81 @@ internal static class ManagedReplicaPushLock
         string databasePath,
         CancellationToken cancellationToken)
     {
-        var carrierPath = ManagedReplicaLockCarrier.Ensure(
-            databasePath,
-            ManagedReplicaLockCarrier.PushKind);
-        var gate = Gates.GetOrAdd(carrierPath, static _ => new SemaphoreSlim(1, 1));
-        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
-
-        SqliteWalByteRangeLockLease? carrierLease = null;
+        var gates = new List<SemaphoreSlim>(2);
+        var carrierLeases = new List<SqliteWalByteRangeLockLease>(2);
         try
         {
-            carrierLease = new SqliteWalByteRangeLock(carrierPath).AcquireExclusive(
+            var stableCarrier = ManagedReplicaLockCarrier.EnsureStable(
+                databasePath,
+                ManagedReplicaLockCarrier.PushKind);
+            var stableGate = Gates.GetOrAdd(stableCarrier, static _ => new SemaphoreSlim(1, 1));
+            await stableGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            gates.Add(stableGate);
+            carrierLeases.Add(new SqliteWalByteRangeLock(stableCarrier).AcquireExclusive(
                 offset: 0,
                 length: 1,
                 Timeout.InfiniteTimeSpan,
-                cancellationToken);
-            return new Lease(gate, carrierLease);
+                cancellationToken));
+
+            while (ManagedReplicaLockCarrier.EnsurePhysical(
+                       databasePath,
+                       ManagedReplicaLockCarrier.PushKind) is { } physicalCarrier)
+            {
+                var physicalGate = Gates.GetOrAdd(physicalCarrier, static _ => new SemaphoreSlim(1, 1));
+                await physicalGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+                gates.Add(physicalGate);
+                var physicalLease = new SqliteWalByteRangeLock(physicalCarrier).AcquireExclusive(
+                    offset: 0,
+                    length: 1,
+                    Timeout.InfiniteTimeSpan,
+                    cancellationToken);
+                if (string.Equals(
+                        ManagedReplicaLockCarrier.TryResolvePhysical(
+                            databasePath,
+                            ManagedReplicaLockCarrier.PushKind),
+                        physicalCarrier,
+                        StringComparison.Ordinal))
+                {
+                    carrierLeases.Add(physicalLease);
+                    break;
+                }
+
+                physicalLease.Dispose();
+                gates.RemoveAt(gates.Count - 1);
+                physicalGate.Release();
+            }
+
+            return new Lease(gates, carrierLeases);
         }
         catch
         {
-            carrierLease?.Dispose();
-            gate.Release();
+            for (var index = carrierLeases.Count - 1; index >= 0; index--)
+                carrierLeases[index].Dispose();
+            for (var index = gates.Count - 1; index >= 0; index--)
+                gates[index].Release();
             throw;
         }
     }
 
     private sealed class Lease(
-        SemaphoreSlim gate,
-        SqliteWalByteRangeLockLease carrierLease) : IAsyncDisposable
+        IReadOnlyList<SemaphoreSlim> gates,
+        IReadOnlyList<SqliteWalByteRangeLockLease> carrierLeases) : IAsyncDisposable
     {
-        private SemaphoreSlim? _gate = gate;
-        private SqliteWalByteRangeLockLease? _carrierLease = carrierLease;
+        private IReadOnlyList<SemaphoreSlim>? _gates = gates;
+        private IReadOnlyList<SqliteWalByteRangeLockLease>? _carrierLeases = carrierLeases;
 
         public ValueTask DisposeAsync()
         {
-            Interlocked.Exchange(ref _carrierLease, null)?.Dispose();
-            Interlocked.Exchange(ref _gate, null)?.Release();
+            if (Interlocked.Exchange(ref _carrierLeases, null) is { } leases)
+            {
+                for (var index = leases.Count - 1; index >= 0; index--)
+                    leases[index].Dispose();
+            }
+            if (Interlocked.Exchange(ref _gates, null) is { } heldGates)
+            {
+                for (var index = heldGates.Count - 1; index >= 0; index--)
+                    heldGates[index].Release();
+            }
             return ValueTask.CompletedTask;
         }
     }
@@ -406,44 +631,82 @@ internal sealed class CrossProcessManagedReplicaApplyLockCoordinator : IManagedR
         string path,
         CancellationToken cancellationToken)
     {
-        var localLease = await InProcessManagedReplicaApplyLockCoordinator.Instance
-            .AcquireExclusiveAsync(path, cancellationToken)
-            .ConfigureAwait(false);
-        SqliteWalByteRangeLockLease? carrierLease = null;
+        var localLeases = new List<IAsyncDisposable>(2);
+        var carrierLeases = new List<SqliteWalByteRangeLockLease>(2);
         try
         {
-            // Named from the database's physical identity, so a hard link or any other alias of the
-            // same file resolves to this very carrier instead of minting a private one.
-            var carrierPath = ManagedReplicaLockCarrier.Ensure(path, ManagedReplicaLockCarrier.ApplyKind);
-            carrierLease = new SqliteWalByteRangeLock(carrierPath).AcquireExclusive(
+            var stableCarrier = ManagedReplicaLockCarrier.EnsureStable(
+                path,
+                ManagedReplicaLockCarrier.ApplyKind);
+            localLeases.Add(await InProcessManagedReplicaApplyLockCoordinator
+                .AcquireCarrierAsync(stableCarrier, cancellationToken)
+                .ConfigureAwait(false));
+            carrierLeases.Add(new SqliteWalByteRangeLock(stableCarrier).AcquireExclusive(
                 offset: 0,
                 length: 1,
                 Timeout.InfiniteTimeSpan,
-                cancellationToken);
+                cancellationToken));
 
-            return new Lease(localLease, carrierLease);
+            while (ManagedReplicaLockCarrier.EnsurePhysical(
+                       path,
+                       ManagedReplicaLockCarrier.ApplyKind) is { } physicalCarrier)
+            {
+                var physicalLocalLease = await InProcessManagedReplicaApplyLockCoordinator
+                    .AcquireCarrierAsync(physicalCarrier, cancellationToken)
+                    .ConfigureAwait(false);
+                localLeases.Add(physicalLocalLease);
+                var physicalLease = new SqliteWalByteRangeLock(physicalCarrier).AcquireExclusive(
+                    offset: 0,
+                    length: 1,
+                    Timeout.InfiniteTimeSpan,
+                    cancellationToken);
+                if (string.Equals(
+                        ManagedReplicaLockCarrier.TryResolvePhysical(
+                            path,
+                            ManagedReplicaLockCarrier.ApplyKind),
+                        physicalCarrier,
+                        StringComparison.Ordinal))
+                {
+                    carrierLeases.Add(physicalLease);
+                    break;
+                }
+
+                physicalLease.Dispose();
+                localLeases.RemoveAt(localLeases.Count - 1);
+                await physicalLocalLease.DisposeAsync().ConfigureAwait(false);
+            }
+
+            return new Lease(localLeases, carrierLeases);
         }
         catch
         {
-            carrierLease?.Dispose();
-            await localLease.DisposeAsync().ConfigureAwait(false);
+            for (var index = carrierLeases.Count - 1; index >= 0; index--)
+                carrierLeases[index].Dispose();
+            for (var index = localLeases.Count - 1; index >= 0; index--)
+                await localLeases[index].DisposeAsync().ConfigureAwait(false);
             throw;
         }
     }
 
     private sealed class Lease(
-        IAsyncDisposable localLease,
-        SqliteWalByteRangeLockLease carrierLease) : IAsyncDisposable
+        IReadOnlyList<IAsyncDisposable> localLeases,
+        IReadOnlyList<SqliteWalByteRangeLockLease> carrierLeases) : IAsyncDisposable
     {
-        private IAsyncDisposable? _localLease = localLease;
-        private SqliteWalByteRangeLockLease? _carrierLease = carrierLease;
+        private IReadOnlyList<IAsyncDisposable>? _localLeases = localLeases;
+        private IReadOnlyList<SqliteWalByteRangeLockLease>? _carrierLeases = carrierLeases;
 
         public async ValueTask DisposeAsync()
         {
-            Interlocked.Exchange(ref _carrierLease, null)?.Dispose();
-            var local = Interlocked.Exchange(ref _localLease, null);
-            if (local is not null)
-                await local.DisposeAsync().ConfigureAwait(false);
+            if (Interlocked.Exchange(ref _carrierLeases, null) is { } carrierLocks)
+            {
+                for (var index = carrierLocks.Count - 1; index >= 0; index--)
+                    carrierLocks[index].Dispose();
+            }
+            if (Interlocked.Exchange(ref _localLeases, null) is { } localLocks)
+            {
+                for (var index = localLocks.Count - 1; index >= 0; index--)
+                    await localLocks[index].DisposeAsync().ConfigureAwait(false);
+            }
         }
     }
 }
@@ -456,7 +719,7 @@ internal sealed class CrossProcessManagedReplicaApplyLockCoordinator : IManagedR
 /// selected on its own by a test that only needs in-process serialization.
 /// </summary>
 /// <remarks>
-/// Gates are created lazily per resolved <see cref="LockKey"/> and never removed. A real replica
+/// Gates are created lazily per resolved carrier path and never removed. A real replica
 /// process only ever touches a small, effectively static set of distinct database paths over its
 /// lifetime, so this keeps the implementation simple and lock-free on the hot (uncontended) path
 /// rather than adding reference-counted teardown for a resource (one <see cref="SemaphoreSlim"/>
@@ -466,109 +729,70 @@ internal sealed class InProcessManagedReplicaApplyLockCoordinator : IManagedRepl
 {
     internal static readonly InProcessManagedReplicaApplyLockCoordinator Instance = new();
 
-    private static readonly ConcurrentDictionary<LockKey, SemaphoreSlim> Gates = new();
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> Gates =
+        new(StringComparer.Ordinal);
 
     public async ValueTask<IAsyncDisposable> AcquireExclusiveAsync(string path, CancellationToken cancellationToken)
     {
-        var key = ResolveLockKey(path);
-        var gate = Gates.GetOrAdd(key, static _ => new SemaphoreSlim(1, 1));
+        var leases = new List<IAsyncDisposable>(2);
+        try
+        {
+            var stableCarrier = ManagedReplicaLockCarrier.EnsureStable(
+                path,
+                ManagedReplicaLockCarrier.ApplyKind);
+            leases.Add(await AcquireCarrierAsync(stableCarrier, cancellationToken).ConfigureAwait(false));
+            while (ManagedReplicaLockCarrier.EnsurePhysical(
+                       path,
+                       ManagedReplicaLockCarrier.ApplyKind) is { } physicalCarrier)
+            {
+                var physicalLease = await AcquireCarrierAsync(physicalCarrier, cancellationToken)
+                    .ConfigureAwait(false);
+                leases.Add(physicalLease);
+                if (string.Equals(
+                        ManagedReplicaLockCarrier.TryResolvePhysical(
+                            path,
+                            ManagedReplicaLockCarrier.ApplyKind),
+                        physicalCarrier,
+                        StringComparison.Ordinal))
+                {
+                    break;
+                }
+
+                leases.RemoveAt(leases.Count - 1);
+                await physicalLease.DisposeAsync().ConfigureAwait(false);
+            }
+            return new CompositeLease(leases);
+        }
+        catch
+        {
+            for (var index = leases.Count - 1; index >= 0; index--)
+                await leases[index].DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    internal static async ValueTask<IAsyncDisposable> AcquireCarrierAsync(
+        string carrierPath,
+        CancellationToken cancellationToken)
+    {
+        var gate = Gates.GetOrAdd(carrierPath, static _ => new SemaphoreSlim(1, 1));
         await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
         return new Lease(gate);
     }
 
-    /// <summary>
-    /// Resolves the mutual-exclusion key for <paramref name="path"/> using true physical file (or,
-    /// failing that, physical parent-directory) identity wherever the platform supports it, so a
-    /// symbolic link, junction/mount point, hard link, or Windows short (8.3) name that aliases the
-    /// same underlying file or directory resolves to the SAME key as the canonical path. A purely
-    /// textual normalization (<see cref="Path.GetFullPath(string)"/> alone) cannot make that
-    /// guarantee -- two textually different paths naming the same physical file would get
-    /// different keys and could race each other through this coordinator instead of serializing.
-    /// </summary>
-    private static LockKey ResolveLockKey(string path)
+    private sealed class CompositeLease(IReadOnlyList<IAsyncDisposable> leases) : IAsyncDisposable
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(path);
-        var fullPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+        private IReadOnlyList<IAsyncDisposable>? _leases = leases;
 
-        try
+        public async ValueTask DisposeAsync()
         {
-            // The common case: the database file already exists (every apply after the replica's
-            // first bootstrap). Its own physical identity is the strongest available key and, by
-            // construction, is immune to every aliasing vector the review called out. Name/TextPath
-            // are deliberately left null: equality for this kind must depend on Identity alone, or
-            // two differently-spelled aliases of the same physical file would wrongly get different
-            // keys.
-            return new LockKey(LockKeyKind.PhysicalFile, SqliteWalSharedMemoryCarrierIdentity.FromPath(fullPath), null, null);
-        }
-        catch (FileNotFoundException)
-        {
-            // The target does not exist yet (first-ever bootstrap for this path); fall through to
-            // canonicalizing its parent directory instead.
-        }
-        catch (DirectoryNotFoundException)
-        {
-            // Same as above, but a directory component of the path is also missing.
-        }
-        catch (PlatformNotSupportedException)
-        {
-            return new LockKey(LockKeyKind.TextFallback, default, null, NormalizeForTextFallback(fullPath));
-        }
-
-        var parentDirectory = Path.GetDirectoryName(fullPath);
-        var fileName = Path.GetFileName(fullPath);
-        if (string.IsNullOrEmpty(parentDirectory) || string.IsNullOrEmpty(fileName))
-        {
-            // No parent-directory component to canonicalize (a degenerate/rooted path); nothing
-            // physical is left to resolve against, so fall back to the plain textual key.
-            return new LockKey(LockKeyKind.TextFallback, default, null, NormalizeForTextFallback(fullPath));
-        }
-
-        try
-        {
-            var parentIdentity = SqliteWalSharedMemoryCarrierIdentity.FromDirectoryPath(parentDirectory);
-            var normalizedFileName = OperatingSystem.IsWindows() ? fileName.ToUpperInvariant() : fileName;
-            return new LockKey(LockKeyKind.PhysicalParentAndName, parentIdentity, normalizedFileName, null);
-        }
-        catch (DirectoryNotFoundException)
-        {
-            // The parent directory does not exist yet either (for example, the very first
-            // bootstrap into a brand-new directory tree). There is nothing physical left to
-            // canonicalize, so fall back to the textual key -- a narrower race window than before
-            // this fix, since it now only applies while the parent directory itself is missing
-            // rather than for every not-yet-bootstrapped path.
-            return new LockKey(LockKeyKind.TextFallback, default, null, NormalizeForTextFallback(fullPath));
-        }
-        catch (PlatformNotSupportedException)
-        {
-            return new LockKey(LockKeyKind.TextFallback, default, null, NormalizeForTextFallback(fullPath));
+            if (Interlocked.Exchange(ref _leases, null) is { } heldLeases)
+            {
+                for (var index = heldLeases.Count - 1; index >= 0; index--)
+                    await heldLeases[index].DisposeAsync().ConfigureAwait(false);
+            }
         }
     }
-
-    private static string NormalizeForTextFallback(string fullPath)
-        => OperatingSystem.IsWindows() ? fullPath.ToUpperInvariant() : fullPath;
-
-    private enum LockKeyKind
-    {
-        /// <summary>Keyed by the physical identity of the target file itself, which already exists.</summary>
-        PhysicalFile,
-
-        /// <summary>Keyed by the physical identity of the target's parent directory plus its (case-normalized) file name, because the target itself does not exist yet.</summary>
-        PhysicalParentAndName,
-
-        /// <summary>Keyed by a purely textual normalization; used only when neither physical resolution above is available on this platform or for this path.</summary>
-        TextFallback,
-    }
-
-    /// <summary>
-    /// Mutual-exclusion key for one database path. Equality is structural over all four fields, so
-    /// two keys of different <see cref="LockKeyKind"/>s are never equal even if their unused fields
-    /// happen to share default values.
-    /// </summary>
-    private readonly record struct LockKey(
-        LockKeyKind Kind,
-        SqliteWalSharedMemoryCarrierIdentity Identity,
-        string? Name,
-        string? TextPath);
 
     private sealed class Lease(SemaphoreSlim gate) : IAsyncDisposable
     {

--- a/src/Ahtola.Data/ManagedReplicaApplyLock.cs
+++ b/src/Ahtola.Data/ManagedReplicaApplyLock.cs
@@ -494,7 +494,7 @@ internal static class ManagedReplicaApplyLock
     internal static ValueTask<IAsyncDisposable> AcquireExclusiveAsync(string path, CancellationToken cancellationToken)
         => Current.AcquireExclusiveAsync(path, cancellationToken);
 
-    internal static IDisposable? AcquireMainFileReplacementLock(
+    internal static SqliteWalByteRangeLockLease? AcquireMainFileReplacementLock(
         string path,
         CancellationToken cancellationToken)
         => File.Exists(path)
@@ -513,8 +513,8 @@ internal static class ManagedReplicaApplyLock
         if (!File.Exists(path))
             return null;
 
-        IDisposable? destinationMainFileLease = null;
-        IDisposable? replacementMainFileLease = null;
+        SqliteWalByteRangeLockLease? destinationMainFileLease = null;
+        SqliteWalByteRangeLockLease? replacementMainFileLease = null;
         ManagedReplicaPhysicalCarrierLease? replacementPushCarrier = null;
         ManagedReplicaPhysicalCarrierLease? replacementApplyCarrier = null;
         try
@@ -536,12 +536,12 @@ internal static class ManagedReplicaApplyLock
                     ManagedReplicaLockCarrier.ApplyKind,
                     cancellationToken)
                 .AsTask().GetAwaiter().GetResult();
-            destinationMainFileLease = new SqliteWalByteRangeLock(path).AcquireExclusive(
+            destinationMainFileLease = new SqliteWalByteRangeLock(path).AcquireExclusiveWritable(
                 PendingByte,
                 SQLiteExclusiveRangeLength,
                 Timeout.InfiniteTimeSpan,
                 cancellationToken);
-            replacementMainFileLease = new SqliteWalByteRangeLock(replacementPath).AcquireExclusive(
+            replacementMainFileLease = new SqliteWalByteRangeLock(replacementPath).AcquireExclusiveWritable(
                 PendingByte,
                 SQLiteExclusiveRangeLength,
                 Timeout.InfiniteTimeSpan,
@@ -596,14 +596,31 @@ internal static class ManagedReplicaApplyLock
         File.Replace(backupPath, destinationPath, displacedPath, ignoreMetadataErrors: false);
     }
 
+    internal static SqliteWalByteRangeLockLease GetMainFileLease(
+        IDisposable? replacementLock,
+        string path)
+    {
+        var identity = SqliteWalSharedMemoryCarrierIdentity.FromPath(path);
+        if (replacementLock is SqliteWalByteRangeLockLease lease
+            && lease.CarrierIdentity == identity)
+        {
+            return lease;
+        }
+        if (replacementLock is MainFileReplacementLease replacementLease)
+            return replacementLease.GetLease(identity);
+
+        throw new InvalidOperationException(
+            "The main-file replacement lock does not own the requested database inode.");
+    }
+
     private sealed class MainFileReplacementLease(
-        IDisposable destinationMainFileLease,
-        IDisposable replacementMainFileLease,
+        SqliteWalByteRangeLockLease destinationMainFileLease,
+        SqliteWalByteRangeLockLease replacementMainFileLease,
         ManagedReplicaPhysicalCarrierLease replacementPushCarrier,
         ManagedReplicaPhysicalCarrierLease replacementApplyCarrier) : IDisposable
     {
-        private IDisposable? _destinationMainFileLease = destinationMainFileLease;
-        private IDisposable? _replacementMainFileLease = replacementMainFileLease;
+        private SqliteWalByteRangeLockLease? _destinationMainFileLease = destinationMainFileLease;
+        private SqliteWalByteRangeLockLease? _replacementMainFileLease = replacementMainFileLease;
         private ManagedReplicaPhysicalCarrierLease? _replacementPushCarrier = replacementPushCarrier;
         private ManagedReplicaPhysicalCarrierLease? _replacementApplyCarrier = replacementApplyCarrier;
 
@@ -639,47 +656,49 @@ internal static class ManagedReplicaApplyLock
             string displacedPath,
             Action beforeLeaseRelease)
         {
-            FileStream? replacementHandoffGuard = null;
             if (OperatingSystem.IsWindows() && _replacementMainFileLease is null)
             {
                 // Forward replacement may have failed while reacquiring the published inode.
                 // Reestablish exclusion before classifying and quarantining its sidecars.
                 _replacementMainFileLease = AcquireSqliteMainFileLease(destinationPath);
             }
-            try
+            if (OperatingSystem.IsWindows())
             {
-                if (OperatingSystem.IsWindows())
-                {
-                    // This read-only handle denies new write handles while permitting ReplaceFile.
-                    // It follows the replacement inode to the displaced path through the swap.
-                    replacementHandoffGuard = File.Open(
-                        destinationPath,
-                        FileMode.Open,
-                        FileAccess.Read,
-                        FileShare.Read | FileShare.Delete);
-                }
+                // Restore into the published inode while retaining both SQLite leases. Windows
+                // ReplaceFile cannot keep a deny-write handle on its source, and its source
+                // byte-range lock does not exclude writers after the replacement handoff.
                 beforeLeaseRelease();
-                if (OperatingSystem.IsWindows())
-                {
-                    ReleaseMainFileLease();
-                    Interlocked.Exchange(ref _replacementMainFileLease, null)?.Dispose();
-                    ManagedReplicaFaultInjection.Hit(
-                        ManagedReplicaDurableBoundary.MainFileRollbackLeasesReleased);
-                }
-                File.Replace(backupPath, destinationPath, displacedPath, ignoreMetadataErrors: false);
-                if (OperatingSystem.IsWindows())
-                {
-                    ManagedReplicaFaultInjection.Hit(
-                        ManagedReplicaDurableBoundary.MainFileRollbackPublishedBeforeLease);
-                    _destinationMainFileLease = AcquireSqliteMainFileLease(destinationPath);
-                    _replacementMainFileLease = replacementHandoffGuard;
-                    replacementHandoffGuard = null;
-                }
+                var destinationIdentity =
+                    SqliteWalSharedMemoryCarrierIdentity.FromPath(destinationPath);
+                var firstLease = _destinationMainFileLease
+                    ?? throw new InvalidOperationException(
+                        "The rollback destination no longer has its SQLite lease.");
+                var secondLease = _replacementMainFileLease
+                    ?? throw new InvalidOperationException(
+                        "The rollback backup no longer has its SQLite lease.");
+                var (publishedLease, backupLease) =
+                    firstLease.CarrierIdentity == destinationIdentity
+                        ? (firstLease, secondLease)
+                        : secondLease.CarrierIdentity == destinationIdentity
+                            ? (secondLease, firstLease)
+                            : throw new InvalidOperationException(
+                                "The rollback leases no longer identify the published database.");
+                ManagedReplicaReplacementState.PreserveDisplacedMainFile(
+                    destinationPath,
+                    displacedPath,
+                    publishedLease);
+                ManagedReplicaFaultInjection.Hit(
+                    ManagedReplicaDurableBoundary.MainFileRollbackDisplacedPreserved);
+                ManagedReplicaReplacementState.RestoreMainFileInPlace(
+                    backupLease,
+                    publishedLease);
+                ManagedReplicaFaultInjection.Hit(
+                    ManagedReplicaDurableBoundary.MainFileRollbackRestoredUnderLease);
+                return;
             }
-            finally
-            {
-                replacementHandoffGuard?.Dispose();
-            }
+
+            beforeLeaseRelease();
+            File.Replace(backupPath, destinationPath, displacedPath, ignoreMetadataErrors: false);
         }
 
         public void Dispose()
@@ -692,8 +711,26 @@ internal static class ManagedReplicaApplyLock
                 ?.DisposeAsync().AsTask().GetAwaiter().GetResult();
         }
 
-        private IDisposable AcquireSqliteMainFileLease(string path)
-            => new SqliteWalByteRangeLock(path).AcquireExclusive(
+        internal SqliteWalByteRangeLockLease GetLease(
+            SqliteWalSharedMemoryCarrierIdentity identity)
+        {
+            if (_destinationMainFileLease is { } destination
+                && destination.CarrierIdentity == identity)
+            {
+                return destination;
+            }
+            if (_replacementMainFileLease is { } replacement
+                && replacement.CarrierIdentity == identity)
+            {
+                return replacement;
+            }
+
+            throw new InvalidOperationException(
+                "The main-file replacement lock does not own the requested database inode.");
+        }
+
+        private SqliteWalByteRangeLockLease AcquireSqliteMainFileLease(string path)
+            => new SqliteWalByteRangeLock(path).AcquireExclusiveWritable(
                 PendingByte,
                 SQLiteExclusiveRangeLength,
                 Timeout.InfiniteTimeSpan,

--- a/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
+++ b/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
@@ -828,7 +828,7 @@ internal static class ManagedReplicaBootstrapper
                 syncOptions,
                 pendingLocalChanges,
                 acknowledgedLocalChanges,
-                quarantinedSequences: null,
+                expectedConflictState: null,
                 cancellationToken)
             .ConfigureAwait(false)).Result;
 
@@ -855,27 +855,31 @@ internal static class ManagedReplicaBootstrapper
     /// the staleness baseline in <see cref="TryUseCurrentLocalStateAsPullBase"/>.
     /// </param>
     /// <param name="acknowledgedLocalChanges">Already-pushed changes retained for base rebuilds.</param>
-    /// <param name="quarantinedSequences">
-    /// Journal sequences that are still durably pending but must never be replayed onto the newly
-    /// pulled base — the unresolved half of an open push conflict (see
-    /// <see cref="ManagedReplicaConflictState"/>). They stay part of
+    /// <param name="expectedConflictState">
+    /// The open conflict an explicit rebase pull was negotiated against. Its unresolved journal
+    /// sequences must never be replayed onto the newly pulled base. They stay part of
     /// <paramref name="pendingLocalChanges"/> for the staleness comparison (which must keep seeing
     /// the journal exactly as it is on disk, or the retry loop could never converge), but are
     /// filtered out of the set handed to the replay path so the remote value wins for the rows
-    /// they touch.
+    /// they touch. A normal pull passes <see langword="null"/> and fails if any conflict appears
+    /// before publication; an explicit rebase fails if the marker no longer exactly matches this
+    /// state.
     /// </param>
     /// <param name="cancellationToken">Cancels the pull.</param>
     internal static async Task<ManagedReplicaPullOutcome> CheckForUpdatesAsync(
         AhtolaReplicaOptions options, ManagedReplicaMetadata metadata, AhtolaSyncOptions syncOptions,
         IReadOnlyList<ReplicaLocalChange> pendingLocalChanges,
         IReadOnlyList<ReplicaLocalChange> acknowledgedLocalChanges,
-        IReadOnlySet<long>? quarantinedSequences,
+        ManagedReplicaConflictState? expectedConflictState,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(pendingLocalChanges);
         ArgumentNullException.ThrowIfNull(acknowledgedLocalChanges);
+        IReadOnlySet<long>? quarantinedSequences = expectedConflictState is { } conflict
+            ? new HashSet<long>(conflict.UnresolvedSequences)
+            : null;
         ManagedReplicaSupportMatrix.ValidateOptions(options);
-        ManagedReplicaRevertWal.EnsureSynchronizationReady(options.Path, metadata);
+        ManagedReplicaRevertWal.ValidateSynchronizationReady(options.Path, metadata);
         // The whole pull-and-apply cycle below is retried, in place, whenever the apply lease
         // reveals that local state already moved past the snapshot (metadata, pending local
         // changes) this iteration's request/response were negotiated against -- see
@@ -962,6 +966,8 @@ internal static class ManagedReplicaBootstrapper
                 // apply. Besides excluding an in-flight push intent, this order prevents a main-file
                 // replacement from changing the physical identity behind the push carrier while an
                 // older carrier is still held.
+                ManagedReplicaFaultInjection.Hit(
+                    ManagedReplicaDurableBoundary.ReplicaPullPublicationLockWaiting);
                 await using var logicalPushLease = await ManagedReplicaPushLock
                     .AcquireExclusiveAsync(options.Path, effectiveToken)
                     .ConfigureAwait(false);
@@ -969,6 +975,7 @@ internal static class ManagedReplicaBootstrapper
                     .ConfigureAwait(false);
                 ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.ReplicaApplyLockAcquired);
                 effectiveToken.ThrowIfCancellationRequested();
+                ManagedReplicaConflictState.ValidatePullPublication(options.Path, expectedConflictState);
 
                 // The request above (and this response) were negotiated against `metadata` and
                 // `pendingLocalChanges` as they stood BEFORE the network round trip and the wait
@@ -988,6 +995,7 @@ internal static class ManagedReplicaBootstrapper
                     acknowledgedLocalChanges = freshLogicalAcknowledgedLocalChanges;
                     continue;
                 }
+                ManagedReplicaRevertWal.EnsureSynchronizationReady(options.Path, metadata);
 
                 var (outcome, statistics, replayed) = await ApplyLogicalUpdatesAsync(
                     options, metadata, header, body, syncOptions,
@@ -1020,6 +1028,29 @@ internal static class ManagedReplicaBootstrapper
             }
             if (pages.Count == 0 && string.Equals(header.Revision, metadata.Revision, StringComparison.Ordinal))
             {
+                ManagedReplicaFaultInjection.Hit(
+                    ManagedReplicaDurableBoundary.ReplicaPullPublicationLockWaiting);
+                await using var noOpPushLease = await ManagedReplicaPushLock
+                    .AcquireExclusiveAsync(options.Path, effectiveToken)
+                    .ConfigureAwait(false);
+                await using var noOpApplyLease = await ManagedReplicaApplyLock
+                    .AcquireExclusiveAsync(options.Path, effectiveToken)
+                    .ConfigureAwait(false);
+                ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.ReplicaApplyLockAcquired);
+                effectiveToken.ThrowIfCancellationRequested();
+                ManagedReplicaConflictState.ValidatePullPublication(options.Path, expectedConflictState);
+                if (!TryUseCurrentLocalStateAsPullBase(
+                        options.Path, metadata, pendingLocalChanges, acknowledgedLocalChanges,
+                        out var freshNoOpMetadata,
+                        out var freshNoOpPendingLocalChanges,
+                        out var freshNoOpAcknowledgedLocalChanges))
+                {
+                    metadata = freshNoOpMetadata;
+                    pendingLocalChanges = freshNoOpPendingLocalChanges;
+                    acknowledgedLocalChanges = freshNoOpAcknowledgedLocalChanges;
+                    continue;
+                }
+                ManagedReplicaRevertWal.EnsureSynchronizationReady(options.Path, metadata);
                 syncOptions.Progress?.Report(new AhtolaSyncProgress(AhtolaSyncProgressStage.Completed));
                 return new ManagedReplicaPullOutcome(
                     new AhtolaSyncResult(AhtolaSyncOutcome.UpToDate,
@@ -1039,6 +1070,8 @@ internal static class ManagedReplicaBootstrapper
 
             // Keep the same push-to-apply order as the logical branch. The response is already fully
             // staged in memory, so no remote I/O is covered by either lease.
+            ManagedReplicaFaultInjection.Hit(
+                ManagedReplicaDurableBoundary.ReplicaPullPublicationLockWaiting);
             await using var pagesPushLease = await ManagedReplicaPushLock
                 .AcquireExclusiveAsync(options.Path, effectiveToken)
                 .ConfigureAwait(false);
@@ -1046,6 +1079,7 @@ internal static class ManagedReplicaBootstrapper
                 .ConfigureAwait(false);
             ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.ReplicaApplyLockAcquired);
             effectiveToken.ThrowIfCancellationRequested();
+            ManagedReplicaConflictState.ValidatePullPublication(options.Path, expectedConflictState);
 
             if (!TryUseCurrentLocalStateAsPullBase(
                     options.Path, metadata, pendingLocalChanges, acknowledgedLocalChanges,
@@ -1058,6 +1092,7 @@ internal static class ManagedReplicaBootstrapper
                 acknowledgedLocalChanges = freshPagesAcknowledgedLocalChanges;
                 continue;
             }
+            ManagedReplicaRevertWal.EnsureSynchronizationReady(options.Path, metadata);
 
             // The response turned out to be a Pages stream (Incremental or ReplaceBase) even though
             // the remembered protocol is MvccLogical (a protocol-2 remote can still answer any given
@@ -1899,6 +1934,14 @@ internal static class ManagedReplicaBootstrapper
         if (!File.Exists(statePath))
             return metadata;
 
+        var requestBaseMetadata = LoadMetadata(options.Path)
+            ?? throw new NotSupportedException(
+                "Managed embedded replica metadata was removed before page materialization began.");
+        var requestBaseJournal = ManagedReplicaChangeJournal.Open(options.Path);
+        var requestBasePendingLocalChanges = requestBaseJournal.ReadBatch(int.MaxValue).Changes;
+        var requestBaseAcknowledgedLocalChanges = requestBaseMetadata.JournalBaseWatermark > 0
+            ? requestBaseJournal.ReadAcknowledged(requestBaseMetadata.JournalBaseWatermark)
+            : [];
         using var ownedFileSystem = retainedMaterializer is null
             ? new ManagedReplicaPageMaterializingFileSystem(
                 PhysicalFileSystem.Instance,
@@ -1925,6 +1968,8 @@ internal static class ManagedReplicaBootstrapper
         ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.PartialImageCompletionStarted);
         await fileSystem.MaterializeAllAsync(cancellationToken).ConfigureAwait(false);
 
+        ManagedReplicaFaultInjection.Hit(
+            ManagedReplicaDurableBoundary.PartialImagePublicationLockWaiting);
         await using var materializationPushLease = await ManagedReplicaPushLock
             .AcquireExclusiveAsync(options.Path, cancellationToken)
             .ConfigureAwait(false);
@@ -1932,7 +1977,21 @@ internal static class ManagedReplicaBootstrapper
             .AcquireExclusiveAsync(options.Path, cancellationToken)
             .ConfigureAwait(false);
         cancellationToken.ThrowIfCancellationRequested();
+        ManagedReplicaConflictState.ValidatePullPublication(options.Path, expectedState: null);
         RevalidateMaterializationPublicationMetadata(options.Path, metadata);
+        if (!TryUseCurrentLocalStateAsPullBase(
+                options.Path,
+                requestBaseMetadata,
+                requestBasePendingLocalChanges,
+                requestBaseAcknowledgedLocalChanges,
+                out _,
+                out _,
+                out _))
+        {
+            throw new InvalidOperationException(
+                "Managed embedded replica state changed while page materialization was in flight; "
+                + "the materialized image was not published.");
+        }
 
         var fingerprint = fileSystem.ComputeDatabaseFingerprint();
         var metadataPath = options.Path + MetadataSuffix;
@@ -2100,10 +2159,9 @@ internal static class ManagedReplicaBootstrapper
                 metadata = ManagedReplicaRevertWal.MarkRemoteApplyStarted(options.Path, metadata);
             mainFileReplacementLock = ManagedReplicaApplyLock.AcquireMainFileReplacementLock(
                 options.Path,
+                stagingPath,
                 cancellationToken);
             File.Replace(stagingPath, options.Path, backupPath, ignoreMetadataErrors: false);
-            mainFileReplacementLock?.Dispose();
-            mainFileReplacementLock = null;
             databaseInstalled = true;
             ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.IncrementalApplyDatabasePublished);
             cancellationToken.ThrowIfCancellationRequested();
@@ -2137,9 +2195,6 @@ internal static class ManagedReplicaBootstrapper
             var remoteBaseSha256 = PublishRemoteBaseSnapshot(options.Path, metadata, options.Path);
             var tableMap = RebuildTableMapFromSchema(options.Path, options.RemoteEncryption);
             var installedFingerprint = ComputeDatabaseFingerprint(options.Path);
-            mainFileReplacementLock = ManagedReplicaApplyLock.AcquireMainFileReplacementLock(
-                options.Path,
-                cancellationToken);
             if (!string.Equals(
                     ComputeDatabaseFingerprint(options.Path),
                     installedFingerprint,
@@ -2179,8 +2234,7 @@ internal static class ManagedReplicaBootstrapper
             // interruption must preserve that matched pair rather than restore only DB.
             if (databaseInstalled && !metadataInstalled && File.Exists(backupPath))
             {
-                mainFileReplacementLock?.Dispose();
-                mainFileReplacementLock = null;
+                ManagedReplicaApplyLock.ReleaseMainFileLeaseForRollback(mainFileReplacementLock);
                 File.Replace(backupPath, options.Path, destinationBackupFileName: null, ignoreMetadataErrors: false);
             }
             throw;
@@ -3620,7 +3674,7 @@ internal static class ManagedReplicaBootstrapper
                      ManagedReplicaLockCarrier.PushKind,
                  })
         {
-            if (ManagedReplicaLockCarrier.TryResolve(databasePath, kind) is { } carrier)
+            foreach (var carrier in ManagedReplicaLockCarrier.TryResolveAll(databasePath, kind))
                 yield return carrier;
         }
     }

--- a/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
+++ b/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
@@ -2241,7 +2241,8 @@ internal static class ManagedReplicaBootstrapper
                     mainFileReplacementLock,
                     backupPath,
                     options.Path,
-                    displacedPath);
+                    displacedPath,
+                    () => ManagedReplicaReplacementState.PrepareRollbackSidecars(options.Path));
                 ManagedReplicaFaultInjection.Hit(
                     ManagedReplicaDurableBoundary.MainFileRollbackDatabaseRestored);
                 ManagedReplicaReplacementState.CompleteRollback(options.Path);

--- a/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
+++ b/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
@@ -2157,34 +2157,21 @@ internal static class ManagedReplicaBootstrapper
             }
             if (metadata.RevertState.HasValue)
                 metadata = ManagedReplicaRevertWal.MarkRemoteApplyStarted(options.Path, metadata);
+            var tableMap = RebuildTableMapFromSchema(stagingPath, options.RemoteEncryption);
+            var installedFingerprint = ComputeDatabaseFingerprint(stagingPath);
+            var remoteBaseSha256 = PublishRemoteBaseSnapshot(options.Path, metadata, stagingPath);
             mainFileReplacementLock = ManagedReplicaApplyLock.AcquireMainFileReplacementLock(
                 options.Path,
                 stagingPath,
                 cancellationToken);
-            File.Replace(stagingPath, options.Path, backupPath, ignoreMetadataErrors: false);
-            databaseInstalled = true;
+            ManagedReplicaApplyLock.ReplaceMainFile(
+                mainFileReplacementLock,
+                stagingPath,
+                options.Path,
+                backupPath,
+                () => databaseInstalled = true);
             ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.IncrementalApplyDatabasePublished);
             cancellationToken.ThrowIfCancellationRequested();
-
-            if (header.ApplyMode == PullApplyMode.ReplaceBase && pendingLocalChanges.Count > 0)
-            {
-                using var opened = ManagedReplicaEncryption.OpenDatabase(options.Path, options.RemoteEncryption);
-                var connection = opened.Database.Connect();
-                ExecuteNonQuery(connection, "BEGIN IMMEDIATE");
-                try
-                {
-                    ManagedReplicaLogicalReplayer.ReplayPendingLocalStatements(
-                        connection, pendingLocalChanges, cancellationToken);
-                    ExecuteNonQuery(connection, "COMMIT");
-                }
-                catch
-                {
-                    TryExecuteNonQuery(connection, "ROLLBACK");
-                    throw;
-                }
-
-                ExecuteNonQuery(connection, "PRAGMA wal_checkpoint(TRUNCATE)");
-            }
 
             // A page-based apply never decodes logical schema identity operations, so the table
             // map is rebuilt fresh from the newly-installed schema (self-healing), matching
@@ -2192,17 +2179,6 @@ internal static class ManagedReplicaBootstrapper
             // freshly detected protocol is recorded too, so a protocol-2 remote that answered this
             // particular pull with Pages (e.g. Pages+ReplaceBase) still enables a logical request
             // on the next pull rather than sticking to pages forever.
-            var remoteBaseSha256 = PublishRemoteBaseSnapshot(options.Path, metadata, options.Path);
-            var tableMap = RebuildTableMapFromSchema(options.Path, options.RemoteEncryption);
-            var installedFingerprint = ComputeDatabaseFingerprint(options.Path);
-            if (!string.Equals(
-                    ComputeDatabaseFingerprint(options.Path),
-                    installedFingerprint,
-                    StringComparison.Ordinal))
-            {
-                throw new InvalidDataException(
-                    "Managed embedded replica changed while its replacement metadata was being published.");
-            }
             await WriteMetadataAsync(
                     metadataStagingPath,
                     metadataPath,
@@ -2234,8 +2210,10 @@ internal static class ManagedReplicaBootstrapper
             // interruption must preserve that matched pair rather than restore only DB.
             if (databaseInstalled && !metadataInstalled && File.Exists(backupPath))
             {
-                ManagedReplicaApplyLock.ReleaseMainFileLeaseForRollback(mainFileReplacementLock);
-                File.Replace(backupPath, options.Path, destinationBackupFileName: null, ignoreMetadataErrors: false);
+                ManagedReplicaApplyLock.RollBackMainFile(
+                    mainFileReplacementLock,
+                    backupPath,
+                    options.Path);
             }
             throw;
         }

--- a/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
+++ b/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
@@ -47,6 +47,7 @@ internal static class ManagedReplicaBootstrapper
         DeleteIfExists(path + BaseSnapshotSuffix);
         DeleteIfExists(path + BaseSnapshotPreviousSuffix);
         ManagedReplicaRevertWal.DeleteArtifacts(path);
+        ManagedReplicaReplacementState.DeleteArtifacts(path);
         DeleteStagingSidecars(path);
         // Keep the main file present until every sidecar is gone. Apply-lock aliases resolve an
         // existing target by physical identity; deleting it first would let a missing-path key
@@ -2065,7 +2066,8 @@ internal static class ManagedReplicaBootstrapper
     {
         var directory = Path.GetDirectoryName(Path.GetFullPath(options.Path))!;
         var stagingPath = Path.Combine(directory, $".{Path.GetFileName(options.Path)}.apply-{Guid.NewGuid():N}.tmp");
-        var backupPath = Path.Combine(directory, $".{Path.GetFileName(options.Path)}.apply-{Guid.NewGuid():N}.bak");
+        var backupPath = ManagedReplicaReplacementState.GetBackupPath(options.Path);
+        var displacedPath = ManagedReplicaReplacementState.GetDisplacedPath(options.Path);
         var metadataPath = options.Path + MetadataSuffix;
         var metadataStagingPath = Path.Combine(
             directory,
@@ -2075,7 +2077,6 @@ internal static class ManagedReplicaBootstrapper
             $".{Path.GetFileName(options.Path)}.protected-{Guid.NewGuid():N}.tmp");
         var databaseInstalled = false;
         var metadataInstalled = false;
-        var preserveBackup = false;
         IDisposable? mainFileReplacementLock = null;
         try
         {
@@ -2161,10 +2162,12 @@ internal static class ManagedReplicaBootstrapper
             var tableMap = RebuildTableMapFromSchema(stagingPath, options.RemoteEncryption);
             var installedFingerprint = ComputeDatabaseFingerprint(stagingPath);
             var remoteBaseSha256 = PublishRemoteBaseSnapshot(options.Path, metadata, stagingPath);
+            ManagedReplicaReplacementState.Recover(options.Path);
             mainFileReplacementLock = ManagedReplicaApplyLock.AcquireMainFileReplacementLock(
                 options.Path,
                 stagingPath,
                 cancellationToken);
+            ManagedReplicaReplacementState.Prepare(options.Path, stagingPath);
             ManagedReplicaApplyLock.ReplaceMainFile(
                 mainFileReplacementLock,
                 stagingPath,
@@ -2212,7 +2215,7 @@ internal static class ManagedReplicaBootstrapper
             }
             ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.IncrementalApplyMetadataPublished);
             cancellationToken.ThrowIfCancellationRequested();
-            DeleteIfExists(backupPath);
+            ManagedReplicaReplacementState.CompletePublication(options.Path);
         }
         catch
         {
@@ -2220,18 +2223,14 @@ internal static class ManagedReplicaBootstrapper
             // interruption must preserve that matched pair rather than restore only DB.
             if (databaseInstalled && !metadataInstalled && File.Exists(backupPath))
             {
-                try
-                {
-                    ManagedReplicaApplyLock.RollBackMainFile(
-                        mainFileReplacementLock,
-                        backupPath,
-                        options.Path);
-                }
-                catch
-                {
-                    preserveBackup = true;
-                    throw;
-                }
+                ManagedReplicaApplyLock.RollBackMainFile(
+                    mainFileReplacementLock,
+                    backupPath,
+                    options.Path,
+                    displacedPath);
+                ManagedReplicaFaultInjection.Hit(
+                    ManagedReplicaDurableBoundary.MainFileRollbackDatabaseRestored);
+                ManagedReplicaReplacementState.CompleteRollback(options.Path);
             }
             throw;
         }
@@ -2242,8 +2241,6 @@ internal static class ManagedReplicaBootstrapper
             DeleteIfExists(metadataStagingPath);
             DeleteIfExists(protectedStagingPath);
             DeleteStagingSidecars(protectedStagingPath);
-            if (!preserveBackup)
-                DeleteIfExists(backupPath);
             mainFileReplacementLock?.Dispose();
         }
     }
@@ -3604,6 +3601,9 @@ internal static class ManagedReplicaBootstrapper
     /// bootstrap/download as a side effect, which existence checks must never do.</summary>
     internal static ManagedReplicaLocalState GetLocalState(string databasePath)
     {
+        if (ManagedReplicaReplacementState.HasArtifacts(databasePath))
+            return ManagedReplicaLocalState.Inconsistent;
+
         var databaseExists = File.Exists(databasePath);
         var metadataExists = File.Exists(databasePath + MetadataSuffix);
         var pageStateExists = File.Exists(
@@ -3648,6 +3648,7 @@ internal static class ManagedReplicaBootstrapper
         databasePath + "-wal",
         databasePath + "-shm",
         databasePath + "-journal",
+        .. ManagedReplicaReplacementState.GetArtifactPaths(databasePath),
         .. ManagedReplicaRevertWal.GetArtifactPaths(databasePath),
         databasePath + BaseSnapshotSuffix,
         databasePath + BaseSnapshotPreviousSuffix,

--- a/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
+++ b/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
@@ -2075,6 +2075,7 @@ internal static class ManagedReplicaBootstrapper
             $".{Path.GetFileName(options.Path)}.protected-{Guid.NewGuid():N}.tmp");
         var databaseInstalled = false;
         var metadataInstalled = false;
+        var preserveBackup = false;
         IDisposable? mainFileReplacementLock = null;
         try
         {
@@ -2170,6 +2171,15 @@ internal static class ManagedReplicaBootstrapper
                 options.Path,
                 backupPath,
                 () => databaseInstalled = true);
+            if (OperatingSystem.IsWindows()
+                && !string.Equals(
+                    ComputeDatabaseFingerprint(options.Path),
+                    installedFingerprint,
+                    StringComparison.Ordinal))
+            {
+                throw new InvalidDataException(
+                    "Managed embedded replica changed during its Windows replacement lock handoff.");
+            }
             ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.IncrementalApplyDatabasePublished);
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -2210,10 +2220,18 @@ internal static class ManagedReplicaBootstrapper
             // interruption must preserve that matched pair rather than restore only DB.
             if (databaseInstalled && !metadataInstalled && File.Exists(backupPath))
             {
-                ManagedReplicaApplyLock.RollBackMainFile(
-                    mainFileReplacementLock,
-                    backupPath,
-                    options.Path);
+                try
+                {
+                    ManagedReplicaApplyLock.RollBackMainFile(
+                        mainFileReplacementLock,
+                        backupPath,
+                        options.Path);
+                }
+                catch
+                {
+                    preserveBackup = true;
+                    throw;
+                }
             }
             throw;
         }
@@ -2224,7 +2242,8 @@ internal static class ManagedReplicaBootstrapper
             DeleteIfExists(metadataStagingPath);
             DeleteIfExists(protectedStagingPath);
             DeleteStagingSidecars(protectedStagingPath);
-            DeleteIfExists(backupPath);
+            if (!preserveBackup)
+                DeleteIfExists(backupPath);
             mainFileReplacementLock?.Dispose();
         }
     }

--- a/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
+++ b/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
@@ -2162,12 +2162,26 @@ internal static class ManagedReplicaBootstrapper
             var tableMap = RebuildTableMapFromSchema(stagingPath, options.RemoteEncryption);
             var installedFingerprint = ComputeDatabaseFingerprint(stagingPath);
             var remoteBaseSha256 = PublishRemoteBaseSnapshot(options.Path, metadata, stagingPath);
+            var replacementMetadata = new ManagedReplicaMetadata(
+                header.Revision,
+                installedFingerprint,
+                metadata.ClientId,
+                header.Protocol,
+                tableMap)
+            {
+                PushState = metadata.PushState,
+                JournalBaseWatermark = AdvanceJournalBaseWatermark(metadata, acknowledgedLocalChanges),
+                RemoteBaseSha256 = remoteBaseSha256,
+            };
             ManagedReplicaReplacementState.Recover(options.Path);
             mainFileReplacementLock = ManagedReplicaApplyLock.AcquireMainFileReplacementLock(
                 options.Path,
                 stagingPath,
                 cancellationToken);
-            ManagedReplicaReplacementState.Prepare(options.Path, stagingPath);
+            ManagedReplicaReplacementState.Prepare(
+                options.Path,
+                stagingPath,
+                ComputeMetadataSha256(replacementMetadata));
             ManagedReplicaApplyLock.ReplaceMainFile(
                 mainFileReplacementLock,
                 stagingPath,
@@ -2195,16 +2209,16 @@ internal static class ManagedReplicaBootstrapper
             await WriteMetadataAsync(
                     metadataStagingPath,
                     metadataPath,
-                    header.Revision,
-                    installedFingerprint,
-                    header.Protocol,
-                    tableMap,
+                    replacementMetadata.Revision,
+                    replacementMetadata.DatabaseSha256,
+                    replacementMetadata.Protocol,
+                    replacementMetadata.TableNamesByStableId,
                     cancellationToken,
                     replaceExisting: true,
-                    clientId: metadata.ClientId,
-                    pushState: metadata.PushState,
-                    journalBaseWatermark: AdvanceJournalBaseWatermark(metadata, acknowledgedLocalChanges),
-                    remoteBaseSha256: remoteBaseSha256)
+                    clientId: replacementMetadata.ClientId,
+                    pushState: replacementMetadata.PushState,
+                    journalBaseWatermark: replacementMetadata.JournalBaseWatermark,
+                    remoteBaseSha256: replacementMetadata.RemoteBaseSha256)
                 .ConfigureAwait(false);
             metadataInstalled = true;
             CompleteRemoteBaseSnapshotPublication(options.Path);
@@ -2743,6 +2757,18 @@ internal static class ManagedReplicaBootstrapper
             destinationBackupFileName: null,
             ignoreMetadataErrors: false);
     }
+
+    internal static string ComputeMetadataSha256(ManagedReplicaMetadata metadata)
+        => Convert.ToHexString(SHA256.HashData(CreateMetadataBytes(
+            metadata.Revision,
+            metadata.DatabaseSha256,
+            metadata.Protocol,
+            metadata.TableNamesByStableId,
+            metadata.ClientId,
+            metadata.RevertState,
+            metadata.PushState,
+            metadata.JournalBaseWatermark,
+            metadata.RemoteBaseSha256)));
 
     private static byte[] CreateMetadataBytes(
         string revision,

--- a/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
+++ b/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
@@ -2181,7 +2181,8 @@ internal static class ManagedReplicaBootstrapper
             ManagedReplicaReplacementState.Prepare(
                 options.Path,
                 stagingPath,
-                ComputeMetadataSha256(replacementMetadata));
+                ComputeMetadataSha256(replacementMetadata),
+                mainFileReplacementLock);
             ManagedReplicaApplyLock.ReplaceMainFile(
                 mainFileReplacementLock,
                 stagingPath,
@@ -2190,7 +2191,9 @@ internal static class ManagedReplicaBootstrapper
                 () => databaseInstalled = true);
             if (OperatingSystem.IsWindows()
                 && !string.Equals(
-                    ComputeDatabaseFingerprint(options.Path),
+                    ManagedReplicaReplacementState.ComputeDatabaseSha256(
+                        mainFileReplacementLock,
+                        options.Path),
                     installedFingerprint,
                     StringComparison.Ordinal))
             {
@@ -2229,7 +2232,11 @@ internal static class ManagedReplicaBootstrapper
             }
             ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.IncrementalApplyMetadataPublished);
             cancellationToken.ThrowIfCancellationRequested();
-            ManagedReplicaReplacementState.CompletePublication(options.Path);
+            ManagedReplicaReplacementState.CompletePublication(
+                options.Path,
+                ManagedReplicaApplyLock.GetMainFileLease(
+                    mainFileReplacementLock,
+                    options.Path));
         }
         catch
         {
@@ -2245,7 +2252,11 @@ internal static class ManagedReplicaBootstrapper
                     () => ManagedReplicaReplacementState.PrepareRollbackSidecars(options.Path));
                 ManagedReplicaFaultInjection.Hit(
                     ManagedReplicaDurableBoundary.MainFileRollbackDatabaseRestored);
-                ManagedReplicaReplacementState.CompleteRollback(options.Path);
+                ManagedReplicaReplacementState.CompleteRollback(
+                    options.Path,
+                    ManagedReplicaApplyLock.GetMainFileLease(
+                        mainFileReplacementLock,
+                        options.Path));
             }
             throw;
         }

--- a/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
+++ b/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
@@ -957,10 +957,14 @@ internal static class ManagedReplicaBootstrapper
 
                 var body = await ReadRemainingBytesAsync(stream, effectiveToken).ConfigureAwait(false);
 
-                // One exclusive apply lease spans the whole logical apply (below): commit, checkpoint,
-                // and metadata publication, or the callee's own rollback on failure. See
-                // ManagedReplicaApplyLock for why this seam is deliberately narrow (acquired only for
-                // the local apply, never for the network round trip above).
+                // Pull publication always takes the physical push-flight lease before the apply
+                // lease. Both stay outside the network round trip above and span only the short local
+                // apply. Besides excluding an in-flight push intent, this order prevents a main-file
+                // replacement from changing the physical identity behind the push carrier while an
+                // older carrier is still held.
+                await using var logicalPushLease = await ManagedReplicaPushLock
+                    .AcquireExclusiveAsync(options.Path, effectiveToken)
+                    .ConfigureAwait(false);
                 await using var logicalApplyLease = await ManagedReplicaApplyLock.AcquireExclusiveAsync(options.Path, effectiveToken)
                     .ConfigureAwait(false);
                 ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.ReplicaApplyLockAcquired);
@@ -1033,15 +1037,27 @@ internal static class ManagedReplicaBootstrapper
                     "The pull-updates response used replace_base apply mode without returning every database page exactly once.");
             }
 
-            // One exclusive apply lease spans the sidecar/fingerprint re-check below through the
-            // page-based apply and its metadata publication (or rollback). Acquired here -- after the
-            // network round trip, before any sidecar inspection -- so a concurrent local write can
-            // never land between "checked clean" and "applied" the way it could when the historical
-            // page-protocol path relied solely on the pre-network EnsureNoLocalDivergence check.
+            // Keep the same push-to-apply order as the logical branch. The response is already fully
+            // staged in memory, so no remote I/O is covered by either lease.
+            await using var pagesPushLease = await ManagedReplicaPushLock
+                .AcquireExclusiveAsync(options.Path, effectiveToken)
+                .ConfigureAwait(false);
             await using var pagesApplyLease = await ManagedReplicaApplyLock.AcquireExclusiveAsync(options.Path, effectiveToken)
                 .ConfigureAwait(false);
             ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.ReplicaApplyLockAcquired);
             effectiveToken.ThrowIfCancellationRequested();
+
+            if (!TryUseCurrentLocalStateAsPullBase(
+                    options.Path, metadata, pendingLocalChanges, acknowledgedLocalChanges,
+                    out var freshPagesMetadata,
+                    out var freshPagesPendingLocalChanges,
+                    out var freshPagesAcknowledgedLocalChanges))
+            {
+                metadata = freshPagesMetadata;
+                pendingLocalChanges = freshPagesPendingLocalChanges;
+                acknowledgedLocalChanges = freshPagesAcknowledgedLocalChanges;
+                continue;
+            }
 
             // The response turned out to be a Pages stream (Incremental or ReplaceBase) even though
             // the remembered protocol is MvccLogical (a protocol-2 remote can still answer any given
@@ -1063,26 +1079,6 @@ internal static class ManagedReplicaBootstrapper
             // mechanism, so there is no way to know local WAL content is already reflected upstream.
             if (requestLogical)
             {
-                // Same staleness hazard as the logical-log branch above, and for the same reason:
-                // this response (Incremental or ReplaceBase) was negotiated against `metadata` as
-                // it stood before the network round trip and the wait for this lease.
-                // CheckpointAndCleanSidecarsBeforePagesApply (the ReplaceBase sub-case below) has no
-                // fingerprint to compare against, because a logical-protocol replica's WAL is
-                // expected to keep evolving between syncs -- without this reload-and-compare, a
-                // stale ReplaceBase response could overwrite local state that a concurrent caller
-                // already advanced past it. Retry against the current base instead of applying it.
-                if (!TryUseCurrentLocalStateAsPullBase(
-                        options.Path, metadata, pendingLocalChanges, acknowledgedLocalChanges,
-                        out var freshPagesMetadata,
-                        out var freshPagesPendingLocalChanges,
-                        out var freshPagesAcknowledgedLocalChanges))
-                {
-                    metadata = freshPagesMetadata;
-                    pendingLocalChanges = freshPagesPendingLocalChanges;
-                    acknowledgedLocalChanges = freshPagesAcknowledgedLocalChanges;
-                    continue;
-                }
-
                 metadata = EnsurePagesApplyIsSafe(
                     options.Path,
                     metadata,
@@ -1114,9 +1110,10 @@ internal static class ManagedReplicaBootstrapper
     }
 
     /// <summary>
-    /// Reloads the durable local state (metadata revision, recorded journal base, the pending-push
-    /// change journal, and the acknowledged journal history) from disk while the apply lease for
-    /// this pull is held, and compares it against the snapshot
+    /// Reloads the durable local state (metadata revision and fingerprint, push/revert state,
+    /// recorded journal base, the pending-push change journal, and the acknowledged journal
+    /// history) from disk while the push and apply leases for this pull are held, and compares it
+    /// against the snapshot
     /// (<paramref name="requestBaseMetadata"/>, <paramref name="requestBasePendingLocalChanges"/>,
     /// <paramref name="requestBaseAcknowledgedLocalChanges"/>) the in-flight request and response
     /// were actually built from -- all captured before the network round trip and the wait for the
@@ -1144,6 +1141,7 @@ internal static class ManagedReplicaBootstrapper
         freshMetadata = LoadMetadata(databasePath)
             ?? throw new NotSupportedException(
                 "Managed embedded replica metadata was removed while an update was in flight.");
+        ManagedReplicaRevertWal.EnsurePushRecoveryComplete(freshMetadata);
         var journal = ManagedReplicaChangeJournal.Open(databasePath);
         freshPendingLocalChanges = journal.ReadBatch(int.MaxValue).Changes;
 
@@ -1157,6 +1155,12 @@ internal static class ManagedReplicaBootstrapper
             : [];
 
         return string.Equals(freshMetadata.Revision, requestBaseMetadata.Revision, StringComparison.Ordinal)
+            && string.Equals(
+                freshMetadata.DatabaseSha256,
+                requestBaseMetadata.DatabaseSha256,
+                StringComparison.Ordinal)
+            && freshMetadata.RevertState == requestBaseMetadata.RevertState
+            && freshMetadata.PushState == requestBaseMetadata.PushState
             && freshMetadata.JournalBaseWatermark == requestBaseMetadata.JournalBaseWatermark
             && HaveSamePendingLocalChangeSequence(requestBasePendingLocalChanges, freshPendingLocalChanges)
             && HaveSamePendingLocalChangeSequence(
@@ -1432,6 +1436,8 @@ internal static class ManagedReplicaBootstrapper
                         cancellationToken,
                         replaceExisting: true,
                         clientId: metadata.ClientId,
+                        revertState: metadata.RevertState,
+                        pushState: metadata.PushState,
                         journalBaseWatermark: journalBaseWatermark,
                         remoteBaseSha256: remoteBaseSha256)
                     .ConfigureAwait(false);
@@ -1847,6 +1853,8 @@ internal static class ManagedReplicaBootstrapper
                     cancellationToken,
                     replaceExisting: true,
                     clientId: metadata.ClientId,
+                    revertState: null,
+                    pushState: null,
                     journalBaseWatermark: metadata.JournalBaseWatermark,
                     remoteBaseSha256: metadata.RemoteBaseSha256)
                 .ConfigureAwait(false);
@@ -1917,6 +1925,15 @@ internal static class ManagedReplicaBootstrapper
         ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.PartialImageCompletionStarted);
         await fileSystem.MaterializeAllAsync(cancellationToken).ConfigureAwait(false);
 
+        await using var materializationPushLease = await ManagedReplicaPushLock
+            .AcquireExclusiveAsync(options.Path, cancellationToken)
+            .ConfigureAwait(false);
+        await using var materializationApplyLease = await ManagedReplicaApplyLock
+            .AcquireExclusiveAsync(options.Path, cancellationToken)
+            .ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+        RevalidateMaterializationPublicationMetadata(options.Path, metadata);
+
         var fingerprint = fileSystem.ComputeDatabaseFingerprint();
         var metadataPath = options.Path + MetadataSuffix;
         var directory = Path.GetDirectoryName(Path.GetFullPath(metadataPath))!;
@@ -1956,6 +1973,7 @@ internal static class ManagedReplicaBootstrapper
                     replaceExisting: true,
                     clientId: metadata.ClientId,
                     revertState: metadata.RevertState,
+                    pushState: metadata.PushState,
                     journalBaseWatermark: metadata.JournalBaseWatermark,
                     remoteBaseSha256: remoteBaseSha256)
                 .ConfigureAwait(false);
@@ -2140,6 +2158,7 @@ internal static class ManagedReplicaBootstrapper
                     cancellationToken,
                     replaceExisting: true,
                     clientId: metadata.ClientId,
+                    pushState: metadata.PushState,
                     journalBaseWatermark: AdvanceJournalBaseWatermark(metadata, acknowledgedLocalChanges),
                     remoteBaseSha256: remoteBaseSha256)
                 .ConfigureAwait(false);
@@ -2619,6 +2638,28 @@ internal static class ManagedReplicaBootstrapper
             File.Replace(stagingPath, metadataPath, destinationBackupFileName: null, ignoreMetadataErrors: false);
         else
             File.Move(stagingPath, metadataPath, overwrite: false);
+    }
+
+    private static void RevalidateMaterializationPublicationMetadata(
+        string databasePath,
+        ManagedReplicaMetadata expected)
+    {
+        var current = LoadMetadata(databasePath)
+            ?? throw new NotSupportedException(
+                "Managed embedded replica metadata was removed while page materialization was in flight.");
+        ManagedReplicaRevertWal.EnsurePushRecoveryComplete(current);
+        if (current.PushState != expected.PushState
+            || current.RevertState != expected.RevertState
+            || !string.Equals(current.Revision, expected.Revision, StringComparison.Ordinal)
+            || !string.Equals(current.DatabaseSha256, expected.DatabaseSha256, StringComparison.Ordinal)
+            || !string.Equals(current.ClientId, expected.ClientId, StringComparison.Ordinal)
+            || current.Protocol != expected.Protocol
+            || !string.Equals(current.RemoteBaseSha256, expected.RemoteBaseSha256, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "Managed embedded replica metadata changed while page materialization was in flight; "
+                + "the materialized image was not published.");
+        }
     }
 
     internal static void WriteMetadata(

--- a/src/Ahtola.Data/ManagedReplicaConflictState.cs
+++ b/src/Ahtola.Data/ManagedReplicaConflictState.cs
@@ -52,6 +52,32 @@ internal readonly record struct ManagedReplicaConflictState(
 
     internal static bool Exists(string databasePath) => File.Exists(GetPath(databasePath));
 
+    internal static void ThrowIfPending(string databasePath)
+    {
+        if (TryRead(databasePath) is { } state)
+            throw CreatePendingException(state);
+    }
+
+    internal static void ValidatePullPublication(
+        string databasePath,
+        ManagedReplicaConflictState? expectedState)
+    {
+        var current = TryRead(databasePath);
+        if (expectedState is not { } expected)
+        {
+            if (current is { } pending)
+                throw CreatePendingException(pending);
+            return;
+        }
+
+        if (current is not { } actual || !HasSameDurableIdentity(actual, expected))
+        {
+            throw new InvalidDataException(
+                "Managed replica conflict state changed while an explicit conflict rebase pull was "
+                + "in flight; the stale pull was not published.");
+        }
+    }
+
     /// <summary>
     /// Reads the durable marker, or returns <see langword="null"/> when no conflict is open.
     /// Corrupt or self-inconsistent content is never silently ignored.
@@ -207,6 +233,26 @@ internal readonly record struct ManagedReplicaConflictState(
         GetPath(databasePath),
         GetStagingPath(databasePath),
     ];
+
+    private static AhtolaReplicaConflictPendingException CreatePendingException(
+        ManagedReplicaConflictState state)
+        => new(
+            "Managed embedded replica has an unresolved push conflict; "
+            + $"{state.UnresolvedSequences.Count} locally journaled change(s) were rejected by the remote "
+            + "and are quarantined. Inspect the conflict and resolve or discard it explicitly before "
+            + "synchronizing again.",
+            state.ConflictKind,
+            state.UnresolvedSequences.Count);
+
+    private static bool HasSameDurableIdentity(
+        ManagedReplicaConflictState left,
+        ManagedReplicaConflictState right)
+        => left.ConflictKind == right.ConflictKind
+           && string.Equals(left.RemoteErrorCode, right.RemoteErrorCode, StringComparison.Ordinal)
+           && left.ConflictingSequence == right.ConflictingSequence
+           && left.BatchFirstSequence == right.BatchFirstSequence
+           && left.BatchWatermark == right.BatchWatermark
+           && left.UnresolvedSequences.SequenceEqual(right.UnresolvedSequences);
 
     private static void DeleteStagingArtifact(string stagingPath, bool throwOnFailure)
     {

--- a/src/Ahtola.Data/ManagedReplicaConnectionHost.cs
+++ b/src/Ahtola.Data/ManagedReplicaConnectionHost.cs
@@ -478,16 +478,25 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
             return;
 
         await syncEntry.PublishAsync(
-                cancellationToken =>
-                {
-                    var current = ManagedReplicaBootstrapper.LoadMetadata(databasePath)
-                                  ?? throw new InvalidDataException(
-                                      "Managed embedded replica checkpoint recovery metadata is missing.");
-                    _ = ManagedReplicaRevertWal.PrepareSynchronization(databasePath, current);
-                    return Task.CompletedTask;
-                },
+                token => PrepareSynchronizationWithPublicationLocksAsync(databasePath, token),
                 cancellationToken)
             .ConfigureAwait(false);
+    }
+
+    private static async Task PrepareSynchronizationWithPublicationLocksAsync(
+        string databasePath,
+        CancellationToken cancellationToken)
+    {
+        await using var pushLease = await ManagedReplicaPushLock
+            .AcquireExclusiveAsync(databasePath, cancellationToken)
+            .ConfigureAwait(false);
+        await using var applyLease = await ManagedReplicaApplyLock
+            .AcquireExclusiveAsync(databasePath, cancellationToken)
+            .ConfigureAwait(false);
+        var current = ManagedReplicaBootstrapper.LoadMetadata(databasePath)
+                      ?? throw new InvalidDataException(
+                          "Managed embedded replica checkpoint recovery metadata is missing.");
+        _ = ManagedReplicaRevertWal.PrepareSynchronization(databasePath, current);
     }
 
     private static bool IsReplicaFilePresent(string path)
@@ -842,15 +851,20 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
         var metadata = ManagedReplicaBootstrapper.LoadMetadata(_options.Path);
         if (metadata is { } value)
         {
-            if (value.RevertState is null
-                || value.RevertState is
+            if (value.RevertState is
                 {
                     Phase: ManagedReplicaBootstrapper.ManagedReplicaRevertPhase.Captured
                     or ManagedReplicaBootstrapper.ManagedReplicaRevertPhase.RestoreCommitted
                     or ManagedReplicaBootstrapper.ManagedReplicaRevertPhase.RestoreOriginal,
-                })
+                }
+                || ManagedReplicaRevertWal.GetArtifactPaths(_options.Path).Any(File.Exists))
             {
-                value = ManagedReplicaRevertWal.PrepareSynchronization(_options.Path, value);
+                PrepareSynchronizationWithPublicationLocksAsync(_options.Path, CancellationToken.None)
+                    .GetAwaiter()
+                    .GetResult();
+                value = ManagedReplicaBootstrapper.LoadMetadata(_options.Path)
+                    ?? throw new InvalidDataException(
+                        "Managed embedded replica checkpoint recovery metadata is missing.");
             }
             metadata = value;
             _metadata = value;
@@ -1414,18 +1428,7 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
     /// authoritative, and a corrupt marker throws rather than being ignored.
     /// </summary>
     private static void ThrowIfReplicaConflictIsPending(string databasePath)
-    {
-        if (ManagedReplicaConflictState.TryRead(databasePath) is not { } state)
-            return;
-
-        throw new AhtolaReplicaConflictPendingException(
-            "Managed embedded replica has an unresolved push conflict; "
-            + $"{state.UnresolvedSequences.Count} locally journaled change(s) were rejected by the remote "
-            + "and are quarantined. Inspect the conflict and resolve or discard it explicitly before "
-            + "synchronizing again.",
-            state.ConflictKind,
-            state.UnresolvedSequences.Count);
-    }
+        => ManagedReplicaConflictState.ThrowIfPending(databasePath);
 
     /// <summary>
     /// Reads the open push conflict, if any, and classifies every change in the rejected batch.
@@ -1662,7 +1665,7 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
                 new AhtolaSyncOptions(options?.Progress),
                 pendingLocalChanges,
                 acknowledgedLocalChanges,
-                quarantined,
+                state,
                 cancellationToken)
             .ConfigureAwait(false);
 

--- a/src/Ahtola.Data/ManagedReplicaConnectionHost.cs
+++ b/src/Ahtola.Data/ManagedReplicaConnectionHost.cs
@@ -689,7 +689,6 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
         metadata = ManagedReplicaBootstrapper.EnsureLegacyRemoteBaseSnapshot(
             replicaOptions.Path,
             metadata);
-        metadata = ManagedReplicaRevertWal.PrepareSynchronization(replicaOptions.Path, metadata);
         var hasTrackedLocalChanges = _changeJournal.ReadBatch(int.MaxValue).Changes.Count != 0
             || _changeJournal.ReadAcknowledged(metadata.JournalBaseWatermark).Count != 0;
         var retainedMaterializer = _materializationLease?.FileSystem;

--- a/src/Ahtola.Data/ManagedReplicaConnectionHost.cs
+++ b/src/Ahtola.Data/ManagedReplicaConnectionHost.cs
@@ -445,6 +445,11 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
         AhtolaReplicaOptions options,
         CancellationToken cancellationToken)
     {
+        if (ManagedReplicaReplacementState.HasArtifacts(options.Path))
+        {
+            await PrepareExistingReplicaForOpenAsync(syncEntry, options.Path, cancellationToken)
+                .ConfigureAwait(false);
+        }
         if (IsReplicaFilePresent(options.Path))
         {
             await PrepareExistingReplicaForOpenAsync(syncEntry, options.Path, cancellationToken)
@@ -463,18 +468,21 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
         string databasePath,
         CancellationToken cancellationToken)
     {
+        var hasReplacementArtifacts = ManagedReplicaReplacementState.HasArtifacts(databasePath);
         var metadata = ManagedReplicaBootstrapper.LoadMetadata(databasePath);
         var hasRecoveryArtifacts = ManagedReplicaRevertWal.GetArtifactPaths(databasePath).Any(File.Exists);
         if (metadata is null)
         {
-            if (hasRecoveryArtifacts)
+            if (hasReplacementArtifacts || hasRecoveryArtifacts)
             {
                 throw new InvalidDataException(
-                    "Managed embedded replica checkpoint recovery artifacts have no matching metadata.");
+                    "Managed embedded replica recovery artifacts have no matching metadata.");
             }
             return;
         }
-        if (!metadata.Value.RevertState.HasValue && !hasRecoveryArtifacts)
+        if (!hasReplacementArtifacts
+            && !metadata.Value.RevertState.HasValue
+            && !hasRecoveryArtifacts)
             return;
 
         await syncEntry.PublishAsync(
@@ -493,6 +501,7 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
         await using var applyLease = await ManagedReplicaApplyLock
             .AcquireExclusiveAsync(databasePath, cancellationToken)
             .ConfigureAwait(false);
+        ManagedReplicaReplacementState.Recover(databasePath);
         var current = ManagedReplicaBootstrapper.LoadMetadata(databasePath)
                       ?? throw new InvalidDataException(
                           "Managed embedded replica checkpoint recovery metadata is missing.");
@@ -851,7 +860,8 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
         var metadata = ManagedReplicaBootstrapper.LoadMetadata(_options.Path);
         if (metadata is { } value)
         {
-            if (value.RevertState is
+            if (ManagedReplicaReplacementState.HasArtifacts(_options.Path)
+                || value.RevertState is
                 {
                     Phase: ManagedReplicaBootstrapper.ManagedReplicaRevertPhase.Captured
                     or ManagedReplicaBootstrapper.ManagedReplicaRevertPhase.RestoreCommitted
@@ -869,10 +879,11 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
             metadata = value;
             _metadata = value;
         }
-        else if (ManagedReplicaRevertWal.GetArtifactPaths(_options.Path).Any(File.Exists))
+        else if (ManagedReplicaReplacementState.HasArtifacts(_options.Path)
+                 || ManagedReplicaRevertWal.GetArtifactPaths(_options.Path).Any(File.Exists))
         {
             throw new InvalidDataException(
-                "Managed embedded replica checkpoint recovery artifacts have no matching metadata.");
+                "Managed embedded replica recovery artifacts have no matching metadata.");
         }
 
         var retainedLease = _materializationLease;

--- a/src/Ahtola.Data/ManagedReplicaFaultInjection.cs
+++ b/src/Ahtola.Data/ManagedReplicaFaultInjection.cs
@@ -191,10 +191,21 @@ internal enum ManagedReplicaDurableBoundary
     MainFileReplacementPublishedBeforeLease,
 
     /// <summary>
+    /// Windows-only boundary after the displaced database hash is durable but before the staged
+    /// displaced image is promoted to its final recovery path.
+    /// </summary>
+    MainFileRollbackDisplacedHashPublished,
+
+    /// <summary>
     /// Windows-only boundary after the replacement image is durably preserved and before the
     /// retained backup is copied over the continuously leased destination inode.
     /// </summary>
     MainFileRollbackDisplacedPreserved,
+
+    /// <summary>
+    /// Hit after rollback retires displaced database images but before their durable hash is retired.
+    /// </summary>
+    MainFileRollbackDisplacedRetired,
 
     /// <summary>
     /// Hit after replacement-generation sidecars are quarantined while both main-file leases remain held.

--- a/src/Ahtola.Data/ManagedReplicaFaultInjection.cs
+++ b/src/Ahtola.Data/ManagedReplicaFaultInjection.cs
@@ -69,6 +69,12 @@ internal enum ManagedReplicaDurableBoundary
     ReplicaPushIntentRetired,
 
     /// <summary>
+    /// Hit after a pull response is fully available locally and immediately before it waits for
+    /// the push-flight lease that protects publication.
+    /// </summary>
+    ReplicaPullPublicationLockWaiting,
+
+    /// <summary>
     /// Hit immediately after the exclusive physical apply lease is acquired for an explicit
     /// conflict resolution's local publication (journal discard and marker retirement), before any
     /// irreversible work.
@@ -164,6 +170,12 @@ internal enum ManagedReplicaDurableBoundary
     RevertRestoreDatabasePublished,
     RevertRestoreMetadataPublished,
     RevertRetired,
+
+    /// <summary>
+    /// Hit after all remote pages are available and immediately before partial-image completion
+    /// waits for the push/apply publication leases.
+    /// </summary>
+    PartialImagePublicationLockWaiting,
 }
 
 /// <summary>

--- a/src/Ahtola.Data/ManagedReplicaFaultInjection.cs
+++ b/src/Ahtola.Data/ManagedReplicaFaultInjection.cs
@@ -197,6 +197,11 @@ internal enum ManagedReplicaDurableBoundary
     MainFileRollbackLeasesReleased,
 
     /// <summary>
+    /// Hit after the original WAL is durably captured but before the replacement intent is published.
+    /// </summary>
+    MainFileReplacementOriginalWalCaptured,
+
+    /// <summary>
     /// Hit after the deterministic replacement intent is durable and before the main-file swap.
     /// </summary>
     MainFileReplacementIntentPublished,
@@ -215,6 +220,12 @@ internal enum ManagedReplicaDurableBoundary
     /// Hit after rollback restores the exact old database image but before retiring recovery state.
     /// </summary>
     MainFileRollbackDatabaseRestored,
+
+    /// <summary>
+    /// Hit after rollback restores the original database sidecar generation but before retiring
+    /// recovery state.
+    /// </summary>
+    MainFileRollbackSidecarsRestored,
 
     /// <summary>
     /// Hit after rollback retires its durable replacement intent and deterministic artifacts.

--- a/src/Ahtola.Data/ManagedReplicaFaultInjection.cs
+++ b/src/Ahtola.Data/ManagedReplicaFaultInjection.cs
@@ -176,6 +176,25 @@ internal enum ManagedReplicaDurableBoundary
     /// waits for the push/apply publication leases.
     /// </summary>
     PartialImagePublicationLockWaiting,
+
+    /// <summary>
+    /// Windows-only boundary after the private replacement inode's SQLite byte-range lease is
+    /// released because ReplaceFile cannot rename a locked source, while the old destination inode
+    /// remains locked.
+    /// </summary>
+    MainFileReplacementSourceLeaseReleased,
+
+    /// <summary>
+    /// Windows-only boundary after ReplaceFile publishes the replacement inode and before its
+    /// SQLite byte-range lease is reacquired through the final path.
+    /// </summary>
+    MainFileReplacementPublishedBeforeLease,
+
+    /// <summary>
+    /// Windows-only boundary after rollback releases both SQLite inode leases and before ReplaceFile
+    /// restores the retained backup.
+    /// </summary>
+    MainFileRollbackLeasesReleased,
 }
 
 /// <summary>

--- a/src/Ahtola.Data/ManagedReplicaFaultInjection.cs
+++ b/src/Ahtola.Data/ManagedReplicaFaultInjection.cs
@@ -191,10 +191,10 @@ internal enum ManagedReplicaDurableBoundary
     MainFileReplacementPublishedBeforeLease,
 
     /// <summary>
-    /// Windows-only boundary after rollback releases both SQLite inode leases and before ReplaceFile
-    /// restores the retained backup.
+    /// Windows-only boundary after the replacement image is durably preserved and before the
+    /// retained backup is copied over the continuously leased destination inode.
     /// </summary>
-    MainFileRollbackLeasesReleased,
+    MainFileRollbackDisplacedPreserved,
 
     /// <summary>
     /// Hit after replacement-generation sidecars are quarantined while both main-file leases remain held.
@@ -227,10 +227,16 @@ internal enum ManagedReplicaDurableBoundary
     MainFileRollbackDatabaseRestored,
 
     /// <summary>
-    /// Windows-only boundary after rollback installs the original main file and before reacquiring
-    /// leases on the restored and displaced inodes.
+    /// Windows-only boundary after rollback restores the original main-file contents under the
+    /// continuously retained destination lease.
     /// </summary>
-    MainFileRollbackPublishedBeforeLease,
+    MainFileRollbackRestoredUnderLease,
+
+    /// <summary>
+    /// Windows-only boundary after the continuously leased destination is truncated for in-place
+    /// rollback and before the original backup image is copied into it.
+    /// </summary>
+    MainFileRollbackRestoreStarted,
 
     /// <summary>
     /// Hit after rollback restores the original database sidecar generation but before retiring
@@ -248,6 +254,12 @@ internal enum ManagedReplicaDurableBoundary
     /// database, metadata, or replacement artifact.
     /// </summary>
     MainFileReplacementRecoveryStarted,
+
+    /// <summary>
+    /// Hit after cold recovery's preliminary main-file classification and before it acquires the
+    /// SQLite lease used for the authoritative classification.
+    /// </summary>
+    MainFileReplacementRecoveryClassifiedBeforeLease,
 }
 
 /// <summary>

--- a/src/Ahtola.Data/ManagedReplicaFaultInjection.cs
+++ b/src/Ahtola.Data/ManagedReplicaFaultInjection.cs
@@ -195,6 +195,37 @@ internal enum ManagedReplicaDurableBoundary
     /// restores the retained backup.
     /// </summary>
     MainFileRollbackLeasesReleased,
+
+    /// <summary>
+    /// Hit after the deterministic replacement intent is durable and before the main-file swap.
+    /// </summary>
+    MainFileReplacementIntentPublished,
+
+    /// <summary>
+    /// Hit after completed publication deletes the old-image backup but before retiring the intent.
+    /// </summary>
+    MainFileReplacementBackupRetired,
+
+    /// <summary>
+    /// Hit after completed publication retires its durable replacement intent.
+    /// </summary>
+    MainFileReplacementIntentRetired,
+
+    /// <summary>
+    /// Hit after rollback restores the exact old database image but before retiring recovery state.
+    /// </summary>
+    MainFileRollbackDatabaseRestored,
+
+    /// <summary>
+    /// Hit after rollback retires its durable replacement intent and deterministic artifacts.
+    /// </summary>
+    MainFileRollbackIntentRetired,
+
+    /// <summary>
+    /// Hit when durable replacement recovery finds an intent, before it validates or mutates any
+    /// database, metadata, or replacement artifact.
+    /// </summary>
+    MainFileReplacementRecoveryStarted,
 }
 
 /// <summary>

--- a/src/Ahtola.Data/ManagedReplicaFaultInjection.cs
+++ b/src/Ahtola.Data/ManagedReplicaFaultInjection.cs
@@ -197,6 +197,11 @@ internal enum ManagedReplicaDurableBoundary
     MainFileRollbackLeasesReleased,
 
     /// <summary>
+    /// Hit after replacement-generation sidecars are quarantined while both main-file leases remain held.
+    /// </summary>
+    MainFileRollbackSidecarsQuarantined,
+
+    /// <summary>
     /// Hit after the original WAL is durably captured but before the replacement intent is published.
     /// </summary>
     MainFileReplacementOriginalWalCaptured,
@@ -220,6 +225,12 @@ internal enum ManagedReplicaDurableBoundary
     /// Hit after rollback restores the exact old database image but before retiring recovery state.
     /// </summary>
     MainFileRollbackDatabaseRestored,
+
+    /// <summary>
+    /// Windows-only boundary after rollback installs the original main file and before reacquiring
+    /// leases on the restored and displaced inodes.
+    /// </summary>
+    MainFileRollbackPublishedBeforeLease,
 
     /// <summary>
     /// Hit after rollback restores the original database sidecar generation but before retiring

--- a/src/Ahtola.Data/ManagedReplicaReplacementState.cs
+++ b/src/Ahtola.Data/ManagedReplicaReplacementState.cs
@@ -220,6 +220,8 @@ internal static class ManagedReplicaReplacementState
         DeleteIfExists(GetBackupPath(databasePath));
         DeleteIfExists(GetDisplacedPath(databasePath));
         DeleteIfExists(databasePath + DisplacedStagingSuffix);
+        ManagedReplicaFaultInjection.Hit(
+            ManagedReplicaDurableBoundary.MainFileRollbackDisplacedRetired);
         DeleteIfExists(databasePath + DisplacedSha256Suffix);
         DeleteIfExists(databasePath + DisplacedSha256StagingSuffix);
         DeleteIfExists(databasePath + StagingSuffix);
@@ -351,6 +353,17 @@ internal static class ManagedReplicaReplacementState
                 rollbackLock?.Dispose();
             }
             return;
+        }
+        if (!File.Exists(displacedPath)
+            && rollbackPrepared
+            && File.Exists(displacedSha256Path))
+        {
+            validatedDisplacedSha256 =
+                ReadSha256(displacedSha256Path, "displaced database");
+            ValidateFile(
+                databasePath + DisplacedStagingSuffix,
+                validatedDisplacedSha256,
+                "staged displaced database");
         }
         if (!string.Equals(currentSha256, intent.ReplacementDatabaseSha256, StringComparison.Ordinal)
             && !rollbackPrepared)
@@ -793,6 +806,8 @@ internal static class ManagedReplicaReplacementState
             WriteSha256Durably(
                 databasePath,
                 ComputeSha256(displacedStagingPath));
+            ManagedReplicaFaultInjection.Hit(
+                ManagedReplicaDurableBoundary.MainFileRollbackDisplacedHashPublished);
         }
         File.Move(displacedStagingPath, displacedPath, overwrite: false);
     }

--- a/src/Ahtola.Data/ManagedReplicaReplacementState.cs
+++ b/src/Ahtola.Data/ManagedReplicaReplacementState.cs
@@ -305,13 +305,16 @@ internal static class ManagedReplicaReplacementState
         if (File.Exists(backupPath))
             ValidateFile(backupPath, intent.OriginalDatabaseSha256, "backup");
         var rollbackPrepared = File.Exists(databasePath + RollbackSidecarsPreparedSuffix);
+        string? validatedDisplacedSha256 = null;
         if (File.Exists(displacedPath))
         {
-            ValidateFile(
-                displacedPath,
+            validatedDisplacedSha256 =
                 rollbackPrepared && File.Exists(displacedSha256Path)
                     ? ReadSha256(displacedSha256Path, "displaced database")
-                    : intent.ReplacementDatabaseSha256,
+                    : intent.ReplacementDatabaseSha256;
+            ValidateFile(
+                displacedPath,
+                validatedDisplacedSha256,
                 "displaced database");
         }
 
@@ -411,6 +414,12 @@ internal static class ManagedReplicaReplacementState
                     lockedSha256,
                     intent.ReplacementDatabaseSha256,
                     StringComparison.Ordinal)
+                && (!rollbackPrepared
+                    || validatedDisplacedSha256 is null
+                    || !string.Equals(
+                        lockedSha256,
+                        validatedDisplacedSha256,
+                        StringComparison.Ordinal))
                 && (!rollbackPrepared
                     || !IsStrictFilePrefix(databaseLease, backupLease)))
             {

--- a/src/Ahtola.Data/ManagedReplicaReplacementState.cs
+++ b/src/Ahtola.Data/ManagedReplicaReplacementState.cs
@@ -12,6 +12,10 @@ internal static class ManagedReplicaReplacementState
     internal const string BackupSuffix = ".ahtola-replica-replacement.bak";
     internal const string DisplacedSuffix = ".ahtola-replica-replacement.displaced";
     internal const string OriginalWalSuffix = ".ahtola-replica-replacement.original-wal";
+    internal const string RollbackSidecarsPreparedSuffix = ".ahtola-replica-replacement.rollback-sidecars";
+    internal const string ReplacementWalSuffix = ".ahtola-replica-replacement.replacement-wal";
+    internal const string ReplacementShmSuffix = ".ahtola-replica-replacement.replacement-shm";
+    internal const string ReplacementJournalSuffix = ".ahtola-replica-replacement.replacement-journal";
     internal const string StagingSuffix = ".ahtola-replica-replacement.tmp";
 
     private const int MaximumIntentLength = 4096;
@@ -33,6 +37,10 @@ internal static class ManagedReplicaReplacementState
         GetBackupPath(databasePath),
         GetDisplacedPath(databasePath),
         GetOriginalWalPath(databasePath),
+        databasePath + RollbackSidecarsPreparedSuffix,
+        databasePath + ReplacementWalSuffix,
+        databasePath + ReplacementShmSuffix,
+        databasePath + ReplacementJournalSuffix,
     ];
 
     internal static void DeleteArtifacts(string databasePath)
@@ -139,6 +147,7 @@ internal static class ManagedReplicaReplacementState
 
         DeleteIfExists(GetBackupPath(databasePath));
         DeleteIfExists(GetOriginalWalPath(databasePath));
+        DeleteRollbackSidecarArtifacts(databasePath, includePreparedMarker: true);
         ManagedReplicaFaultInjection.Hit(
             ManagedReplicaDurableBoundary.MainFileReplacementBackupRetired);
         DeleteIfExists(GetDisplacedPath(databasePath));
@@ -174,8 +183,46 @@ internal static class ManagedReplicaReplacementState
         DeleteIfExists(GetDisplacedPath(databasePath));
         DeleteIfExists(databasePath + StagingSuffix);
         DeleteIfExists(databasePath + IntentSuffix);
+        DeleteIfExists(databasePath + RollbackSidecarsPreparedSuffix);
         ManagedReplicaFaultInjection.Hit(
             ManagedReplicaDurableBoundary.MainFileRollbackIntentRetired);
+    }
+
+    internal static void PrepareRollbackSidecars(string databasePath)
+    {
+        var liveSidecars = GetSqliteSidecarPaths(databasePath);
+        var quarantinedSidecars = GetReplacementSidecarPaths(databasePath);
+        for (var index = 0; index < liveSidecars.Count; index++)
+        {
+            var livePath = liveSidecars[index];
+            if (!File.Exists(livePath))
+                continue;
+
+            var quarantinePath = quarantinedSidecars[index];
+            if (File.Exists(quarantinePath))
+            {
+                // Re-entry can follow a crash after quarantine but before the main-file swap.
+                // The caller holds the still-published replacement inode, so a recreated live
+                // sidecar belongs to that same generation and is discarded with it.
+                DeleteIfExists(livePath);
+                continue;
+            }
+            File.Move(livePath, quarantinePath, overwrite: false);
+        }
+
+        var preparedPath = databasePath + RollbackSidecarsPreparedSuffix;
+        if (!File.Exists(preparedPath))
+            WriteDurableMarker(preparedPath);
+        ManagedReplicaFaultInjection.Hit(
+            ManagedReplicaDurableBoundary.MainFileRollbackSidecarsQuarantined);
+
+        var intent = Read(databasePath);
+        if (intent.OriginalWalSha256 is not { } expectedOriginalWal)
+            return;
+
+        var originalWalBackupPath = GetOriginalWalPath(databasePath);
+        ValidateFile(originalWalBackupPath, expectedOriginalWal, "original WAL backup");
+        CopyFileDurably(originalWalBackupPath, databasePath + "-wal");
     }
 
     internal static void Recover(string databasePath)
@@ -193,6 +240,7 @@ internal static class ManagedReplicaReplacementState
                     "Managed embedded replica replacement recovery found a backup without its durable intent.");
             }
             DeleteIfExists(GetOriginalWalPath(databasePath));
+            DeleteRollbackSidecarArtifacts(databasePath, includePreparedMarker: true);
             DeleteIfExists(stagingPath);
             return;
         }
@@ -217,7 +265,7 @@ internal static class ManagedReplicaReplacementState
         var currentSha256 = ComputeSha256(databasePath);
         if (string.Equals(currentSha256, intent.OriginalDatabaseSha256, StringComparison.Ordinal))
         {
-            ValidateOriginalWalState(databasePath, intent);
+            ValidateOriginalWalState(databasePath, intent, originalDatabaseInstalled: true);
             IDisposable? rollbackLock = null;
             try
             {
@@ -257,8 +305,6 @@ internal static class ManagedReplicaReplacementState
             throw new InvalidDataException(
                 "Managed embedded replica replacement recovery cannot restore the original database because its backup is missing.");
         }
-        ValidateOriginalWalState(databasePath, intent);
-
         IDisposable? replacementLock = null;
         try
         {
@@ -266,12 +312,13 @@ internal static class ManagedReplicaReplacementState
                 databasePath,
                 backupPath,
                 CancellationToken.None);
-            ManagedReplicaApplyLock.ReplaceMainFile(
+            ValidateOriginalWalState(databasePath, intent, originalDatabaseInstalled: false);
+            ManagedReplicaApplyLock.RollBackMainFile(
                 replacementLock,
                 backupPath,
                 databasePath,
                 displacedPath,
-                static () => { });
+                () => PrepareRollbackSidecars(databasePath));
             ManagedReplicaFaultInjection.Hit(
                 ManagedReplicaDurableBoundary.MainFileRollbackDatabaseRestored);
             CompleteRollback(databasePath);
@@ -383,10 +430,20 @@ internal static class ManagedReplicaReplacementState
         }
     }
 
-    private static void ValidateOriginalWalState(string databasePath, ReplacementIntent intent)
+    private static void ValidateOriginalWalState(
+        string databasePath,
+        ReplacementIntent intent,
+        bool originalDatabaseInstalled)
     {
         var backupPath = GetOriginalWalPath(databasePath);
         var walPath = databasePath + "-wal";
+        if (originalDatabaseInstalled
+            && File.Exists(databasePath + RollbackSidecarsPreparedSuffix)
+            && File.Exists(walPath))
+        {
+            ValidateLiveRollbackSidecars(databasePath);
+            return;
+        }
         if (intent.OriginalWalSha256 is not { } expected)
         {
             if (File.Exists(backupPath))
@@ -407,10 +464,36 @@ internal static class ManagedReplicaReplacementState
         string databasePath,
         ReplacementIntent intent)
     {
-        var sidecars = GetSqliteSidecarPaths(databasePath);
         var displacedExists = File.Exists(GetDisplacedPath(databasePath));
         var walPath = databasePath + "-wal";
         var originalWalBackupPath = GetOriginalWalPath(databasePath);
+        var sidecarsPrepared = File.Exists(databasePath + RollbackSidecarsPreparedSuffix);
+        if (sidecarsPrepared)
+        {
+            ValidateLiveRollbackSidecars(databasePath);
+            if (File.Exists(walPath))
+            {
+                DeleteIfExists(originalWalBackupPath);
+            }
+            else if (intent.OriginalWalSha256 is not null)
+            {
+                if (!File.Exists(originalWalBackupPath))
+                {
+                    throw new InvalidDataException(
+                        "Managed embedded replica replacement rollback cannot restore the original WAL because its backup is missing.");
+                }
+                File.Move(originalWalBackupPath, walPath, overwrite: false);
+            }
+            else
+            {
+                DeleteIfExists(originalWalBackupPath);
+            }
+
+            DeleteRollbackSidecarArtifacts(databasePath, includePreparedMarker: false);
+            return;
+        }
+
+        var sidecars = GetSqliteSidecarPaths(databasePath);
         var originalWalAlreadyRestored =
             intent.OriginalWalSha256 is { } expectedOriginalWal
             && !File.Exists(originalWalBackupPath)
@@ -453,12 +536,39 @@ internal static class ManagedReplicaReplacementState
         }
     }
 
+    private static void ValidateLiveRollbackSidecars(string databasePath)
+    {
+        var walExists = File.Exists(databasePath + "-wal");
+        var shmExists = File.Exists(databasePath + "-shm");
+        var journalExists = File.Exists(databasePath + "-journal");
+        if ((shmExists && !walExists) || (journalExists && (walExists || shmExists)))
+        {
+            throw new InvalidDataException(
+                "Managed embedded replica replacement rollback found an incoherent restored-database sidecar set.");
+        }
+    }
+
     private static IReadOnlyList<string> GetSqliteSidecarPaths(string databasePath) =>
     [
         databasePath + "-wal",
         databasePath + "-shm",
         databasePath + "-journal",
     ];
+
+    private static IReadOnlyList<string> GetReplacementSidecarPaths(string databasePath) =>
+    [
+        databasePath + ReplacementWalSuffix,
+        databasePath + ReplacementShmSuffix,
+        databasePath + ReplacementJournalSuffix,
+    ];
+
+    private static void DeleteRollbackSidecarArtifacts(string databasePath, bool includePreparedMarker)
+    {
+        foreach (var path in GetReplacementSidecarPaths(databasePath))
+            DeleteIfExists(path);
+        if (includePreparedMarker)
+            DeleteIfExists(databasePath + RollbackSidecarsPreparedSuffix);
+    }
 
     private static void ValidateFile(string path, string expectedSha256, string role)
     {
@@ -498,6 +608,18 @@ internal static class ManagedReplicaReplacementState
             FileOptions.WriteThrough);
         source.CopyTo(destination);
         destination.Flush(flushToDisk: true);
+    }
+
+    private static void WriteDurableMarker(string path)
+    {
+        using var stream = new FileStream(
+            path,
+            FileMode.CreateNew,
+            FileAccess.Write,
+            FileShare.Read,
+            bufferSize: 1,
+            FileOptions.WriteThrough);
+        stream.Flush(flushToDisk: true);
     }
 
     private static InvalidDataException InvalidIntent()

--- a/src/Ahtola.Data/ManagedReplicaReplacementState.cs
+++ b/src/Ahtola.Data/ManagedReplicaReplacementState.cs
@@ -1,0 +1,346 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Ahtola;
+
+/// <summary>
+/// Durable intent for an atomic managed-replica main-file replacement.
+/// </summary>
+internal static class ManagedReplicaReplacementState
+{
+    internal const string IntentSuffix = ".ahtola-replica-replacement";
+    internal const string BackupSuffix = ".ahtola-replica-replacement.bak";
+    internal const string DisplacedSuffix = ".ahtola-replica-replacement.displaced";
+    internal const string StagingSuffix = ".ahtola-replica-replacement.tmp";
+
+    private const int MaximumIntentLength = 4096;
+    private static readonly UTF8Encoding StrictUtf8 = new(false, true);
+
+    internal static string GetBackupPath(string databasePath) => databasePath + BackupSuffix;
+
+    internal static string GetDisplacedPath(string databasePath) => databasePath + DisplacedSuffix;
+
+    internal static bool HasArtifacts(string databasePath)
+        => GetArtifactPaths(databasePath).Any(File.Exists);
+
+    internal static IReadOnlyList<string> GetArtifactPaths(string databasePath) =>
+    [
+        databasePath + IntentSuffix,
+        databasePath + StagingSuffix,
+        GetBackupPath(databasePath),
+        GetDisplacedPath(databasePath),
+    ];
+
+    internal static void DeleteArtifacts(string databasePath)
+    {
+        foreach (var path in GetArtifactPaths(databasePath))
+            DeleteIfExists(path);
+    }
+
+    internal static void Prepare(string databasePath, string replacementPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(databasePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(replacementPath);
+
+        if (HasArtifacts(databasePath))
+        {
+            throw new InvalidDataException(
+                "Managed embedded replica replacement intent cannot be prepared while recovery artifacts remain.");
+        }
+        if (!File.Exists(databasePath)
+            || !File.Exists(replacementPath)
+            || !File.Exists(databasePath + ManagedReplicaBootstrapper.MetadataSuffix))
+        {
+            throw new InvalidDataException(
+                "Managed embedded replica replacement intent requires the database, replacement, and metadata files.");
+        }
+
+        var intent = new ReplacementIntent(
+            ComputeSha256(databasePath),
+            ComputeSha256(replacementPath),
+            ComputeSha256(databasePath + ManagedReplicaBootstrapper.MetadataSuffix));
+        var intentPath = databasePath + IntentSuffix;
+        var stagingPath = databasePath + StagingSuffix;
+        var bytes = StrictUtf8.GetBytes(
+            "version=1\n"
+            + $"backup={Path.GetFileName(GetBackupPath(databasePath))}\n"
+            + $"displaced={Path.GetFileName(GetDisplacedPath(databasePath))}\n"
+            + $"original_sha256={intent.OriginalDatabaseSha256}\n"
+            + $"replacement_sha256={intent.ReplacementDatabaseSha256}\n"
+            + $"metadata_sha256={intent.OriginalMetadataSha256}\n");
+
+        try
+        {
+            using (var stream = new FileStream(
+                       stagingPath,
+                       FileMode.CreateNew,
+                       FileAccess.Write,
+                       FileShare.None,
+                       bufferSize: 1024,
+                       FileOptions.WriteThrough))
+            {
+                stream.Write(bytes);
+                stream.Flush(flushToDisk: true);
+            }
+            File.Move(stagingPath, intentPath, overwrite: false);
+        }
+        finally
+        {
+            DeleteIfExists(stagingPath);
+        }
+
+        ManagedReplicaFaultInjection.Hit(
+            ManagedReplicaDurableBoundary.MainFileReplacementIntentPublished);
+    }
+
+    internal static void CompletePublication(string databasePath)
+    {
+        var intent = Read(databasePath);
+        _ = ManagedReplicaBootstrapper.LoadMetadata(databasePath)
+            ?? throw new InvalidDataException(
+                "Managed embedded replica replacement publication has no metadata.");
+        ValidateCurrentDatabase(databasePath, intent.ReplacementDatabaseSha256);
+        if (string.Equals(
+                ComputeSha256(databasePath + ManagedReplicaBootstrapper.MetadataSuffix),
+                intent.OriginalMetadataSha256,
+                StringComparison.Ordinal))
+        {
+            throw new InvalidDataException(
+                "Managed embedded replica replacement metadata does not describe the published database.");
+        }
+
+        DeleteIfExists(GetBackupPath(databasePath));
+        ManagedReplicaFaultInjection.Hit(
+            ManagedReplicaDurableBoundary.MainFileReplacementBackupRetired);
+        DeleteIfExists(GetDisplacedPath(databasePath));
+        DeleteIfExists(databasePath + StagingSuffix);
+        DeleteIfExists(databasePath + IntentSuffix);
+        ManagedReplicaFaultInjection.Hit(
+            ManagedReplicaDurableBoundary.MainFileReplacementIntentRetired);
+    }
+
+    internal static bool TryCompletePublication(string databasePath)
+    {
+        var intent = Read(databasePath);
+        ValidateCurrentDatabase(databasePath, intent.ReplacementDatabaseSha256);
+        if (string.Equals(
+                ComputeSha256(databasePath + ManagedReplicaBootstrapper.MetadataSuffix),
+                intent.OriginalMetadataSha256,
+                StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        CompletePublication(databasePath);
+        return true;
+    }
+
+    internal static void CompleteRollback(string databasePath)
+    {
+        var intent = Read(databasePath);
+        ValidateCurrentDatabase(databasePath, intent.OriginalDatabaseSha256);
+        DeleteIfExists(GetBackupPath(databasePath));
+        DeleteIfExists(GetDisplacedPath(databasePath));
+        DeleteIfExists(databasePath + StagingSuffix);
+        DeleteIfExists(databasePath + IntentSuffix);
+        ManagedReplicaFaultInjection.Hit(
+            ManagedReplicaDurableBoundary.MainFileRollbackIntentRetired);
+    }
+
+    internal static void Recover(string databasePath)
+    {
+        var intentPath = databasePath + IntentSuffix;
+        var stagingPath = databasePath + StagingSuffix;
+        var backupPath = GetBackupPath(databasePath);
+        var displacedPath = GetDisplacedPath(databasePath);
+        if (!File.Exists(intentPath))
+        {
+            if (File.Exists(backupPath) || File.Exists(displacedPath))
+            {
+                throw new InvalidDataException(
+                    "Managed embedded replica replacement recovery found a backup without its durable intent.");
+            }
+            DeleteIfExists(stagingPath);
+            return;
+        }
+
+        ManagedReplicaFaultInjection.Hit(
+            ManagedReplicaDurableBoundary.MainFileReplacementRecoveryStarted);
+        var intent = Read(databasePath);
+        var metadataPath = databasePath + ManagedReplicaBootstrapper.MetadataSuffix;
+        _ = ManagedReplicaBootstrapper.LoadMetadata(databasePath)
+            ?? throw new InvalidDataException(
+                "Managed embedded replica replacement recovery metadata is missing.");
+        if (!File.Exists(databasePath))
+        {
+            throw new InvalidDataException(
+                "Managed embedded replica replacement recovery database is missing.");
+        }
+        if (File.Exists(backupPath))
+            ValidateFile(backupPath, intent.OriginalDatabaseSha256, "backup");
+        if (File.Exists(displacedPath))
+            ValidateFile(displacedPath, intent.ReplacementDatabaseSha256, "displaced database");
+
+        var currentSha256 = ComputeSha256(databasePath);
+        if (string.Equals(currentSha256, intent.OriginalDatabaseSha256, StringComparison.Ordinal))
+        {
+            CompleteRollback(databasePath);
+            return;
+        }
+        if (!string.Equals(currentSha256, intent.ReplacementDatabaseSha256, StringComparison.Ordinal))
+        {
+            throw new InvalidDataException(
+                "Managed embedded replica replacement recovery found an unrecognized database image.");
+        }
+
+        var metadataChanged = !string.Equals(
+            ComputeSha256(metadataPath),
+            intent.OriginalMetadataSha256,
+            StringComparison.Ordinal);
+        if (metadataChanged)
+        {
+            CompletePublication(databasePath);
+            return;
+        }
+        if (!File.Exists(backupPath))
+        {
+            throw new InvalidDataException(
+                "Managed embedded replica replacement recovery cannot restore the original database because its backup is missing.");
+        }
+
+        IDisposable? replacementLock = null;
+        try
+        {
+            replacementLock = ManagedReplicaApplyLock.AcquireMainFileReplacementLock(
+                databasePath,
+                backupPath,
+                CancellationToken.None);
+            ManagedReplicaApplyLock.ReplaceMainFile(
+                replacementLock,
+                backupPath,
+                databasePath,
+                displacedPath,
+                static () => { });
+            ManagedReplicaFaultInjection.Hit(
+                ManagedReplicaDurableBoundary.MainFileRollbackDatabaseRestored);
+            CompleteRollback(databasePath);
+        }
+        finally
+        {
+            replacementLock?.Dispose();
+        }
+    }
+
+    private static ReplacementIntent Read(string databasePath)
+    {
+        var intentPath = databasePath + IntentSuffix;
+        byte[] bytes;
+        try
+        {
+            bytes = File.ReadAllBytes(intentPath);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            throw new InvalidDataException(
+                "Managed embedded replica replacement intent could not be read.",
+                exception);
+        }
+        if (bytes.Length == 0 || bytes.Length > MaximumIntentLength)
+            throw InvalidIntent();
+
+        string text;
+        try
+        {
+            text = StrictUtf8.GetString(bytes);
+        }
+        catch (DecoderFallbackException exception)
+        {
+            throw new InvalidDataException(
+                "Managed embedded replica replacement intent is not valid UTF-8.",
+                exception);
+        }
+
+        var lines = text.Split('\n');
+        var filenameComparison = OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        if (lines.Length != 7
+            || lines[0] != "version=1"
+            || !string.Equals(
+                lines[1],
+                $"backup={Path.GetFileName(GetBackupPath(databasePath))}",
+                filenameComparison)
+            || !string.Equals(
+                lines[2],
+                $"displaced={Path.GetFileName(GetDisplacedPath(databasePath))}",
+                filenameComparison)
+            || !lines[3].StartsWith("original_sha256=", StringComparison.Ordinal)
+            || !lines[4].StartsWith("replacement_sha256=", StringComparison.Ordinal)
+            || !lines[5].StartsWith("metadata_sha256=", StringComparison.Ordinal)
+            || lines[6].Length != 0)
+        {
+            throw InvalidIntent();
+        }
+
+        return new ReplacementIntent(
+            ParseSha256(lines[3]["original_sha256=".Length..]),
+            ParseSha256(lines[4]["replacement_sha256=".Length..]),
+            ParseSha256(lines[5]["metadata_sha256=".Length..]));
+    }
+
+    private static string ParseSha256(string value)
+    {
+        if (value.Length != 64)
+            throw InvalidIntent();
+        try
+        {
+            _ = Convert.FromHexString(value);
+        }
+        catch (FormatException exception)
+        {
+            throw new InvalidDataException(
+                "Managed embedded replica replacement intent contains an invalid SHA-256 value.",
+                exception);
+        }
+        return value;
+    }
+
+    private static void ValidateCurrentDatabase(string databasePath, string expectedSha256)
+        => ValidateFile(databasePath, expectedSha256, "database");
+
+    private static void ValidateFile(string path, string expectedSha256, string role)
+    {
+        if (!File.Exists(path)
+            || !string.Equals(ComputeSha256(path), expectedSha256, StringComparison.Ordinal))
+        {
+            throw new InvalidDataException(
+                $"Managed embedded replica replacement recovery {role} is missing or corrupt.");
+        }
+    }
+
+    private static string ComputeSha256(string path)
+    {
+        using var stream = new FileStream(
+            path,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.ReadWrite | FileShare.Delete,
+            bufferSize: 128 * 1024,
+            FileOptions.SequentialScan);
+        return Convert.ToHexString(SHA256.HashData(stream));
+    }
+
+    private static InvalidDataException InvalidIntent()
+        => new("Managed embedded replica replacement intent is invalid or corrupt.");
+
+    private static void DeleteIfExists(string path)
+    {
+        if (File.Exists(path))
+            File.Delete(path);
+    }
+
+    private readonly record struct ReplacementIntent(
+        string OriginalDatabaseSha256,
+        string ReplacementDatabaseSha256,
+        string OriginalMetadataSha256);
+}

--- a/src/Ahtola.Data/ManagedReplicaReplacementState.cs
+++ b/src/Ahtola.Data/ManagedReplicaReplacementState.cs
@@ -11,6 +11,7 @@ internal static class ManagedReplicaReplacementState
     internal const string IntentSuffix = ".ahtola-replica-replacement";
     internal const string BackupSuffix = ".ahtola-replica-replacement.bak";
     internal const string DisplacedSuffix = ".ahtola-replica-replacement.displaced";
+    internal const string OriginalWalSuffix = ".ahtola-replica-replacement.original-wal";
     internal const string StagingSuffix = ".ahtola-replica-replacement.tmp";
 
     private const int MaximumIntentLength = 4096;
@@ -19,6 +20,8 @@ internal static class ManagedReplicaReplacementState
     internal static string GetBackupPath(string databasePath) => databasePath + BackupSuffix;
 
     internal static string GetDisplacedPath(string databasePath) => databasePath + DisplacedSuffix;
+
+    internal static string GetOriginalWalPath(string databasePath) => databasePath + OriginalWalSuffix;
 
     internal static bool HasArtifacts(string databasePath)
         => GetArtifactPaths(databasePath).Any(File.Exists);
@@ -29,6 +32,7 @@ internal static class ManagedReplicaReplacementState
         databasePath + StagingSuffix,
         GetBackupPath(databasePath),
         GetDisplacedPath(databasePath),
+        GetOriginalWalPath(databasePath),
     ];
 
     internal static void DeleteArtifacts(string databasePath)
@@ -38,9 +42,19 @@ internal static class ManagedReplicaReplacementState
     }
 
     internal static void Prepare(string databasePath, string replacementPath)
+        => Prepare(
+            databasePath,
+            replacementPath,
+            ComputeSha256(databasePath + ManagedReplicaBootstrapper.MetadataSuffix));
+
+    internal static void Prepare(
+        string databasePath,
+        string replacementPath,
+        string replacementMetadataSha256)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(databasePath);
         ArgumentException.ThrowIfNullOrWhiteSpace(replacementPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(replacementMetadataSha256);
 
         if (HasArtifacts(databasePath))
         {
@@ -54,20 +68,39 @@ internal static class ManagedReplicaReplacementState
             throw new InvalidDataException(
                 "Managed embedded replica replacement intent requires the database, replacement, and metadata files.");
         }
+        if (File.Exists(databasePath + "-journal"))
+        {
+            throw new InvalidDataException(
+                "Managed embedded replica replacement cannot capture a database with an active rollback journal.");
+        }
 
+        var originalWalPath = databasePath + "-wal";
+        var originalWalBackupPath = GetOriginalWalPath(databasePath);
+        string? originalWalSha256 = null;
+        if (File.Exists(originalWalPath))
+        {
+            CopyFileDurably(originalWalPath, originalWalBackupPath);
+            originalWalSha256 = ComputeSha256(originalWalBackupPath);
+            ManagedReplicaFaultInjection.Hit(
+                ManagedReplicaDurableBoundary.MainFileReplacementOriginalWalCaptured);
+        }
         var intent = new ReplacementIntent(
             ComputeSha256(databasePath),
             ComputeSha256(replacementPath),
-            ComputeSha256(databasePath + ManagedReplicaBootstrapper.MetadataSuffix));
+            ComputeSha256(databasePath + ManagedReplicaBootstrapper.MetadataSuffix),
+            ParseSha256(replacementMetadataSha256),
+            originalWalSha256);
         var intentPath = databasePath + IntentSuffix;
         var stagingPath = databasePath + StagingSuffix;
         var bytes = StrictUtf8.GetBytes(
-            "version=1\n"
+            "version=2\n"
             + $"backup={Path.GetFileName(GetBackupPath(databasePath))}\n"
             + $"displaced={Path.GetFileName(GetDisplacedPath(databasePath))}\n"
+            + $"original_wal_sha256={intent.OriginalWalSha256 ?? "absent"}\n"
             + $"original_sha256={intent.OriginalDatabaseSha256}\n"
             + $"replacement_sha256={intent.ReplacementDatabaseSha256}\n"
-            + $"metadata_sha256={intent.OriginalMetadataSha256}\n");
+            + $"original_metadata_sha256={intent.OriginalMetadataSha256}\n"
+            + $"replacement_metadata_sha256={intent.ReplacementMetadataSha256}\n");
 
         try
         {
@@ -91,25 +124,21 @@ internal static class ManagedReplicaReplacementState
 
         ManagedReplicaFaultInjection.Hit(
             ManagedReplicaDurableBoundary.MainFileReplacementIntentPublished);
+        DeleteIfExists(databasePath + "-wal");
+        DeleteIfExists(databasePath + "-shm");
     }
 
     internal static void CompletePublication(string databasePath)
     {
         var intent = Read(databasePath);
-        _ = ManagedReplicaBootstrapper.LoadMetadata(databasePath)
+        var metadata = ManagedReplicaBootstrapper.LoadMetadata(databasePath)
             ?? throw new InvalidDataException(
                 "Managed embedded replica replacement publication has no metadata.");
         ValidateCurrentDatabase(databasePath, intent.ReplacementDatabaseSha256);
-        if (string.Equals(
-                ComputeSha256(databasePath + ManagedReplicaBootstrapper.MetadataSuffix),
-                intent.OriginalMetadataSha256,
-                StringComparison.Ordinal))
-        {
-            throw new InvalidDataException(
-                "Managed embedded replica replacement metadata does not describe the published database.");
-        }
+        ValidateReplacementMetadata(databasePath, metadata, intent);
 
         DeleteIfExists(GetBackupPath(databasePath));
+        DeleteIfExists(GetOriginalWalPath(databasePath));
         ManagedReplicaFaultInjection.Hit(
             ManagedReplicaDurableBoundary.MainFileReplacementBackupRetired);
         DeleteIfExists(GetDisplacedPath(databasePath));
@@ -123,10 +152,9 @@ internal static class ManagedReplicaReplacementState
     {
         var intent = Read(databasePath);
         ValidateCurrentDatabase(databasePath, intent.ReplacementDatabaseSha256);
-        if (string.Equals(
-                ComputeSha256(databasePath + ManagedReplicaBootstrapper.MetadataSuffix),
-                intent.OriginalMetadataSha256,
-                StringComparison.Ordinal))
+        var metadataSha256 = ComputeSha256(
+            databasePath + ManagedReplicaBootstrapper.MetadataSuffix);
+        if (string.Equals(metadataSha256, intent.OriginalMetadataSha256, StringComparison.Ordinal))
         {
             return false;
         }
@@ -139,6 +167,9 @@ internal static class ManagedReplicaReplacementState
     {
         var intent = Read(databasePath);
         ValidateCurrentDatabase(databasePath, intent.OriginalDatabaseSha256);
+        ReconcileRollbackSidecars(databasePath, intent);
+        ManagedReplicaFaultInjection.Hit(
+            ManagedReplicaDurableBoundary.MainFileRollbackSidecarsRestored);
         DeleteIfExists(GetBackupPath(databasePath));
         DeleteIfExists(GetDisplacedPath(databasePath));
         DeleteIfExists(databasePath + StagingSuffix);
@@ -155,11 +186,13 @@ internal static class ManagedReplicaReplacementState
         var displacedPath = GetDisplacedPath(databasePath);
         if (!File.Exists(intentPath))
         {
-            if (File.Exists(backupPath) || File.Exists(displacedPath))
+            if (File.Exists(backupPath)
+                || File.Exists(displacedPath))
             {
                 throw new InvalidDataException(
                     "Managed embedded replica replacement recovery found a backup without its durable intent.");
             }
+            DeleteIfExists(GetOriginalWalPath(databasePath));
             DeleteIfExists(stagingPath);
             return;
         }
@@ -184,7 +217,24 @@ internal static class ManagedReplicaReplacementState
         var currentSha256 = ComputeSha256(databasePath);
         if (string.Equals(currentSha256, intent.OriginalDatabaseSha256, StringComparison.Ordinal))
         {
-            CompleteRollback(databasePath);
+            ValidateOriginalWalState(databasePath, intent);
+            IDisposable? rollbackLock = null;
+            try
+            {
+                rollbackLock = File.Exists(displacedPath)
+                    ? ManagedReplicaApplyLock.AcquireMainFileReplacementLock(
+                        databasePath,
+                        displacedPath,
+                        CancellationToken.None)
+                    : ManagedReplicaApplyLock.AcquireMainFileReplacementLock(
+                        databasePath,
+                        CancellationToken.None);
+                CompleteRollback(databasePath);
+            }
+            finally
+            {
+                rollbackLock?.Dispose();
+            }
             return;
         }
         if (!string.Equals(currentSha256, intent.ReplacementDatabaseSha256, StringComparison.Ordinal))
@@ -207,6 +257,7 @@ internal static class ManagedReplicaReplacementState
             throw new InvalidDataException(
                 "Managed embedded replica replacement recovery cannot restore the original database because its backup is missing.");
         }
+        ValidateOriginalWalState(databasePath, intent);
 
         IDisposable? replacementLock = null;
         try
@@ -264,8 +315,8 @@ internal static class ManagedReplicaReplacementState
         var filenameComparison = OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
             ? StringComparison.OrdinalIgnoreCase
             : StringComparison.Ordinal;
-        if (lines.Length != 7
-            || lines[0] != "version=1"
+        if (lines.Length != 9
+            || lines[0] != "version=2"
             || !string.Equals(
                 lines[1],
                 $"backup={Path.GetFileName(GetBackupPath(databasePath))}",
@@ -274,18 +325,22 @@ internal static class ManagedReplicaReplacementState
                 lines[2],
                 $"displaced={Path.GetFileName(GetDisplacedPath(databasePath))}",
                 filenameComparison)
-            || !lines[3].StartsWith("original_sha256=", StringComparison.Ordinal)
-            || !lines[4].StartsWith("replacement_sha256=", StringComparison.Ordinal)
-            || !lines[5].StartsWith("metadata_sha256=", StringComparison.Ordinal)
-            || lines[6].Length != 0)
+            || !lines[3].StartsWith("original_wal_sha256=", StringComparison.Ordinal)
+            || !lines[4].StartsWith("original_sha256=", StringComparison.Ordinal)
+            || !lines[5].StartsWith("replacement_sha256=", StringComparison.Ordinal)
+            || !lines[6].StartsWith("original_metadata_sha256=", StringComparison.Ordinal)
+            || !lines[7].StartsWith("replacement_metadata_sha256=", StringComparison.Ordinal)
+            || lines[8].Length != 0)
         {
             throw InvalidIntent();
         }
 
         return new ReplacementIntent(
-            ParseSha256(lines[3]["original_sha256=".Length..]),
-            ParseSha256(lines[4]["replacement_sha256=".Length..]),
-            ParseSha256(lines[5]["metadata_sha256=".Length..]));
+            ParseSha256(lines[4]["original_sha256=".Length..]),
+            ParseSha256(lines[5]["replacement_sha256=".Length..]),
+            ParseSha256(lines[6]["original_metadata_sha256=".Length..]),
+            ParseSha256(lines[7]["replacement_metadata_sha256=".Length..]),
+            ParseOptionalSha256(lines[3]["original_wal_sha256=".Length..]));
     }
 
     private static string ParseSha256(string value)
@@ -305,8 +360,105 @@ internal static class ManagedReplicaReplacementState
         return value;
     }
 
+    private static string? ParseOptionalSha256(string value)
+        => string.Equals(value, "absent", StringComparison.Ordinal)
+            ? null
+            : ParseSha256(value);
+
     private static void ValidateCurrentDatabase(string databasePath, string expectedSha256)
         => ValidateFile(databasePath, expectedSha256, "database");
+
+    private static void ValidateReplacementMetadata(
+        string databasePath,
+        ManagedReplicaBootstrapper.ManagedReplicaMetadata metadata,
+        ReplacementIntent intent)
+    {
+        if (!string.Equals(
+                ComputeSha256(databasePath + ManagedReplicaBootstrapper.MetadataSuffix),
+                intent.ReplacementMetadataSha256,
+                StringComparison.Ordinal))
+        {
+            throw new InvalidDataException(
+                "Managed embedded replica replacement metadata does not match the expected published generation.");
+        }
+    }
+
+    private static void ValidateOriginalWalState(string databasePath, ReplacementIntent intent)
+    {
+        var backupPath = GetOriginalWalPath(databasePath);
+        var walPath = databasePath + "-wal";
+        if (intent.OriginalWalSha256 is not { } expected)
+        {
+            if (File.Exists(backupPath))
+                throw new InvalidDataException(
+                    "Managed embedded replica replacement recovery found an unexpected original WAL backup.");
+            return;
+        }
+
+        if (File.Exists(backupPath))
+        {
+            ValidateFile(backupPath, expected, "original WAL backup");
+            return;
+        }
+        ValidateFile(walPath, expected, "restored original WAL");
+    }
+
+    private static void ReconcileRollbackSidecars(
+        string databasePath,
+        ReplacementIntent intent)
+    {
+        var sidecars = GetSqliteSidecarPaths(databasePath);
+        var displacedExists = File.Exists(GetDisplacedPath(databasePath));
+        var walPath = databasePath + "-wal";
+        var originalWalBackupPath = GetOriginalWalPath(databasePath);
+        var originalWalAlreadyRestored =
+            intent.OriginalWalSha256 is { } expectedOriginalWal
+            && !File.Exists(originalWalBackupPath)
+            && File.Exists(walPath)
+            && string.Equals(ComputeSha256(walPath), expectedOriginalWal, StringComparison.Ordinal);
+        if (!displacedExists && File.Exists(databasePath + "-journal"))
+        {
+            throw new InvalidDataException(
+                "Managed embedded replica replacement rollback found a rollback journal without the displaced replacement database.");
+        }
+        if (!displacedExists && File.Exists(walPath))
+        {
+            if (intent.OriginalWalSha256 is not { } expected
+                || !string.Equals(ComputeSha256(walPath), expected, StringComparison.Ordinal))
+            {
+                throw new InvalidDataException(
+                    "Managed embedded replica replacement rollback found an unrecognized WAL without the displaced replacement database.");
+            }
+        }
+
+        foreach (var path in sidecars)
+        {
+            if (!originalWalAlreadyRestored || !string.Equals(path, walPath, StringComparison.Ordinal))
+                DeleteIfExists(path);
+        }
+        if (intent.OriginalWalSha256 is not null)
+        {
+            if (originalWalAlreadyRestored)
+                return;
+            if (!File.Exists(originalWalBackupPath))
+            {
+                throw new InvalidDataException(
+                    "Managed embedded replica replacement rollback cannot restore the original WAL because its backup is missing.");
+            }
+            File.Move(originalWalBackupPath, walPath, overwrite: true);
+        }
+        else
+        {
+            DeleteIfExists(originalWalBackupPath);
+        }
+    }
+
+    private static IReadOnlyList<string> GetSqliteSidecarPaths(string databasePath) =>
+    [
+        databasePath + "-wal",
+        databasePath + "-shm",
+        databasePath + "-journal",
+    ];
 
     private static void ValidateFile(string path, string expectedSha256, string role)
     {
@@ -330,6 +482,24 @@ internal static class ManagedReplicaReplacementState
         return Convert.ToHexString(SHA256.HashData(stream));
     }
 
+    private static void CopyFileDurably(string sourcePath, string destinationPath)
+    {
+        using var source = new FileStream(
+            sourcePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.ReadWrite | FileShare.Delete);
+        using var destination = new FileStream(
+            destinationPath,
+            FileMode.CreateNew,
+            FileAccess.Write,
+            FileShare.None,
+            bufferSize: 128 * 1024,
+            FileOptions.WriteThrough);
+        source.CopyTo(destination);
+        destination.Flush(flushToDisk: true);
+    }
+
     private static InvalidDataException InvalidIntent()
         => new("Managed embedded replica replacement intent is invalid or corrupt.");
 
@@ -342,5 +512,7 @@ internal static class ManagedReplicaReplacementState
     private readonly record struct ReplacementIntent(
         string OriginalDatabaseSha256,
         string ReplacementDatabaseSha256,
-        string OriginalMetadataSha256);
+        string OriginalMetadataSha256,
+        string ReplacementMetadataSha256,
+        string? OriginalWalSha256);
 }

--- a/src/Ahtola.Data/ManagedReplicaReplacementState.cs
+++ b/src/Ahtola.Data/ManagedReplicaReplacementState.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using System.Text;
+using Ahtola.Core.Storage;
 
 namespace Ahtola;
 
@@ -11,6 +12,10 @@ internal static class ManagedReplicaReplacementState
     internal const string IntentSuffix = ".ahtola-replica-replacement";
     internal const string BackupSuffix = ".ahtola-replica-replacement.bak";
     internal const string DisplacedSuffix = ".ahtola-replica-replacement.displaced";
+    internal const string DisplacedStagingSuffix = ".ahtola-replica-replacement.displaced-staging";
+    internal const string DisplacedSha256Suffix = ".ahtola-replica-replacement.displaced-sha256";
+    internal const string DisplacedSha256StagingSuffix =
+        ".ahtola-replica-replacement.displaced-sha256-staging";
     internal const string OriginalWalSuffix = ".ahtola-replica-replacement.original-wal";
     internal const string RollbackSidecarsPreparedSuffix = ".ahtola-replica-replacement.rollback-sidecars";
     internal const string ReplacementWalSuffix = ".ahtola-replica-replacement.replacement-wal";
@@ -36,6 +41,9 @@ internal static class ManagedReplicaReplacementState
         databasePath + StagingSuffix,
         GetBackupPath(databasePath),
         GetDisplacedPath(databasePath),
+        databasePath + DisplacedStagingSuffix,
+        databasePath + DisplacedSha256Suffix,
+        databasePath + DisplacedSha256StagingSuffix,
         GetOriginalWalPath(databasePath),
         databasePath + RollbackSidecarsPreparedSuffix,
         databasePath + ReplacementWalSuffix,
@@ -59,6 +67,17 @@ internal static class ManagedReplicaReplacementState
         string databasePath,
         string replacementPath,
         string replacementMetadataSha256)
+        => Prepare(
+            databasePath,
+            replacementPath,
+            replacementMetadataSha256,
+            replacementLock: null);
+
+    internal static void Prepare(
+        string databasePath,
+        string replacementPath,
+        string replacementMetadataSha256,
+        IDisposable? replacementLock)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(databasePath);
         ArgumentException.ThrowIfNullOrWhiteSpace(replacementPath);
@@ -93,8 +112,12 @@ internal static class ManagedReplicaReplacementState
                 ManagedReplicaDurableBoundary.MainFileReplacementOriginalWalCaptured);
         }
         var intent = new ReplacementIntent(
-            ComputeSha256(databasePath),
-            ComputeSha256(replacementPath),
+            replacementLock is null
+                ? ComputeSha256(databasePath)
+                : ComputeDatabaseSha256(replacementLock, databasePath),
+            replacementLock is null
+                ? ComputeSha256(replacementPath)
+                : ComputeDatabaseSha256(replacementLock, replacementPath),
             ComputeSha256(databasePath + ManagedReplicaBootstrapper.MetadataSuffix),
             ParseSha256(replacementMetadataSha256),
             originalWalSha256);
@@ -136,13 +159,15 @@ internal static class ManagedReplicaReplacementState
         DeleteIfExists(databasePath + "-shm");
     }
 
-    internal static void CompletePublication(string databasePath)
+    internal static void CompletePublication(
+        string databasePath,
+        SqliteWalByteRangeLockLease? databaseLease = null)
     {
         var intent = Read(databasePath);
         var metadata = ManagedReplicaBootstrapper.LoadMetadata(databasePath)
             ?? throw new InvalidDataException(
                 "Managed embedded replica replacement publication has no metadata.");
-        ValidateCurrentDatabase(databasePath, intent.ReplacementDatabaseSha256);
+        ValidateCurrentDatabase(databasePath, intent.ReplacementDatabaseSha256, databaseLease);
         ValidateReplacementMetadata(databasePath, metadata, intent);
 
         DeleteIfExists(GetBackupPath(databasePath));
@@ -151,16 +176,21 @@ internal static class ManagedReplicaReplacementState
         ManagedReplicaFaultInjection.Hit(
             ManagedReplicaDurableBoundary.MainFileReplacementBackupRetired);
         DeleteIfExists(GetDisplacedPath(databasePath));
+        DeleteIfExists(databasePath + DisplacedStagingSuffix);
+        DeleteIfExists(databasePath + DisplacedSha256Suffix);
+        DeleteIfExists(databasePath + DisplacedSha256StagingSuffix);
         DeleteIfExists(databasePath + StagingSuffix);
         DeleteIfExists(databasePath + IntentSuffix);
         ManagedReplicaFaultInjection.Hit(
             ManagedReplicaDurableBoundary.MainFileReplacementIntentRetired);
     }
 
-    internal static bool TryCompletePublication(string databasePath)
+    internal static bool TryCompletePublication(
+        string databasePath,
+        SqliteWalByteRangeLockLease? databaseLease = null)
     {
         var intent = Read(databasePath);
-        ValidateCurrentDatabase(databasePath, intent.ReplacementDatabaseSha256);
+        ValidateCurrentDatabase(databasePath, intent.ReplacementDatabaseSha256, databaseLease);
         var metadataSha256 = ComputeSha256(
             databasePath + ManagedReplicaBootstrapper.MetadataSuffix);
         if (string.Equals(metadataSha256, intent.OriginalMetadataSha256, StringComparison.Ordinal))
@@ -168,19 +198,30 @@ internal static class ManagedReplicaReplacementState
             return false;
         }
 
-        CompletePublication(databasePath);
+        CompletePublication(databasePath, databaseLease);
         return true;
     }
 
-    internal static void CompleteRollback(string databasePath)
+    internal static string ComputeDatabaseSha256(
+        IDisposable? replacementLock,
+        string databasePath)
+        => ComputeSha256(
+            ManagedReplicaApplyLock.GetMainFileLease(replacementLock, databasePath));
+
+    internal static void CompleteRollback(
+        string databasePath,
+        SqliteWalByteRangeLockLease? databaseLease = null)
     {
         var intent = Read(databasePath);
-        ValidateCurrentDatabase(databasePath, intent.OriginalDatabaseSha256);
+        ValidateCurrentDatabase(databasePath, intent.OriginalDatabaseSha256, databaseLease);
         ReconcileRollbackSidecars(databasePath, intent);
         ManagedReplicaFaultInjection.Hit(
             ManagedReplicaDurableBoundary.MainFileRollbackSidecarsRestored);
         DeleteIfExists(GetBackupPath(databasePath));
         DeleteIfExists(GetDisplacedPath(databasePath));
+        DeleteIfExists(databasePath + DisplacedStagingSuffix);
+        DeleteIfExists(databasePath + DisplacedSha256Suffix);
+        DeleteIfExists(databasePath + DisplacedSha256StagingSuffix);
         DeleteIfExists(databasePath + StagingSuffix);
         DeleteIfExists(databasePath + IntentSuffix);
         DeleteIfExists(databasePath + RollbackSidecarsPreparedSuffix);
@@ -231,10 +272,14 @@ internal static class ManagedReplicaReplacementState
         var stagingPath = databasePath + StagingSuffix;
         var backupPath = GetBackupPath(databasePath);
         var displacedPath = GetDisplacedPath(databasePath);
+        var displacedSha256Path = databasePath + DisplacedSha256Suffix;
         if (!File.Exists(intentPath))
         {
             if (File.Exists(backupPath)
-                || File.Exists(displacedPath))
+                || File.Exists(displacedPath)
+                || File.Exists(databasePath + DisplacedStagingSuffix)
+                || File.Exists(displacedSha256Path)
+                || File.Exists(databasePath + DisplacedSha256StagingSuffix))
             {
                 throw new InvalidDataException(
                     "Managed embedded replica replacement recovery found a backup without its durable intent.");
@@ -259,8 +304,16 @@ internal static class ManagedReplicaReplacementState
         }
         if (File.Exists(backupPath))
             ValidateFile(backupPath, intent.OriginalDatabaseSha256, "backup");
+        var rollbackPrepared = File.Exists(databasePath + RollbackSidecarsPreparedSuffix);
         if (File.Exists(displacedPath))
-            ValidateFile(displacedPath, intent.ReplacementDatabaseSha256, "displaced database");
+        {
+            ValidateFile(
+                displacedPath,
+                rollbackPrepared && File.Exists(displacedSha256Path)
+                    ? ReadSha256(displacedSha256Path, "displaced database")
+                    : intent.ReplacementDatabaseSha256,
+                "displaced database");
+        }
 
         var currentSha256 = ComputeSha256(databasePath);
         if (string.Equals(currentSha256, intent.OriginalDatabaseSha256, StringComparison.Ordinal))
@@ -277,7 +330,18 @@ internal static class ManagedReplicaReplacementState
                     : ManagedReplicaApplyLock.AcquireMainFileReplacementLock(
                         databasePath,
                         CancellationToken.None);
-                CompleteRollback(databasePath);
+                var databaseLease = ManagedReplicaApplyLock.GetMainFileLease(
+                    rollbackLock,
+                    databasePath);
+                if (!string.Equals(
+                        ComputeSha256(databaseLease),
+                        intent.OriginalDatabaseSha256,
+                        StringComparison.Ordinal))
+                {
+                    throw new InvalidDataException(
+                        "Managed embedded replica replacement recovery found an unrecognized database image.");
+                }
+                CompleteRollback(databasePath, databaseLease);
             }
             finally
             {
@@ -285,23 +349,39 @@ internal static class ManagedReplicaReplacementState
             }
             return;
         }
-        if (!string.Equals(currentSha256, intent.ReplacementDatabaseSha256, StringComparison.Ordinal))
+        if (!string.Equals(currentSha256, intent.ReplacementDatabaseSha256, StringComparison.Ordinal)
+            && !rollbackPrepared)
         {
             throw new InvalidDataException(
                 "Managed embedded replica replacement recovery found an unrecognized database image.");
         }
+        ManagedReplicaFaultInjection.Hit(
+            ManagedReplicaDurableBoundary.MainFileReplacementRecoveryClassifiedBeforeLease);
 
-        var metadataChanged = !string.Equals(
-            ComputeSha256(metadataPath),
-            intent.OriginalMetadataSha256,
-            StringComparison.Ordinal);
-        if (metadataChanged)
-        {
-            CompletePublication(databasePath);
-            return;
-        }
         if (!File.Exists(backupPath))
         {
+            if (!rollbackPrepared)
+            {
+                using var publicationLock =
+                    ManagedReplicaApplyLock.AcquireMainFileReplacementLock(
+                        databasePath,
+                        CancellationToken.None);
+                var databaseLease = ManagedReplicaApplyLock.GetMainFileLease(
+                    publicationLock,
+                    databasePath);
+                if (string.Equals(
+                        ComputeSha256(databaseLease),
+                        intent.ReplacementDatabaseSha256,
+                        StringComparison.Ordinal)
+                    && !string.Equals(
+                        ComputeSha256(metadataPath),
+                        intent.OriginalMetadataSha256,
+                        StringComparison.Ordinal))
+                {
+                    CompletePublication(databasePath, databaseLease);
+                    return;
+                }
+            }
             throw new InvalidDataException(
                 "Managed embedded replica replacement recovery cannot restore the original database because its backup is missing.");
         }
@@ -312,6 +392,40 @@ internal static class ManagedReplicaReplacementState
                 databasePath,
                 backupPath,
                 CancellationToken.None);
+            var databaseLease = ManagedReplicaApplyLock.GetMainFileLease(
+                replacementLock,
+                databasePath);
+            var backupLease = ManagedReplicaApplyLock.GetMainFileLease(
+                replacementLock,
+                backupPath);
+            if (!string.Equals(
+                    ComputeSha256(backupLease),
+                    intent.OriginalDatabaseSha256,
+                    StringComparison.Ordinal))
+            {
+                throw new InvalidDataException(
+                    "Managed embedded replica replacement recovery backup is missing or corrupt.");
+            }
+            var lockedSha256 = ComputeSha256(databaseLease);
+            if (!string.Equals(
+                    lockedSha256,
+                    intent.ReplacementDatabaseSha256,
+                    StringComparison.Ordinal)
+                && (!rollbackPrepared
+                    || !IsStrictFilePrefix(databaseLease, backupLease)))
+            {
+                throw new InvalidDataException(
+                    "Managed embedded replica replacement recovery found an unrecognized database image.");
+            }
+            if (!rollbackPrepared
+                && !string.Equals(
+                    ComputeSha256(metadataPath),
+                    intent.OriginalMetadataSha256,
+                    StringComparison.Ordinal))
+            {
+                CompletePublication(databasePath, databaseLease);
+                return;
+            }
             ValidateOriginalWalState(databasePath, intent, originalDatabaseInstalled: false);
             ManagedReplicaApplyLock.RollBackMainFile(
                 replacementLock,
@@ -321,7 +435,9 @@ internal static class ManagedReplicaReplacementState
                 () => PrepareRollbackSidecars(databasePath));
             ManagedReplicaFaultInjection.Hit(
                 ManagedReplicaDurableBoundary.MainFileRollbackDatabaseRestored);
-            CompleteRollback(databasePath);
+            CompleteRollback(
+                databasePath,
+                ManagedReplicaApplyLock.GetMainFileLease(replacementLock, databasePath));
         }
         finally
         {
@@ -412,8 +528,22 @@ internal static class ManagedReplicaReplacementState
             ? null
             : ParseSha256(value);
 
-    private static void ValidateCurrentDatabase(string databasePath, string expectedSha256)
-        => ValidateFile(databasePath, expectedSha256, "database");
+    private static void ValidateCurrentDatabase(
+        string databasePath,
+        string expectedSha256,
+        SqliteWalByteRangeLockLease? databaseLease = null)
+    {
+        if (databaseLease is null)
+        {
+            ValidateFile(databasePath, expectedSha256, "database");
+            return;
+        }
+        if (!string.Equals(ComputeSha256(databaseLease), expectedSha256, StringComparison.Ordinal))
+        {
+            throw new InvalidDataException(
+                "Managed embedded replica replacement recovery database is missing or corrupt.");
+        }
+    }
 
     private static void ValidateReplacementMetadata(
         string databasePath,
@@ -592,6 +722,20 @@ internal static class ManagedReplicaReplacementState
         return Convert.ToHexString(SHA256.HashData(stream));
     }
 
+    private static string ComputeSha256(SqliteWalByteRangeLockLease lease)
+    {
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        var buffer = new byte[128 * 1024];
+        long offset = 0;
+        int read;
+        while ((read = lease.Read(buffer, offset)) != 0)
+        {
+            hash.AppendData(buffer, 0, read);
+            offset += read;
+        }
+        return Convert.ToHexString(hash.GetHashAndReset());
+    }
+
     private static void CopyFileDurably(string sourcePath, string destinationPath)
     {
         using var source = new FileStream(
@@ -608,6 +752,161 @@ internal static class ManagedReplicaReplacementState
             FileOptions.WriteThrough);
         source.CopyTo(destination);
         destination.Flush(flushToDisk: true);
+    }
+
+    internal static void PreserveDisplacedMainFile(
+        string databasePath,
+        string displacedPath,
+        SqliteWalByteRangeLockLease databaseLease)
+    {
+        var displacedSha256Path = databasePath + DisplacedSha256Suffix;
+        var displacedStagingPath = databasePath + DisplacedStagingSuffix;
+        if (File.Exists(displacedPath))
+        {
+            ValidateFile(
+                displacedPath,
+                ReadSha256(displacedSha256Path, "displaced database"),
+                "displaced database");
+            return;
+        }
+
+        if (File.Exists(displacedSha256Path))
+        {
+            ValidateFile(
+                displacedStagingPath,
+                ReadSha256(displacedSha256Path, "displaced database"),
+                "staged displaced database");
+        }
+        else
+        {
+            DeleteIfExists(displacedStagingPath);
+            CopyLeaseToFileDurably(databaseLease, displacedStagingPath);
+            WriteSha256Durably(
+                databasePath,
+                ComputeSha256(displacedStagingPath));
+        }
+        File.Move(displacedStagingPath, displacedPath, overwrite: false);
+    }
+
+    internal static void RestoreMainFileInPlace(
+        SqliteWalByteRangeLockLease backupLease,
+        SqliteWalByteRangeLockLease databaseLease)
+    {
+        databaseLease.SetLength(0);
+        ManagedReplicaFaultInjection.Hit(
+            ManagedReplicaDurableBoundary.MainFileRollbackRestoreStarted);
+        CopyLease(backupLease, databaseLease);
+        databaseLease.FlushToDisk();
+    }
+
+    private static void CopyLeaseToFileDurably(
+        SqliteWalByteRangeLockLease source,
+        string destinationPath)
+    {
+        using var destination = new FileStream(
+            destinationPath,
+            FileMode.CreateNew,
+            FileAccess.Write,
+            FileShare.None,
+            bufferSize: 128 * 1024,
+            FileOptions.WriteThrough);
+        var buffer = new byte[128 * 1024];
+        long offset = 0;
+        int read;
+        while ((read = source.Read(buffer, offset)) != 0)
+        {
+            destination.Write(buffer, 0, read);
+            offset += read;
+        }
+        destination.Flush(flushToDisk: true);
+    }
+
+    private static void CopyLease(
+        SqliteWalByteRangeLockLease source,
+        SqliteWalByteRangeLockLease destination)
+    {
+        var buffer = new byte[128 * 1024];
+        long offset = 0;
+        int read;
+        while ((read = source.Read(buffer, offset)) != 0)
+        {
+            destination.Write(buffer.AsSpan(0, read), offset);
+            offset += read;
+        }
+    }
+
+    private static bool IsStrictFilePrefix(
+        SqliteWalByteRangeLockLease candidate,
+        SqliteWalByteRangeLockLease expected)
+    {
+        var candidateBuffer = new byte[128 * 1024];
+        var expectedBuffer = new byte[candidateBuffer.Length];
+        long offset = 0;
+        int candidateRead;
+        while ((candidateRead = candidate.Read(candidateBuffer, offset)) != 0)
+        {
+            var expectedRead = expected.Read(expectedBuffer.AsSpan(0, candidateRead), offset);
+            if (expectedRead != candidateRead)
+                return false;
+            if (!candidateBuffer.AsSpan(0, candidateRead)
+                    .SequenceEqual(expectedBuffer.AsSpan(0, candidateRead)))
+            {
+                return false;
+            }
+            offset += candidateRead;
+        }
+        return expected.Read(expectedBuffer.AsSpan(0, 1), offset) != 0;
+    }
+
+    private static string ReadSha256(string path, string role)
+    {
+        string value;
+        try
+        {
+            value = File.ReadAllText(path, StrictUtf8);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            throw new InvalidDataException(
+                $"Managed embedded replica replacement recovery {role} hash could not be read.",
+                exception);
+        }
+        try
+        {
+            return ParseSha256(value);
+        }
+        catch (InvalidDataException exception)
+        {
+            throw new InvalidDataException(
+                $"Managed embedded replica replacement recovery {role} hash is corrupt.",
+                exception);
+        }
+    }
+
+    private static void WriteSha256Durably(string databasePath, string sha256)
+    {
+        var path = databasePath + DisplacedSha256Suffix;
+        var stagingPath = databasePath + DisplacedSha256StagingSuffix;
+        DeleteIfExists(stagingPath);
+        try
+        {
+            using (var stream = new FileStream(
+                       stagingPath,
+                       FileMode.CreateNew,
+                       FileAccess.Write,
+                       FileShare.None,
+                       bufferSize: 64,
+                       FileOptions.WriteThrough))
+            {
+                stream.Write(StrictUtf8.GetBytes(sha256));
+                stream.Flush(flushToDisk: true);
+            }
+            File.Move(stagingPath, path, overwrite: false);
+        }
+        finally
+        {
+            DeleteIfExists(stagingPath);
+        }
     }
 
     private static void WriteDurableMarker(string path)

--- a/src/Ahtola.Data/ManagedReplicaRevertWal.cs
+++ b/src/Ahtola.Data/ManagedReplicaRevertWal.cs
@@ -122,6 +122,7 @@ internal static class ManagedReplicaRevertWal
         ManagedReplicaBootstrapper.ManagedReplicaMetadata metadata)
     {
         ArgumentException.ThrowIfNullOrEmpty(databasePath);
+        ManagedReplicaReplacementState.Recover(databasePath);
         CleanupTemporaryArtifacts(databasePath);
         if (metadata.RevertState is not { } state)
         {
@@ -930,10 +931,10 @@ internal static class ManagedReplicaRevertWal
         CancellationToken cancellationToken)
     {
         var databaseStagingPath = CreateStagingPath(databasePath, "restore");
-        var databaseBackupPath = CreateStagingPath(databasePath, "restore-backup");
+        var databaseBackupPath = ManagedReplicaReplacementState.GetBackupPath(databasePath);
+        var displacedPath = ManagedReplicaReplacementState.GetDisplacedPath(databasePath);
         IDisposable? mainFileReplacementLock = null;
         var databaseInstalled = false;
-        var preserveBackup = false;
         try
         {
             using (var stream = new FileStream(
@@ -965,10 +966,12 @@ internal static class ManagedReplicaRevertWal
             if (stagedBoundary is { } staged)
                 ManagedReplicaFaultInjection.Hit(staged);
             cancellationToken.ThrowIfCancellationRequested();
+            ManagedReplicaReplacementState.Recover(databasePath);
             mainFileReplacementLock = ManagedReplicaApplyLock.AcquireMainFileReplacementLock(
                 databasePath,
                 databaseStagingPath,
                 cancellationToken);
+            ManagedReplicaReplacementState.Prepare(databasePath, databaseStagingPath);
             DeleteSqliteSidecars(databasePath);
             ManagedReplicaApplyLock.ReplaceMainFile(
                 mainFileReplacementLock,
@@ -991,7 +994,7 @@ internal static class ManagedReplicaRevertWal
             return new SnapshotPublicationLease(
                 mainFileReplacementLock,
                 databaseStagingPath,
-                databaseBackupPath);
+                databasePath);
         }
         catch
         {
@@ -999,26 +1002,20 @@ internal static class ManagedReplicaRevertWal
             {
                 if (databaseInstalled && File.Exists(databaseBackupPath))
                 {
-                    try
-                    {
-                        ManagedReplicaApplyLock.RollBackMainFile(
-                            mainFileReplacementLock,
-                            databaseBackupPath,
-                            databasePath);
-                    }
-                    catch
-                    {
-                        preserveBackup = true;
-                        throw;
-                    }
+                    ManagedReplicaApplyLock.RollBackMainFile(
+                        mainFileReplacementLock,
+                        databaseBackupPath,
+                        databasePath,
+                        displacedPath);
+                    ManagedReplicaFaultInjection.Hit(
+                        ManagedReplicaDurableBoundary.MainFileRollbackDatabaseRestored);
+                    ManagedReplicaReplacementState.CompleteRollback(databasePath);
                 }
             }
             finally
             {
                 mainFileReplacementLock?.Dispose();
                 DeleteIfExists(databaseStagingPath);
-                if (!preserveBackup)
-                    DeleteIfExists(databaseBackupPath);
             }
             throw;
         }
@@ -1027,15 +1024,21 @@ internal static class ManagedReplicaRevertWal
     private sealed class SnapshotPublicationLease(
         IDisposable? mainFileReplacementLock,
         string databaseStagingPath,
-        string databaseBackupPath) : IDisposable
+        string databasePath) : IDisposable
     {
         private IDisposable? _mainFileReplacementLock = mainFileReplacementLock;
 
         public void Dispose()
         {
-            Interlocked.Exchange(ref _mainFileReplacementLock, null)?.Dispose();
-            DeleteIfExists(databaseStagingPath);
-            DeleteIfExists(databaseBackupPath);
+            try
+            {
+                _ = ManagedReplicaReplacementState.TryCompletePublication(databasePath);
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _mainFileReplacementLock, null)?.Dispose();
+                DeleteIfExists(databaseStagingPath);
+            }
         }
     }
 

--- a/src/Ahtola.Data/ManagedReplicaRevertWal.cs
+++ b/src/Ahtola.Data/ManagedReplicaRevertWal.cs
@@ -933,6 +933,7 @@ internal static class ManagedReplicaRevertWal
         var databaseBackupPath = CreateStagingPath(databasePath, "restore-backup");
         IDisposable? mainFileReplacementLock = null;
         var databaseInstalled = false;
+        var preserveBackup = false;
         try
         {
             using (var stream = new FileStream(
@@ -975,6 +976,15 @@ internal static class ManagedReplicaRevertWal
                 databasePath,
                 databaseBackupPath,
                 () => databaseInstalled = true);
+            if (OperatingSystem.IsWindows()
+                && !string.Equals(
+                    ComputeSha256(databasePath),
+                    expectedSha256,
+                    StringComparison.Ordinal))
+            {
+                throw new InvalidDataException(
+                    "Managed embedded replica checkpoint recovery changed during its Windows replacement lock handoff.");
+            }
             if (publishedBoundary is { } published)
                 ManagedReplicaFaultInjection.Hit(published);
             cancellationToken.ThrowIfCancellationRequested();
@@ -989,17 +999,26 @@ internal static class ManagedReplicaRevertWal
             {
                 if (databaseInstalled && File.Exists(databaseBackupPath))
                 {
-                    ManagedReplicaApplyLock.RollBackMainFile(
-                        mainFileReplacementLock,
-                        databaseBackupPath,
-                        databasePath);
+                    try
+                    {
+                        ManagedReplicaApplyLock.RollBackMainFile(
+                            mainFileReplacementLock,
+                            databaseBackupPath,
+                            databasePath);
+                    }
+                    catch
+                    {
+                        preserveBackup = true;
+                        throw;
+                    }
                 }
             }
             finally
             {
                 mainFileReplacementLock?.Dispose();
                 DeleteIfExists(databaseStagingPath);
-                DeleteIfExists(databaseBackupPath);
+                if (!preserveBackup)
+                    DeleteIfExists(databaseBackupPath);
             }
             throw;
         }

--- a/src/Ahtola.Data/ManagedReplicaRevertWal.cs
+++ b/src/Ahtola.Data/ManagedReplicaRevertWal.cs
@@ -89,20 +89,22 @@ internal static class ManagedReplicaRevertWal
             cancellationToken.ThrowIfCancellationRequested();
 
             var snapshots = ReadAndValidate(databasePath, state);
-            PublishSnapshot(
-                databasePath,
-                state.CommittedDatabaseSizeInPages,
-                state.CommittedDatabaseSha256,
-                snapshots.CommittedPages,
-                snapshots.PageSize,
-                ManagedReplicaDurableBoundary.RevertCommittedRestoreStagedDatabase,
-                ManagedReplicaDurableBoundary.RevertCommittedRestoreDatabasePublished,
-                cancellationToken);
-            return TransitionPhase(
-                databasePath,
-                pending,
-                ManagedReplicaBootstrapper.ManagedReplicaRevertPhase.CommittedReady,
-                ManagedReplicaDurableBoundary.RevertCommittedReadyMetadataPublished);
+            using (PublishSnapshot(
+                       databasePath,
+                       state.CommittedDatabaseSizeInPages,
+                       state.CommittedDatabaseSha256,
+                       snapshots.CommittedPages,
+                       snapshots.PageSize,
+                       ManagedReplicaDurableBoundary.RevertCommittedRestoreStagedDatabase,
+                       ManagedReplicaDurableBoundary.RevertCommittedRestoreDatabasePublished,
+                       cancellationToken))
+            {
+                return TransitionPhase(
+                    databasePath,
+                    pending,
+                    ManagedReplicaBootstrapper.ManagedReplicaRevertPhase.CommittedReady,
+                    ManagedReplicaDurableBoundary.RevertCommittedReadyMetadataPublished);
+            }
         }
         finally
         {
@@ -151,20 +153,22 @@ internal static class ManagedReplicaRevertWal
                 throw new InvalidDataException("Managed embedded replica checkpoint recovery phase is invalid.");
         }
 
-        PublishSnapshot(
-            databasePath,
-            state.CommittedDatabaseSizeInPages,
-            state.CommittedDatabaseSha256,
-            snapshots.CommittedPages,
-            snapshots.PageSize,
-            ManagedReplicaDurableBoundary.RevertCommittedRestoreStagedDatabase,
-            ManagedReplicaDurableBoundary.RevertCommittedRestoreDatabasePublished,
-            CancellationToken.None);
-        return TransitionPhase(
-            databasePath,
-            metadata,
-            ManagedReplicaBootstrapper.ManagedReplicaRevertPhase.CommittedReady,
-            ManagedReplicaDurableBoundary.RevertCommittedReadyMetadataPublished);
+        using (PublishSnapshot(
+                   databasePath,
+                   state.CommittedDatabaseSizeInPages,
+                   state.CommittedDatabaseSha256,
+                   snapshots.CommittedPages,
+                   snapshots.PageSize,
+                   ManagedReplicaDurableBoundary.RevertCommittedRestoreStagedDatabase,
+                   ManagedReplicaDurableBoundary.RevertCommittedRestoreDatabasePublished,
+                   CancellationToken.None))
+        {
+            return TransitionPhase(
+                databasePath,
+                metadata,
+                ManagedReplicaBootstrapper.ManagedReplicaRevertPhase.CommittedReady,
+                ManagedReplicaDurableBoundary.RevertCommittedReadyMetadataPublished);
+        }
     }
 
     internal static ManagedReplicaBootstrapper.ManagedReplicaMetadata MarkRemoteApplyStarted(
@@ -269,6 +273,21 @@ internal static class ManagedReplicaRevertWal
             Retire(databasePath);
             return;
         }
+
+        _ = ReadAndValidate(databasePath, state);
+        throw new InvalidOperationException(
+            "Managed embedded replica has a pending checkpoint recovery bundle that must be "
+            + "resolved before starting another pull or checkpoint.");
+    }
+
+    internal static void ValidateSynchronizationReady(
+        string databasePath,
+        ManagedReplicaBootstrapper.ManagedReplicaMetadata metadata)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(databasePath);
+        EnsurePushRecoveryComplete(metadata);
+        if (metadata.RevertState is not { } state)
+            return;
 
         _ = ReadAndValidate(databasePath, state);
         throw new InvalidOperationException(
@@ -840,27 +859,30 @@ internal static class ManagedReplicaRevertWal
         ValidatedRevertWal frames,
         CancellationToken cancellationToken)
     {
-        PublishSnapshot(
-            databasePath,
-            state.OriginalDatabaseSizeInPages,
-            state.OriginalDatabaseSha256,
-            frames.OriginalPages,
-            frames.PageSize,
-            ManagedReplicaDurableBoundary.RevertRestoreStagedDatabase,
-            ManagedReplicaDurableBoundary.RevertRestoreDatabasePublished,
-            cancellationToken);
-
-        var restored = metadata with
+        using (PublishSnapshot(
+                   databasePath,
+                   state.OriginalDatabaseSizeInPages,
+                   state.OriginalDatabaseSha256,
+                   frames.OriginalPages,
+                   frames.PageSize,
+                   ManagedReplicaDurableBoundary.RevertRestoreStagedDatabase,
+                   ManagedReplicaDurableBoundary.RevertRestoreDatabasePublished,
+                   cancellationToken))
         {
-            DatabaseSha256 = state.OriginalDatabaseSha256,
-            RevertState = null,
-        };
-        ClearPendingMetadata(databasePath, restored, state.OriginalDatabaseSha256);
-        ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.RevertRestoreMetadataPublished);
-        cancellationToken.ThrowIfCancellationRequested();
+            var restored = metadata with
+            {
+                DatabaseSha256 = state.OriginalDatabaseSha256,
+                RevertState = null,
+            };
+            ClearPendingMetadata(databasePath, restored, state.OriginalDatabaseSha256);
+            ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.RevertRestoreMetadataPublished);
+            cancellationToken.ThrowIfCancellationRequested();
+            metadata = restored;
+        }
+
         Retire(databasePath);
         ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.RevertRetired);
-        return restored;
+        return metadata;
     }
 
     private static string ComputeSha256(string path)
@@ -897,7 +919,7 @@ internal static class ManagedReplicaRevertWal
             File.Delete(path);
     }
 
-    private static void PublishSnapshot(
+    private static IDisposable PublishSnapshot(
         string databasePath,
         uint databaseSizeInPages,
         string expectedSha256,
@@ -909,6 +931,7 @@ internal static class ManagedReplicaRevertWal
     {
         var databaseStagingPath = CreateStagingPath(databasePath, "restore");
         var databaseBackupPath = CreateStagingPath(databasePath, "restore-backup");
+        IDisposable? mainFileReplacementLock = null;
         try
         {
             using (var stream = new FileStream(
@@ -940,10 +963,10 @@ internal static class ManagedReplicaRevertWal
             if (stagedBoundary is { } staged)
                 ManagedReplicaFaultInjection.Hit(staged);
             cancellationToken.ThrowIfCancellationRequested();
-            using var mainFileReplacementLock =
-                ManagedReplicaApplyLock.AcquireMainFileReplacementLock(
-                    databasePath,
-                    cancellationToken);
+            mainFileReplacementLock = ManagedReplicaApplyLock.AcquireMainFileReplacementLock(
+                databasePath,
+                databaseStagingPath,
+                cancellationToken);
             DeleteSqliteSidecars(databasePath);
             File.Replace(
                 databaseStagingPath,
@@ -953,9 +976,30 @@ internal static class ManagedReplicaRevertWal
             if (publishedBoundary is { } published)
                 ManagedReplicaFaultInjection.Hit(published);
             cancellationToken.ThrowIfCancellationRequested();
+            return new SnapshotPublicationLease(
+                mainFileReplacementLock,
+                databaseStagingPath,
+                databaseBackupPath);
         }
-        finally
+        catch
         {
+            mainFileReplacementLock?.Dispose();
+            DeleteIfExists(databaseStagingPath);
+            DeleteIfExists(databaseBackupPath);
+            throw;
+        }
+    }
+
+    private sealed class SnapshotPublicationLease(
+        IDisposable? mainFileReplacementLock,
+        string databaseStagingPath,
+        string databaseBackupPath) : IDisposable
+    {
+        private IDisposable? _mainFileReplacementLock = mainFileReplacementLock;
+
+        public void Dispose()
+        {
+            Interlocked.Exchange(ref _mainFileReplacementLock, null)?.Dispose();
             DeleteIfExists(databaseStagingPath);
             DeleteIfExists(databaseBackupPath);
         }

--- a/src/Ahtola.Data/ManagedReplicaRevertWal.cs
+++ b/src/Ahtola.Data/ManagedReplicaRevertWal.cs
@@ -93,6 +93,9 @@ internal static class ManagedReplicaRevertWal
                        databasePath,
                        state.CommittedDatabaseSizeInPages,
                        state.CommittedDatabaseSha256,
+                       WithPhase(
+                           pending,
+                           ManagedReplicaBootstrapper.ManagedReplicaRevertPhase.CommittedReady),
                        snapshots.CommittedPages,
                        snapshots.PageSize,
                        ManagedReplicaDurableBoundary.RevertCommittedRestoreStagedDatabase,
@@ -158,6 +161,9 @@ internal static class ManagedReplicaRevertWal
                    databasePath,
                    state.CommittedDatabaseSizeInPages,
                    state.CommittedDatabaseSha256,
+                   WithPhase(
+                       metadata,
+                       ManagedReplicaBootstrapper.ManagedReplicaRevertPhase.CommittedReady),
                    snapshots.CommittedPages,
                    snapshots.PageSize,
                    ManagedReplicaDurableBoundary.RevertCommittedRestoreStagedDatabase,
@@ -246,6 +252,28 @@ internal static class ManagedReplicaRevertWal
         WritePhaseMetadata(databasePath, updated);
         ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.ReplicaPushIntentPublished);
         return updated;
+    }
+
+    private static ManagedReplicaBootstrapper.ManagedReplicaMetadata WithPhase(
+        ManagedReplicaBootstrapper.ManagedReplicaMetadata metadata,
+        ManagedReplicaBootstrapper.ManagedReplicaRevertPhase phase)
+    {
+        var state = metadata.RevertState
+                    ?? throw new InvalidOperationException(
+                        "Managed embedded replica metadata has no pending checkpoint revert capture.");
+        return metadata with
+        {
+            RevertState = state with
+            {
+                Phase = phase,
+                AttemptedFirstSequence = phase == ManagedReplicaBootstrapper.ManagedReplicaRevertPhase.PushOutcomeUnknown
+                    ? state.AttemptedFirstSequence
+                    : 0,
+                AttemptedWatermark = phase == ManagedReplicaBootstrapper.ManagedReplicaRevertPhase.PushOutcomeUnknown
+                    ? state.AttemptedWatermark
+                    : 0,
+            },
+        };
     }
 
     internal static ManagedReplicaBootstrapper.ManagedReplicaMetadata ClearPushIntent(
@@ -814,22 +842,7 @@ internal static class ManagedReplicaRevertWal
         ManagedReplicaBootstrapper.ManagedReplicaRevertPhase phase,
         ManagedReplicaDurableBoundary boundary)
     {
-        var state = metadata.RevertState
-                    ?? throw new InvalidOperationException(
-                        "Managed embedded replica metadata has no pending checkpoint revert capture.");
-        var updated = metadata with
-        {
-            RevertState = state with
-            {
-                Phase = phase,
-                AttemptedFirstSequence = phase == ManagedReplicaBootstrapper.ManagedReplicaRevertPhase.PushOutcomeUnknown
-                    ? state.AttemptedFirstSequence
-                    : 0,
-                AttemptedWatermark = phase == ManagedReplicaBootstrapper.ManagedReplicaRevertPhase.PushOutcomeUnknown
-                    ? state.AttemptedWatermark
-                    : 0,
-            },
-        };
+        var updated = WithPhase(metadata, phase);
         WritePhaseMetadata(databasePath, updated);
         ManagedReplicaFaultInjection.Hit(boundary);
         return updated;
@@ -864,6 +877,11 @@ internal static class ManagedReplicaRevertWal
                    databasePath,
                    state.OriginalDatabaseSizeInPages,
                    state.OriginalDatabaseSha256,
+                   metadata with
+                   {
+                       DatabaseSha256 = state.OriginalDatabaseSha256,
+                       RevertState = null,
+                   },
                    frames.OriginalPages,
                    frames.PageSize,
                    ManagedReplicaDurableBoundary.RevertRestoreStagedDatabase,
@@ -907,13 +925,6 @@ internal static class ManagedReplicaRevertWal
             DeleteIfExists(path);
     }
 
-    private static void DeleteSqliteSidecars(string databasePath)
-    {
-        DeleteIfExists(databasePath + "-wal");
-        DeleteIfExists(databasePath + "-shm");
-        DeleteIfExists(databasePath + "-journal");
-    }
-
     private static void DeleteIfExists(string path)
     {
         if (File.Exists(path))
@@ -924,6 +935,7 @@ internal static class ManagedReplicaRevertWal
         string databasePath,
         uint databaseSizeInPages,
         string expectedSha256,
+        ManagedReplicaBootstrapper.ManagedReplicaMetadata replacementMetadata,
         IReadOnlyList<SqliteCheckpointRevertPage> pages,
         int pageSize,
         ManagedReplicaDurableBoundary? stagedBoundary,
@@ -971,8 +983,10 @@ internal static class ManagedReplicaRevertWal
                 databasePath,
                 databaseStagingPath,
                 cancellationToken);
-            ManagedReplicaReplacementState.Prepare(databasePath, databaseStagingPath);
-            DeleteSqliteSidecars(databasePath);
+            ManagedReplicaReplacementState.Prepare(
+                databasePath,
+                databaseStagingPath,
+                ManagedReplicaBootstrapper.ComputeMetadataSha256(replacementMetadata));
             ManagedReplicaApplyLock.ReplaceMainFile(
                 mainFileReplacementLock,
                 databaseStagingPath,

--- a/src/Ahtola.Data/ManagedReplicaRevertWal.cs
+++ b/src/Ahtola.Data/ManagedReplicaRevertWal.cs
@@ -932,6 +932,7 @@ internal static class ManagedReplicaRevertWal
         var databaseStagingPath = CreateStagingPath(databasePath, "restore");
         var databaseBackupPath = CreateStagingPath(databasePath, "restore-backup");
         IDisposable? mainFileReplacementLock = null;
+        var databaseInstalled = false;
         try
         {
             using (var stream = new FileStream(
@@ -968,11 +969,12 @@ internal static class ManagedReplicaRevertWal
                 databaseStagingPath,
                 cancellationToken);
             DeleteSqliteSidecars(databasePath);
-            File.Replace(
+            ManagedReplicaApplyLock.ReplaceMainFile(
+                mainFileReplacementLock,
                 databaseStagingPath,
                 databasePath,
                 databaseBackupPath,
-                ignoreMetadataErrors: false);
+                () => databaseInstalled = true);
             if (publishedBoundary is { } published)
                 ManagedReplicaFaultInjection.Hit(published);
             cancellationToken.ThrowIfCancellationRequested();
@@ -983,9 +985,22 @@ internal static class ManagedReplicaRevertWal
         }
         catch
         {
-            mainFileReplacementLock?.Dispose();
-            DeleteIfExists(databaseStagingPath);
-            DeleteIfExists(databaseBackupPath);
+            try
+            {
+                if (databaseInstalled && File.Exists(databaseBackupPath))
+                {
+                    ManagedReplicaApplyLock.RollBackMainFile(
+                        mainFileReplacementLock,
+                        databaseBackupPath,
+                        databasePath);
+                }
+            }
+            finally
+            {
+                mainFileReplacementLock?.Dispose();
+                DeleteIfExists(databaseStagingPath);
+                DeleteIfExists(databaseBackupPath);
+            }
             throw;
         }
     }

--- a/src/Ahtola.Data/ManagedReplicaRevertWal.cs
+++ b/src/Ahtola.Data/ManagedReplicaRevertWal.cs
@@ -263,6 +263,7 @@ internal static class ManagedReplicaRevertWal
     {
         ArgumentException.ThrowIfNullOrEmpty(databasePath);
         CleanupTemporaryArtifacts(databasePath);
+        EnsurePushRecoveryComplete(metadata);
         if (metadata.RevertState is not { } state)
         {
             Retire(databasePath);
@@ -273,6 +274,17 @@ internal static class ManagedReplicaRevertWal
         throw new InvalidOperationException(
             "Managed embedded replica has a pending checkpoint recovery bundle that must be "
             + "resolved before starting another pull or checkpoint.");
+    }
+
+    internal static void EnsurePushRecoveryComplete(
+        ManagedReplicaBootstrapper.ManagedReplicaMetadata metadata)
+    {
+        if (metadata.PushState.HasValue)
+        {
+            throw new InvalidOperationException(
+                "Managed embedded replica has a pending push outcome that must be recovered "
+                + "before publishing pulled or materialized state.");
+        }
     }
 
     internal static ManagedReplicaBootstrapper.ManagedReplicaMetadata CompletePreparedCheckpoint(

--- a/src/Ahtola.Data/ManagedReplicaRevertWal.cs
+++ b/src/Ahtola.Data/ManagedReplicaRevertWal.cs
@@ -986,7 +986,8 @@ internal static class ManagedReplicaRevertWal
             ManagedReplicaReplacementState.Prepare(
                 databasePath,
                 databaseStagingPath,
-                ManagedReplicaBootstrapper.ComputeMetadataSha256(replacementMetadata));
+                ManagedReplicaBootstrapper.ComputeMetadataSha256(replacementMetadata),
+                mainFileReplacementLock);
             ManagedReplicaApplyLock.ReplaceMainFile(
                 mainFileReplacementLock,
                 databaseStagingPath,
@@ -995,7 +996,9 @@ internal static class ManagedReplicaRevertWal
                 () => databaseInstalled = true);
             if (OperatingSystem.IsWindows()
                 && !string.Equals(
-                    ComputeSha256(databasePath),
+                    ManagedReplicaReplacementState.ComputeDatabaseSha256(
+                        mainFileReplacementLock,
+                        databasePath),
                     expectedSha256,
                     StringComparison.Ordinal))
             {
@@ -1024,7 +1027,11 @@ internal static class ManagedReplicaRevertWal
                         () => ManagedReplicaReplacementState.PrepareRollbackSidecars(databasePath));
                     ManagedReplicaFaultInjection.Hit(
                         ManagedReplicaDurableBoundary.MainFileRollbackDatabaseRestored);
-                    ManagedReplicaReplacementState.CompleteRollback(databasePath);
+                    ManagedReplicaReplacementState.CompleteRollback(
+                        databasePath,
+                        ManagedReplicaApplyLock.GetMainFileLease(
+                            mainFileReplacementLock,
+                            databasePath));
                 }
             }
             finally
@@ -1047,7 +1054,11 @@ internal static class ManagedReplicaRevertWal
         {
             try
             {
-                _ = ManagedReplicaReplacementState.TryCompletePublication(databasePath);
+                _ = ManagedReplicaReplacementState.TryCompletePublication(
+                    databasePath,
+                    ManagedReplicaApplyLock.GetMainFileLease(
+                        _mainFileReplacementLock,
+                        databasePath));
             }
             finally
             {

--- a/src/Ahtola.Data/ManagedReplicaRevertWal.cs
+++ b/src/Ahtola.Data/ManagedReplicaRevertWal.cs
@@ -1020,7 +1020,8 @@ internal static class ManagedReplicaRevertWal
                         mainFileReplacementLock,
                         databaseBackupPath,
                         databasePath,
-                        displacedPath);
+                        displacedPath,
+                        () => ManagedReplicaReplacementState.PrepareRollbackSidecars(databasePath));
                     ManagedReplicaFaultInjection.Hit(
                         ManagedReplicaDurableBoundary.MainFileRollbackDatabaseRestored);
                     ManagedReplicaReplacementState.CompleteRollback(databasePath);

--- a/src/Ahtola.Tests/ManagedEmbeddedReplicaPushRecoveryTests.cs
+++ b/src/Ahtola.Tests/ManagedEmbeddedReplicaPushRecoveryTests.cs
@@ -557,7 +557,15 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
             var requestPending = requestJournal.ReadBatch(int.MaxValue).Changes;
             var stalePullHandler = new DelayedPullHandler(
                 CreateLogicalPullResponse("revision-43", body: []));
-            var stalePull = ManagedReplicaBootstrapper.CheckForUpdatesAsync(
+            var pullWaitingForPublication = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            Task<AhtolaSyncResult> stalePull;
+            using var pullBoundary = ManagedReplicaFaultInjection.Push(boundary =>
+            {
+                if (boundary == ManagedReplicaDurableBoundary.ReplicaPullPublicationLockWaiting)
+                    pullWaitingForPublication.TrySetResult();
+            });
+            stalePull = ManagedReplicaBootstrapper.CheckForUpdatesAsync(
                 CreateOptions(aliasPath, stalePullHandler),
                 requestMetadata,
                 new AhtolaSyncOptions(),
@@ -570,7 +578,7 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
                 TestContext.CurrentContext.WorkDirectory,
                 path);
             stalePullHandler.Release();
-            await Task.Delay(TimeSpan.FromMilliseconds(250));
+            await pullWaitingForPublication.Task.WaitAsync(TimeSpan.FromSeconds(30));
 
             stalePull.IsCompleted.Should().BeFalse(
                 "pull publication through an alias must queue behind the process holding the "

--- a/src/Ahtola.Tests/ManagedEmbeddedReplicaPushRecoveryTests.cs
+++ b/src/Ahtola.Tests/ManagedEmbeddedReplicaPushRecoveryTests.cs
@@ -1,7 +1,9 @@
 using System.Buffers.Binary;
+using System.Diagnostics;
 using AwesomeAssertions;
 using System.Net;
 using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 
 namespace Ahtola.Tests;
@@ -510,11 +512,289 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
         }
     }
 
+    [Test]
+    public async Task CrossProcessAliasPullCannotEraseOrReplayACommittedPushIntent()
+    {
+        var realDirectory = Path.Combine(
+            TestContext.CurrentContext.WorkDirectory,
+            $"push-publication-real-{Guid.NewGuid():N}");
+        var aliasDirectory = Path.Combine(
+            TestContext.CurrentContext.WorkDirectory,
+            $"push-publication-alias-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(realDirectory);
+        var path = Path.Combine(realDirectory, "replica.db");
+        var aliasPath = Path.Combine(aliasDirectory, "replica.db");
+        var image = CreateJournalDatabaseImage(path + ".source");
+        var bootstrapHandler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", image, protocol: 2),
+            CreateLogicalPullResponse("revision-42", body: []),
+        ]);
+
+        try
+        {
+            try
+            {
+                Directory.CreateSymbolicLink(aliasDirectory, realDirectory);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                Assert.Ignore("Creating symbolic links is not permitted on this host.");
+            }
+            catch (PlatformNotSupportedException)
+            {
+                Assert.Ignore("Symbolic links are not supported on this host.");
+            }
+
+            using (var setup = AhtolaConnection.CreateReplica(CreateOptions(path, bootstrapHandler)))
+            {
+                setup.Open();
+                setup.ExecuteNonQuery("INSERT INTO journal_events VALUES (10);");
+            }
+
+            var requestMetadata = ManagedReplicaBootstrapper.LoadMetadata(aliasPath)!.Value;
+            var requestJournal = ManagedReplicaChangeJournal.Open(aliasPath);
+            var requestPending = requestJournal.ReadBatch(int.MaxValue).Changes;
+            var stalePullHandler = new DelayedPullHandler(
+                CreateLogicalPullResponse("revision-43", body: []));
+            var stalePull = ManagedReplicaBootstrapper.CheckForUpdatesAsync(
+                CreateOptions(aliasPath, stalePullHandler),
+                requestMetadata,
+                new AhtolaSyncOptions(),
+                requestPending,
+                acknowledgedLocalChanges: [],
+                CancellationToken.None);
+            await stalePullHandler.RequestStarted.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+            using var worker = new CrossProcessCommittedPushWorker(
+                TestContext.CurrentContext.WorkDirectory,
+                path);
+            stalePullHandler.Release();
+            await Task.Delay(TimeSpan.FromMilliseconds(250));
+
+            stalePull.IsCompleted.Should().BeFalse(
+                "pull publication through an alias must queue behind the process holding the "
+                + "physical push-flight lease");
+            ManagedReplicaBootstrapper.LoadMetadata(aliasPath)!.Value.PushState.Should().Be(
+                new ManagedReplicaBootstrapper.ManagedReplicaPushState(0, 1, 2),
+                "the stale pull must not erase the durable evidence of the remote commit");
+
+            worker.Release();
+            var rejected = Assert.ThrowsAsync<InvalidOperationException>(() => stalePull);
+            rejected!.Message.Should().Contain("pending push outcome");
+            var interrupted = ManagedReplicaBootstrapper.LoadMetadata(path)!.Value;
+            interrupted.Revision.Should().Be("revision-42");
+            interrupted.PushState.Should().Be(
+                new ManagedReplicaBootstrapper.ManagedReplicaPushState(0, 1, 2));
+
+            var replayCount = 0;
+            var watermarkReadCount = 0;
+            var recoveryHandler = new ReplicaPushHandler(
+                [CreateLogicalPullResponse("revision-42", body: [])],
+                request =>
+                {
+                    if (IsReplicaPushBatch(request))
+                    {
+                        replayCount++;
+                        return ReplicaPushHandler.SuccessfulBatchResponse(1);
+                    }
+
+                    watermarkReadCount++;
+                    return ReplicaPushHandler.WatermarkResponse(0, 1);
+                });
+            using var recovery = AhtolaConnection.CreateReplica(CreateOptions(path, recoveryHandler));
+            recovery.Open();
+            var result = await recovery.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
+
+            result.Statistics.CdcOperations.Should().Be(1);
+            replayCount.Should().Be(0, "the remote watermark proves the protected batch already committed");
+            watermarkReadCount.Should().Be(1);
+            recovery.ReadManagedReplicaLocalChanges(10).Changes.Should().BeEmpty();
+            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.PushState.Should().BeNull();
+        }
+        finally
+        {
+            if (Directory.Exists(aliasDirectory))
+                Directory.Delete(aliasDirectory);
+            DeleteReplicaFiles(path);
+            if (Directory.Exists(realDirectory))
+                Directory.Delete(realDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    [Category("ProcessWorker")]
+    [NonParallelizable]
+    public async Task CrossProcessCommittedPushIntentWorker()
+    {
+        var databasePath = Environment.GetEnvironmentVariable("AHTOLA_PUSH_INTENT_WORKER_DATABASE");
+        if (string.IsNullOrEmpty(databasePath))
+            return;
+
+        var readyPath = ReadWorkerValue("AHTOLA_PUSH_INTENT_WORKER_READY");
+        var releasePath = ReadWorkerValue("AHTOLA_PUSH_INTENT_WORKER_RELEASE");
+        var resultPath = ReadWorkerValue("AHTOLA_PUSH_INTENT_WORKER_RESULT");
+        await using var pushLease = await ManagedReplicaPushLock
+            .AcquireExclusiveAsync(databasePath, CancellationToken.None)
+            .ConfigureAwait(false);
+        await using (await ManagedReplicaApplyLock
+                         .AcquireExclusiveAsync(databasePath, CancellationToken.None)
+                         .ConfigureAwait(false))
+        {
+            var metadata = ManagedReplicaBootstrapper.LoadMetadata(databasePath)!.Value;
+            var batch = ManagedReplicaChangeJournal.Open(databasePath).ReadBatch(int.MaxValue);
+            _ = ManagedReplicaRevertWal.MarkPushStarted(
+                databasePath,
+                metadata,
+                batch,
+                sourcePullGeneration: 0);
+        }
+
+        File.WriteAllText(resultPath, "committed");
+        File.WriteAllText(readyPath, string.Empty);
+        WaitForWorkerFile(releasePath, TimeSpan.FromSeconds(30), "The push-intent worker was not released.");
+    }
+
     private static bool IsReplicaPushBatch(HttpRequestMessage request)
     {
         using var document = JsonDocument.Parse(
             request.Content!.ReadAsStringAsync().GetAwaiter().GetResult());
         return document.RootElement.GetProperty("requests")[0].TryGetProperty("batch", out _);
+    }
+
+    private static string ReadWorkerValue(string name)
+        => Environment.GetEnvironmentVariable(name)
+           ?? throw new InvalidOperationException($"The push-intent worker is missing {name}.");
+
+    private static void WaitForWorkerFile(string path, TimeSpan timeout, string message, Process? worker = null)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (!File.Exists(path))
+        {
+            if (worker is { HasExited: true })
+                Assert.Fail($"{message} The worker exited with code {worker.ExitCode}.");
+            if (stopwatch.Elapsed >= timeout)
+                Assert.Fail(message);
+            Thread.Sleep(25);
+        }
+    }
+
+    private sealed class DelayedPullHandler(byte[] response) : HttpMessageHandler
+    {
+        private readonly TaskCompletionSource _release =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal TaskCompletionSource RequestStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal void Release() => _release.TrySetResult();
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            RequestStarted.TrySetResult();
+            await _release.Task.WaitAsync(cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(response),
+            };
+        }
+    }
+
+    private sealed class CrossProcessCommittedPushWorker : IDisposable
+    {
+        private readonly Process _worker;
+        private readonly string _readyPath;
+        private readonly string _releasePath;
+        private readonly string _resultPath;
+        private readonly StringBuilder _output = new();
+        private bool _released;
+
+        internal CrossProcessCommittedPushWorker(string workDirectory, string databasePath)
+        {
+            var token = Guid.NewGuid().ToString("N");
+            _readyPath = Path.Combine(workDirectory, $"push-intent-ready-{token}");
+            _releasePath = Path.Combine(workDirectory, $"push-intent-release-{token}");
+            _resultPath = Path.Combine(workDirectory, $"push-intent-result-{token}");
+            var testDirectory = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
+            var startInfo = new ProcessStartInfo(
+                Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ?? "dotnet")
+            {
+                WorkingDirectory = testDirectory.FullName,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+            startInfo.ArgumentList.Add("vstest");
+            startInfo.ArgumentList.Add(Path.Combine(testDirectory.FullName, "Ahtola.Tests.dll"));
+            startInfo.ArgumentList.Add(
+                "--TestCaseFilter:FullyQualifiedName=Ahtola.Tests.ManagedEmbeddedReplicaConnectionTests."
+                + nameof(CrossProcessCommittedPushIntentWorker));
+            startInfo.Environment["AHTOLA_PUSH_INTENT_WORKER_DATABASE"] = databasePath;
+            startInfo.Environment["AHTOLA_PUSH_INTENT_WORKER_READY"] = _readyPath;
+            startInfo.Environment["AHTOLA_PUSH_INTENT_WORKER_RELEASE"] = _releasePath;
+            startInfo.Environment["AHTOLA_PUSH_INTENT_WORKER_RESULT"] = _resultPath;
+
+            _worker = Process.Start(startInfo)
+                ?? throw new InvalidOperationException("Failed to start the committed-push worker.");
+            _worker.OutputDataReceived += AppendOutput;
+            _worker.ErrorDataReceived += AppendOutput;
+            _worker.BeginOutputReadLine();
+            _worker.BeginErrorReadLine();
+            WaitForWorkerFile(
+                _readyPath,
+                TimeSpan.FromSeconds(60),
+                "The committed-push worker did not report readiness.",
+                _worker);
+        }
+
+        internal void Release()
+        {
+            if (_released)
+                return;
+            _released = true;
+            File.WriteAllText(_releasePath, string.Empty);
+            if (!_worker.WaitForExit(TimeSpan.FromSeconds(60)))
+            {
+                _worker.Kill(entireProcessTree: true);
+                Assert.Fail(
+                    "The committed-push worker did not exit within 60 seconds:"
+                    + Environment.NewLine
+                    + _output);
+            }
+
+            _worker.WaitForExit();
+            _worker.ExitCode.Should().Be(0, $"worker output:{Environment.NewLine}{_output}");
+            File.ReadAllText(_resultPath).Should().Be("committed");
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Release();
+            }
+            finally
+            {
+                _worker.Dispose();
+                DeleteIfExists(_readyPath);
+                DeleteIfExists(_releasePath);
+                DeleteIfExists(_resultPath);
+            }
+        }
+
+        private void AppendOutput(object sender, DataReceivedEventArgs args)
+        {
+            if (args.Data is { } line)
+                _output.AppendLine(line);
+        }
+
+        private static void DeleteIfExists(string path)
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
     }
 
     private static void CorruptPushState(string metadataPath, string corruption)

--- a/src/Ahtola.Tests/ManagedReplicaJournalAndLockCarrierRegressionTests.cs
+++ b/src/Ahtola.Tests/ManagedReplicaJournalAndLockCarrierRegressionTests.cs
@@ -649,7 +649,10 @@ public sealed class ManagedReplicaJournalAndLockCarrierRegressionTests
     /// one. .NET exposes no managed hard-link API (only symbolic links) and this repository does not
     /// add P/Invoke outside <c>Ahtola.Core/Storage</c>, so the platform tool is used instead.
     /// </summary>
-    private static void RequireHardLink(string linkPath, string targetPath)
+    internal static void RequireHardLink(
+        string linkPath,
+        string targetPath,
+        bool verifyPhysicalIdentity = true)
     {
         var startInfo = OperatingSystem.IsWindows()
             ? new ProcessStartInfo("fsutil.exe", ["hardlink", "create", linkPath, targetPath])
@@ -682,6 +685,9 @@ public sealed class ManagedReplicaJournalAndLockCarrierRegressionTests
 
         if (!File.Exists(linkPath))
             Assert.Ignore("The host reported success but produced no hard link.");
+
+        if (!verifyPhysicalIdentity)
+            return;
 
         // Prove the result really is one physical file under two names before relying on it: a tool
         // that silently copied would make every assertion in the caller vacuously pass.

--- a/src/Ahtola.Tests/ManagedReplicaPublicationRaceTests.cs
+++ b/src/Ahtola.Tests/ManagedReplicaPublicationRaceTests.cs
@@ -249,15 +249,14 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
                            throw new IOException("Injected replacement reacquisition failure.");
                        }
 
-                       if (boundary == ManagedReplicaDurableBoundary.MainFileRollbackLeasesReleased)
+                       if (boundary == ManagedReplicaDurableBoundary.MainFileRollbackLeasesReleased
+                           && rollbackWriter is null)
                        {
                            rollbackWriter = new CrossProcessReplicaRaceWorker(
                                TestContext.CurrentContext.WorkDirectory,
                                path,
-                               "sqlite-hold");
-                           rollbackWriter.WaitForProbeState("acquired");
-                           rollbackWriter.ReleaseBlockedProbe();
-                           rollbackWriter.WaitForCompletion();
+                               "sqlite-write");
+                           rollbackWriter.WaitForBlockedProbe();
                            rollbackInterrupted = true;
                            throw new IOException("Injected rollback handoff interruption.");
                        }
@@ -285,6 +284,8 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
             using var recovered = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
             recovered.Open();
 
+            rollbackWriter!.ReleaseBlockedProbe();
+            rollbackWriter.WaitForCompletion();
             ReadBootstrapMarker(recovered).Should().Be(42);
             recovered.Dispose();
             File.ReadAllBytes(path).Should().Equal(initialImage);
@@ -373,6 +374,158 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
         }
     }
 
+    [Test]
+    public async Task ColdOpenRollbackPreservesCommittedRestoredGenerationWal()
+    {
+        Assume.That(OperatingSystem.IsWindows(), Is.True);
+        var path = NewReplicaPath("rollback-restored-wal");
+        var initialImage = CreateDatabaseImageWithMarker(path + ".initial", 42);
+        var updatedImage = CreateDatabaseImageWithMarker(path + ".updated", 84);
+        var handler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", initialImage),
+            CreatePullResponse("revision-43", updatedImage),
+        ]);
+        CrossProcessReplicaRaceWorker? walWriter = null;
+        var rollbackPublished = false;
+        var rollbackReconciled = false;
+
+        try
+        {
+            using (var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler)))
+            {
+                connection.Open();
+                using (ManagedReplicaFaultInjection.Push(boundary =>
+                       {
+                           if (boundary == ManagedReplicaDurableBoundary.MainFileReplacementPublishedBeforeLease)
+                           {
+                               throw new IOException("Injected replacement reacquisition failure.");
+                           }
+                           if (boundary == ManagedReplicaDurableBoundary.MainFileRollbackPublishedBeforeLease
+                               && walWriter is null)
+                           {
+                               rollbackPublished = true;
+                               walWriter = new CrossProcessReplicaRaceWorker(
+                                   TestContext.CurrentContext.WorkDirectory,
+                                   path,
+                                   "sqlite-wal-crash");
+                               walWriter.WaitForProbeState("committed");
+                               walWriter.WaitForCrashCompletion();
+                           }
+                           else if (rollbackPublished
+                                    && boundary == ManagedReplicaDurableBoundary.MainFileRollbackSidecarsRestored)
+                           {
+                               rollbackReconciled = true;
+                               throw new IOException("Injected crash after preserving the restored-generation WAL.");
+                           }
+                           else if (rollbackReconciled
+                                    && boundary == ManagedReplicaDurableBoundary.MainFileReplacementRecoveryStarted)
+                           {
+                               throw new IOException("Injected automatic recovery interruption.");
+                           }
+                       }))
+                {
+                    var exception = Assert.ThrowsAsync<IOException>(
+                        () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+                    exception!.Message.Should().Be("Injected automatic recovery interruption.");
+                }
+            }
+
+            walWriter.Should().NotBeNull();
+            File.Exists(path + "-wal").Should().BeTrue();
+            File.Exists(ManagedReplicaReplacementState.GetDisplacedPath(path)).Should().BeTrue();
+            ManagedReplicaReplacementState.HasArtifacts(path).Should().BeTrue();
+
+            using var recovered = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            recovered.Open();
+
+            ReadBootstrapMarker(recovered).Should().Be(126);
+            ManagedReplicaReplacementState.HasArtifacts(path).Should().BeFalse();
+        }
+        finally
+        {
+            walWriter?.Dispose();
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task ColdOpenRollbackDiscardsReplacementWalRecreatedAfterQuarantineCrash()
+    {
+        Assume.That(OperatingSystem.IsWindows(), Is.True);
+        var path = NewReplicaPath("rollback-recreated-replacement-wal");
+        var initialImage = CreateDatabaseImageWithMarker(path + ".initial", 42);
+        var updatedImage = CreateDatabaseImageWithMarker(path + ".updated", 84);
+        var handler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", initialImage),
+            CreatePullResponse("revision-43", updatedImage),
+        ]);
+        var rollbackInterrupted = false;
+        CrossProcessReplicaRaceWorker? preQuarantineWriter = null;
+        CrossProcessReplicaRaceWorker? walWriter = null;
+
+        try
+        {
+            using (var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler)))
+            {
+                connection.Open();
+                using (ManagedReplicaFaultInjection.Push(boundary =>
+                       {
+                           if (boundary == ManagedReplicaDurableBoundary.MainFileReplacementPublishedBeforeLease)
+                           {
+                               preQuarantineWriter = new CrossProcessReplicaRaceWorker(
+                                   TestContext.CurrentContext.WorkDirectory,
+                                   path,
+                                   "sqlite-wal-crash");
+                               preQuarantineWriter.WaitForProbeState("committed");
+                               preQuarantineWriter.WaitForCrashCompletion();
+                               throw new IOException("Injected replacement reacquisition failure.");
+                           }
+                           if (!rollbackInterrupted
+                               && boundary == ManagedReplicaDurableBoundary.MainFileRollbackSidecarsQuarantined)
+                           {
+                               rollbackInterrupted = true;
+                               throw new IOException("Injected crash after replacement sidecar quarantine.");
+                           }
+                           if (rollbackInterrupted
+                               && boundary == ManagedReplicaDurableBoundary.MainFileReplacementRecoveryStarted)
+                           {
+                               throw new IOException("Injected automatic recovery interruption.");
+                           }
+                       }))
+                {
+                    var exception = Assert.ThrowsAsync<IOException>(
+                        () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+                    exception!.Message.Should().Be("Injected automatic recovery interruption.");
+                }
+            }
+
+            walWriter = new CrossProcessReplicaRaceWorker(
+                TestContext.CurrentContext.WorkDirectory,
+                path,
+                "sqlite-wal-crash");
+            walWriter.WaitForProbeState("committed");
+            walWriter.WaitForCrashCompletion();
+            File.Exists(path + "-wal").Should().BeTrue();
+            File.Exists(path + ManagedReplicaReplacementState.ReplacementWalSuffix).Should().BeTrue();
+
+            using var recovered = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            recovered.Open();
+
+            ReadBootstrapMarker(recovered).Should().Be(42);
+            ManagedReplicaReplacementState.HasArtifacts(path).Should().BeFalse();
+        }
+        finally
+        {
+            if (walWriter is not null)
+                walWriter.WaitForCrashCompletion();
+            preQuarantineWriter?.Dispose();
+            walWriter?.Dispose();
+            DeleteReplicaFiles(path);
+        }
+    }
+
     [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileReplacementOriginalWalCaptured), 42)]
     [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileReplacementIntentPublished), 42)]
     [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileReplacementSourceLeaseReleased), 42)]
@@ -442,6 +595,8 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
     }
 
     [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileRollbackLeasesReleased))]
+    [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileRollbackSidecarsQuarantined))]
+    [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileRollbackPublishedBeforeLease))]
     [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileRollbackDatabaseRestored))]
     [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileRollbackSidecarsRestored))]
     [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileRollbackIntentRetired))]
@@ -1250,7 +1405,7 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
             }
 
             catch (Microsoft.Data.Sqlite.SqliteException exception)
-                when (exception.SqliteErrorCode is 5 or 6)
+                when (exception.SqliteErrorCode is 5 or 6 or 8)
             {
                 File.WriteAllText(blockedPath, "blocked");
             }

--- a/src/Ahtola.Tests/ManagedReplicaPublicationRaceTests.cs
+++ b/src/Ahtola.Tests/ManagedReplicaPublicationRaceTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Text;
 using AwesomeAssertions;
+using NativeSqliteConnection = Microsoft.Data.Sqlite.SqliteConnection;
 
 namespace Ahtola.Tests;
 
@@ -52,6 +53,103 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
         {
             contender?.Dispose();
             DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task MainFileReplacementKeepsTheNewGenerationBehindOrdinarySqliteWriters()
+    {
+        var path = NewReplicaPath("replace-sqlite-publication-lock");
+        var initialImage = CreateDatabaseImageWithMarker(path + ".initial", 42);
+        var updatedImage = CreateDatabaseImageWithMarker(path + ".updated", 84);
+        var handler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", initialImage),
+            CreatePullResponse("revision-43", updatedImage),
+        ]);
+        CrossProcessReplicaRaceWorker? contender = null;
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            connection.Open();
+            using (ManagedReplicaFaultInjection.Push(boundary =>
+                   {
+                       if (boundary != ManagedReplicaDurableBoundary.IncrementalApplyDatabasePublished
+                           || contender is not null)
+                       {
+                           return;
+                       }
+
+                       contender = new CrossProcessReplicaRaceWorker(
+                           TestContext.CurrentContext.WorkDirectory,
+                           path,
+                           "sqlite-write");
+                       contender.WaitForBlockedProbe();
+                   }))
+            {
+                var result = await connection.SyncAsync(
+                    new AhtolaSyncOptions(),
+                    CancellationToken.None);
+                result.Outcome.Should().Be(AhtolaSyncOutcome.RemoteChangesApplied);
+            }
+
+            contender.Should().NotBeNull();
+            contender!.ReleaseBlockedProbe();
+            contender!.WaitForCompletion();
+            ReadBootstrapMarker(connection).Should().Be(84);
+        }
+        finally
+        {
+            contender?.Dispose();
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void RepeatedMainFileReplacementDoesNotCreateGuidStagingCarriers()
+    {
+        var path = NewReplicaPath("replace-carrier-growth");
+        var lockDirectory = path + ".locks";
+        var previousLockDirectory = Environment.GetEnvironmentVariable(
+            ManagedReplicaLockCarrier.DirectoryVariable);
+        File.WriteAllBytes(path, CreateDatabaseImageWithMarker(path + ".source", 42));
+
+        try
+        {
+            Environment.SetEnvironmentVariable(
+                ManagedReplicaLockCarrier.DirectoryVariable,
+                lockDirectory);
+            for (var index = 0; index < 32; index++)
+            {
+                var stagingPath = path + $".replacement-{Guid.NewGuid():N}.tmp";
+                var backupPath = path + $".backup-{Guid.NewGuid():N}.tmp";
+                File.Copy(path, stagingPath);
+                using (var replacementLock = ManagedReplicaApplyLock.AcquireMainFileReplacementLock(
+                           path, stagingPath, CancellationToken.None))
+                {
+                    ManagedReplicaApplyLock.ReplaceMainFile(
+                        replacementLock,
+                        stagingPath,
+                        path,
+                        backupPath,
+                        static () => { });
+                }
+                File.Delete(backupPath);
+            }
+
+            Directory.Exists(lockDirectory).Should().BeFalse(
+                "private replacement paths use their database inode directly and create no named carriers");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(
+                ManagedReplicaLockCarrier.DirectoryVariable,
+                previousLockDirectory);
+            DeleteReplicaFiles(path);
+            if (Directory.Exists(lockDirectory))
+                Directory.Delete(lockDirectory, recursive: true);
         }
     }
 
@@ -236,7 +334,31 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
         var startedPath = ReadWorkerValue("AHTOLA_REPLICA_RACE_STARTED");
         var blockedPath = ReadWorkerValue("AHTOLA_REPLICA_RACE_BLOCKED");
         var completedPath = ReadWorkerValue("AHTOLA_REPLICA_RACE_COMPLETED");
+        var releasePath = ReadWorkerValue("AHTOLA_REPLICA_RACE_RELEASE");
         File.WriteAllText(startedPath, string.Empty);
+
+        if (mode == "sqlite-write")
+        {
+            try
+            {
+                ProbeOrdinarySqliteWrite(databasePath, timeoutSeconds: 1);
+                File.WriteAllText(completedPath, "sqlite-write-acquired-without-blocking");
+                return;
+            }
+            catch (Microsoft.Data.Sqlite.SqliteException exception)
+                when (exception.SqliteErrorCode is 5 or 6)
+            {
+                File.WriteAllText(blockedPath, "blocked");
+            }
+
+            WaitForWorkerFile(
+                releasePath,
+                TimeSpan.FromSeconds(30),
+                "The ordinary SQLite writer was not released after publication.");
+            ProbeOrdinarySqliteWrite(databasePath, timeoutSeconds: 30);
+            File.WriteAllText(completedPath, mode);
+            return;
+        }
 
         if (mode == "publication")
         {
@@ -296,11 +418,26 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
         File.WriteAllText(completedPath, mode);
     }
 
+    private static void ProbeOrdinarySqliteWrite(string databasePath, int timeoutSeconds)
+    {
+        using var connection = new NativeSqliteConnection(
+            $"Data Source={databasePath};Mode=ReadWrite;Default Timeout={timeoutSeconds};Pooling=False");
+        connection.Open();
+        using var transaction = connection.BeginTransaction();
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = "UPDATE bootstrap_marker SET value = value;";
+        command.ExecuteNonQuery().Should().Be(1);
+        transaction.Rollback();
+    }
+
     private sealed class CrossProcessReplicaRaceWorker : IDisposable
     {
         private readonly Process _worker;
+        private readonly string _startedPath;
         private readonly string _blockedPath;
         private readonly string _completedPath;
+        private readonly string _releasePath;
         private readonly string _mode;
         private readonly StringBuilder _output = new();
         private bool _completed;
@@ -312,9 +449,10 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
         {
             _mode = mode;
             var token = Guid.NewGuid().ToString("N");
-            var startedPath = Path.Combine(workDirectory, $"replica-race-started-{token}");
+            _startedPath = Path.Combine(workDirectory, $"replica-race-started-{token}");
             _blockedPath = Path.Combine(workDirectory, $"replica-race-blocked-{token}");
             _completedPath = Path.Combine(workDirectory, $"replica-race-completed-{token}");
+            _releasePath = Path.Combine(workDirectory, $"replica-race-release-{token}");
             var testDirectory = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
             var startInfo = new ProcessStartInfo(
                 Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ?? "dotnet")
@@ -331,9 +469,10 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
                 + nameof(CrossProcessReplicaRaceWorkerEntryPoint));
             startInfo.Environment["AHTOLA_REPLICA_RACE_MODE"] = mode;
             startInfo.Environment["AHTOLA_REPLICA_RACE_DATABASE"] = databasePath;
-            startInfo.Environment["AHTOLA_REPLICA_RACE_STARTED"] = startedPath;
+            startInfo.Environment["AHTOLA_REPLICA_RACE_STARTED"] = _startedPath;
             startInfo.Environment["AHTOLA_REPLICA_RACE_BLOCKED"] = _blockedPath;
             startInfo.Environment["AHTOLA_REPLICA_RACE_COMPLETED"] = _completedPath;
+            startInfo.Environment["AHTOLA_REPLICA_RACE_RELEASE"] = _releasePath;
 
             _worker = Process.Start(startInfo)
                 ?? throw new InvalidOperationException("Failed to start the replica race worker.");
@@ -342,7 +481,7 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
             _worker.BeginOutputReadLine();
             _worker.BeginErrorReadLine();
             WaitForWorkerFile(
-                startedPath,
+                _startedPath,
                 TimeSpan.FromSeconds(60),
                 "The replica race worker did not report readiness.",
                 _worker);
@@ -357,6 +496,9 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
                 _worker);
             File.ReadAllText(_blockedPath).Should().Be("blocked");
         }
+
+        internal void ReleaseBlockedProbe()
+            => File.WriteAllText(_releasePath, string.Empty);
 
         internal void WaitForCompletion()
         {
@@ -386,6 +528,10 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
             finally
             {
                 _worker.Dispose();
+                File.Delete(_startedPath);
+                File.Delete(_blockedPath);
+                File.Delete(_completedPath);
+                File.Delete(_releasePath);
             }
         }
 

--- a/src/Ahtola.Tests/ManagedReplicaPublicationRaceTests.cs
+++ b/src/Ahtola.Tests/ManagedReplicaPublicationRaceTests.cs
@@ -297,6 +297,83 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
         }
     }
 
+    [Test]
+    public async Task ColdOpenRollbackDiscardsCommittedReplacementGenerationWal()
+    {
+        Assume.That(OperatingSystem.IsWindows(), Is.True);
+        var path = NewReplicaPath("rollback-replacement-wal");
+        var initialImage = CreateDatabaseImageWithMarker(path + ".initial", 42);
+        var updatedImage = CreateDatabaseImageWithMarker(path + ".updated", 84);
+        var handler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", initialImage),
+            CreatePullResponse("revision-43", updatedImage),
+        ]);
+        CrossProcessReplicaRaceWorker? walWriter = null;
+        var publicationFailed = false;
+        var rollbackRestored = false;
+
+        try
+        {
+            using (var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler)))
+            {
+                connection.Open();
+                using (ManagedReplicaFaultInjection.Push(boundary =>
+                       {
+                           if (boundary == ManagedReplicaDurableBoundary.MainFileReplacementPublishedBeforeLease
+                               && walWriter is null)
+                           {
+                               walWriter = new CrossProcessReplicaRaceWorker(
+                                   TestContext.CurrentContext.WorkDirectory,
+                                   path,
+                                   "sqlite-wal-crash");
+                               walWriter.WaitForProbeState("committed");
+                               walWriter.WaitForCrashCompletion();
+                               File.Exists(path + "-wal").Should().BeTrue();
+                           }
+                           else if (boundary == ManagedReplicaDurableBoundary.IncrementalApplyDatabasePublished)
+                           {
+                               publicationFailed = true;
+                               throw new IOException("Injected publication failure after replacement WAL commit.");
+                           }
+                           else if (publicationFailed
+                                    && boundary == ManagedReplicaDurableBoundary.MainFileRollbackSidecarsRestored)
+                           {
+                               rollbackRestored = true;
+                               throw new IOException("Injected crash after restoring the original database generation.");
+                           }
+                           else if (rollbackRestored
+                                    && boundary == ManagedReplicaDurableBoundary.MainFileReplacementRecoveryStarted)
+                           {
+                               throw new IOException("Injected automatic recovery interruption.");
+                           }
+                       }))
+                {
+                    var exception = Assert.ThrowsAsync<IOException>(
+                        () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+                    exception!.Message.Should().Be("Injected automatic recovery interruption.");
+                }
+            }
+
+            File.Exists(path + "-wal").Should().BeTrue(
+                "the committed replacement-generation WAL must survive until cold recovery reconciles it");
+            File.Exists(ManagedReplicaReplacementState.GetDisplacedPath(path)).Should().BeTrue();
+            ManagedReplicaReplacementState.HasArtifacts(path).Should().BeTrue();
+
+            using var recovered = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            recovered.Open();
+
+            ReadBootstrapMarker(recovered).Should().Be(42);
+            ManagedReplicaReplacementState.HasArtifacts(path).Should().BeFalse();
+        }
+        finally
+        {
+            walWriter?.Dispose();
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileReplacementOriginalWalCaptured), 42)]
     [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileReplacementIntentPublished), 42)]
     [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileReplacementSourceLeaseReleased), 42)]
     [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileReplacementPublishedBeforeLease), 42)]
@@ -366,6 +443,7 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
 
     [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileRollbackLeasesReleased))]
     [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileRollbackDatabaseRestored))]
+    [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileRollbackSidecarsRestored))]
     [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileRollbackIntentRetired))]
     public async Task ColdOpenRecoversEveryWindowsReplacementRollbackPhase(
         string interruptedBoundaryName)
@@ -628,6 +706,74 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
             DeleteReplicaFiles(path);
             if (File.Exists(stagingPath))
                 File.Delete(stagingPath);
+        }
+    }
+
+    [Test]
+    public void ChangedParseableMetadataCannotRetireAReplacementBackup()
+    {
+        var path = NewReplicaPath("replacement-unrelated-metadata");
+        var initialImage = CreateDatabaseImageWithMarker(path + ".initial", 42);
+        var updatedImage = CreateDatabaseImageWithMarker(path + ".updated", 84);
+        var handler = new PullUpdatesHandler(CreatePullResponse("revision-42", initialImage));
+        var stagingPath = path + ".replacement";
+        var metadataStagingPath = path + ".unrelated-metadata";
+        IDisposable? replacementLock = null;
+
+        try
+        {
+            using (var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler)))
+                connection.Open();
+            var metadata = ManagedReplicaBootstrapper.LoadMetadata(path)!.Value;
+            var replacementSha256 = Convert.ToHexString(
+                System.Security.Cryptography.SHA256.HashData(updatedImage));
+            var expectedReplacementMetadata = metadata with
+            {
+                Revision = "revision-43",
+                DatabaseSha256 = replacementSha256,
+            };
+            File.WriteAllBytes(stagingPath, updatedImage);
+            replacementLock = ManagedReplicaApplyLock.AcquireMainFileReplacementLock(
+                path,
+                stagingPath,
+                CancellationToken.None);
+            ManagedReplicaReplacementState.Prepare(
+                path,
+                stagingPath,
+                ManagedReplicaBootstrapper.ComputeMetadataSha256(expectedReplacementMetadata));
+            ManagedReplicaApplyLock.ReplaceMainFile(
+                replacementLock,
+                stagingPath,
+                path,
+                ManagedReplicaReplacementState.GetBackupPath(path),
+                static () => { });
+            replacementLock!.Dispose();
+            replacementLock = null;
+
+            ManagedReplicaBootstrapper.WriteMetadata(
+                metadataStagingPath,
+                path + ManagedReplicaBootstrapper.MetadataSuffix,
+                expectedReplacementMetadata with { Revision = "unrelated-revision" });
+
+            Action reopen = () =>
+            {
+                using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+                connection.Open();
+            };
+
+            reopen.Should().Throw<InvalidDataException>()
+                .WithMessage("*metadata does not match the expected published generation*");
+            File.Exists(ManagedReplicaReplacementState.GetBackupPath(path)).Should().BeTrue();
+            File.Exists(path + ManagedReplicaReplacementState.IntentSuffix).Should().BeTrue();
+        }
+        finally
+        {
+            replacementLock?.Dispose();
+            DeleteReplicaFiles(path);
+            if (File.Exists(stagingPath))
+                File.Delete(stagingPath);
+            if (File.Exists(metadataStagingPath))
+                File.Delete(metadataStagingPath);
         }
     }
 
@@ -1034,6 +1180,30 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
             return;
         }
 
+        if (mode == "sqlite-wal-crash")
+        {
+            using var connection = new NativeSqliteConnection(
+                $"Data Source={databasePath};Mode=ReadWrite;Default Timeout=30;Pooling=False");
+            connection.Open();
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0;";
+                command.ExecuteNonQuery();
+            }
+            using (var transaction = connection.BeginTransaction())
+            using (var command = connection.CreateCommand())
+            {
+                command.Transaction = transaction;
+                command.CommandText = "UPDATE bootstrap_marker SET value = 126;";
+                command.ExecuteNonQuery().Should().Be(1);
+                transaction.Commit();
+            }
+            File.Exists(databasePath + "-wal").Should().BeTrue();
+            File.WriteAllText(blockedPath, "committed");
+            Process.GetCurrentProcess().Kill(entireProcessTree: false);
+            Thread.Sleep(Timeout.Infinite);
+        }
+
         if (mode == "alias-noop-pull")
         {
             var metadata = ManagedReplicaBootstrapper.LoadMetadata(databasePath)!.Value;
@@ -1254,6 +1424,17 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
             _worker.WaitForExit();
             _worker.ExitCode.Should().Be(0, $"worker output:{Environment.NewLine}{_output}");
             File.ReadAllText(_completedPath).Should().Be(_mode);
+        }
+
+        internal void WaitForCrashCompletion()
+        {
+            if (_completed)
+                return;
+            _worker.WaitForExit(TimeSpan.FromSeconds(30)).Should().BeTrue(
+                "the committed WAL writer must terminate without SQLite cleanup");
+            _worker.WaitForExit();
+            _completed = true;
+            _worker.ExitCode.Should().NotBe(0);
         }
 
         public void Dispose()

--- a/src/Ahtola.Tests/ManagedReplicaPublicationRaceTests.cs
+++ b/src/Ahtola.Tests/ManagedReplicaPublicationRaceTests.cs
@@ -602,6 +602,7 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
     [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileRollbackRestoredUnderLease))]
     [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileRollbackDatabaseRestored))]
     [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileRollbackSidecarsRestored))]
+    [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileRollbackDisplacedRetired))]
     [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileRollbackIntentRetired))]
     public async Task ColdOpenRecoversEveryWindowsReplacementRollbackPhase(
         string interruptedBoundaryName)
@@ -689,7 +690,7 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
 
         try
         {
-            await InterruptRollbackAfterPreservingMutatedReplacementAsync(
+            await InterruptRollbackAfterMutatingReplacementAsync(
                 path,
                 handler,
                 writerMode);
@@ -727,7 +728,7 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
 
         try
         {
-            await InterruptRollbackAfterPreservingMutatedReplacementAsync(
+            await InterruptRollbackAfterMutatingReplacementAsync(
                 path,
                 handler,
                 "sqlite-wal-checkpoint-commit");
@@ -746,6 +747,83 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
             using var recovered = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
             var exception = Assert.Throws<InvalidDataException>(() => recovered.Open());
             exception!.Message.Should().Contain("unrecognized database image");
+            ManagedReplicaReplacementState.HasArtifacts(path).Should().BeTrue();
+            File.ReadAllBytes(ManagedReplicaReplacementState.GetBackupPath(path))
+                .Should().Equal(initialImage);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task ColdOpenPromotesHashedStagedDisplacedGenerationBeforeRestoringRollback()
+    {
+        Assume.That(OperatingSystem.IsWindows(), Is.True);
+        var path = NewReplicaPath("rollback-hashed-staged-displaced");
+        var initialImage = CreateDatabaseImageWithMarker(path + ".initial", 42);
+        var updatedImage = CreateDatabaseImageWithMarker(path + ".updated", 84);
+        var handler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", initialImage),
+            CreatePullResponse("revision-43", updatedImage),
+        ]);
+
+        try
+        {
+            await InterruptRollbackAfterMutatingReplacementAsync(
+                path,
+                handler,
+                "sqlite-delete-commit",
+                ManagedReplicaDurableBoundary.MainFileRollbackDisplacedHashPublished);
+
+            File.ReadAllBytes(path).Should().NotEqual(updatedImage);
+            File.Exists(ManagedReplicaReplacementState.GetDisplacedPath(path)).Should().BeFalse();
+            File.Exists(path + ManagedReplicaReplacementState.DisplacedStagingSuffix).Should().BeTrue();
+            File.Exists(path + ManagedReplicaReplacementState.DisplacedSha256Suffix).Should().BeTrue();
+
+            using var recovered = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            recovered.Open();
+
+            ReadBootstrapMarker(recovered).Should().Be(42);
+            recovered.Dispose();
+            File.ReadAllBytes(path).Should().Equal(initialImage);
+            ManagedReplicaReplacementState.HasArtifacts(path).Should().BeFalse();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task ColdOpenRejectsCorruptHashedStagedDisplacedGeneration()
+    {
+        Assume.That(OperatingSystem.IsWindows(), Is.True);
+        var path = NewReplicaPath("rollback-corrupt-hashed-staged-displaced");
+        var initialImage = CreateDatabaseImageWithMarker(path + ".initial", 42);
+        var updatedImage = CreateDatabaseImageWithMarker(path + ".updated", 84);
+        var handler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", initialImage),
+            CreatePullResponse("revision-43", updatedImage),
+        ]);
+        var displacedStagingPath = path + ManagedReplicaReplacementState.DisplacedStagingSuffix;
+
+        try
+        {
+            await InterruptRollbackAfterMutatingReplacementAsync(
+                path,
+                handler,
+                "sqlite-wal-checkpoint-commit",
+                ManagedReplicaDurableBoundary.MainFileRollbackDisplacedHashPublished);
+
+            File.WriteAllBytes(displacedStagingPath, [0x53, 0x54, 0x41, 0x47, 0x45]);
+
+            using var recovered = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            var exception = Assert.Throws<InvalidDataException>(() => recovered.Open());
+            exception!.Message.Should().Contain("staged displaced database is missing or corrupt");
             ManagedReplicaReplacementState.HasArtifacts(path).Should().BeTrue();
             File.ReadAllBytes(ManagedReplicaReplacementState.GetBackupPath(path))
                 .Should().Equal(initialImage);
@@ -1712,10 +1790,12 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
         transaction.Commit();
     }
 
-    private static async Task InterruptRollbackAfterPreservingMutatedReplacementAsync(
+    private static async Task InterruptRollbackAfterMutatingReplacementAsync(
         string path,
         PullUpdatesHandler handler,
-        string writerMode)
+        string writerMode,
+        ManagedReplicaDurableBoundary interruptedBoundary =
+            ManagedReplicaDurableBoundary.MainFileRollbackDisplacedPreserved)
     {
         CrossProcessReplicaRaceWorker? writer = null;
         var replacementMutated = false;
@@ -1740,11 +1820,10 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
                        }
                        else if (replacementMutated
                                 && !rollbackInterrupted
-                                && boundary
-                                    == ManagedReplicaDurableBoundary.MainFileRollbackDisplacedPreserved)
+                                && boundary == interruptedBoundary)
                        {
                            rollbackInterrupted = true;
-                           throw new IOException("Injected crash after preserving the displaced database.");
+                           throw new IOException($"Injected crash at {boundary}.");
                        }
                        else if (rollbackInterrupted
                                 && boundary

--- a/src/Ahtola.Tests/ManagedReplicaPublicationRaceTests.cs
+++ b/src/Ahtola.Tests/ManagedReplicaPublicationRaceTests.cs
@@ -1,0 +1,398 @@
+using System.Diagnostics;
+using System.Text;
+using AwesomeAssertions;
+
+namespace Ahtola.Tests;
+
+public sealed partial class ManagedEmbeddedReplicaConnectionTests
+{
+    [Test]
+    public async Task MainFileReplacementKeepsTheNewGenerationBehindExistingPublicationLeases()
+    {
+        var path = NewReplicaPath("replace-stable-publication-lock");
+        var initialImage = CreateDatabaseImageWithMarker(path + ".initial", 42);
+        var updatedImage = CreateDatabaseImageWithMarker(path + ".updated", 84);
+        var handler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", initialImage),
+            CreatePullResponse("revision-43", updatedImage),
+        ]);
+        CrossProcessReplicaRaceWorker? contender = null;
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            connection.Open();
+            using (ManagedReplicaFaultInjection.Push(boundary =>
+                   {
+                       if (boundary != ManagedReplicaDurableBoundary.IncrementalApplyDatabasePublished
+                           || contender is not null)
+                       {
+                           return;
+                       }
+
+                       contender = new CrossProcessReplicaRaceWorker(
+                           TestContext.CurrentContext.WorkDirectory,
+                           path,
+                           "publication");
+                       contender.WaitForBlockedProbe();
+                   }))
+            {
+                var result = await connection.SyncAsync(
+                    new AhtolaSyncOptions(),
+                    CancellationToken.None);
+                result.Outcome.Should().Be(AhtolaSyncOutcome.RemoteChangesApplied);
+            }
+
+            contender.Should().NotBeNull();
+            contender!.WaitForCompletion();
+            ReadBootstrapMarker(connection).Should().Be(84);
+        }
+        finally
+        {
+            contender?.Dispose();
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task OrdinaryPullRejectsAConflictRecordedCrossProcessDuringTheNetworkWait(
+        bool sameRevisionNoOp)
+    {
+        var path = NewReplicaPath("pull-conflict-publication-race");
+        var initialImage = CreateDatabaseImageWithMarker(path + ".initial", 42);
+        var updatedImage = CreateDatabaseImageWithMarker(path + ".updated", 84);
+
+        try
+        {
+            using (var setup = AhtolaConnection.CreateReplica(
+                       CreateOptions(
+                           path,
+                           new PullUpdatesHandler(CreatePullResponse("revision-42", initialImage)))))
+            {
+                setup.Open();
+            }
+
+            var metadata = ManagedReplicaBootstrapper.LoadMetadata(path)!.Value;
+            var delayed = new DelayedPullHandler(
+                sameRevisionNoOp
+                    ? CreatePullResponse("revision-42", [], declaredPages: 1)
+                    : CreatePullResponse("revision-43", updatedImage));
+            var pull = ManagedReplicaBootstrapper.CheckForUpdatesAsync(
+                CreateOptions(path, delayed),
+                metadata,
+                new AhtolaSyncOptions(),
+                pendingLocalChanges: [],
+                acknowledgedLocalChanges: [],
+                CancellationToken.None);
+            await delayed.RequestStarted.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+            using (var writer = new CrossProcessReplicaRaceWorker(
+                       TestContext.CurrentContext.WorkDirectory,
+                       path,
+                       "record-conflict"))
+            {
+                writer.WaitForCompletion();
+            }
+
+            delayed.Release();
+            var pending = Assert.ThrowsAsync<AhtolaReplicaConflictPendingException>(() => pull);
+            pending!.ConflictKind.Should().Be(AhtolaReplicaConflictKind.RowWrite);
+            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.Revision.Should().Be("revision-42");
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task ConflictRebasePullRejectsAMarkerChangedCrossProcessDuringTheNetworkWait()
+    {
+        var path = NewReplicaPath("rebase-conflict-publication-race");
+        var initialImage = CreateDatabaseImageWithMarker(path + ".initial", 42);
+        var expected = new ManagedReplicaConflictState(
+            AhtolaReplicaConflictKind.RowWrite,
+            "initial",
+            ConflictingSequence: 1,
+            BatchFirstSequence: 1,
+            BatchWatermark: 2,
+            UnresolvedSequences: [1]);
+
+        try
+        {
+            using (var setup = AhtolaConnection.CreateReplica(
+                       CreateOptions(
+                           path,
+                           new PullUpdatesHandler(
+                           [
+                               CreatePullResponse("revision-42", initialImage, protocol: 2),
+                               CreateLogicalPullResponse("revision-42", body: []),
+                           ]))))
+            {
+                setup.Open();
+            }
+
+            ManagedReplicaConflictState.Write(path, expected);
+
+            var metadata = ManagedReplicaBootstrapper.LoadMetadata(path)!.Value;
+            var delayed = new DelayedPullHandler(
+                CreateLogicalPullResponse("revision-43", body: []));
+            var pull = ManagedReplicaBootstrapper.CheckForUpdatesAsync(
+                CreateOptions(path, delayed),
+                metadata,
+                new AhtolaSyncOptions(),
+                pendingLocalChanges: [],
+                acknowledgedLocalChanges: [],
+                expected,
+                CancellationToken.None);
+            await delayed.RequestStarted.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+            using (var writer = new CrossProcessReplicaRaceWorker(
+                       TestContext.CurrentContext.WorkDirectory,
+                       path,
+                       "change-conflict"))
+            {
+                writer.WaitForCompletion();
+            }
+
+            delayed.Release();
+            Assert.ThrowsAsync<InvalidDataException>(() => pull);
+            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.Revision.Should().Be("revision-42");
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task PartialImageCompletionRejectsAConflictRecordedBeforePublication()
+    {
+        var path = NewReplicaPath("materialization-conflict-publication-race");
+        var image = CreateMultiPageDatabaseImage(path + ".source");
+        var handler = new QueryBootstrapPullHandler("revision-query", image, bootstrapPages: [0u]);
+        var options = CreateOptions(
+            path,
+            handler,
+            partialBootstrap: AhtolaPartialBootstrapOptions.QueryPages(BootstrapQuery));
+        CrossProcessReplicaRaceWorker? writer = null;
+
+        try
+        {
+            await ManagedReplicaBootstrapper.BootstrapAsync(options, CancellationToken.None);
+            var metadata = ManagedReplicaBootstrapper.LoadMetadata(path)!.Value;
+
+            using (ManagedReplicaFaultInjection.Push(boundary =>
+                   {
+                       if (boundary != ManagedReplicaDurableBoundary.PartialImagePublicationLockWaiting
+                           || writer is not null)
+                       {
+                           return;
+                       }
+
+                       writer = new CrossProcessReplicaRaceWorker(
+                           TestContext.CurrentContext.WorkDirectory,
+                           path,
+                           "record-conflict");
+                       writer.WaitForCompletion();
+                   }))
+            {
+                var pending = Assert.ThrowsAsync<AhtolaReplicaConflictPendingException>(
+                    () => ManagedReplicaBootstrapper.CompletePartialReplicaAsync(
+                        options,
+                        metadata,
+                        allowTrackedLocalMutations: false,
+                        retainedMaterializer: null,
+                        CancellationToken.None));
+                pending!.ConflictKind.Should().Be(AhtolaReplicaConflictKind.RowWrite);
+            }
+
+            writer.Should().NotBeNull();
+            File.Exists(path + ManagedReplicaPageMaterializingFileSystem.StateSuffix).Should().BeTrue();
+            var current = ManagedReplicaBootstrapper.LoadMetadata(path)!.Value;
+            current.Revision.Should().Be(metadata.Revision);
+            current.DatabaseSha256.Should().Be(metadata.DatabaseSha256);
+            current.RemoteBaseSha256.Should().Be(metadata.RemoteBaseSha256);
+        }
+        finally
+        {
+            writer?.Dispose();
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    [Category("ProcessWorker")]
+    [NonParallelizable]
+    public async Task CrossProcessReplicaRaceWorkerEntryPoint()
+    {
+        var mode = Environment.GetEnvironmentVariable("AHTOLA_REPLICA_RACE_MODE");
+        if (string.IsNullOrEmpty(mode))
+            return;
+
+        var databasePath = ReadWorkerValue("AHTOLA_REPLICA_RACE_DATABASE");
+        var startedPath = ReadWorkerValue("AHTOLA_REPLICA_RACE_STARTED");
+        var blockedPath = ReadWorkerValue("AHTOLA_REPLICA_RACE_BLOCKED");
+        var completedPath = ReadWorkerValue("AHTOLA_REPLICA_RACE_COMPLETED");
+        File.WriteAllText(startedPath, string.Empty);
+
+        if (mode == "publication")
+        {
+            using var probeTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            IAsyncDisposable? probePushLease = null;
+            IAsyncDisposable? probeApplyLease = null;
+            try
+            {
+                probePushLease = await ManagedReplicaPushLock
+                    .AcquireExclusiveAsync(databasePath, probeTimeout.Token)
+                    .ConfigureAwait(false);
+                probeApplyLease = await ManagedReplicaApplyLock
+                    .AcquireExclusiveAsync(databasePath, probeTimeout.Token)
+                    .ConfigureAwait(false);
+                File.WriteAllText(completedPath, "publication-acquired-without-blocking");
+                return;
+            }
+            catch (OperationCanceledException) when (probeTimeout.IsCancellationRequested)
+            {
+                File.WriteAllText(blockedPath, "blocked");
+            }
+            finally
+            {
+                if (probeApplyLease is not null)
+                    await probeApplyLease.DisposeAsync().ConfigureAwait(false);
+                if (probePushLease is not null)
+                    await probePushLease.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        await using var pushLease = await ManagedReplicaPushLock
+            .AcquireExclusiveAsync(databasePath, CancellationToken.None)
+            .ConfigureAwait(false);
+        await using var applyLease = await ManagedReplicaApplyLock
+            .AcquireExclusiveAsync(databasePath, CancellationToken.None)
+            .ConfigureAwait(false);
+
+        if (mode is "record-conflict" or "change-conflict")
+        {
+            ManagedReplicaConflictState.Write(
+                databasePath,
+                new ManagedReplicaConflictState(
+                    mode == "record-conflict"
+                        ? AhtolaReplicaConflictKind.RowWrite
+                        : AhtolaReplicaConflictKind.SchemaChange,
+                    mode,
+                    ConflictingSequence: 1,
+                    BatchFirstSequence: 1,
+                    BatchWatermark: 2,
+                    UnresolvedSequences: [1]));
+        }
+        else if (mode != "publication")
+        {
+            throw new InvalidOperationException($"Unknown replica race worker mode '{mode}'.");
+        }
+
+        File.WriteAllText(completedPath, mode);
+    }
+
+    private sealed class CrossProcessReplicaRaceWorker : IDisposable
+    {
+        private readonly Process _worker;
+        private readonly string _blockedPath;
+        private readonly string _completedPath;
+        private readonly string _mode;
+        private readonly StringBuilder _output = new();
+        private bool _completed;
+
+        internal CrossProcessReplicaRaceWorker(
+            string workDirectory,
+            string databasePath,
+            string mode)
+        {
+            _mode = mode;
+            var token = Guid.NewGuid().ToString("N");
+            var startedPath = Path.Combine(workDirectory, $"replica-race-started-{token}");
+            _blockedPath = Path.Combine(workDirectory, $"replica-race-blocked-{token}");
+            _completedPath = Path.Combine(workDirectory, $"replica-race-completed-{token}");
+            var testDirectory = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
+            var startInfo = new ProcessStartInfo(
+                Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ?? "dotnet")
+            {
+                WorkingDirectory = testDirectory.FullName,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+            startInfo.ArgumentList.Add("vstest");
+            startInfo.ArgumentList.Add(Path.Combine(testDirectory.FullName, "Ahtola.Tests.dll"));
+            startInfo.ArgumentList.Add(
+                "--TestCaseFilter:FullyQualifiedName=Ahtola.Tests.ManagedEmbeddedReplicaConnectionTests."
+                + nameof(CrossProcessReplicaRaceWorkerEntryPoint));
+            startInfo.Environment["AHTOLA_REPLICA_RACE_MODE"] = mode;
+            startInfo.Environment["AHTOLA_REPLICA_RACE_DATABASE"] = databasePath;
+            startInfo.Environment["AHTOLA_REPLICA_RACE_STARTED"] = startedPath;
+            startInfo.Environment["AHTOLA_REPLICA_RACE_BLOCKED"] = _blockedPath;
+            startInfo.Environment["AHTOLA_REPLICA_RACE_COMPLETED"] = _completedPath;
+
+            _worker = Process.Start(startInfo)
+                ?? throw new InvalidOperationException("Failed to start the replica race worker.");
+            _worker.OutputDataReceived += AppendOutput;
+            _worker.ErrorDataReceived += AppendOutput;
+            _worker.BeginOutputReadLine();
+            _worker.BeginErrorReadLine();
+            WaitForWorkerFile(
+                startedPath,
+                TimeSpan.FromSeconds(60),
+                "The replica race worker did not report readiness.",
+                _worker);
+        }
+
+        internal void WaitForBlockedProbe()
+        {
+            WaitForWorkerFile(
+                _blockedPath,
+                TimeSpan.FromSeconds(30),
+                "The replacement-generation publication contender acquired without blocking.",
+                _worker);
+            File.ReadAllText(_blockedPath).Should().Be("blocked");
+        }
+
+        internal void WaitForCompletion()
+        {
+            if (_completed)
+                return;
+            _completed = true;
+            if (!_worker.WaitForExit(TimeSpan.FromSeconds(60)))
+            {
+                _worker.Kill(entireProcessTree: true);
+                Assert.Fail(
+                    "The replica race worker did not exit within 60 seconds:"
+                    + Environment.NewLine
+                    + _output);
+            }
+
+            _worker.WaitForExit();
+            _worker.ExitCode.Should().Be(0, $"worker output:{Environment.NewLine}{_output}");
+            File.ReadAllText(_completedPath).Should().Be(_mode);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                WaitForCompletion();
+            }
+            finally
+            {
+                _worker.Dispose();
+            }
+        }
+
+        private void AppendOutput(object sender, DataReceivedEventArgs args)
+        {
+            if (args.Data is { } line)
+                _output.AppendLine(line);
+        }
+    }
+}

--- a/src/Ahtola.Tests/ManagedReplicaPublicationRaceTests.cs
+++ b/src/Ahtola.Tests/ManagedReplicaPublicationRaceTests.cs
@@ -249,7 +249,7 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
                            throw new IOException("Injected replacement reacquisition failure.");
                        }
 
-                       if (boundary == ManagedReplicaDurableBoundary.MainFileRollbackLeasesReleased
+                       if (boundary == ManagedReplicaDurableBoundary.MainFileRollbackDisplacedPreserved
                            && rollbackWriter is null)
                        {
                            rollbackWriter = new CrossProcessReplicaRaceWorker(
@@ -268,9 +268,9 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
                        }
                    }))
             {
-                var exception = Assert.ThrowsAsync<IOException>(
+                var syncException = Assert.ThrowsAsync<IOException>(
                    () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
-                exception!.Message.Should().Be("Injected automatic recovery interruption.");
+                syncException!.Message.Should().Be("Injected automatic recovery interruption.");
             }
 
             rollbackWriter.Should().NotBeNull();
@@ -350,9 +350,9 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
                            }
                        }))
                 {
-                    var exception = Assert.ThrowsAsync<IOException>(
+                    var syncException = Assert.ThrowsAsync<IOException>(
                         () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
-                    exception!.Message.Should().Be("Injected automatic recovery interruption.");
+                    syncException!.Message.Should().Be("Injected automatic recovery interruption.");
                 }
             }
 
@@ -375,10 +375,10 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
     }
 
     [Test]
-    public async Task ColdOpenRollbackPreservesCommittedRestoredGenerationWal()
+    public async Task WindowsRollbackBlocksMainMutatingWritersUntilRecoveryCompletes()
     {
         Assume.That(OperatingSystem.IsWindows(), Is.True);
-        var path = NewReplicaPath("rollback-restored-wal");
+        var path = NewReplicaPath("rollback-main-writer-guard");
         var initialImage = CreateDatabaseImageWithMarker(path + ".initial", 42);
         var updatedImage = CreateDatabaseImageWithMarker(path + ".updated", 84);
         var handler = new PullUpdatesHandler(
@@ -386,65 +386,67 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
             CreatePullResponse("revision-42", initialImage),
             CreatePullResponse("revision-43", updatedImage),
         ]);
-        CrossProcessReplicaRaceWorker? walWriter = null;
-        var rollbackPublished = false;
-        var rollbackReconciled = false;
+        CrossProcessReplicaRaceWorker? deleteWriter = null;
+        CrossProcessReplicaRaceWorker? checkpointWriter = null;
 
         try
         {
-            using (var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler)))
-            {
-                connection.Open();
-                using (ManagedReplicaFaultInjection.Push(boundary =>
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            connection.Open();
+            using (ManagedReplicaFaultInjection.Push(boundary =>
+                   {
+                       if (boundary == ManagedReplicaDurableBoundary.MainFileReplacementPublishedBeforeLease)
                        {
-                           if (boundary == ManagedReplicaDurableBoundary.MainFileReplacementPublishedBeforeLease)
-                           {
-                               throw new IOException("Injected replacement reacquisition failure.");
-                           }
-                           if (boundary == ManagedReplicaDurableBoundary.MainFileRollbackPublishedBeforeLease
-                               && walWriter is null)
-                           {
-                               rollbackPublished = true;
-                               walWriter = new CrossProcessReplicaRaceWorker(
-                                   TestContext.CurrentContext.WorkDirectory,
-                                   path,
-                                   "sqlite-wal-crash");
-                               walWriter.WaitForProbeState("committed");
-                               walWriter.WaitForCrashCompletion();
-                           }
-                           else if (rollbackPublished
-                                    && boundary == ManagedReplicaDurableBoundary.MainFileRollbackSidecarsRestored)
-                           {
-                               rollbackReconciled = true;
-                               throw new IOException("Injected crash after preserving the restored-generation WAL.");
-                           }
-                           else if (rollbackReconciled
-                                    && boundary == ManagedReplicaDurableBoundary.MainFileReplacementRecoveryStarted)
-                           {
-                               throw new IOException("Injected automatic recovery interruption.");
-                           }
-                       }))
-                {
-                    var exception = Assert.ThrowsAsync<IOException>(
-                        () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
-                    exception!.Message.Should().Be("Injected automatic recovery interruption.");
-                }
+                           throw new IOException("Injected replacement reacquisition failure.");
+                       }
+                       if (boundary == ManagedReplicaDurableBoundary.MainFileRollbackRestoredUnderLease
+                           && deleteWriter is null)
+                       {
+                           deleteWriter = new CrossProcessReplicaRaceWorker(
+                               TestContext.CurrentContext.WorkDirectory,
+                               path,
+                               "sqlite-delete-commit");
+                           checkpointWriter = new CrossProcessReplicaRaceWorker(
+                               TestContext.CurrentContext.WorkDirectory,
+                               path,
+                               "sqlite-wal-checkpoint-commit");
+                           deleteWriter.WaitForBlockedProbe();
+                           checkpointWriter.WaitForBlockedProbe();
+                       }
+                   }))
+            {
+                var exception = Assert.ThrowsAsync<IOException>(
+                    () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+                exception!.Message.Should().Be("Injected replacement reacquisition failure.");
             }
 
-            walWriter.Should().NotBeNull();
-            File.Exists(path + "-wal").Should().BeTrue();
-            File.Exists(ManagedReplicaReplacementState.GetDisplacedPath(path)).Should().BeTrue();
-            ManagedReplicaReplacementState.HasArtifacts(path).Should().BeTrue();
+            deleteWriter.Should().NotBeNull();
+            checkpointWriter.Should().NotBeNull();
+            ManagedReplicaReplacementState.HasArtifacts(path).Should().BeFalse(
+                "rollback recovery must complete before either writer is released");
 
+            connection.Dispose();
+            deleteWriter!.ReleaseBlockedProbe();
+            deleteWriter.WaitForCompletion();
+            checkpointWriter!.ReleaseBlockedProbe();
+            checkpointWriter.WaitForCompletion();
             using var recovered = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
             recovered.Open();
 
-            ReadBootstrapMarker(recovered).Should().Be(126);
-            ManagedReplicaReplacementState.HasArtifacts(path).Should().BeFalse();
+            using (var command = recovered.CreateCommand())
+            {
+                command.CommandText = "SELECT value FROM rollback_delete_writer";
+                Convert.ToInt64(command.ExecuteScalar()).Should().Be(701);
+                command.CommandText = "SELECT value FROM rollback_wal_checkpoint_writer";
+                Convert.ToInt64(command.ExecuteScalar()).Should().Be(702);
+            }
         }
         finally
         {
-            walWriter?.Dispose();
+            deleteWriter?.ReleaseBlockedProbe();
+            checkpointWriter?.ReleaseBlockedProbe();
+            deleteWriter?.Dispose();
+            checkpointWriter?.Dispose();
             DeleteReplicaFiles(path);
         }
     }
@@ -495,9 +497,9 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
                            }
                        }))
                 {
-                    var exception = Assert.ThrowsAsync<IOException>(
+                    var syncException = Assert.ThrowsAsync<IOException>(
                         () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
-                    exception!.Message.Should().Be("Injected automatic recovery interruption.");
+                    syncException!.Message.Should().Be("Injected automatic recovery interruption.");
                 }
             }
 
@@ -594,9 +596,10 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
         }
     }
 
-    [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileRollbackLeasesReleased))]
+    [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileRollbackDisplacedPreserved))]
     [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileRollbackSidecarsQuarantined))]
-    [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileRollbackPublishedBeforeLease))]
+    [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileRollbackRestoreStarted))]
+    [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileRollbackRestoredUnderLease))]
     [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileRollbackDatabaseRestored))]
     [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileRollbackSidecarsRestored))]
     [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileRollbackIntentRetired))]
@@ -670,6 +673,91 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
     }
 
     [Test]
+    public async Task ColdOpenFailsClosedForACommitAfterInterruptedInPlaceRollback()
+    {
+        Assume.That(OperatingSystem.IsWindows(), Is.True);
+        var path = NewReplicaPath("rollback-interrupted-external-commit");
+        var initialImage = CreateDatabaseImageWithMarker(path + ".initial", 42);
+        var updatedImage = CreateDatabaseImageWithMarker(path + ".updated", 84);
+        var handler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", initialImage),
+            CreatePullResponse("revision-43", updatedImage),
+        ]);
+        var forwardInterrupted = false;
+        var rollbackInterrupted = false;
+        var externalWriterCommitted = false;
+
+        try
+        {
+            using (var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler)))
+            {
+                connection.Open();
+                using (ManagedReplicaFaultInjection.Push(boundary =>
+                       {
+                           if (!forwardInterrupted
+                               && boundary == ManagedReplicaDurableBoundary.MainFileReplacementPublishedBeforeLease)
+                           {
+                               forwardInterrupted = true;
+                               throw new IOException("Injected forward handoff interruption.");
+                           }
+                           if (forwardInterrupted
+                               && !rollbackInterrupted
+                               && boundary == ManagedReplicaDurableBoundary.MainFileRollbackRestoreStarted)
+                           {
+                               rollbackInterrupted = true;
+                               throw new IOException("Injected interrupted in-place rollback.");
+                           }
+                           if (rollbackInterrupted
+                               && boundary == ManagedReplicaDurableBoundary.MainFileReplacementRecoveryStarted)
+                           {
+                               throw new IOException("Injected automatic recovery interruption.");
+                           }
+                       }))
+                {
+                    var exception = Assert.ThrowsAsync<IOException>(
+                        () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+                    exception!.Message.Should().Be("Injected automatic recovery interruption.");
+                }
+            }
+
+            using var recovered = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            using (ManagedReplicaFaultInjection.Push(boundary =>
+                   {
+                       if (boundary
+                               != ManagedReplicaDurableBoundary.MainFileReplacementRecoveryClassifiedBeforeLease
+                           || externalWriterCommitted)
+                       {
+                           return;
+                       }
+
+                       using var writer = new NativeSqliteConnection(
+                           $"Data Source={path};Mode=ReadWriteCreate;Pooling=False");
+                       writer.Open();
+                       using var command = writer.CreateCommand();
+                       command.CommandText =
+                           "CREATE TABLE external_rollback_writer(value INTEGER);"
+                           + " INSERT INTO external_rollback_writer VALUES (126);";
+                       command.ExecuteNonQuery();
+                       externalWriterCommitted = true;
+                   }))
+            {
+                var recoveryException = Assert.Throws<InvalidDataException>(() => recovered.Open());
+                recoveryException!.Message.Should().Contain("unrecognized database image");
+            }
+
+            externalWriterCommitted.Should().BeTrue();
+            ManagedReplicaReplacementState.HasArtifacts(path).Should().BeTrue();
+            File.ReadAllBytes(ManagedReplicaReplacementState.GetBackupPath(path))
+                .Should().Equal(initialImage);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
     public async Task SameProcessRetryRecoversAnInterruptedWindowsRollbackWithoutReenteringTheMainFileLease()
     {
         Assume.That(OperatingSystem.IsWindows(), Is.True);
@@ -698,7 +786,7 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
                            throw new IOException("Injected forward handoff interruption.");
                        }
                        if (!rollbackInterrupted
-                           && boundary == ManagedReplicaDurableBoundary.MainFileRollbackLeasesReleased)
+                           && boundary == ManagedReplicaDurableBoundary.MainFileRollbackDisplacedPreserved)
                        {
                            rollbackInterrupted = true;
                            throw new IOException("Injected rollback interruption.");
@@ -1419,6 +1507,29 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
             return;
         }
 
+        if (mode is "sqlite-delete-commit" or "sqlite-wal-checkpoint-commit")
+        {
+            try
+            {
+                CommitOrdinarySqliteMainMutation(databasePath, mode, timeoutSeconds: 1);
+                File.WriteAllText(completedPath, $"{mode}-acquired-without-blocking");
+                return;
+            }
+            catch (Microsoft.Data.Sqlite.SqliteException exception)
+                when (exception.SqliteErrorCode is 5 or 6 or 8)
+            {
+                File.WriteAllText(blockedPath, "blocked");
+            }
+
+            WaitForWorkerFile(
+                releasePath,
+                TimeSpan.FromSeconds(30),
+                "The main-mutating SQLite writer was not released after rollback recovery.");
+            CommitOrdinarySqliteMainMutation(databasePath, mode, timeoutSeconds: 30);
+            File.WriteAllText(completedPath, mode);
+            return;
+        }
+
         if (mode == "publication")
         {
             using var probeTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(2));
@@ -1488,6 +1599,33 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
         command.CommandText = "UPDATE bootstrap_marker SET value = value;";
         command.ExecuteNonQuery().Should().Be(1);
         transaction.Rollback();
+    }
+
+    private static void CommitOrdinarySqliteMainMutation(
+        string databasePath,
+        string mode,
+        int timeoutSeconds)
+    {
+        using var connection = new NativeSqliteConnection(
+            $"Data Source={databasePath};Mode=ReadWrite;Default Timeout={timeoutSeconds};Pooling=False");
+        connection.Open();
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText = mode == "sqlite-delete-commit"
+                ? "PRAGMA journal_mode=DELETE;"
+                : "PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=1;";
+            command.ExecuteNonQuery();
+        }
+        using var transaction = connection.BeginTransaction();
+        using var mutation = connection.CreateCommand();
+        mutation.Transaction = transaction;
+        mutation.CommandText = mode == "sqlite-delete-commit"
+            ? "CREATE TABLE rollback_delete_writer(value INTEGER);"
+              + " INSERT INTO rollback_delete_writer VALUES (701);"
+            : "CREATE TABLE rollback_wal_checkpoint_writer(value INTEGER);"
+              + " INSERT INTO rollback_wal_checkpoint_writer VALUES (702);";
+        mutation.ExecuteNonQuery();
+        transaction.Commit();
     }
 
     private sealed class CrossProcessReplicaRaceWorker : IDisposable

--- a/src/Ahtola.Tests/ManagedReplicaPublicationRaceTests.cs
+++ b/src/Ahtola.Tests/ManagedReplicaPublicationRaceTests.cs
@@ -107,6 +107,56 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
     }
 
     [Test]
+    public async Task ReplacementIntentIsCapturedUnderOrdinarySqliteWriteExclusion()
+    {
+        var path = NewReplicaPath("replace-intent-sqlite-lock");
+        var initialImage = CreateDatabaseImageWithMarker(path + ".initial", 42);
+        var updatedImage = CreateDatabaseImageWithMarker(path + ".updated", 84);
+        var handler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", initialImage),
+            CreatePullResponse("revision-43", updatedImage),
+        ]);
+        CrossProcessReplicaRaceWorker? contender = null;
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            connection.Open();
+            using (ManagedReplicaFaultInjection.Push(boundary =>
+                   {
+                       if (boundary != ManagedReplicaDurableBoundary.MainFileReplacementIntentPublished
+                           || contender is not null)
+                       {
+                           return;
+                       }
+
+                       contender = new CrossProcessReplicaRaceWorker(
+                           TestContext.CurrentContext.WorkDirectory,
+                           path,
+                           "sqlite-write");
+                       contender.WaitForBlockedProbe();
+                   }))
+            {
+                var result = await connection.SyncAsync(
+                    new AhtolaSyncOptions(),
+                    CancellationToken.None);
+                result.Outcome.Should().Be(AhtolaSyncOutcome.RemoteChangesApplied);
+            }
+
+            contender.Should().NotBeNull();
+            contender!.ReleaseBlockedProbe();
+            contender.WaitForCompletion();
+            ReadBootstrapMarker(connection).Should().Be(84);
+        }
+        finally
+        {
+            contender?.Dispose();
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
     public async Task WindowsReplacementHandoffsRemainContentionSafeForOrdinarySqliteWriters()
     {
         Assume.That(OperatingSystem.IsWindows(), Is.True);
@@ -186,6 +236,7 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
             CreatePullResponse("revision-43", updatedImage),
         ]);
         CrossProcessReplicaRaceWorker? rollbackWriter = null;
+        var rollbackInterrupted = false;
 
         try
         {
@@ -207,32 +258,440 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
                            rollbackWriter.WaitForProbeState("acquired");
                            rollbackWriter.ReleaseBlockedProbe();
                            rollbackWriter.WaitForCompletion();
+                           rollbackInterrupted = true;
                            throw new IOException("Injected rollback handoff interruption.");
+                       }
+
+                       if (rollbackInterrupted
+                           && boundary == ManagedReplicaDurableBoundary.MainFileReplacementRecoveryStarted)
+                       {
+                           throw new IOException("Injected automatic recovery interruption.");
                        }
                    }))
             {
                 var exception = Assert.ThrowsAsync<IOException>(
-                    () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
-                exception!.Message.Should().Be("Injected rollback handoff interruption.");
+                   () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+                exception!.Message.Should().Be("Injected automatic recovery interruption.");
             }
 
             rollbackWriter.Should().NotBeNull();
-            Directory.GetFiles(
-                    Path.GetDirectoryName(path)!,
-                    $".{Path.GetFileName(path)}.apply-*.bak")
-                .Should().ContainSingle(
-                    "an interrupted rollback must retain the old database image for recovery");
+            File.Exists(ManagedReplicaReplacementState.GetBackupPath(path)).Should().BeTrue(
+                "an interrupted rollback must retain the deterministic old-image backup");
+            File.Exists(path + ManagedReplicaReplacementState.IntentSuffix).Should().BeTrue(
+                "the backup must remain discoverable through durable replacement intent");
             ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.Revision.Should().Be("revision-42");
+
+            connection.Dispose();
+            using var recovered = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            recovered.Open();
+
+            ReadBootstrapMarker(recovered).Should().Be(42);
+            recovered.Dispose();
+            File.ReadAllBytes(path).Should().Equal(initialImage);
+            ManagedReplicaReplacementState.HasArtifacts(path).Should().BeFalse();
         }
         finally
         {
             rollbackWriter?.Dispose();
-            foreach (var backupPath in Directory.GetFiles(
-                         Path.GetDirectoryName(path)!,
-                         $".{Path.GetFileName(path)}.apply-*.bak"))
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileReplacementIntentPublished), 42)]
+    [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileReplacementSourceLeaseReleased), 42)]
+    [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileReplacementPublishedBeforeLease), 42)]
+    [TestCase(nameof(ManagedReplicaDurableBoundary.IncrementalApplyDatabasePublished), 42)]
+    [TestCase(nameof(ManagedReplicaDurableBoundary.IncrementalApplyMetadataPublished), 84)]
+    [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileReplacementBackupRetired), 84)]
+    [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileReplacementIntentRetired), 84)]
+    public async Task ColdOpenRecoversEveryWindowsReplacementPublicationPhase(
+        string interruptedBoundaryName,
+        long expectedMarker)
+    {
+        Assume.That(OperatingSystem.IsWindows(), Is.True);
+        var interruptedBoundary = Enum.Parse<ManagedReplicaDurableBoundary>(interruptedBoundaryName);
+        var path = NewReplicaPath($"replace-cold-open-{interruptedBoundary}");
+        var initialImage = CreateDatabaseImageWithMarker(path + ".initial", 42);
+        var updatedImage = CreateDatabaseImageWithMarker(path + ".updated", 84);
+        var handler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", initialImage),
+            CreatePullResponse("revision-43", updatedImage),
+        ]);
+        var phaseInterrupted = false;
+        var automaticRecoveryInterrupted = false;
+
+        try
+        {
+            using (var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler)))
             {
-                File.Delete(backupPath);
+                connection.Open();
+                using (ManagedReplicaFaultInjection.Push(boundary =>
+                       {
+                           if (!phaseInterrupted && boundary == interruptedBoundary)
+                           {
+                               phaseInterrupted = true;
+                               throw new IOException($"Interrupted at {boundary}.");
+                           }
+                           if (phaseInterrupted
+                               && boundary == ManagedReplicaDurableBoundary.MainFileReplacementRecoveryStarted)
+                           {
+                               automaticRecoveryInterrupted = true;
+                               throw new IOException("Interrupted automatic replacement recovery.");
+                           }
+                       }))
+                {
+                    var exception = Assert.ThrowsAsync<IOException>(
+                        () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+                    exception!.Message.Should().Be(
+                        automaticRecoveryInterrupted
+                            ? "Interrupted automatic replacement recovery."
+                            : $"Interrupted at {interruptedBoundary}.");
+                }
             }
+
+            using var recovered = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            recovered.Open();
+
+            ReadBootstrapMarker(recovered).Should().Be(expectedMarker);
+            ManagedReplicaReplacementState.HasArtifacts(path).Should().BeFalse();
+            var expectedRevision = expectedMarker == 42 ? "revision-42" : "revision-43";
+            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.Revision.Should().Be(expectedRevision);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileRollbackLeasesReleased))]
+    [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileRollbackDatabaseRestored))]
+    [TestCase(nameof(ManagedReplicaDurableBoundary.MainFileRollbackIntentRetired))]
+    public async Task ColdOpenRecoversEveryWindowsReplacementRollbackPhase(
+        string interruptedBoundaryName)
+    {
+        Assume.That(OperatingSystem.IsWindows(), Is.True);
+        var interruptedBoundary = Enum.Parse<ManagedReplicaDurableBoundary>(interruptedBoundaryName);
+        var path = NewReplicaPath($"rollback-cold-open-{interruptedBoundary}");
+        var initialImage = CreateDatabaseImageWithMarker(path + ".initial", 42);
+        var updatedImage = CreateDatabaseImageWithMarker(path + ".updated", 84);
+        var handler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", initialImage),
+            CreatePullResponse("revision-43", updatedImage),
+        ]);
+        var forwardInterrupted = false;
+        var rollbackInterrupted = false;
+        var automaticRecoveryInterrupted = false;
+
+        try
+        {
+            using (var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler)))
+            {
+                connection.Open();
+                using (ManagedReplicaFaultInjection.Push(boundary =>
+                       {
+                           if (!forwardInterrupted
+                               && boundary == ManagedReplicaDurableBoundary.MainFileReplacementPublishedBeforeLease)
+                           {
+                               forwardInterrupted = true;
+                               throw new IOException("Injected forward handoff interruption.");
+                           }
+                           if (forwardInterrupted
+                               && !rollbackInterrupted
+                               && boundary == interruptedBoundary)
+                           {
+                               rollbackInterrupted = true;
+                               throw new IOException($"Interrupted at {boundary}.");
+                           }
+                           if (rollbackInterrupted
+                               && boundary == ManagedReplicaDurableBoundary.MainFileReplacementRecoveryStarted)
+                           {
+                               automaticRecoveryInterrupted = true;
+                               throw new IOException("Interrupted automatic replacement recovery.");
+                           }
+                       }))
+                {
+                    var exception = Assert.ThrowsAsync<IOException>(
+                        () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+                    exception!.Message.Should().Be(
+                        automaticRecoveryInterrupted
+                            ? "Interrupted automatic replacement recovery."
+                            : $"Interrupted at {interruptedBoundary}.");
+                }
+            }
+
+            using var recovered = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            recovered.Open();
+
+            ReadBootstrapMarker(recovered).Should().Be(42);
+            recovered.Dispose();
+            File.ReadAllBytes(path).Should().Equal(initialImage);
+            ManagedReplicaReplacementState.HasArtifacts(path).Should().BeFalse();
+            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.Revision.Should().Be("revision-42");
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task SameProcessRetryRecoversAnInterruptedWindowsRollbackWithoutReenteringTheMainFileLease()
+    {
+        Assume.That(OperatingSystem.IsWindows(), Is.True);
+        var path = NewReplicaPath("rollback-same-process-retry");
+        var initialImage = CreateDatabaseImageWithMarker(path + ".initial", 42);
+        var updatedImage = CreateDatabaseImageWithMarker(path + ".updated", 84);
+        var handler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", initialImage),
+            CreatePullResponse("revision-43", updatedImage),
+            CreatePullResponse("revision-43", updatedImage),
+        ]);
+        var forwardInterrupted = false;
+        var rollbackInterrupted = false;
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            connection.Open();
+            using (ManagedReplicaFaultInjection.Push(boundary =>
+                   {
+                       if (!forwardInterrupted
+                           && boundary == ManagedReplicaDurableBoundary.MainFileReplacementPublishedBeforeLease)
+                       {
+                           forwardInterrupted = true;
+                           throw new IOException("Injected forward handoff interruption.");
+                       }
+                       if (!rollbackInterrupted
+                           && boundary == ManagedReplicaDurableBoundary.MainFileRollbackLeasesReleased)
+                       {
+                           rollbackInterrupted = true;
+                           throw new IOException("Injected rollback interruption.");
+                       }
+                   }))
+            {
+                Assert.ThrowsAsync<IOException>(
+                    () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+            }
+
+            var result = await connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None)
+                .WaitAsync(TimeSpan.FromSeconds(30));
+
+            result.Outcome.Should().Be(AhtolaSyncOutcome.RemoteChangesApplied);
+            ReadBootstrapMarker(connection).Should().Be(84);
+            ManagedReplicaReplacementState.HasArtifacts(path).Should().BeFalse();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task FailedPublicationReopenRecoversAPreSwapReplacementIntent()
+    {
+        var path = NewReplicaPath("replace-reopen-recovery");
+        var initialImage = CreateDatabaseImageWithMarker(path + ".initial", 42);
+        var updatedImage = CreateDatabaseImageWithMarker(path + ".updated", 84);
+        var handler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", initialImage),
+            CreatePullResponse("revision-43", updatedImage),
+        ]);
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            connection.Open();
+            using (ManagedReplicaFaultInjection.Push(boundary =>
+                   {
+                       if (boundary == ManagedReplicaDurableBoundary.MainFileReplacementIntentPublished)
+                           throw new IOException("Injected pre-swap publication interruption.");
+                   }))
+            {
+                var exception = Assert.ThrowsAsync<IOException>(
+                    () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+                exception!.Message.Should().Be("Injected pre-swap publication interruption.");
+            }
+
+            ManagedReplicaReplacementState.HasArtifacts(path).Should().BeFalse(
+                "failed publication reopen must recover replacement state before exposing the database");
+            ReadBootstrapMarker(connection).Should().Be(42);
+            using var command = connection.CreateCommand();
+            command.CommandText = "CREATE TABLE post_recovery(value INTEGER)";
+            command.ExecuteNonQuery();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public void ColdOpenFailsClosedForAReplacementBackupWithoutIntent()
+    {
+        var path = NewReplicaPath("replacement-backup-without-intent");
+        var image = CreateDatabaseImageWithMarker(path + ".initial", 42);
+        var handler = new PullUpdatesHandler(CreatePullResponse("revision-42", image));
+
+        try
+        {
+            using (var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler)))
+                connection.Open();
+            File.Copy(path, ManagedReplicaReplacementState.GetBackupPath(path));
+
+            Action reopen = () =>
+            {
+                using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+                connection.Open();
+            };
+
+            reopen.Should().Throw<InvalidDataException>()
+                .WithMessage("*backup without its durable intent*");
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public void ColdOpenFailsClosedForACorruptReplacementIntent()
+    {
+        var path = NewReplicaPath("corrupt-replacement-intent");
+        var image = CreateDatabaseImageWithMarker(path + ".initial", 42);
+        var handler = new PullUpdatesHandler(CreatePullResponse("revision-42", image));
+
+        try
+        {
+            using (var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler)))
+                connection.Open();
+            File.WriteAllText(
+                path + ManagedReplicaReplacementState.IntentSuffix,
+                "not-a-valid-intent");
+
+            Action reopen = () =>
+            {
+                using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+                connection.Open();
+            };
+
+            reopen.Should().Throw<InvalidDataException>()
+                .WithMessage("*intent is invalid or corrupt*");
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void ColdOpenFailsClosedForAMissingOrCorruptReplacementBackup(bool corruptBackup)
+    {
+        var path = NewReplicaPath(corruptBackup
+            ? "corrupt-replacement-backup"
+            : "missing-replacement-backup");
+        var initialImage = CreateDatabaseImageWithMarker(path + ".initial", 42);
+        var updatedImage = CreateDatabaseImageWithMarker(path + ".updated", 84);
+        var handler = new PullUpdatesHandler(CreatePullResponse("revision-42", initialImage));
+        var stagingPath = path + ".replacement.tmp";
+        var backupPath = ManagedReplicaReplacementState.GetBackupPath(path);
+
+        try
+        {
+            using (var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler)))
+                connection.Open();
+            File.WriteAllBytes(stagingPath, updatedImage);
+            ManagedReplicaReplacementState.Prepare(path, stagingPath);
+            File.Replace(stagingPath, path, backupPath);
+            if (corruptBackup)
+                File.WriteAllText(backupPath, "corrupt");
+            else
+                File.Delete(backupPath);
+
+            Action reopen = () =>
+            {
+                using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+                connection.Open();
+            };
+
+            reopen.Should().Throw<InvalidDataException>()
+                .WithMessage(corruptBackup
+                    ? "*backup is missing or corrupt*"
+                    : "*backup is missing*");
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+            if (File.Exists(stagingPath))
+                File.Delete(stagingPath);
+        }
+    }
+
+    [Test]
+    public void LocalArtifactEnumerationIncludesReplacementRecoveryState()
+    {
+        var path = NewReplicaPath("replacement-artifact-enumeration");
+
+        ManagedReplicaBootstrapper.GetLocalArtifactPaths(path).Should().Contain(
+            ManagedReplicaReplacementState.GetArtifactPaths(path));
+    }
+
+    [Test]
+    public void CaseInsensitiveFileSystemsAcceptEquivalentReplacementPathCasing()
+    {
+        Assume.That(OperatingSystem.IsWindows() || OperatingSystem.IsMacOS(), Is.True);
+        var path = NewReplicaPath("replacement-path-case");
+        var image = CreateDatabaseImageWithMarker(path + ".initial", 42);
+        var handler = new PullUpdatesHandler(CreatePullResponse("revision-42", image));
+        var stagingPath = path + ".replacement";
+
+        try
+        {
+            using (var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler)))
+                connection.Open();
+            File.Copy(path, stagingPath);
+            ManagedReplicaReplacementState.Prepare(path, stagingPath);
+
+            var equivalentPath = path.ToUpperInvariant();
+            ManagedReplicaReplacementState.HasArtifacts(equivalentPath).Should().BeTrue();
+            ManagedReplicaReplacementState.Recover(equivalentPath);
+
+            ManagedReplicaReplacementState.HasArtifacts(path).Should().BeFalse();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public void WindowsReplacementIntentSupportsLongUnicodeFilenames()
+    {
+        Assume.That(OperatingSystem.IsWindows(), Is.True);
+        var path = Path.Combine(
+            TestContext.CurrentContext.WorkDirectory,
+            $"{new string('\u754c', 130)}-{Guid.NewGuid():N}.db");
+        var image = CreateDatabaseImageWithMarker(path + ".initial", 42);
+        var handler = new PullUpdatesHandler(CreatePullResponse("revision-42", image));
+        var stagingPath = path + ".replacement";
+
+        try
+        {
+            using (var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler)))
+                connection.Open();
+            File.Copy(path, stagingPath);
+            ManagedReplicaReplacementState.Prepare(path, stagingPath);
+
+            ManagedReplicaReplacementState.Recover(path);
+
+            ManagedReplicaReplacementState.HasArtifacts(path).Should().BeFalse();
+        }
+        finally
+        {
             DeleteReplicaFiles(path);
         }
     }

--- a/src/Ahtola.Tests/ManagedReplicaPublicationRaceTests.cs
+++ b/src/Ahtola.Tests/ManagedReplicaPublicationRaceTests.cs
@@ -107,6 +107,220 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
     }
 
     [Test]
+    public async Task WindowsReplacementHandoffsRemainContentionSafeForOrdinarySqliteWriters()
+    {
+        Assume.That(OperatingSystem.IsWindows(), Is.True);
+        var path = NewReplicaPath("replace-windows-handoff");
+        var initialImage = CreateDatabaseImageWithMarker(path + ".initial", 42);
+        var updatedImage = CreateDatabaseImageWithMarker(path + ".updated", 84);
+        var handler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", initialImage),
+            CreatePullResponse("revision-43", updatedImage),
+        ]);
+        CrossProcessReplicaRaceWorker? sourceGapWriter = null;
+        CrossProcessReplicaRaceWorker? publishedGapWriter = null;
+        Task? releasePublishedWriter = null;
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            connection.Open();
+            using (ManagedReplicaFaultInjection.Push(boundary =>
+                   {
+                       if (boundary == ManagedReplicaDurableBoundary.MainFileReplacementSourceLeaseReleased
+                           && sourceGapWriter is null)
+                       {
+                           sourceGapWriter = new CrossProcessReplicaRaceWorker(
+                               TestContext.CurrentContext.WorkDirectory,
+                               path,
+                               "sqlite-write");
+                           sourceGapWriter.WaitForBlockedProbe();
+                       }
+                       else if (boundary == ManagedReplicaDurableBoundary.MainFileReplacementPublishedBeforeLease
+                                && publishedGapWriter is null)
+                       {
+                           publishedGapWriter = new CrossProcessReplicaRaceWorker(
+                               TestContext.CurrentContext.WorkDirectory,
+                               path,
+                               "sqlite-hold");
+                           publishedGapWriter.WaitForProbeState("acquired");
+                           releasePublishedWriter = Task.Run(async () =>
+                           {
+                               await Task.Delay(500).ConfigureAwait(false);
+                               publishedGapWriter.ReleaseBlockedProbe();
+                           });
+                       }
+                   }))
+            {
+                var result = await connection.SyncAsync(
+                    new AhtolaSyncOptions(),
+                    CancellationToken.None);
+                result.Outcome.Should().Be(AhtolaSyncOutcome.RemoteChangesApplied);
+            }
+
+            await releasePublishedWriter!.WaitAsync(TimeSpan.FromSeconds(30));
+            publishedGapWriter!.WaitForCompletion();
+            sourceGapWriter!.ReleaseBlockedProbe();
+            sourceGapWriter.WaitForCompletion();
+            ReadBootstrapMarker(connection).Should().Be(84);
+        }
+        finally
+        {
+            sourceGapWriter?.Dispose();
+            publishedGapWriter?.Dispose();
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task WindowsRollbackHandoffPreservesTheRecoverableBackupWhenInterrupted()
+    {
+        Assume.That(OperatingSystem.IsWindows(), Is.True);
+        var path = NewReplicaPath("rollback-windows-handoff");
+        var initialImage = CreateDatabaseImageWithMarker(path + ".initial", 42);
+        var updatedImage = CreateDatabaseImageWithMarker(path + ".updated", 84);
+        var handler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", initialImage),
+            CreatePullResponse("revision-43", updatedImage),
+        ]);
+        CrossProcessReplicaRaceWorker? rollbackWriter = null;
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            connection.Open();
+            using (ManagedReplicaFaultInjection.Push(boundary =>
+                   {
+                       if (boundary == ManagedReplicaDurableBoundary.MainFileReplacementPublishedBeforeLease)
+                       {
+                           throw new IOException("Injected replacement reacquisition failure.");
+                       }
+
+                       if (boundary == ManagedReplicaDurableBoundary.MainFileRollbackLeasesReleased)
+                       {
+                           rollbackWriter = new CrossProcessReplicaRaceWorker(
+                               TestContext.CurrentContext.WorkDirectory,
+                               path,
+                               "sqlite-hold");
+                           rollbackWriter.WaitForProbeState("acquired");
+                           rollbackWriter.ReleaseBlockedProbe();
+                           rollbackWriter.WaitForCompletion();
+                           throw new IOException("Injected rollback handoff interruption.");
+                       }
+                   }))
+            {
+                var exception = Assert.ThrowsAsync<IOException>(
+                    () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+                exception!.Message.Should().Be("Injected rollback handoff interruption.");
+            }
+
+            rollbackWriter.Should().NotBeNull();
+            Directory.GetFiles(
+                    Path.GetDirectoryName(path)!,
+                    $".{Path.GetFileName(path)}.apply-*.bak")
+                .Should().ContainSingle(
+                    "an interrupted rollback must retain the old database image for recovery");
+            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.Revision.Should().Be("revision-42");
+        }
+        finally
+        {
+            rollbackWriter?.Dispose();
+            foreach (var backupPath in Directory.GetFiles(
+                         Path.GetDirectoryName(path)!,
+                         $".{Path.GetFileName(path)}.apply-*.bak"))
+            {
+                File.Delete(backupPath);
+            }
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task ReplacementPhysicalCarriersBlockAHardLinkAliasNoOpPullAfterPublication()
+    {
+        var path = NewReplicaPath("replace-physical-alias");
+        var aliasPath = path + ".alias";
+        var initialImage = CreateDatabaseImageWithMarker(path + ".initial", 42);
+        var updatedImage = CreateDatabaseImageWithMarker(path + ".updated", 84);
+        var handler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", initialImage),
+            CreatePullResponse("revision-43", updatedImage),
+        ]);
+        CrossProcessReplicaRaceWorker? aliasPull = null;
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            connection.Open();
+            using (ManagedReplicaFaultInjection.Push(boundary =>
+                   {
+                       if (boundary == ManagedReplicaDurableBoundary.IncrementalApplyStagedDatabase)
+                       {
+                           var directory = Path.GetDirectoryName(path)!;
+                           var stagingPath = Directory.GetFiles(
+                                   directory,
+                                   $".{Path.GetFileName(path)}.apply-*.tmp")
+                               .Single();
+                           ManagedReplicaJournalAndLockCarrierRegressionTests.RequireHardLink(
+                               aliasPath,
+                               stagingPath,
+                               verifyPhysicalIdentity: false);
+                           using var stream = new FileStream(
+                               stagingPath,
+                               FileMode.Open,
+                               FileAccess.Read,
+                               FileShare.ReadWrite | FileShare.Delete);
+                           var fingerprint = Convert.ToHexString(
+                               System.Security.Cryptography.SHA256.HashData(stream));
+                           var aliasMetadataPath =
+                               aliasPath + ManagedReplicaBootstrapper.MetadataSuffix;
+                           File.Copy(
+                               path + ManagedReplicaBootstrapper.MetadataSuffix,
+                               aliasMetadataPath);
+                           var aliasMetadataStagingPath =
+                               aliasMetadataPath + $".{Guid.NewGuid():N}.tmp";
+                           ManagedReplicaBootstrapper.WriteMetadata(
+                               aliasMetadataStagingPath,
+                               aliasMetadataPath,
+                               ManagedReplicaBootstrapper.LoadMetadata(path)!.Value with
+                               {
+                                   Revision = "revision-43",
+                                   DatabaseSha256 = fingerprint,
+                               });
+                       }
+                       else if (boundary == ManagedReplicaDurableBoundary.IncrementalApplyDatabasePublished)
+                       {
+                           aliasPull = new CrossProcessReplicaRaceWorker(
+                               TestContext.CurrentContext.WorkDirectory,
+                               aliasPath,
+                               "alias-noop-pull");
+                           aliasPull.WaitForBlockedProbe();
+                       }
+                   }))
+            {
+                var result = await connection.SyncAsync(
+                    new AhtolaSyncOptions(),
+                    CancellationToken.None);
+                result.Outcome.Should().Be(AhtolaSyncOutcome.RemoteChangesApplied);
+            }
+
+            aliasPull.Should().NotBeNull();
+            aliasPull!.ReleaseBlockedProbe();
+            aliasPull.WaitForCompletion();
+            ReadBootstrapMarker(connection).Should().Be(84);
+        }
+        finally
+        {
+            aliasPull?.Dispose();
+            DeleteReplicaFiles(aliasPath);
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
     [NonParallelizable]
     public void RepeatedMainFileReplacementDoesNotCreateGuidStagingCarriers()
     {
@@ -139,8 +353,12 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
                 File.Delete(backupPath);
             }
 
-            Directory.Exists(lockDirectory).Should().BeFalse(
-                "private replacement paths use their database inode directly and create no named carriers");
+            var retainedFiles = Directory.Exists(lockDirectory)
+                ? Directory.GetFiles(lockDirectory)
+                : [];
+            retainedFiles.Should().ContainSingle(
+                path => Path.GetFileName(path) == "physical-carrier-registry.lock",
+                "replacement generations reclaim their physical carriers and holder registrations");
         }
         finally
         {
@@ -337,6 +555,62 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
         var releasePath = ReadWorkerValue("AHTOLA_REPLICA_RACE_RELEASE");
         File.WriteAllText(startedPath, string.Empty);
 
+        if (mode == "sqlite-hold")
+        {
+            using var connection = new NativeSqliteConnection(
+                $"Data Source={databasePath};Mode=ReadWrite;Default Timeout=30;Pooling=False");
+            connection.Open();
+            using var transaction = connection.BeginTransaction();
+            using var command = connection.CreateCommand();
+            command.Transaction = transaction;
+            command.CommandText = "UPDATE bootstrap_marker SET value = value;";
+            command.ExecuteNonQuery().Should().Be(1);
+            File.WriteAllText(blockedPath, "acquired");
+            WaitForWorkerFile(
+                releasePath,
+                TimeSpan.FromSeconds(30),
+                "The ordinary SQLite writer was not released from the handoff probe.");
+            transaction.Rollback();
+            File.WriteAllText(completedPath, mode);
+            return;
+        }
+
+        if (mode == "alias-noop-pull")
+        {
+            var metadata = ManagedReplicaBootstrapper.LoadMetadata(databasePath)!.Value;
+            using var probeTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            try
+            {
+                await ManagedReplicaBootstrapper.CheckForUpdatesAsync(
+                        CreateOptions(
+                            databasePath,
+                            new PullUpdatesHandler(
+                                CreatePullResponse(
+                                    metadata.Revision,
+                                    [],
+                                    declaredPages: 1))),
+                        metadata,
+                        new AhtolaSyncOptions(),
+                        pendingLocalChanges: [],
+                        acknowledgedLocalChanges: [],
+                        probeTimeout.Token)
+                    .ConfigureAwait(false);
+                File.WriteAllText(completedPath, "alias-noop-pull-acquired-without-blocking");
+                return;
+            }
+            catch (OperationCanceledException) when (probeTimeout.IsCancellationRequested)
+            {
+                File.WriteAllText(blockedPath, "blocked");
+            }
+
+            WaitForWorkerFile(
+                releasePath,
+                TimeSpan.FromSeconds(30),
+                "The alias no-op pull was not released after publication.");
+            File.WriteAllText(completedPath, mode);
+            return;
+        }
+
         if (mode == "sqlite-write")
         {
             try
@@ -345,6 +619,7 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
                 File.WriteAllText(completedPath, "sqlite-write-acquired-without-blocking");
                 return;
             }
+
             catch (Microsoft.Data.Sqlite.SqliteException exception)
                 when (exception.SqliteErrorCode is 5 or 6)
             {
@@ -488,13 +763,16 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
         }
 
         internal void WaitForBlockedProbe()
+            => WaitForProbeState("blocked");
+
+        internal void WaitForProbeState(string expected)
         {
             WaitForWorkerFile(
                 _blockedPath,
                 TimeSpan.FromSeconds(30),
                 "The replacement-generation publication contender acquired without blocking.",
                 _worker);
-            File.ReadAllText(_blockedPath).Should().Be("blocked");
+            File.ReadAllText(_blockedPath).Should().Be(expected);
         }
 
         internal void ReleaseBlockedProbe()

--- a/src/Ahtola.Tests/ManagedReplicaPublicationRaceTests.cs
+++ b/src/Ahtola.Tests/ManagedReplicaPublicationRaceTests.cs
@@ -672,6 +672,90 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
         }
     }
 
+    [TestCase("sqlite-delete-commit")]
+    [TestCase("sqlite-wal-checkpoint-commit")]
+    public async Task ColdOpenRestoresRollbackWhoseDisplacedGenerationWasDurablyRecorded(
+        string writerMode)
+    {
+        Assume.That(OperatingSystem.IsWindows(), Is.True);
+        var path = NewReplicaPath($"rollback-recorded-displaced-{writerMode}");
+        var initialImage = CreateDatabaseImageWithMarker(path + ".initial", 42);
+        var updatedImage = CreateDatabaseImageWithMarker(path + ".updated", 84);
+        var handler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", initialImage),
+            CreatePullResponse("revision-43", updatedImage),
+        ]);
+
+        try
+        {
+            await InterruptRollbackAfterPreservingMutatedReplacementAsync(
+                path,
+                handler,
+                writerMode);
+
+            File.ReadAllBytes(path).Should().NotEqual(updatedImage);
+            File.Exists(ManagedReplicaReplacementState.GetDisplacedPath(path)).Should().BeTrue();
+            File.Exists(path + ManagedReplicaReplacementState.DisplacedSha256Suffix).Should().BeTrue();
+
+            using var recovered = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            recovered.Open();
+
+            ReadBootstrapMarker(recovered).Should().Be(42);
+            recovered.Dispose();
+            File.ReadAllBytes(path).Should().Equal(initialImage);
+            ManagedReplicaReplacementState.HasArtifacts(path).Should().BeFalse();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task ColdOpenRejectsMutationAfterDisplacedGenerationWasDurablyRecorded()
+    {
+        Assume.That(OperatingSystem.IsWindows(), Is.True);
+        var path = NewReplicaPath("rollback-recorded-displaced-mutation");
+        var initialImage = CreateDatabaseImageWithMarker(path + ".initial", 42);
+        var updatedImage = CreateDatabaseImageWithMarker(path + ".updated", 84);
+        var handler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", initialImage),
+            CreatePullResponse("revision-43", updatedImage),
+        ]);
+
+        try
+        {
+            await InterruptRollbackAfterPreservingMutatedReplacementAsync(
+                path,
+                handler,
+                "sqlite-wal-checkpoint-commit");
+
+            using (var writer = new NativeSqliteConnection(
+                       $"Data Source={path};Mode=ReadWriteCreate;Pooling=False"))
+            {
+                writer.Open();
+                using var command = writer.CreateCommand();
+                command.CommandText =
+                    "CREATE TABLE unrelated_displaced_writer(value INTEGER);"
+                    + " INSERT INTO unrelated_displaced_writer VALUES (127);";
+                command.ExecuteNonQuery();
+            }
+
+            using var recovered = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            var exception = Assert.Throws<InvalidDataException>(() => recovered.Open());
+            exception!.Message.Should().Contain("unrecognized database image");
+            ManagedReplicaReplacementState.HasArtifacts(path).Should().BeTrue();
+            File.ReadAllBytes(ManagedReplicaReplacementState.GetBackupPath(path))
+                .Should().Equal(initialImage);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
     [Test]
     public async Task ColdOpenFailsClosedForACommitAfterInterruptedInPlaceRollback()
     {
@@ -1628,6 +1712,59 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
         transaction.Commit();
     }
 
+    private static async Task InterruptRollbackAfterPreservingMutatedReplacementAsync(
+        string path,
+        PullUpdatesHandler handler,
+        string writerMode)
+    {
+        CrossProcessReplicaRaceWorker? writer = null;
+        var replacementMutated = false;
+        var rollbackInterrupted = false;
+
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            connection.Open();
+            using (ManagedReplicaFaultInjection.Push(boundary =>
+                   {
+                       if (boundary
+                               == ManagedReplicaDurableBoundary.MainFileReplacementPublishedBeforeLease
+                           && writer is null)
+                       {
+                           writer = new CrossProcessReplicaRaceWorker(
+                               TestContext.CurrentContext.WorkDirectory,
+                               path,
+                               writerMode);
+                           writer.WaitForUnblockedCompletion();
+                           replacementMutated = true;
+                       }
+                       else if (replacementMutated
+                                && !rollbackInterrupted
+                                && boundary
+                                    == ManagedReplicaDurableBoundary.MainFileRollbackDisplacedPreserved)
+                       {
+                           rollbackInterrupted = true;
+                           throw new IOException("Injected crash after preserving the displaced database.");
+                       }
+                       else if (rollbackInterrupted
+                                && boundary
+                                    == ManagedReplicaDurableBoundary.MainFileReplacementRecoveryStarted)
+                       {
+                           throw new IOException("Injected automatic recovery interruption.");
+                       }
+                   }))
+            {
+                var exception = Assert.ThrowsAsync<IOException>(
+                    () => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+                exception!.Message.Should().Be("Injected automatic recovery interruption.");
+            }
+        }
+        finally
+        {
+            writer?.Dispose();
+        }
+    }
+
     private sealed class CrossProcessReplicaRaceWorker : IDisposable
     {
         private readonly Process _worker;
@@ -1701,6 +1838,12 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
             => File.WriteAllText(_releasePath, string.Empty);
 
         internal void WaitForCompletion()
+            => WaitForCompletion(_mode);
+
+        internal void WaitForUnblockedCompletion()
+            => WaitForCompletion($"{_mode}-acquired-without-blocking");
+
+        private void WaitForCompletion(string expectedResult)
         {
             if (_completed)
                 return;
@@ -1716,7 +1859,7 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
 
             _worker.WaitForExit();
             _worker.ExitCode.Should().Be(0, $"worker output:{Environment.NewLine}{_output}");
-            File.ReadAllText(_completedPath).Should().Be(_mode);
+            File.ReadAllText(_completedPath).Should().Be(expectedResult);
         }
 
         internal void WaitForCrashCompletion()

--- a/src/Ahtola.Tests/SqliteWalByteRangeLockTests.cs
+++ b/src/Ahtola.Tests/SqliteWalByteRangeLockTests.cs
@@ -38,6 +38,38 @@ public sealed class SqliteWalByteRangeLockTests
     }
 
     [Test]
+    public void WindowsWritableLeaseCanAccessItsOwnLockedRange()
+    {
+        Assume.That(OperatingSystem.IsWindows(), Is.True);
+        const long pendingByte = 0x4000_0000;
+        var workDirectory = CreateWorkDirectory();
+        try
+        {
+            var path = CreateLockCarrier(workDirectory);
+            using (var stream = new FileStream(path, FileMode.Open, FileAccess.Write, FileShare.ReadWrite))
+                stream.SetLength(pendingByte + 512);
+
+            var locks = new SqliteWalByteRangeLock(path);
+            using var lease = locks.AcquireExclusiveWritable(
+                pendingByte,
+                length: 512,
+                TimeSpan.Zero,
+                CancellationToken.None);
+            byte[] expected = [0x41, 0x48, 0x54, 0x4f, 0x4c, 0x41];
+            lease.Write(expected, pendingByte);
+            lease.FlushToDisk();
+            var actual = new byte[expected.Length];
+
+            lease.Read(actual, pendingByte).Should().Be(expected.Length);
+            actual.Should().Equal(expected);
+        }
+        finally
+        {
+            DeleteWorkDirectory(workDirectory);
+        }
+    }
+
+    [Test]
     [NonParallelizable]
     public void IndependentProcessesCanShareTheSameRange()
     {


### PR DESCRIPTION
## Summary

- preserve durable push recovery state across concurrent pull/materialization publication
- use stable-first lock-carrier resolution and span old/replacement identities across database and metadata publication
- revalidate live physical identity, conflict state, and durable journal generation under push/apply publication locks
- keep remote I/O outside long-held locks while preventing stale pull publication and committed SQL replay
- add deterministic cross-process alias, File.Replace, conflict, cancellation, and no-op race coverage

## Validation

- original ambiguous-push regression: 1 passed
- race/cancellation set: 7 passed
- targeted managed replica suite: 239 passed
- full managed/package gate: 6,429 passed, 0 failed
- canonical multi-target build: zero warnings/errors
- changed-file formatting: passed

## History

PR #38 merged before independent review completed. PR #42 attempted to carry the fix but retained rewritten pre-merge history and conflicted. This branch is cleanly based on current `master` and contains only the corrective follow-up.
