### PR TITLE
Implement aggregate subquery decorrelation

### DIFF
--- a/docs/turso-gap-analysis.md
+++ b/docs/turso-gap-analysis.md
@@ -15,10 +15,11 @@ the machine-readable inventory, with stable IDs for status tracking
 time (171 entries)**; the JSON is the live tracking source of truth. Closure
 progress since analysis (waves F1–F2.18) is recorded in
 [section 11](#11-closure-progress-since-analysis), and current counts are:
-**211 entries, 182+ closed**; expected-failures file down from **606 → 0**
-lines after Phase 1 MVCC surface (`journal_mode=mvcc` + `BEGIN CONCURRENT` +
-in-process `MvStore`). Remaining MVCC depth (row-version cursors, durable
-logical log, checkpoint SM) is tracked in [`mvcc-port-contract.md`](mvcc-port-contract.md).
+**216 entries, 216 closed, 0 open**; expected-failures file down from
+**606 → 0** lines after Phase 1 MVCC surface (`journal_mode=mvcc` +
+`BEGIN CONCURRENT` + in-process `MvStore`). Remaining MVCC depth (row-version
+cursors, durable logical log, checkpoint SM) is tracked in
+[`mvcc-port-contract.md`](mvcc-port-contract.md).
 
 **Ground truth.** `src/Ahtola.Tests/Conformance/managed-sqltest-expected-failures.txt`
 (606 failure lines at analysis time). Every line was cross-referenced to at least
@@ -498,12 +499,13 @@ Highest-impact entries:
   statements and same-file ATTACH are unsupported/limited — by design for the
   managed single-file model, but it gates a large DDL-test surface. Read-only
   main/temp base-table joins are supported from a connection-local snapshot.
-- **Planner** (s3): FROM-derived-table flattening and correlated
-  EXISTS/NOT EXISTS/IN unnesting into semi/anti joins **are now implemented**
-  (see `compile-no-subquery-flattening`,
-  `compile-correlated-exists-in-semi-anti-join` and section 4.1); still open are
-  aggregate-subquery decorrelation
-  (`compile-no-aggregate-subquery-decorrelation`), join-order optimization,
+- **Planner** (s3): FROM-derived-table flattening, correlated
+  EXISTS/NOT EXISTS/IN unnesting into semi/anti joins, and correlated
+  single-value **aggregate decorrelation** (group-first and join-first)
+  **are now implemented** (see `compile-no-subquery-flattening`,
+  `compile-correlated-exists-in-semi-anti-join`,
+  `compile-no-aggregate-subquery-decorrelation` and section 4.1); still open in
+  the historical sense are join-order optimization (now covered by section 4.2),
   ORDER BY elision from indexes (17), and partial (18) / expression (19)
   index planning.
 - **CTE/DML shapes** (s2): recursive CTEs limited to a single term (27),
@@ -521,9 +523,9 @@ Highest-impact entries:
 | `compile-alter-rename-trigger-body-not-rebound` | missing | s1-correctness | M | 44 | 6 | After `ALTER TABLE t1 RENAME TO t2`, six conformance cases show existing triggers referencing the old table name inside their body (e.g. `INSERT INTO t1 ...` in a trigger… |
 | `compile-affinity-rules-diverge-in-subquery-and-compound-contexts` | divergent | s1-correctness | M | 28 | 8 | A cluster of affinity.sqltest failures shows Ahtola computing a different column affinity than SQLite/Turso specifically when the affinity-bearing column flows through a… |
 | `compile-recursive-cte-single-term-only` | partial | s2-capability | M | 27 | 2 | RecursiveCteProgramBuilder explicitly documents its scope as "the well-defined linear recursion (a single recursive transform)" and states "Multiple distinct recursive te… |
-| `compile-scalar-subquery-not-decorrelated` | parity | s3-perf | M | 25 | 0 | Uncorrelated subqueries memoize once per statement (SubqueryMemoizationReproTests). Correlated EXISTS/NOT EXISTS/IN now unnest into semi/anti joins — see `compile-correlated-exists-in-semi-anti-join`. Correlated *aggregate* subqueries stay per-row: `compile-no-aggregate-subquery-decorrelation`. |
+| `compile-scalar-subquery-not-decorrelated` | parity | s3-perf | M | 25 | 0 | Uncorrelated subqueries memoize once per statement (SubqueryMemoizationReproTests). Correlated EXISTS/NOT EXISTS/IN now unnest into semi/anti joins — see `compile-correlated-exists-in-semi-anti-join`. Correlated *aggregate* subqueries now decorrelate group-first or join-first — see `compile-no-aggregate-subquery-decorrelation`. Anything either rewrite declines keeps the per-outer-row path. |
 | `compile-correlated-exists-in-semi-anti-join` | parity | s3-perf | M | 0 | 0 | Closed 2026-08-23: a top-level conjunctive correlated `EXISTS` / `NOT EXISTS` / direct positive `IN` over a single base table unnests into the internal `JoinKind.Semi` / `JoinKind.Anti` join, scanning the inner table once per statement. Declines when a multi-conjunct WHERE holds any term that can raise (AND short-circuits, so a join would hide or invent an error) and when an `IN`'s operands or inner WHERE can raise. Ports `try_rewrite_exists` / `try_rewrite_in` / `rewrite_as_semi_or_anti_join` from turso-src v0.8.0-pre.7 `core/translate/optimizer/unnest.rs`. See section 4.1 for the exact accepted and excluded shapes. |
-| `compile-no-aggregate-subquery-decorrelation` | missing | s3-perf | L | 0 | 0 | Not ported: Turso's `try_rewrite_single_value_aggregate` turns `o.v < (SELECT avg(i.v) FROM i WHERE i.k = o.k)` into a grouped LEFT JOIN (group-first) or a join-then-`GROUP BY o.rowid` (join-first). Both need a synthesized derived table with `GROUP BY`, empty-input value analysis (`count`→0, `total`→0.0, else NULL), overflow/failure analysis for unused keys, and a rowid-based grouping key. Ahtola evaluates such subqueries once per outer row. |
+| `compile-no-aggregate-subquery-decorrelation` | parity | s3-perf | L | 0 | 0 | Closed 2026-08-26: `EmbeddedDatabase.SubqueryRewrites.cs` ports both conservative forms of `try_rewrite_single_value_aggregate`. **Group-first** replaces a correlated single-value aggregate subquery with a LEFT JOIN against a synthesized `GROUP BY <correlation key>` derived table (one per subquery), restoring `count` → integer 0 and `total` → real 0.0 through COALESCE while null-producing aggregates read the left join's padding. It runs only when evaluating the aggregate for a key no outer row asks for cannot raise: avg/count/min/max/total only, no fallible aggregate argument, FILTER or inner WHERE term, and — Ahtola-specific — no application-registered collation on the grouping key. **Join-first** otherwise LEFT JOINs the inner table, groups by the outer rowid and moves the single whole WHERE comparison to HAVING with each aggregate guarded by `FILTER (WHERE inner.rowid IS NOT NULL)`. Correlation terms must be plain inner=outer column equalities with matching declared affinity **and** collation resolving to one outer base table. See section 4.1 for the exact accepted and excluded shapes. |
 | `compile-cte-dml-and-materialization-restrictions` | partial | s2-capability | M | 22 | 5 | CTE use inside DML is artificially restricted ("every CTE must contribute"); expression-CTE materialization semantics diverge. |
 | `compile-select-compiler-single-table-fast-paths-only` | divergent | s4-intentional | S | 20 | 0 | SelectStatementCompiler is architected as a set of narrow, provably-correct single-table fast paths (plain scan, backward/descending scan, indexed seek with bounds) with… |
 | `compile-collation-propagation-through-subquery` | divergent | s1-correctness | M | 19 | 5 | Column collation is lost across subquery boundaries and compound arms, flipping NOCASE comparisons and window peer groups. |
@@ -564,7 +566,8 @@ diagnostic is always produced from the original statement. For the same reason
 the stage is disabled inside trigger bodies, where that validation is skipped.
 `EXPLAIN` and `EXPLAIN QUERY PLAN` use their own routes and therefore describe
 the **un-rewritten** statement; `EmbeddedDatabase.RewriteDiagnostics` (internal)
-is the execution-side evidence used by `SubqueryRewriteTests`.
+is the execution-side evidence used by `SubqueryRewriteTests` and
+`AggregateSubqueryDecorrelationTests`.
 
 **Rewrite 1 — FROM-derived-table flattening.** `SELECT … FROM (SELECT p FROM s
 WHERE a) [AS d] WHERE b` becomes `SELECT … FROM s WHERE a' AND b'`, substituting
@@ -668,15 +671,122 @@ collation). When either side's affinity or collation cannot be proven — an
 unresolvable column, a `CAST`, a custom collation — that conjunct is skipped and
 the scan simply runs unpruned.
 
-**Deliberately not ported.** `unnest.rs`'s aggregate decorrelation
-(`try_rewrite_single_value_aggregate`, group-first and join-first) is tracked as
-`compile-no-aggregate-subquery-decorrelation`.
+**Rewrite 3 — correlated single-value aggregate subquery → decorrelated join.**
+Ports `try_rewrite_single_value_aggregate` and
+`rewrite_aggregate_as_join_then_group` in both of their conservative forms.
 
-**Stage interaction.** The two rewrites run in sequence (flattening first, to a
-fixed point, then unnesting) but rarely both fire on one statement: a correlated
+*Group-first* (the default) evaluates each correlation key once. Every eligible
+subquery becomes its own LEFT JOIN against a synthesized derived table
+`SELECT <aggregate expression> AS ahtola_aggregate_value,
+<key> AS ahtola_correlation_key_N … GROUP BY <key>`, whose ON condition is the
+subquery's correlation equalities written in the operand order the subquery used
+(SQLite resolves a comparison's collation from the left operand first, and the
+grouped column carries none). Because the grouped table holds exactly one row
+per distinct key and the join tests that key for equality, at most one grouped
+row can match an outer row — so the outer row count, and with it every outer
+clause, is preserved and several subqueries can decorrelate into the same
+statement. An outer row whose key matches nothing reads the left join's `NULL`
+padding, which is what `avg`/`min`/`max`/`sum` answer for an empty input;
+`count` and `total` instead answer integer `0` and real `0.0`, so those come back
+through `COALESCE`. An aggregate wrapped in NULL-propagating arithmetic,
+concatenation, `CAST`, `COLLATE` or a unary operator inherits the NULL answer;
+anything else (`count(*) + 0`, which is `0` and not NULL for an empty input)
+declines.
+
+*Group-first is only used when computing the aggregate for a key that no outer
+row asks for cannot fail.* The original subquery reads only the keys its outer
+rows ask for, so the rewrite must not be able to raise an error the statement
+never raises: `sum` can overflow, `group_concat`/`string_agg` can outgrow the
+largest SQL value, and `avg(json_extract(v,'$'))` can hit invalid JSON stored
+under an unused key. Every aggregate must therefore be `avg`, `count`, `min`,
+`max` or `total`, and no aggregate argument, aggregate `FILTER` or inner WHERE
+term may be able to raise — the same strict `expression_can_fail_on_input`
+classification the semi/anti rewrite uses. Ahtola adds the grouping key itself:
+a group is formed under the key's declared collation, so an
+application-registered sequence would run for unused keys too, and a key
+carrying one declines.
+
+*Join-first* is the fallback for a `sum`, a `group_concat` or a fallible
+aggregate input that appears as one whole WHERE comparison. The inner table is LEFT JOINed
+directly, the joined rows are grouped back to one group per outer row through
+`GROUP BY o.rowid`, and the comparison moves to `HAVING` with every aggregate
+guarded by `FILTER (WHERE i.rowid IS NOT NULL)`. The join only reaches inner
+rows whose key some outer row asks for, which is the whole point; the filter
+keeps the row a left join invents for an unmatched outer row out of the fold,
+without which `count(*)` would answer 1 where the subquery answers 0.
+
+*Accepted only when all of these hold.* The subquery has exactly one non-star
+projection containing at least one built-in aggregate; reads exactly one
+ordinary base table; has no `DISTINCT`, `GROUP BY`, `HAVING`, `ORDER BY`, named
+window, `LIMIT` or `OFFSET`; contains no nested subquery, window function or
+non-deterministic scalar call; and every column it reads belongs to that table
+*and* sits inside an aggregate's arguments or `FILTER` — a column read outside
+an aggregate would make the value depend on which row of the group the engine
+happens to keep. Ordered-set and extension aggregates decline, the latter
+because their value for an empty input is unknown. Every WHERE conjunct that
+reaches out of the subquery must be a plain `inner = outer` equality between two
+columns, and at least one must (an uncorrelated aggregate subquery already
+evaluates once per statement). Both columns must have the **same declared
+affinity and the same declared collation**: an inner `BINARY` key splits `A` and
+`a` into two groups that a `NOCASE` outer key joins to both, and a BLOB-affinity
+inner key splits `1` from `'1'` where a numeric outer key joins to both — either
+would emit the outer row twice. All correlation columns must resolve to a single
+outer base table, so the join-order rewriter cannot move the grouped table in
+front of one of them. The enclosing FROM clause contains no outer join.
+
+*Ahtola-specific conservatism.* A bare `SELECT *` in the enclosing query
+declines: this stage runs before star expansion, so the grouped table's two
+synthetic columns would be published as result columns, and expanding the star
+here would mean reimplementing SQLite's result-column naming. A qualified
+`t.*` names one source and is unaffected. Join-first additionally requires rowid
+B-tree tables on both sides whose `rowid` spelling is not shadowed by a declared
+column; no outer aggregate, `GROUP BY`, `HAVING`, `DISTINCT`, window, `ORDER
+BY`, `LIMIT` or `OFFSET` (none of them survives being pushed around the new
+grouping step); the subquery as one complete side of exactly one top-level WHERE
+comparison with no other use of its value; and every other WHERE term
+deterministic and free of correlated subqueries, because after the join those
+terms run once per joined copy of an outer row rather than once per outer row.
+A fallible inner-only WHERE term declines both routes: group-first would run it
+for unused keys, while join-first would move it into an ON condition whose
+key-first evaluation could hide an error from a non-matching row.
+
+*Name stability under join-first.* Group-first publishes two synthetic
+`ahtola_`-prefixed columns, which cannot collide with anything a statement
+already refers to. Join-first instead moves a **real** table into the enclosing
+scope, so it also checks that no name changes meaning: an *unqualified*
+reference already in the enclosing query must not name a column of the inner
+table (or a rowid spelling), and every reference the rewrite carries out of the
+subquery must be qualified by the inner table. Without those checks
+`SELECT id FROM o WHERE v > (SELECT sum(i.v) FROM i WHERE i.k = o.k)` would
+start raising "ambiguous column name", and `SELECT sum(v) …` inside the subquery
+would silently gain a second candidate. A surviving enclosing expression that
+contains another nested query also declines: an unqualified name in that query
+may fall back to the enclosing FROM scope, and moving the inner aggregate table
+there could make the name ambiguous. A surviving reference already qualified by
+the inner table's name declines too when that name is absent from the current
+FROM scope: it necessarily resolves through an outer scope today and the moved
+table would capture it.
+
+*Route evidence.* `SelectRewriteDiagnostics` counts
+`AggregateGroupFirstRewrites`, `AggregateJoinFirstRewrites` and
+`AggregateDecorrelationDeclines`, the last incremented for a correlated
+aggregate subquery that reached the stage and was rejected — so a test can prove
+an excluded shape was considered rather than never seen.
+`AggregateSubqueryDecorrelationTests` asserts them alongside a differential
+comparison against Microsoft.Data.Sqlite.
+
+**Stage interaction.** The three rewrites run in sequence: flattening first, to a
+fixed point, then `EXISTS`/`IN` unnesting, then aggregate decorrelation.
+Flattening and unnesting rarely both fire on one statement — a correlated
 `EXISTS`/`IN` that references the derived table is exactly the nested-subquery
-case flattening declines. Unnesting then uses the un-flattened derived table as
-the semi-join's outer side, so one stage declining never blocks the other.
+case flattening declines, and unnesting then uses the un-flattened derived table
+as the semi-join's outer side, so one stage declining never blocks the other.
+Aggregate decorrelation analyses every candidate against the FROM clause as it
+stands when the stage begins, before any grouped table is appended, so a second
+subquery is judged in the same scope the first one was. A statement that already
+contains an outer join declines decorrelation outright, which also means the
+join-first form (whose gates require a single outer table anyway) never sees a
+FROM clause a semi/anti join has already reshaped.
 
 ### 4.2 Cost-based N-way join ordering (`EmbeddedDatabase.JoinOrderRewrites.cs`)
 
@@ -1189,10 +1299,10 @@ conformance cases → full managed lane (3755+ tests, green) → resolved keys
 removed from `managed-sqltest-expected-failures.txt` → inventory entry flipped
 `open → closed`.
 
-**Totals.** 180 entries closed since analysis (182 including the 2 `parity`
-entries closed at analysis time); the inventory grew 171 → **211** entries as
+**Totals.** 181 entries closed since analysis (183 including the 2 `parity`
+entries closed at analysis time); the inventory grew 171 → **216** entries as
 closure work surfaced adjacent gaps that were recorded rather than folded in;
-the expected-failures file dropped **606 → 11** lines (595 cleared; lines
+the expected-failures file dropped **606 → 0** lines (all cleared; lines
 multi-map, so a cleared line may redistribute to the next blocker in its
 chain rather than disappear). One deliberate extension was recorded:
 `compile-ordered-aggregates-intentional-extension` (s4 — Ahtola keeps ordered
@@ -1340,13 +1450,46 @@ defects, all now closed with regression coverage in
 - A `SELECT` with a viable method plan is no longer lowered to bytecode, so the plan
   `EXPLAIN QUERY PLAN` advertises is the plan that executes.
 
-**Current residual (honest, not scoreboard).** Inventory is **211 closed · 0 open**,
+**Current residual (honest, not scoreboard).** Inventory is **216 closed · 0 open**,
 but “closed” includes intentional scope and closed-with-residual notes (e.g.
 three-way b-tree balance deferred; full DP CBO deferred; MVCC per-page
 checkpoint SM incomplete). Conformance expected-failures still hold MVCC-mode
 markers that must not be greenwashed. Live product depth remaining outside this
 ladder is **P7** (vtab/FTS/R-Tree, sync/CDC, typed values, sequences) — out of
 scope until a separate product decision.
+
+### F5 — correlated aggregate subquery decorrelation (2026-08-26)
+
+`compile-no-aggregate-subquery-decorrelation` — the last `open` entry in the
+inventory — moves `missing → parity`. `EmbeddedDatabase.SubqueryRewrites.cs`
+gains a third rewrite that ports both conservative forms of
+`try_rewrite_single_value_aggregate`: **group-first** (a `GROUP BY`
+correlation-key derived table LEFT JOINed onto the outer rows) and
+**join-first** (the inner table LEFT JOINed, grouped by the outer rowid, with
+the comparison moved to `HAVING` behind an aggregate `FILTER`). The exact
+accepted and excluded shapes are in section 4.1; the semantic gates ported from
+upstream are the empty-input value analysis, the unused-key failure analysis,
+the grouping-vs-join comparison-compatibility check, the single-outer-table
+restriction and the join-first outer-clause exclusions.
+
+**Honest residuals.** Three narrowings are Ahtola-specific rather than upstream
+behavior, all because this stage runs on the AST before star expansion and
+before name binding: a bare `SELECT *` in the enclosing query declines (a
+qualified `t.*` does not), a correlation key spelled as a `rowid` alias
+declines, and join-first declines when moving the inner table into the enclosing
+scope would make an unqualified name ambiguous in either direction. Everything
+else that declines matches an upstream gate. Join-first declines an outer
+`ORDER BY`/`LIMIT`/`OFFSET`/`DISTINCT` exactly as upstream does, so its
+differential tests compare result multisets rather than row order.
+
+**Route evidence.** `SelectRewriteDiagnostics` gains
+`AggregateGroupFirstRewrites`, `AggregateJoinFirstRewrites` and
+`AggregateDecorrelationDeclines`; `AggregateSubqueryDecorrelationTests` asserts
+all three next to a differential comparison against Microsoft.Data.Sqlite,
+including the empty-input storage classes (`count` → INTEGER 0, `total` →
+REAL 0.0), duplicate and NULL correlation keys, multi-column correlations,
+collation/affinity compatibility, and the preserved prepare-time and runtime
+diagnostics.
 
 
 ## Appendix A — Inventory JSON schema
@@ -1401,8 +1544,8 @@ they are listed below for completeness — absence of mapped failures means
 
 ## Appendix C — Entries with zero mapped failure lines (by layer)
 
-> Historical source-evidence list from analysis time. As of F2.36 the live
-> inventory is **0 open / 211 closed**; entries below may be closed intentional
+> Historical source-evidence list from analysis time. As of F5 the live
+> inventory is **0 open / 216 closed**; entries below may be closed intentional
 > or delivered surfaces that simply had no conf corpus line.
 
 - **vdbe** (16): `vdbe-bloom-filter-opcodes`, `vdbe-virtual-table-opcodes`, `vdbe-index-method-opcodes`, `vdbe-schema-cookie-opcodes`, `vdbe-deferred-seek`, `vdbe-rowset-test`, `vdbe-record-construction-model`, `vdbe-scalar-control-opcodes`, `vdbe-integrity-check-opcode`, `vdbe-coroutine-machinery`, `vdbe-misc-cursor-opcodes`, `vdbe-typed-value-opcode-family`, `vdbe-sequence-opcode-family`, `vdbe-materialized-view-opcodes`, `vdbe-ext-window-buffer-family`, `vdbe-ext-worktable-and-gate-families`

--- a/docs/turso-gap-inventory.json
+++ b/docs/turso-gap-inventory.json
@@ -14,8 +14,8 @@
       "commit_at_analysis": "7b62a3f"
     },
     "conformance_ground_truth": "src/Ahtola.Tests/Conformance/managed-sqltest-expected-failures.txt (606 failure lines at analysis time)",
-    "current_conformance_expected_failures": 11,
-    "last_reconciled": "2026-08-24",
+    "current_conformance_expected_failures": 0,
+    "last_reconciled": "2026-08-26",
     "entry_count": 216,
     "counts": {
       "by_layer": {
@@ -23,32 +23,32 @@
         "functions": 26,
         "mvcc": 14,
         "parser": 29,
-        "storage": 22,
+        "storage": 23,
         "sync": 18,
         "vdbe": 38
       },
       "by_kind": {
-        "divergent": 71,
+        "divergent": 72,
         "extension": 9,
         "intentional-divergence": 1,
-        "missing": 74,
-        "parity": 54,
+        "missing": 73,
+        "parity": 55,
         "partial": 6
       },
       "by_severity": {
         "s1-correctness": 39,
         "s2-capability": 88,
         "s3-perf": 33,
-        "s4-intentional": 55
+        "s4-intentional": 56
       },
       "by_effort": {
-        "L": 39,
+        "L": 40,
         "M": 76,
         "S": 100
       },
       "by_status": {
-        "closed": 214,
-        "open": 1
+        "closed": 216,
+        "open": 0
       }
     },
     "schema": {
@@ -3129,14 +3129,14 @@
     {
       "id": "compile-no-aggregate-subquery-decorrelation",
       "layer": "compilation",
-      "kind": "missing",
-      "turso_ref": "turso-src/core/translate/optimizer/unnest.rs::try_rewrite_single_value_aggregate / rewrite_aggregate_as_join_then_group / aggregate_can_run_for_unused_rows (v0.8.0-pre.7)",
-      "ahtola_ref": "src/Ahtola.Core/EmbeddedDatabase.SubqueryRewrites.cs (deliberately out of scope); correlated aggregate subqueries stay on the per-row ExecuteSubquery path",
+      "kind": "parity",
+      "turso_ref": "turso-src/core/translate/optimizer/unnest.rs::try_rewrite_single_value_aggregate / rewrite_aggregate_as_join_then_group / aggregate_can_run_for_unused_rows / result_on_empty_input / column_pair_compares_the_same (v0.8.0-pre.7)",
+      "ahtola_ref": "src/Ahtola.Core/EmbeddedDatabase.SubqueryRewrites.cs (TryDecorrelateAggregateSubqueries / TryRewriteAggregateGroupFirst / TryRewriteAggregateJoinFirst); src/Ahtola.Tests/AggregateSubqueryDecorrelationTests.cs",
       "severity": "s3-perf",
       "effort": "L",
       "conformance_links": [],
-      "notes": "Open. Turso rewrites `o.v < (SELECT avg(i.v) FROM i WHERE i.k = o.k)` either group-first (LEFT JOIN a `GROUP BY key` derived table) or join-first (LEFT JOIN then `GROUP BY o.rowid` with the comparison moved to HAVING). Porting needs a synthesized grouped derived table, empty-input value analysis (count -> 0, total -> 0.0, otherwise NULL), a can-this-expression-fail analysis so group-first never computes an aggregate for a key no outer row asks for, comparison-compatibility checks between the grouping and joining keys (collation and numeric/text conversion), and a rowid-based grouping key for join-first. None of that is implemented; such subqueries evaluate once per outer row.",
-      "status": "open"
+      "notes": "Closed 2026-08-26: both conservative forms of `try_rewrite_single_value_aggregate` are ported into the pure AST rewrite stage. Group-first turns `o.v < (SELECT avg(i.v) FROM i WHERE i.k = o.k)` into a LEFT JOIN against a synthesized `SELECT <agg> AS ahtola_aggregate_value, <key> AS ahtola_correlation_key_N ... GROUP BY <key>` derived table, one per decorrelated subquery, with the correlation equalities as the ON condition; empty-input analysis restores `count` -> integer 0 and `total` -> real 0.0 through COALESCE while the null-producing aggregates read the left join's padding directly, and NULL-propagating arithmetic/cast/collate/unary expressions over such an aggregate inherit NULL. Group-first runs only when evaluating the aggregate for a key no outer row asks for cannot raise: every aggregate must be avg/count/min/max/total, and no aggregate argument, aggregate FILTER, inner WHERE term, or (Ahtola-specific) grouping-key collation may be able to fail — the last because a registered collation would run while grouping unused keys. Otherwise join-first LEFT JOINs the inner table, groups by the outer rowid, and moves the single whole WHERE comparison to HAVING with every aggregate guarded by `FILTER (WHERE inner.rowid IS NOT NULL)` so the row a left join invents is not folded in. A fallible inner-only WHERE term declines both routes because moving it into ON could change source-order error timing on non-matching rows. Correlation terms must be plain inner=outer column equalities whose declared affinity and collation match on both sides (otherwise the grouping and the join partition the key space differently and an outer row could match two groups), must resolve to a single outer base table, and the subquery's result expression must be self-contained: one non-star projection, a built-in aggregate, no nested subquery, no window, no DISTINCT/GROUP BY/HAVING/ORDER BY/LIMIT/OFFSET, no nondeterministic scalar call, and every column read from the inner table inside an aggregate. Ahtola-specific conservatism beyond upstream: a bare `SELECT *` in the enclosing query declines (the rewrite stage runs before star expansion, so the grouped table's synthetic columns would leak into the result; `t.*` is unaffected), and an ordered-set or extension aggregate declines. Join-first additionally requires rowid B-tree tables on both sides with unshadowed rowid spellings, no outer aggregate/GROUP BY/HAVING/DISTINCT/window/ORDER BY/LIMIT/OFFSET, the subquery as one complete side of exactly one top-level WHERE comparison, every other WHERE term deterministic and free of correlated subqueries, and — because unlike group-first it moves a real table into the enclosing scope rather than two `ahtola_`-prefixed synthetic columns — that no name changes meaning: no unqualified enclosing reference may name an inner column or a rowid spelling, every reference carried out of the subquery must be inner-qualified, surviving enclosing expressions containing another nested query decline because their unqualified correlations can fall back to the enlarged FROM scope, and a surviving reference qualified by the moved table's name declines when that name currently resolves through an outer scope. Everything else declines and keeps the per-outer-row ExecuteSubquery path. Route evidence: `SelectRewriteDiagnostics.AggregateGroupFirstRewrites` / `AggregateJoinFirstRewrites` / `AggregateDecorrelationDeclines`.",
+      "status": "closed"
     },
     {
       "id": "index-method-fts-persistence-divergence",

--- a/src/Ahtola.Core/EmbeddedDatabase.SubqueryRewrites.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.SubqueryRewrites.cs
@@ -21,13 +21,24 @@ namespace Ahtola.Core;
 /// <c>rewrite_as_semi_or_anti_join</c>. The inner table is then scanned once for the whole
 /// statement instead of once per outer row.
 /// </item>
+/// <item>
+/// Correlated single-value aggregate decorrelation, mirroring
+/// <c>try_rewrite_single_value_aggregate</c> and <c>rewrite_aggregate_as_join_then_group</c>.
+/// <c>o.v &lt; (SELECT avg(i.v) FROM i WHERE i.k = o.k)</c> becomes either a
+/// <b>group-first</b> LEFT JOIN against a <c>GROUP BY</c> derived table keyed by the
+/// correlation columns, or — when computing the aggregate for a key no outer row asks for
+/// could fail (<c>sum</c> overflow, a fallible input expression) — a <b>join-first</b>
+/// LEFT JOIN of the inner table grouped by the outer rowid, with the comparison moved to
+/// <c>HAVING</c> and every aggregate guarded by
+/// <c>FILTER (WHERE i.rowid IS NOT NULL)</c> so the NULL-padded row a left join invents is
+/// not counted.
+/// </item>
 /// </list>
 /// <para>
 /// Everything here is fail-closed: any AST node, clause or reference the rewriter does not
-/// explicitly model declines the rewrite and leaves the original statement untouched. The
-/// aggregate decorrelation rewrites of <c>unnest.rs</c>
-/// (<c>try_rewrite_single_value_aggregate</c>, group-first and join-first) are deliberately
-/// <b>not</b> ported; see <c>docs/turso-gap-analysis.md</c>.
+/// explicitly model declines the rewrite and leaves the original statement untouched. A
+/// declined aggregate subquery keeps the original per-outer-row
+/// <c>ExecuteSubquery</c> behavior.
 /// </para>
 /// <para>
 /// The stage runs inside <c>ExecuteSelectStatement</c>, after <c>ValidateQuerySchema</c>, so
@@ -43,6 +54,9 @@ public sealed partial class EmbeddedDatabase
     private long _flattenedFromSubqueries;
     private long _semiJoinRewrites;
     private long _antiJoinRewrites;
+    private long _aggregateGroupFirstRewrites;
+    private long _aggregateJoinFirstRewrites;
+    private long _aggregateDecorrelationDeclines;
 
     /// <summary>
     /// Counts of the rewrites this database instance has applied. Test-only evidence that an
@@ -52,13 +66,19 @@ public sealed partial class EmbeddedDatabase
     internal SelectRewriteDiagnostics RewriteDiagnostics => new(
         Interlocked.Read(ref _flattenedFromSubqueries),
         Interlocked.Read(ref _semiJoinRewrites),
-        Interlocked.Read(ref _antiJoinRewrites));
+        Interlocked.Read(ref _antiJoinRewrites),
+        Interlocked.Read(ref _aggregateGroupFirstRewrites),
+        Interlocked.Read(ref _aggregateJoinFirstRewrites),
+        Interlocked.Read(ref _aggregateDecorrelationDeclines));
 
     internal void ResetRewriteDiagnostics()
     {
         Interlocked.Exchange(ref _flattenedFromSubqueries, 0);
         Interlocked.Exchange(ref _semiJoinRewrites, 0);
         Interlocked.Exchange(ref _antiJoinRewrites, 0);
+        Interlocked.Exchange(ref _aggregateGroupFirstRewrites, 0);
+        Interlocked.Exchange(ref _aggregateJoinFirstRewrites, 0);
+        Interlocked.Exchange(ref _aggregateDecorrelationDeclines, 0);
     }
 
     /// <summary>
@@ -94,7 +114,9 @@ public sealed partial class EmbeddedDatabase
             rewritten = flattened;
         }
 
-        return RewriteCorrelatedSubqueriesAsJoins(rewritten, context);
+        return RewriteCorrelatedAggregateSubqueries(
+            RewriteCorrelatedSubqueriesAsJoins(rewritten, context),
+            context);
     }
 
     // ---------------------------------------------------------------------------------------
@@ -250,23 +272,24 @@ public sealed partial class EmbeddedDatabase
         void Count(string name)
             => referenceCounts[name] = referenceCounts.TryGetValue(name, out var count) ? count + 1 : 1;
 
+        var substitution = AstSubstitution.ForColumns(Substitute);
         var projections = RewriteFlattenedProjections(
             select,
             derivedColumns,
             outerColumnNames,
             alias,
-            Substitute,
+            substitution,
             Count,
             ref declined);
         if (declined || projections is null)
             return select;
 
-        if (!TryRewriteClause(select.Where, Substitute, ref declined, out var outerWhere)
-            || !TryRewriteClause(select.Having, Substitute, ref declined, out var having)
-            || !TryRewriteClause(select.Limit, Substitute, ref declined, out var limit)
-            || !TryRewriteClause(select.Offset, Substitute, ref declined, out var offset)
-            || !TryRewriteExpressionList(select.GroupBy, Substitute, ref declined, out var groupBy)
-            || !TryRewriteOrderBy(select.OrderBy, Substitute, ref declined, out var orderBy)
+        if (!TryRewriteClause(select.Where, substitution, ref declined, out var outerWhere)
+            || !TryRewriteClause(select.Having, substitution, ref declined, out var having)
+            || !TryRewriteClause(select.Limit, substitution, ref declined, out var limit)
+            || !TryRewriteClause(select.Offset, substitution, ref declined, out var offset)
+            || !TryRewriteExpressionList(select.GroupBy, substitution, ref declined, out var groupBy)
+            || !TryRewriteOrderBy(select.OrderBy, substitution, ref declined, out var orderBy)
             || declined)
         {
             return select;
@@ -520,7 +543,7 @@ public sealed partial class EmbeddedDatabase
         IReadOnlyList<SelectBindingColumn> derivedColumns,
         string[] outerColumnNames,
         string? alias,
-        Func<ColumnExpression, Expression?> substitute,
+        AstSubstitution substitute,
         Action<string> count,
         ref bool declined)
     {
@@ -912,26 +935,7 @@ public sealed partial class EmbeddedDatabase
         QueryContext context,
         out NamedTableSource innerTable,
         out string innerQualifier)
-    {
-        innerTable = null!;
-        innerQualifier = string.Empty;
-
-        if (inner.Source is not NamedTableSource named
-            || named.IsSchemaQualified
-            || IsSchemaTable(named.Name)
-            || IsCommonTableExpression(named, context)
-            || TryGetView(context, named.Name, out _)
-            || TryGetVirtualTable(context, named, out _)
-            || TryBindBareTableValuedFunction(named, context, out _)
-            || !context.Tables.ContainsKey(named.Name))
-        {
-            return false;
-        }
-
-        innerTable = named;
-        innerQualifier = named.Alias ?? named.Name;
-        return true;
-    }
+        => TryGetDecorrelationBaseTable(inner.Source, context, out innerTable, out innerQualifier);
 
     /// <summary>
     /// Clause-level exclusions for a semi/anti join candidate, mirroring
@@ -1049,6 +1053,1245 @@ public sealed partial class EmbeddedDatabase
             && (join.Kind is JoinKind.Left or JoinKind.Right or JoinKind.Full
                 || SourceContainsOuterJoin(join.Left)
                 || SourceContainsOuterJoin(join.Right));
+
+    // ---------------------------------------------------------------------------------------
+    // Rewrite 3: correlated single-value aggregate subquery decorrelation.
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Decorrelates every eligible correlated single-value aggregate subquery of one SELECT,
+    /// mirroring <c>rewrite_correlated_subqueries</c>' aggregate arm
+    /// (turso-src/core/translate/optimizer/unnest.rs:171-215) through
+    /// <c>try_rewrite_single_value_aggregate</c> (unnest.rs:500-688).
+    /// <para>
+    /// Group-first runs when computing the aggregate for a correlation key that no outer row
+    /// asks for cannot fail. It computes each key once, adds one grouped table per subquery, and
+    /// keeps every outer clause intact. Otherwise join-first is tried, which never touches an
+    /// unused key but restructures the whole statement and therefore only runs when it is the
+    /// single candidate. When neither applies the statement is returned unchanged and the
+    /// subquery keeps its per-outer-row evaluation.
+    /// </para>
+    /// <para>
+    /// Every candidate is analysed against the <em>original</em> FROM clause, before any grouped
+    /// table is appended, so a second subquery is judged by the same scope the first one was.
+    /// </para>
+    /// </summary>
+    private SelectStatement RewriteCorrelatedAggregateSubqueries(
+        SelectStatement select,
+        QueryContext context)
+    {
+        if (select.Source is null)
+            return select;
+
+        var candidates = new List<ScalarSubqueryExpression>();
+        if (!TryCollectScopedScalarSubqueries(select, candidates) || candidates.Count == 0)
+            return select;
+
+        // Cheap pre-filter so an ordinary scalar subquery never pays for the outer column
+        // description the correlation-key analysis needs.
+        List<ScalarSubqueryExpression>? plausible = null;
+        foreach (var candidate in candidates)
+        {
+            if (candidate.Query is SelectStatement { Projections.Count: 1 } inner
+                && inner.Projections[0].Expression is not (StarExpression or QualifiedStarExpression)
+                && ContainsAggregate(inner.Projections[0].Expression))
+            {
+                (plausible ??= []).Add(candidate);
+            }
+        }
+
+        if (plausible is null)
+            return select;
+
+        var outerColumns = GetOutputColumns(select.Source, context);
+        var shapes = new List<AggregateSubqueryShape>();
+        var declines = 0L;
+        foreach (var candidate in plausible)
+        {
+            switch (TryAnalyzeAggregateSubquery(candidate, outerColumns, context, out var shape))
+            {
+                case true:
+                    shapes.Add(shape);
+                    break;
+                case false:
+                    declines++;
+                    break;
+            }
+        }
+
+        // A pre-existing outer join already decides which rows get NULL-padded; appending
+        // another LEFT JOIN in front of that decision, or moving one of its terms, would change
+        // the padding. unnest.rs declines the individual terms (unnest.rs:515-519, 570-572);
+        // declining the whole statement is the conservative superset.
+        if (shapes.Count == 0 || SourceContainsOuterJoin(select.Source))
+        {
+            CountDeclines(declines + shapes.Count);
+            return select;
+        }
+
+        // Join-first replaces the statement's grouping and its WHERE clause, so it cannot be
+        // combined with another rewrite of the same SELECT.
+        if (shapes is [{ CanRunForUnusedKeys: false } only])
+        {
+            if (TryRewriteAggregateJoinFirst(select, context, only, out var joined))
+            {
+                CountDeclines(declines);
+                _ = Interlocked.Increment(ref _aggregateJoinFirstRewrites);
+                return joined;
+            }
+
+            CountDeclines(declines + 1);
+            return select;
+        }
+
+        var rewritten = select;
+        var applied = 0L;
+        foreach (var shape in shapes)
+        {
+            if (shape.CanRunForUnusedKeys
+                && TryRewriteAggregateGroupFirst(rewritten, context, shape, out var grouped))
+            {
+                rewritten = grouped;
+                applied++;
+                continue;
+            }
+
+            declines++;
+        }
+
+        CountDeclines(declines);
+        if (applied > 0)
+            _ = Interlocked.Add(ref _aggregateGroupFirstRewrites, applied);
+
+        return rewritten;
+
+        void CountDeclines(long count)
+        {
+            if (count > 0)
+                _ = Interlocked.Add(ref _aggregateDecorrelationDeclines, count);
+        }
+    }
+
+    /// <summary>
+    /// Collects the scalar subqueries that belong to <paramref name="select"/>'s own scope: the
+    /// ones reachable from its clauses without descending through another subquery body or a
+    /// FROM-clause derived table, both of which are separate scopes that get their own rewrite
+    /// pass. Returns false when an unmodelled node is reached, so the caller fails closed.
+    /// </summary>
+    private static bool TryCollectScopedScalarSubqueries(
+        SelectStatement select,
+        List<ScalarSubqueryExpression> found)
+    {
+        var clauses = new List<Expression>();
+        foreach (var projection in select.Projections)
+            clauses.Add(projection.Expression);
+        if (select.Where is not null)
+            clauses.Add(select.Where);
+        clauses.AddRange(select.GroupBy);
+        if (select.Having is not null)
+            clauses.Add(select.Having);
+        foreach (var term in select.OrderBy)
+            clauses.Add(term.Expression);
+        if (select.Limit is not null)
+            clauses.Add(select.Limit);
+        if (select.Offset is not null)
+            clauses.Add(select.Offset);
+
+        foreach (var clause in clauses)
+        {
+            if (!ForEachScopedExpression(clause, candidate =>
+                {
+                    if (candidate is ScalarSubqueryExpression scalar)
+                        found.Add(scalar);
+
+                    return true;
+                }))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Like <see cref="ForEachExpression"/>, but treats a subquery operand as a leaf instead of
+    /// walking its body: everything inside belongs to another scope.
+    /// </summary>
+    private static bool ForEachScopedExpression(Expression expression, Func<Expression, bool> visit)
+    {
+        var pending = new Stack<object>();
+        pending.Push(expression);
+        while (pending.Count > 0)
+        {
+            if (pending.Pop() is not Expression current)
+                return false;
+
+            if (!visit(current))
+                return true;
+
+            if (current is ScalarSubqueryExpression or ExistsExpression or InSubqueryExpression)
+            {
+                // The value operand of `x IN (SELECT …)` is evaluated in this scope, so it can
+                // still hold a scalar subquery of its own.
+                if (current is InSubqueryExpression inSubquery)
+                    pending.Push(inSubquery.Value);
+
+                continue;
+            }
+
+            if (!PushExpressionChildren(current, pending))
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Classifies one correlated aggregate subquery against the shared rules of
+    /// <c>can_rewrite_single_value_aggregate</c> (unnest.rs:934-979), the correlation-term
+    /// analysis of <c>try_rewrite_single_value_aggregate</c> (unnest.rs:560-583), the
+    /// empty-input value analysis of <c>result_on_empty_input</c> (unnest.rs:1070-1130), and the
+    /// unused-key safety analysis of <c>aggregate_can_run_for_unused_rows</c>
+    /// (unnest.rs:997-1020).
+    /// <para>
+    /// Returns <see langword="null"/> when the subquery is not even a candidate (it is not a
+    /// correlated aggregate over one base table), and <see langword="false"/> when it is a
+    /// candidate that one of the semantic gates rejected. The distinction only feeds the decline
+    /// counter; both answers leave the statement untouched.
+    /// </para>
+    /// </summary>
+    private bool? TryAnalyzeAggregateSubquery(
+        ScalarSubqueryExpression subquery,
+        IReadOnlyList<OutputColumn> outerColumns,
+        QueryContext context,
+        out AggregateSubqueryShape shape)
+    {
+        shape = null!;
+        if (subquery.Query is not SelectStatement inner
+            || inner.Projections.Count != 1
+            || inner.Projections[0].Expression is StarExpression or QualifiedStarExpression
+            || !ContainsAggregate(inner.Projections[0].Expression))
+        {
+            return null;
+        }
+
+        if (!TryGetDecorrelationBaseTable(inner.Source, context, out var innerTable, out var innerQualifier))
+            return false;
+
+        // Without a WHERE clause there is nothing to correlate through, and an uncorrelated
+        // aggregate subquery already evaluates once for the whole statement.
+        if (inner.Where is null)
+            return null;
+
+        var value = inner.Projections[0].Expression;
+        var innerColumns = new HashSet<string>(
+            GetSourceColumns(innerTable, context),
+            StringComparer.OrdinalIgnoreCase);
+
+        var pairs = new List<AggregateCorrelationPair>();
+        List<Expression>? innerOnly = null;
+        var correlated = false;
+        foreach (var conjunct in IndexExpressionSemantics.SplitConjuncts(inner.Where))
+        {
+            if (!TryClassifyJoinTerm(conjunct, innerQualifier, innerColumns, out _, out var referencesOuter))
+                return false;
+
+            if (!referencesOuter)
+            {
+                (innerOnly ??= []).Add(conjunct);
+                continue;
+            }
+
+            correlated = true;
+
+            // Only a plain `inner = outer` equality can become a grouping key and a join
+            // condition; anything else stays a per-row filter (unnest.rs:1133-1172).
+            if (!TryReadCorrelationPair(conjunct, innerQualifier, innerColumns, out var pair))
+                return false;
+
+            pairs.Add(pair);
+        }
+
+        if (!correlated)
+            return null;
+
+        // Each excluded clause changes which inner rows the aggregate sees, in what order, or
+        // how many results the subquery produces. Both rewrites replace the subquery's own
+        // grouping, so none of them survives (unnest.rs:934-953). Ahtola's AST carries no
+        // synthesized `LIMIT 1`, so the upstream "limit must be exactly 1" test becomes "no
+        // limit at all".
+        if (inner.Distinct
+            || inner.GroupBy.Count != 0
+            || inner.Having is not null
+            || inner.NamedWindows.Count != 0
+            || inner.OrderBy.Count != 0
+            || inner.Limit is not null
+            || inner.Offset is not null)
+        {
+            return false;
+        }
+
+        // A nested subquery keeps its own correlation scope, which neither rewrite moves; a
+        // nondeterministic scalar call would be evaluated a different number of times
+        // (unnest.rs:944, 968-977).
+        if (ContainsWindowFunction(value)
+            || ContainsSubqueryExpression(value)
+            || ContainsSubqueryExpression(inner.Where)
+            || ContainsNonDeterministicScalarFunction(value)
+            || ContainsNonDeterministicScalarFunction(inner.Where)
+            || ContainsAggregate(inner.Where)
+            || ContainsWindowFunction(inner.Where))
+        {
+            return false;
+        }
+
+        if (!TryCollectAggregateCalls(value, innerQualifier, innerColumns, out var aggregates))
+            return false;
+
+        object? outerOrigin = null;
+        foreach (var pair in pairs)
+        {
+            if (!TryDescribeInnerKey(pair.Inner, innerTable, context, out var innerKey)
+                || !TryDescribeOuterKey(pair.Outer, outerColumns, context, out var outerKey, out var origin))
+            {
+                return false;
+            }
+
+            // An inner BINARY key can split `A` and `a` into two groups that a NOCASE outer key
+            // then joins to both, and an affinity mismatch can do the same for `1` and `'1'`.
+            // Either would emit the outer row twice (unnest.rs:1182-1192).
+            if (innerKey.Affinity != outerKey.Affinity
+                || !string.Equals(innerKey.Collation, outerKey.Collation, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            // Linking the grouped table to more than one outer table would let the join-order
+            // rewriter move it in front of one of them (unnest.rs:542-551).
+            if (outerOrigin is not null && !ReferenceEquals(outerOrigin, origin))
+                return false;
+
+            outerOrigin = origin;
+        }
+
+        if (!TryGetAggregateEmptyInputValue(value, aggregates, out var empty))
+            return false;
+
+        shape = new AggregateSubqueryShape(
+            subquery,
+            inner,
+            innerTable,
+            innerQualifier,
+            value,
+            pairs,
+            innerOnly is null ? null : innerOnly.Aggregate((Expression?)null, CombineConjuncts),
+            empty,
+            AggregateCanRunForUnusedKeys(aggregates, inner.Where, pairs, innerTable, context));
+        return true;
+    }
+
+    /// <summary>
+    /// Group-first: the whole inner table is grouped by the correlation columns once, and the
+    /// resulting one-row-per-key table is LEFT JOINed to the outer rows (unnest.rs:589-687).
+    /// <para>
+    /// The join can match at most one grouped row per outer row — that is exactly what the
+    /// affinity/collation compatibility gate buys — so the outer row count, and with it every
+    /// outer clause, is preserved untouched.
+    /// </para>
+    /// </summary>
+    private bool TryRewriteAggregateGroupFirst(
+        SelectStatement select,
+        QueryContext context,
+        AggregateSubqueryShape shape,
+        out SelectStatement rewritten)
+    {
+        rewritten = select;
+
+        // `SELECT *` would start publishing the grouped table's columns. Expanding the star here
+        // would mean reimplementing SQLite's result-column naming, so decline instead. `t.*`
+        // names one source and is unaffected.
+        foreach (var projection in select.Projections)
+        {
+            if (projection.Expression is StarExpression)
+                return false;
+        }
+
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        CollectFromSourceNames(select.Source, names);
+        var alias = MakeUniqueSourceAlias(names, "ahtola_group_first");
+
+        var keys = new List<ColumnExpression>();
+        var keyIndices = new int[shape.Pairs.Count];
+        for (var index = 0; index < shape.Pairs.Count; index++)
+        {
+            var key = shape.Pairs[index].Inner;
+            var position = keys.FindIndex(existing => existing == key);
+            if (position < 0)
+            {
+                keys.Add(key);
+                position = keys.Count - 1;
+            }
+
+            keyIndices[index] = position;
+        }
+
+        var projections = new List<Projection>(keys.Count + 1)
+        {
+            new(shape.Value, AggregateValueAlias),
+        };
+        for (var index = 0; index < keys.Count; index++)
+            projections.Add(new Projection(keys[index], CorrelationKeyAlias(index)));
+
+        var grouped = new SelectStatement(
+            Distinct: false,
+            Projections: projections,
+            Source: shape.Inner.Source,
+            Where: shape.InnerFilter,
+            GroupBy: keys,
+            Having: null,
+            NamedWindows: [],
+            OrderBy: [],
+            Limit: null,
+            Offset: null);
+
+        Expression? condition = null;
+        for (var index = 0; index < shape.Pairs.Count; index++)
+        {
+            var pair = shape.Pairs[index];
+            var keyReference = QualifiedColumn(alias, CorrelationKeyAlias(keyIndices[index]));
+
+            // Keep the operand order the subquery wrote. SQLite resolves a comparison's
+            // collation from the left operand first, and the grouped column carries none.
+            var equality = pair.InnerWasLeft
+                ? new BinaryExpression(keyReference, BinaryOperator.Equal, pair.Outer)
+                : new BinaryExpression(pair.Outer, BinaryOperator.Equal, keyReference);
+            condition = CombineConjuncts(condition, equality);
+        }
+
+        var value = QualifiedColumn(alias, AggregateValueAlias);
+
+        // An outer row with no matching key reads the left join's NULL padding, which is what
+        // the subquery returns for `avg`/`min`/`max`. `count` and `total` answer 0 and 0.0 for
+        // an empty input, so those keep their identity through COALESCE (unnest.rs:658-662).
+        Expression replacement = shape.EmptyInputValue switch
+        {
+            AggregateEmptyInputValue.IntegerZero => CoalesceWithZero(value, SqlValue.Integer(0)),
+            AggregateEmptyInputValue.RealZero => CoalesceWithZero(value, SqlValue.Real(0.0)),
+            _ => value,
+        };
+
+        if (!TryReplaceScalarSubqueryValue(select, shape.Subquery, replacement, out var replaced))
+            return false;
+
+        rewritten = replaced with
+        {
+            Source = new JoinTableSource(
+                select.Source!,
+                new DerivedTableSource(grouped, alias),
+                condition,
+                JoinKind.Left),
+        };
+        return true;
+    }
+
+    /// <summary>
+    /// Join-first: the inner table is LEFT JOINed directly, the joined rows are grouped back to
+    /// one group per outer row through the outer rowid, and the single WHERE comparison that
+    /// consumed the subquery moves to HAVING (unnest.rs:726-817).
+    /// <para>
+    /// The join only reaches inner rows whose key some outer row asks for, so this form never
+    /// evaluates the aggregate over an unused key — the reason it exists. Each aggregate gains a
+    /// <c>FILTER (WHERE inner.rowid IS NOT NULL)</c> guard so the NULL-padded row a left join
+    /// invents for an unmatched outer row is not counted; without it <c>count(*)</c> would
+    /// answer 1 where the subquery answers 0.
+    /// </para>
+    /// </summary>
+    private bool TryRewriteAggregateJoinFirst(
+        SelectStatement select,
+        QueryContext context,
+        AggregateSubqueryShape shape,
+        out SelectStatement rewritten)
+    {
+        rewritten = select;
+
+        // Grouping by the outer rowid is what keeps outer rows apart, and none of these clauses
+        // survives being pushed around that new grouping step (unnest.rs:732-743).
+        if (select.Distinct
+            || select.GroupBy.Count != 0
+            || select.Having is not null
+            || select.NamedWindows.Count != 0
+            || select.OrderBy.Count != 0
+            || select.Limit is not null
+            || select.Offset is not null
+            || select.Where is null)
+        {
+            return false;
+        }
+
+        foreach (var projection in select.Projections)
+        {
+            if (projection.Expression is StarExpression
+                || ContainsAggregate(projection.Expression)
+                || ContainsWindowFunction(projection.Expression))
+            {
+                return false;
+            }
+        }
+
+        // `GROUP BY o.rowid` needs one group per original outer row, and
+        // `i.rowid IS NOT NULL` needs to mean "a real inner row matched", so both sides must be
+        // ordinary rowid B-tree tables whose rowid spelling is not shadowed by a declared
+        // column (unnest.rs:745-761).
+        if (!TryGetDecorrelationBaseTable(select.Source, context, out var outerTable, out var outerQualifier)
+            || !TryGetRowidTable(outerTable, context, out _)
+            || !TryGetRowidTable(shape.InnerTable, context, out _)
+            || string.Equals(outerQualifier, shape.InnerQualifier, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var outerNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        CollectFromSourceNames(select.Source, outerNames);
+        if (outerNames.Contains(shape.InnerQualifier))
+            return false;
+
+        // An inner-only WHERE term moves into the LEFT JOIN's ON condition. The join executor is
+        // free to test the equality keys before that residual, while the original subquery
+        // evaluates its WHERE conjuncts in source order for every inner row. Moving a fallible
+        // term could therefore hide an error from a non-matching row. Keep the per-row subquery
+        // whenever that evaluation order is observable.
+        if (ExpressionCanFail(shape.InnerFilter))
+            return false;
+
+        // Unlike group-first, whose grouped table publishes two synthetic names, join-first
+        // moves a real table into the enclosing scope. An unqualified outer reference that
+        // names one of its columns would become ambiguous, and a reference the rewrite carries
+        // out of the subquery would resolve against the outer table instead — neither is a
+        // diagnostic or a binding the original statement had.
+        var innerColumns = new HashSet<string>(
+            GetSourceColumns(shape.InnerTable, context),
+            StringComparer.OrdinalIgnoreCase);
+        if (!JoinFirstNamesStayUnambiguous(select, shape, innerColumns))
+            return false;
+
+        foreach (var projection in select.Projections)
+        {
+            if (ExpressionReferencesScalarSubquery(projection.Expression, shape.Subquery))
+                return false;
+        }
+
+        var terms = IndexExpressionSemantics.SplitConjuncts(select.Where);
+        var comparisonIndex = -1;
+        Expression? having = null;
+        for (var index = 0; index < terms.Count; index++)
+        {
+            var term = terms[index];
+            if (!ExpressionReferencesScalarSubquery(term, shape.Subquery))
+            {
+                // After the rewrite an outer row appears once per matching inner row, so every
+                // surviving WHERE term runs once per copy. A term whose value can differ
+                // between copies could keep some and drop others, and the aggregate would then
+                // see only part of the outer row's inner rows (unnest.rs:858-865).
+                if (ContainsNonDeterministicFunction(term)
+                    || ExpressionContainsCorrelatedSubquery(term, outerNames))
+                {
+                    return false;
+                }
+
+                continue;
+            }
+
+            // The rewrite deletes the subquery, so this one comparison must be its only use.
+            if (comparisonIndex >= 0
+                || !TryMoveAggregateComparisonToHaving(term, shape, out having))
+            {
+                return false;
+            }
+
+            comparisonIndex = index;
+        }
+
+        if (comparisonIndex < 0 || having is null)
+            return false;
+
+        Expression? where = null;
+        for (var index = 0; index < terms.Count; index++)
+        {
+            if (index != comparisonIndex)
+                where = CombineConjuncts(where, terms[index]);
+        }
+
+        // The inner WHERE becomes the join condition: its correlation equalities are the join
+        // keys, and its inner-only filters must not reject rows before the left join decides
+        // whether to null-pad (unnest.rs:783-787).
+        Expression? condition = shape.InnerFilter;
+        foreach (var pair in shape.Pairs)
+        {
+            condition = CombineConjuncts(
+                condition,
+                pair.InnerWasLeft
+                    ? new BinaryExpression(pair.Inner, BinaryOperator.Equal, pair.Outer)
+                    : new BinaryExpression(pair.Outer, BinaryOperator.Equal, pair.Inner));
+        }
+
+        rewritten = select with
+        {
+            Source = new JoinTableSource(
+                select.Source!,
+                shape.InnerTable,
+                condition,
+                JoinKind.Left),
+            Where = where,
+            GroupBy = [QualifiedColumn(outerQualifier, "rowid")],
+            Having = having,
+        };
+        return true;
+    }
+
+    /// <summary>
+    /// True when join-first can move the inner table into the enclosing FROM clause without
+    /// changing what any name means.
+    /// <para>
+    /// Two directions have to hold. An <em>unqualified</em> reference already in the enclosing
+    /// query must not name a column of the inner table (or a rowid spelling), because the extra
+    /// table would make it ambiguous. And every reference the rewrite carries out of the
+    /// subquery — the aggregate expression, the inner-only filters and the inner side of each
+    /// correlation equality — must be qualified by the inner table, because an unqualified
+    /// <c>sum(v)</c> that resolved to the subquery's only table would suddenly have two
+    /// candidates.
+    /// </para>
+    /// </summary>
+    private static bool JoinFirstNamesStayUnambiguous(
+        SelectStatement select,
+        AggregateSubqueryShape shape,
+        HashSet<string> innerColumns)
+    {
+        var safe = true;
+        bool VisitEnclosing(Expression expression)
+            => ForEachScopedExpression(expression, candidate =>
+            {
+                if (candidate is ScalarSubqueryExpression scalar)
+                {
+                    // The aggregate subquery itself is the value this rewrite removes. Any
+                    // other nested query has its own name-resolution scope, but an unqualified
+                    // name in that scope may still fall back to this enclosing FROM clause.
+                    // Moving the inner table here could therefore make a previously unique
+                    // correlation ambiguous. Decline rather than duplicate the binder's scope
+                    // and shadowing rules in this safety check.
+                    if (!ReferenceEquals(scalar, shape.Subquery))
+                        safe = false;
+                }
+                else if (candidate is ExistsExpression or InSubqueryExpression)
+                {
+                    safe = false;
+                }
+
+                if (candidate is ColumnExpression { BooleanKeyword: null } column)
+                {
+                    if (column.Qualifier is null)
+                    {
+                        var name = column.UnqualifiedName ?? column.Name;
+                        if (innerColumns.Contains(name) || IsRowIdAlias(name))
+                            safe = false;
+                    }
+                    else if (string.Equals(
+                                 column.Qualifier,
+                                 shape.InnerQualifier,
+                                 StringComparison.OrdinalIgnoreCase))
+                    {
+                        // The enclosing FROM does not currently answer to this qualifier (that
+                        // was checked before this walk), so the reference resolves through an
+                        // outer scope today. Moving the inner table here would capture it.
+                        safe = false;
+                    }
+                }
+
+                return safe;
+            });
+
+        bool VisitMoved(Expression expression)
+            => ForEachExpression(expression, candidate =>
+            {
+                if (candidate is ColumnExpression { BooleanKeyword: null } column
+                    && !string.Equals(column.Qualifier, shape.InnerQualifier, StringComparison.OrdinalIgnoreCase))
+                {
+                    safe = false;
+                }
+
+                return safe;
+            });
+
+        foreach (var projection in select.Projections)
+        {
+            if (!VisitEnclosing(projection.Expression) || !safe)
+                return false;
+        }
+
+        if (select.Where is not null && (!VisitEnclosing(select.Where) || !safe))
+            return false;
+
+        if (!VisitMoved(shape.Value) || !safe)
+            return false;
+
+        if (shape.InnerFilter is not null && (!VisitMoved(shape.InnerFilter) || !safe))
+            return false;
+
+        foreach (var pair in shape.Pairs)
+        {
+            if (!string.Equals(pair.Inner.Qualifier, shape.InnerQualifier, StringComparison.OrdinalIgnoreCase))
+                return false;
+        }
+
+        return safe;
+    }
+
+    /// <summary>
+    /// Rebuilds one WHERE comparison as the HAVING clause of the join-first form: the subquery
+    /// operand becomes the inner aggregate expression, with every aggregate call in it guarded
+    /// against the row a left join invents when nothing matched (unnest.rs:843-897).
+    /// <para>
+    /// Only a comparison whose whole operand is the subquery qualifies. <c>1 + (SELECT …)</c>
+    /// and <c>(SELECT sum(…)) &gt; (SELECT max(…))</c> are rejected: moving one of them would
+    /// leave another use of a removed subquery behind, or evaluate an aggregate outside the
+    /// grouping the rewrite just created.
+    /// </para>
+    /// </summary>
+    private bool TryMoveAggregateComparisonToHaving(
+        Expression term,
+        AggregateSubqueryShape shape,
+        out Expression? having)
+    {
+        having = null;
+        if (term is not BinaryExpression binary || !IsComparisonOperator(binary.Operator))
+            return false;
+
+        var leftIsSubquery = ReferenceEquals(binary.Left, shape.Subquery);
+        var rightIsSubquery = ReferenceEquals(binary.Right, shape.Subquery);
+        if (leftIsSubquery == rightIsSubquery)
+            return false;
+
+        var other = leftIsSubquery ? binary.Right : binary.Left;
+        if (ContainsSubqueryExpression(other))
+            return false;
+
+        var innerRowExists = new BinaryExpression(
+            QualifiedColumn(shape.InnerQualifier, "rowid"),
+            BinaryOperator.IsNot,
+            new LiteralExpression(SqlValue.Null));
+
+        var declined = false;
+        var substitution = new AstSubstitution(
+            Column: null,
+            Function: function => IsAggregateFunctionCall(function) && function.Window is null
+                ? function with
+                {
+                    Filter = function.Filter is null
+                        ? innerRowExists
+                        : new BinaryExpression(innerRowExists, BinaryOperator.And, function.Filter),
+                }
+                : null);
+
+        if (!TryRewriteExpression(shape.Value, substitution, ref declined, out var guarded) || declined)
+            return false;
+
+        having = leftIsSubquery
+            ? new BinaryExpression(guarded, binary.Operator, other)
+            : new BinaryExpression(other, binary.Operator, guarded);
+        return true;
+    }
+
+    /// <summary>
+    /// Replaces every use of one scalar subquery's value with <paramref name="replacement"/>,
+    /// mirroring <c>replace_subquery_value</c> (unnest.rs:1235-1297). Returns false when the
+    /// subquery was not found or a clause holds a node the rewriter does not model.
+    /// </summary>
+    private static bool TryReplaceScalarSubqueryValue(
+        SelectStatement select,
+        ScalarSubqueryExpression subquery,
+        Expression replacement,
+        out SelectStatement rewritten)
+    {
+        rewritten = select;
+        var found = false;
+        var declined = false;
+        var substitution = new AstSubstitution(
+            Column: null,
+            ScalarSubquery: candidate =>
+            {
+                if (!ReferenceEquals(candidate, subquery))
+                    return null;
+
+                found = true;
+                return replacement;
+            });
+
+        List<Projection>? projections = null;
+        for (var index = 0; index < select.Projections.Count; index++)
+        {
+            var projection = select.Projections[index];
+            if (!TryRewriteExpression(projection.Expression, substitution, ref declined, out var expression))
+                return false;
+
+            if (ReferenceEquals(expression, projection.Expression))
+                continue;
+
+            projections ??= [.. select.Projections];
+
+            // Substituting the subquery renames an unaliased result column, so pin the name the
+            // original statement published.
+            projections[index] = projection with
+            {
+                Expression = expression,
+                Alias = projection.Alias ?? projection.SourceText,
+            };
+        }
+
+        if (!TryRewriteClause(select.Where, substitution, ref declined, out var where)
+            || !TryRewriteClause(select.Having, substitution, ref declined, out var having)
+            || !TryRewriteClause(select.Limit, substitution, ref declined, out var limit)
+            || !TryRewriteClause(select.Offset, substitution, ref declined, out var offset)
+            || !TryRewriteExpressionList(select.GroupBy, substitution, ref declined, out var groupBy)
+            || !TryRewriteOrderBy(select.OrderBy, substitution, ref declined, out var orderBy)
+            || declined
+            || !found)
+        {
+            return false;
+        }
+
+        rewritten = select with
+        {
+            Projections = projections ?? select.Projections,
+            Where = where,
+            Having = having,
+            GroupBy = groupBy,
+            OrderBy = orderBy,
+            Limit = limit,
+            Offset = offset,
+        };
+        return true;
+    }
+
+    /// <summary>
+    /// Collects the aggregate calls of the subquery's single result expression and checks that
+    /// the expression is self-contained: every column it reads must come from the inner table
+    /// and must sit inside an aggregate's arguments, FILTER or ORDER BY.
+    /// <para>
+    /// A column read outside an aggregate makes the result depend on which row of the group the
+    /// engine happens to keep, and an outer reference outside the WHERE clause cannot move into
+    /// a grouped table at all (unnest.rs:1195-1214). Extension aggregates decline: their value
+    /// for an empty input is unknown, so neither rewrite can reproduce it (unnest.rs:97-99).
+    /// </para>
+    /// </summary>
+    private bool TryCollectAggregateCalls(
+        Expression value,
+        string innerQualifier,
+        HashSet<string> innerColumns,
+        out List<FunctionExpression> aggregates)
+    {
+        aggregates = [];
+        var calls = aggregates;
+        if (!ForEachExpression(value, candidate =>
+            {
+                if (candidate is FunctionExpression { Window: null } function && IsAggregateFunctionCall(function))
+                    calls.Add(function);
+
+                return true;
+            }))
+        {
+            return false;
+        }
+
+        if (aggregates.Count == 0)
+            return false;
+
+        var covered = new HashSet<object>(AstReferenceComparer.Instance);
+        foreach (var aggregate in aggregates)
+        {
+            // Ordered-set and ORDER BY aggregates carry an ordering the grouped form would have
+            // to reproduce, and a non-built-in aggregate has no known empty-input value.
+            if (aggregate.OrderedSet
+                || aggregate.AggregateOrderBy is { Count: > 0 }
+                || !IsBuiltInAggregate(aggregate))
+            {
+                return false;
+            }
+
+            foreach (var argument in aggregate.Arguments)
+            {
+                if (!ForEachExpression(argument, node => covered.Add(node) || true))
+                    return false;
+            }
+
+            if (aggregate.Filter is not null
+                && !ForEachExpression(aggregate.Filter, node => covered.Add(node) || true))
+            {
+                return false;
+            }
+        }
+
+        var selfContained = true;
+        if (!ForEachExpression(value, candidate =>
+            {
+                if (candidate is not ColumnExpression { BooleanKeyword: null } column)
+                    return true;
+
+                if (!covered.Contains(column) || !IsInnerColumnReference(column, innerQualifier, innerColumns))
+                    selfContained = false;
+
+                return selfContained;
+            }))
+        {
+            return false;
+        }
+
+        return selfContained;
+    }
+
+    /// <summary>
+    /// True when group-first may evaluate the aggregate for every key of the inner table,
+    /// including keys that no outer row asks for (unnest.rs:997-1020).
+    /// <para>
+    /// The original subquery only ever reads the keys the outer rows ask for, so group-first must
+    /// not be able to raise an error those keys never produce. <c>sum</c> can overflow and the
+    /// string aggregates can outgrow the largest SQL value, so only <c>avg</c>, <c>count</c>,
+    /// <c>min</c>, <c>max</c> and <c>total</c> qualify, and only when no aggregate input, no
+    /// aggregate FILTER and no inner WHERE term can fail on its input. Ahtola adds the grouping
+    /// key itself: a group is formed with the key's declared collation, so an
+    /// application-registered sequence would run for unused keys too.
+    /// </para>
+    /// </summary>
+    private bool AggregateCanRunForUnusedKeys(
+        List<FunctionExpression> aggregates,
+        Expression? innerWhere,
+        List<AggregateCorrelationPair> pairs,
+        NamedTableSource innerTable,
+        QueryContext context)
+    {
+        foreach (var aggregate in aggregates)
+        {
+            if (aggregate.Name is not ("AVG" or "COUNT" or "MIN" or "MAX" or "TOTAL"))
+                return false;
+
+            foreach (var argument in aggregate.Arguments)
+            {
+                if (ExpressionCanFail(argument))
+                    return false;
+            }
+
+            if (ExpressionCanFail(aggregate.Filter))
+                return false;
+        }
+
+        if (ExpressionCanFail(innerWhere))
+            return false;
+
+        if (!_hasCustomCollations)
+            return true;
+
+        foreach (var pair in pairs)
+        {
+            if (!TryDescribeInnerKey(pair.Inner, innerTable, context, out var key)
+                || key.Collation is not ("BINARY" or "NOCASE" or "RTRIM"))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// The value the subquery produces when no inner row matches, if it is known
+    /// (unnest.rs:1070-1130). <c>count</c> answers integer 0 and <c>total</c> real 0.0; the
+    /// null-producing aggregates answer NULL, and so does any arithmetic, concatenation, cast,
+    /// collate or unary expression built over one of them.
+    /// </summary>
+    private static bool TryGetAggregateEmptyInputValue(
+        Expression value,
+        List<FunctionExpression> aggregates,
+        out AggregateEmptyInputValue empty)
+    {
+        empty = AggregateEmptyInputValue.Null;
+        if (value is FunctionExpression function && aggregates.Contains(function))
+        {
+            switch (function.Name)
+            {
+                case "COUNT":
+                    empty = AggregateEmptyInputValue.IntegerZero;
+                    return true;
+                case "TOTAL":
+                    empty = AggregateEmptyInputValue.RealZero;
+                    return true;
+                case "AVG" or "GROUP_CONCAT" or "MAX" or "MIN" or "STRING_AGG" or "SUM":
+                    empty = AggregateEmptyInputValue.Null;
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        return IsNullOnEmptyInput(value, aggregates);
+    }
+
+    private static bool IsNullOnEmptyInput(Expression expression, List<FunctionExpression> aggregates)
+    {
+        switch (expression)
+        {
+            case FunctionExpression function when aggregates.Contains(function):
+                return function.Name is "AVG" or "GROUP_CONCAT" or "MAX" or "MIN" or "STRING_AGG" or "SUM";
+            case BinaryExpression
+            {
+                Operator: BinaryOperator.Add
+                    or BinaryOperator.Subtract
+                    or BinaryOperator.Multiply
+                    or BinaryOperator.Divide
+                    or BinaryOperator.Modulo
+                    or BinaryOperator.BitwiseAnd
+                    or BinaryOperator.BitwiseOr
+                    or BinaryOperator.ShiftLeft
+                    or BinaryOperator.ShiftRight
+                    or BinaryOperator.Concatenate,
+            } binary:
+                return IsNullOnEmptyInput(binary.Left, aggregates)
+                    || IsNullOnEmptyInput(binary.Right, aggregates);
+            case UnaryExpression unary:
+                return IsNullOnEmptyInput(unary.Operand, aggregates);
+            case CastExpression cast:
+                return IsNullOnEmptyInput(cast.Expression, aggregates);
+            case CollationExpression collation:
+                return IsNullOnEmptyInput(collation.Expression, aggregates);
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Reads one <c>inner = outer</c> (or <c>outer = inner</c>) correlation term, keeping which
+    /// side the inner column was on so the rewritten comparison resolves its collation from the
+    /// same operand (unnest.rs:1133-1172).
+    /// </summary>
+    private static bool TryReadCorrelationPair(
+        Expression expression,
+        string innerQualifier,
+        HashSet<string> innerColumns,
+        out AggregateCorrelationPair pair)
+    {
+        pair = null!;
+        if (expression is not BinaryExpression { Operator: BinaryOperator.Equal } equality
+            || equality.Left is not ColumnExpression { BooleanKeyword: null } left
+            || equality.Right is not ColumnExpression { BooleanKeyword: null } right)
+        {
+            return false;
+        }
+
+        var leftIsInner = IsInnerColumnReference(left, innerQualifier, innerColumns);
+        var rightIsInner = IsInnerColumnReference(right, innerQualifier, innerColumns);
+        if (leftIsInner == rightIsInner)
+            return false;
+
+        pair = leftIsInner
+            ? new AggregateCorrelationPair(left, right, InnerWasLeft: true)
+            : new AggregateCorrelationPair(right, left, InnerWasLeft: false);
+        return true;
+    }
+
+    /// <summary>
+    /// Resolves the declared affinity and collation of a correlation column of the subquery's
+    /// own table. A rowid spelling declines: grouping by the rowid would put every inner row in
+    /// its own group, which is never worth a rewrite.
+    /// </summary>
+    private static bool TryDescribeInnerKey(
+        ColumnExpression column,
+        NamedTableSource innerTable,
+        QueryContext context,
+        out CorrelationKeyDescription key)
+    {
+        key = default;
+        if (column.Schema is not null || !context.Tables.TryGetValue(innerTable.Name, out var table))
+            return false;
+
+        return TryDescribeTableColumn(table, column.UnqualifiedName ?? column.Name, out key);
+    }
+
+    /// <summary>
+    /// Resolves the declared affinity and collation of a correlation column of the enclosing
+    /// query, and the FROM source it came from. A name that resolves to no source, to more than
+    /// one, or to anything other than an ordinary base table declines: it may belong to a scope
+    /// further out, which neither rewrite can reach (unnest.rs:531-541).
+    /// </summary>
+    private static bool TryDescribeOuterKey(
+        ColumnExpression column,
+        IReadOnlyList<OutputColumn> outerColumns,
+        QueryContext context,
+        out CorrelationKeyDescription key,
+        out object? origin)
+    {
+        key = default;
+        origin = null;
+        if (column.Schema is not null)
+            return false;
+
+        var name = column.UnqualifiedName ?? column.Name;
+        OutputColumn? match = null;
+        foreach (var candidate in outerColumns)
+        {
+            if (!string.Equals(candidate.Name, name, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (column.Qualifier is { } qualifier
+                && !string.Equals(candidate.Qualifier, qualifier, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (match is not null)
+                return false;
+
+            match = candidate;
+        }
+
+        if (match?.Origin is not NamedTableSource named
+            || !context.Tables.TryGetValue(named.Name, out var table)
+            || !TryDescribeTableColumn(table, name, out key))
+        {
+            return false;
+        }
+
+        origin = match.Origin;
+        return true;
+    }
+
+    private static bool TryDescribeTableColumn(
+        EmbeddedTable table,
+        string columnName,
+        out CorrelationKeyDescription key)
+    {
+        key = default;
+        if (!table.TryGetColumnIndex(columnName, out var index))
+            return false;
+
+        var definition = table.ColumnDefinitions[index];
+
+        // A STRICT ANY column keeps whatever it was given, so no single affinity describes how
+        // it compares.
+        if (definition.StrictAny)
+            return false;
+
+        key = new CorrelationKeyDescription(
+            table.GetColumnAffinity(definition),
+            NormalizeDeclaredCollation(definition.Collation));
+        return true;
+    }
+
+    /// <summary>
+    /// The FROM clause must be exactly one ordinary base table. Both rewrites move that table
+    /// into the enclosing query (join-first) or group it in place (group-first), which a view,
+    /// CTE, virtual table, table-valued function or joined source cannot express
+    /// (unnest.rs:754-761, 954-967).
+    /// </summary>
+    private bool TryGetDecorrelationBaseTable(
+        TableSource? source,
+        QueryContext context,
+        out NamedTableSource table,
+        out string qualifier)
+    {
+        table = null!;
+        qualifier = string.Empty;
+
+        if (source is not NamedTableSource named
+            || named.IsSchemaQualified
+            || IsSchemaTable(named.Name)
+            || IsCommonTableExpression(named, context)
+            || TryGetView(context, named.Name, out _)
+            || TryGetVirtualTable(context, named, out _)
+            || TryBindBareTableValuedFunction(named, context, out _)
+            || !context.Tables.ContainsKey(named.Name))
+        {
+            return false;
+        }
+
+        table = named;
+        qualifier = named.Alias ?? named.Name;
+        return true;
+    }
+
+    /// <summary>
+    /// True when the source is a rowid B-tree table whose rowid spelling is not shadowed by a
+    /// declared column, so <c>t.rowid</c> really is the one-per-row identity join-first groups
+    /// by and tests for NULL.
+    /// </summary>
+    private static bool TryGetRowidTable(
+        NamedTableSource source,
+        QueryContext context,
+        out EmbeddedTable table)
+    {
+        table = null!;
+        if (!context.Tables.TryGetValue(source.Name, out var candidate) || !candidate.HasRowid)
+            return false;
+
+        foreach (var column in candidate.Columns)
+        {
+            if (IsRowIdAlias(column))
+                return false;
+        }
+
+        table = candidate;
+        return true;
+    }
+
+    private static bool ExpressionReferencesScalarSubquery(
+        Expression expression,
+        ScalarSubqueryExpression subquery)
+    {
+        var found = false;
+        var modelled = ForEachScopedExpression(expression, candidate =>
+        {
+            if (ReferenceEquals(candidate, subquery))
+                found = true;
+
+            return !found;
+        });
+
+        return found || !modelled;
+    }
+
+    private static Expression CoalesceWithZero(Expression value, SqlValue zero)
+        => new FunctionExpression("COALESCE", [value, new LiteralExpression(zero)], CountStar: false);
+
+    /// <summary>
+    /// Builds a qualified column reference exactly the way the parser builds <c>t.c</c>: the
+    /// canonical <see cref="ColumnExpression.Name"/> is the dotted spelling and
+    /// <see cref="ColumnExpression.UnqualifiedName"/> carries the column on its own. Binding
+    /// looks at both, so a synthesized reference that sets only one of them fails to resolve.
+    /// </summary>
+    private static ColumnExpression QualifiedColumn(string qualifier, string name)
+        => new(
+            Name: string.Concat(qualifier, ".", name),
+            Qualifier: qualifier,
+            UnqualifiedName: name);
+
+    private const string AggregateValueAlias = "ahtola_aggregate_value";
+
+    private static string CorrelationKeyAlias(int index)
+        => string.Create(
+            System.Globalization.CultureInfo.InvariantCulture,
+            $"ahtola_correlation_key_{index}");
+
+    private static string MakeUniqueSourceAlias(HashSet<string> taken, string prefix)
+    {
+        if (!taken.Contains(prefix))
+            return prefix;
+
+        for (var suffix = 0; ; suffix++)
+        {
+            var candidate = string.Create(
+                System.Globalization.CultureInfo.InvariantCulture,
+                $"{prefix}_{suffix}");
+            if (!taken.Contains(candidate))
+                return candidate;
+        }
+    }
 
     // ---------------------------------------------------------------------------------------
     // Shared expression predicates and the fail-closed rewriting walker.
@@ -1260,6 +2503,44 @@ public sealed partial class EmbeddedDatabase
     }
 
     /// <summary>
+    /// True when the expression calls a <em>scalar</em> function whose value can change between
+    /// invocations, mirroring <c>expr_contains_nondeterministic_scalar_function</c>.
+    /// <para>
+    /// A built-in aggregate call is exempt from the test applied to itself — it is a fold over a
+    /// set of input rows, not a per-call value — while its arguments are still examined. Anything
+    /// else this engine does not recognize as a deterministic built-in counts, including an
+    /// application-registered aggregate, whose fold the rewriter cannot reason about.
+    /// </para>
+    /// </summary>
+    private static bool ContainsNonDeterministicScalarFunction(Expression? expression)
+    {
+        if (expression is null)
+            return false;
+
+        var found = false;
+        var modelled = ForEachExpression(expression, candidate =>
+        {
+            switch (candidate)
+            {
+                case FunctionExpression { Window: null } aggregate when IsBuiltInAggregate(aggregate):
+                    break;
+                case FunctionExpression function
+                    when !SqliteBuiltinFunctions.Contains(function.Name)
+                        || !SqliteBuiltinFunctions.IsDeterministic(function.Name):
+                    found = true;
+                    break;
+                case CurrentTimeExpression:
+                    found = true;
+                    break;
+            }
+
+            return !found;
+        });
+
+        return found || !modelled;
+    }
+
+    /// <summary>
     /// True when substituting the expression into more than one place preserves meaning: it
     /// must be free of calls whose result can change and of subqueries (which carry their own
     /// evaluation and memoization lifetime).
@@ -1284,7 +2565,7 @@ public sealed partial class EmbeddedDatabase
 
     private static bool TryRewriteClause(
         Expression? expression,
-        Func<ColumnExpression, Expression?> substitute,
+        AstSubstitution substitute,
         ref bool declined,
         out Expression? result)
     {
@@ -1301,7 +2582,7 @@ public sealed partial class EmbeddedDatabase
 
     private static bool TryRewriteExpressionList(
         IReadOnlyList<Expression> expressions,
-        Func<ColumnExpression, Expression?> substitute,
+        AstSubstitution substitute,
         ref bool declined,
         out IReadOnlyList<Expression> result)
     {
@@ -1328,7 +2609,7 @@ public sealed partial class EmbeddedDatabase
 
     private static bool TryRewriteOrderBy(
         IReadOnlyList<OrderByTerm> orderBy,
-        Func<ColumnExpression, Expression?> substitute,
+        AstSubstitution substitute,
         ref bool declined,
         out IReadOnlyList<OrderByTerm> result)
     {
@@ -1354,14 +2635,19 @@ public sealed partial class EmbeddedDatabase
     }
 
     /// <summary>
-    /// Structural expression rewrite that replaces column references through
-    /// <paramref name="substitute"/>. Subquery operands are opaque leaves (callers vet them
-    /// separately), and any node type not listed declines the rewrite rather than being copied
-    /// through unexamined.
+    /// Structural expression rewrite that replaces nodes through <paramref name="substitute"/>.
+    /// Any node type not listed declines the rewrite rather than being copied through
+    /// unexamined.
+    /// <para>
+    /// A subquery operand is an opaque leaf unless the substitution asks for scalar subqueries
+    /// by name: the flattening rewrite vets them separately, while the aggregate decorrelation
+    /// rewrite replaces exactly the node it decorrelated. Neither descends into a subquery body,
+    /// which belongs to its own scope and gets its own rewrite pass.
+    /// </para>
     /// </summary>
     private static bool TryRewriteExpression(
         Expression expression,
-        Func<ColumnExpression, Expression?> substitute,
+        AstSubstitution substitute,
         ref bool declined,
         out Expression result)
     {
@@ -1373,17 +2659,31 @@ public sealed partial class EmbeddedDatabase
         {
             case ColumnExpression column:
                 {
-                    var replacement = substitute(column);
+                    if (substitute.Column is null)
+                        return true;
+
+                    var replacement = substitute.Column(column);
                     if (declined)
                         return false;
 
                     result = replacement ?? column;
                     return true;
                 }
+            case ScalarSubqueryExpression scalarSubquery:
+                {
+                    if (substitute.ScalarSubquery is null)
+                        return true;
+
+                    var replacement = substitute.ScalarSubquery(scalarSubquery);
+                    if (declined)
+                        return false;
+
+                    result = replacement ?? scalarSubquery;
+                    return true;
+                }
             case LiteralExpression:
             case ParameterExpression:
             case CurrentTimeExpression:
-            case ScalarSubqueryExpression:
             case ExistsExpression:
             case InSubqueryExpression:
             case StarExpression:
@@ -1577,6 +2877,16 @@ public sealed partial class EmbeddedDatabase
                                 Filter = filter,
                                 AggregateOrderBy = aggregateOrderBy,
                             };
+
+                    if (substitute.Function is not null)
+                    {
+                        var replacement = substitute.Function((FunctionExpression)result);
+                        if (declined)
+                            return false;
+
+                        result = replacement ?? result;
+                    }
+
                     return true;
                 }
             default:
@@ -1863,10 +3173,107 @@ public sealed partial class EmbeddedDatabase
 }
 
 /// <summary>Counts of applied AST rewrites, used as test evidence.</summary>
+/// <param name="FlattenedFromSubqueries">FROM-clause derived tables hoisted into their parent.</param>
+/// <param name="SemiJoins">Correlated <c>EXISTS</c>/<c>IN</c> terms turned into a semi join.</param>
+/// <param name="AntiJoins">Correlated <c>NOT EXISTS</c> terms turned into an anti join.</param>
+/// <param name="AggregateGroupFirstRewrites">
+/// Correlated single-value aggregate subqueries decorrelated through the group-first route: a
+/// grouped derived table LEFT JOINed on the correlation keys.
+/// </param>
+/// <param name="AggregateJoinFirstRewrites">
+/// Correlated single-value aggregate subqueries decorrelated through the join-first route: the
+/// inner table LEFT JOINed, grouped by the outer rowid, with the comparison moved to HAVING.
+/// </param>
+/// <param name="AggregateDecorrelationDeclines">
+/// Correlated scalar subqueries that reached the aggregate decorrelation stage carrying an
+/// aggregate — i.e. plausible candidates — and were declined by one of its semantic gates. This
+/// is the positive evidence that an excluded shape was actually considered and rejected, rather
+/// than never reaching the rewriter at all.
+/// </param>
 internal readonly record struct SelectRewriteDiagnostics(
     long FlattenedFromSubqueries,
     long SemiJoins,
-    long AntiJoins);
+    long AntiJoins,
+    long AggregateGroupFirstRewrites,
+    long AggregateJoinFirstRewrites,
+    long AggregateDecorrelationDeclines);
+
+/// <summary>
+/// The node replacements one structural rewrite pass applies. A null delegate leaves that node
+/// kind untouched, which is how the flattening rewrite keeps subquery operands opaque while the
+/// aggregate decorrelation rewrite replaces exactly the scalar subquery it decorrelated.
+/// </summary>
+/// <param name="Column">Applied to every column reference.</param>
+/// <param name="ScalarSubquery">
+/// Applied to every scalar subquery operand, without descending into its body.
+/// </param>
+/// <param name="Function">
+/// Applied to every function call <em>after</em> its arguments, FILTER and ORDER BY have been
+/// rewritten, so a replacement observes the already-rewritten call.
+/// </param>
+internal readonly record struct AstSubstitution(
+    Func<ColumnExpression, Expression?>? Column,
+    Func<ScalarSubqueryExpression, Expression?>? ScalarSubquery = null,
+    Func<FunctionExpression, Expression?>? Function = null)
+{
+    public static AstSubstitution ForColumns(Func<ColumnExpression, Expression?> column) => new(column);
+}
+
+/// <summary>The value a single-value aggregate subquery produces when no inner row matches.</summary>
+internal enum AggregateEmptyInputValue
+{
+    /// <summary>SQL NULL, as returned by <c>avg</c>, <c>min</c>, <c>max</c> and <c>sum</c>.</summary>
+    Null,
+
+    /// <summary>Integer zero, as returned by <c>count</c>.</summary>
+    IntegerZero,
+
+    /// <summary>Real zero, as returned by <c>total</c>.</summary>
+    RealZero,
+}
+
+/// <summary>
+/// One <c>inner = outer</c> equality that links a correlated aggregate subquery to its enclosing
+/// query. <paramref name="InnerWasLeft"/> records which operand the subquery wrote the inner
+/// column on, so the rewritten comparison resolves its collation from the same side.
+/// </summary>
+internal sealed record AggregateCorrelationPair(
+    ColumnExpression Inner,
+    ColumnExpression Outer,
+    bool InnerWasLeft);
+
+/// <summary>The declared comparison behavior of one correlation key column.</summary>
+internal readonly record struct CorrelationKeyDescription(
+    ColumnAffinity Affinity,
+    string Collation);
+
+/// <summary>
+/// A correlated single-value aggregate subquery that passed every shared eligibility gate, with
+/// the pieces both decorrelation routes need.
+/// </summary>
+/// <param name="Subquery">The scalar subquery node to be replaced.</param>
+/// <param name="Inner">Its SELECT body.</param>
+/// <param name="InnerTable">The single base table it reads.</param>
+/// <param name="InnerQualifier">The name that table answers to inside the subquery.</param>
+/// <param name="Value">Its single result expression, which contains the aggregate.</param>
+/// <param name="Pairs">The correlation equalities that link it to the enclosing query.</param>
+/// <param name="InnerFilter">The WHERE terms that stay local to the inner table, if any.</param>
+/// <param name="EmptyInputValue">What the subquery answers when nothing matches.</param>
+/// <param name="CanRunForUnusedKeys">
+/// True when evaluating the aggregate for a correlation key no outer row asks for cannot raise
+/// an error the original statement never raises — the condition that selects group-first over
+/// join-first.
+/// </param>
+internal sealed record AggregateSubqueryShape(
+    ScalarSubqueryExpression Subquery,
+    SelectStatement Inner,
+    NamedTableSource InnerTable,
+    string InnerQualifier,
+    Expression Value,
+    IReadOnlyList<AggregateCorrelationPair> Pairs,
+    Expression? InnerFilter,
+    AggregateEmptyInputValue EmptyInputValue,
+    bool CanRunForUnusedKeys);
 
 /// <summary>
 /// Identity comparer for AST nodes. The AST is built from records, so structural equality

--- a/src/Ahtola.Tests/AggregateSubqueryDecorrelationTests.cs
+++ b/src/Ahtola.Tests/AggregateSubqueryDecorrelationTests.cs
@@ -1,0 +1,1419 @@
+using AwesomeAssertions;
+using MsData = Microsoft.Data.Sqlite;
+using Ahtola.Core;
+
+namespace Ahtola.Tests;
+
+/// <summary>
+/// Coverage for the correlated single-value aggregate decorrelation of
+/// <c>EmbeddedDatabase.SubqueryRewrites.cs</c>: the group-first route (a <c>GROUP BY</c> derived
+/// table LEFT JOINed on the correlation keys) and the join-first route (the inner table LEFT
+/// JOINed, grouped by the outer rowid, with the comparison moved to <c>HAVING</c> behind an
+/// aggregate <c>FILTER</c>).
+/// <para>
+/// Every correctness assertion is differential against Microsoft.Data.Sqlite, and the counters on
+/// <see cref="EmbeddedDatabase.RewriteDiagnostics"/> pin which route ran. An "eligible" test
+/// asserts the route fired; an "excluded" test asserts it declined <em>and</em> that the decline
+/// was counted, so a gate that stops being reached at all is caught rather than passing silently.
+/// </para>
+/// </summary>
+public sealed class AggregateSubqueryDecorrelationTests
+{
+    private const string Setup =
+        """
+        CREATE TABLE outer_rows(id INTEGER PRIMARY KEY, k INTEGER, v INTEGER);
+        CREATE TABLE inner_rows(id INTEGER PRIMARY KEY, k INTEGER, v INTEGER);
+        INSERT INTO outer_rows VALUES
+            (1,1,10),
+            (2,1,200),
+            (3,2,5),
+            (4,NULL,1),
+            (5,9,1),
+            (6,2,4);
+        INSERT INTO inner_rows VALUES
+            (1,1,100),
+            (2,1,300),
+            (3,2,7),
+            (4,NULL,4),
+            (5,2,NULL);
+        """;
+
+    // ------------------------------------------------------------------------------------
+    // Group-first: eligible shapes.
+    // ------------------------------------------------------------------------------------
+
+    [TestCase("avg(i.v)")]
+    [TestCase("count(i.v)")]
+    [TestCase("count(*)")]
+    [TestCase("total(i.v)")]
+    [TestCase("min(i.v)")]
+    [TestCase("max(i.v)")]
+    public void GroupFirstDecorrelatesTheSafeAggregatesInAComparison(string aggregate)
+    {
+        var query =
+            $"""
+            SELECT o.id, o.v
+            FROM outer_rows o
+            WHERE o.v < (SELECT {aggregate} FROM inner_rows i WHERE i.k = o.k)
+            ORDER BY o.id;
+            """;
+
+        AssertMatchesSqlite(Setup, query);
+        AssertRewrites(Setup, query, groupFirst: 1, joinFirst: 0, declines: 0);
+    }
+
+    [TestCase("avg(i.v)")]
+    [TestCase("count(i.v)")]
+    [TestCase("count(*)")]
+    [TestCase("total(i.v)")]
+    [TestCase("min(i.v)")]
+    [TestCase("max(i.v)")]
+    public void GroupFirstDecorrelatesTheSafeAggregatesInTheSelectList(string aggregate)
+    {
+        var query =
+            $"""
+            SELECT o.id, (SELECT {aggregate} FROM inner_rows i WHERE i.k = o.k) AS agg
+            FROM outer_rows o
+            ORDER BY o.id;
+            """;
+
+        AssertMatchesSqlite(Setup, query);
+        AssertRewrites(Setup, query, groupFirst: 1, joinFirst: 0, declines: 0);
+    }
+
+    /// <summary>
+    /// SQLite names an unaliased result column after the source text of the expression that
+    /// produced it. Substituting the subquery with a joined column must not rename it.
+    /// </summary>
+    [Test]
+    public void GroupFirstKeepsTheResultColumnNameOfAnUnaliasedSubquery()
+    {
+        const string query =
+            """
+            SELECT o.id, (SELECT avg(i.v) FROM inner_rows i WHERE i.k = o.k)
+            FROM outer_rows o
+            ORDER BY o.id;
+            """;
+
+        AssertMatchesSqlite(Setup, query);
+        AssertRewrites(Setup, query, groupFirst: 1, joinFirst: 0, declines: 0);
+
+        // count() and total() go through COALESCE, which replaces the projection expression
+        // wholesale — the published name still has to be the original source text.
+        const string counted =
+            """
+            SELECT o.id, (SELECT count(*) FROM inner_rows i WHERE i.k = o.k)
+            FROM outer_rows o
+            ORDER BY o.id;
+            """;
+
+        AssertMatchesSqlite(Setup, counted);
+        AssertRewrites(Setup, counted, groupFirst: 1, joinFirst: 0, declines: 0);
+    }
+
+    /// <summary>
+    /// Several correlated aggregate subqueries in one statement each get their own grouped
+    /// table, and the synthetic alias of the second must not collide with the first.
+    /// </summary>
+    [Test]
+    public void GroupFirstDecorrelatesSeveralSubqueriesInOneStatement()
+    {
+        const string query =
+            """
+            SELECT o.id,
+                   (SELECT avg(i.v) FROM inner_rows i WHERE i.k = o.k) AS a,
+                   (SELECT max(i.v) FROM inner_rows i WHERE i.k = o.id) AS b
+            FROM outer_rows o
+            WHERE o.v < (SELECT count(*) FROM inner_rows i WHERE i.k = o.k) * 1000
+            ORDER BY o.id;
+            """;
+
+        AssertMatchesSqlite(Setup, query);
+        AssertRewrites(Setup, query, groupFirst: 3, joinFirst: 0, declines: 0);
+    }
+
+    /// <summary>
+    /// The whole point of the empty-input analysis: <c>count</c> answers integer 0 and
+    /// <c>total</c> real 0.0 for a key with no matching inner row, while the null-producing
+    /// aggregates answer NULL. A left join produces NULL for all of them, so the two zero cases
+    /// must come back through COALESCE — including the exact storage class, which the
+    /// differential comparison distinguishes.
+    /// </summary>
+    [Test]
+    public void GroupFirstKeepsTheEmptyInputValueOfEveryAggregate()
+    {
+        const string query =
+            """
+            SELECT o.id,
+                   (SELECT count(*) FROM inner_rows i WHERE i.k = o.k) AS c,
+                   (SELECT count(i.v) FROM inner_rows i WHERE i.k = o.k) AS cv,
+                   (SELECT total(i.v) FROM inner_rows i WHERE i.k = o.k) AS t,
+                   (SELECT avg(i.v) FROM inner_rows i WHERE i.k = o.k) AS a,
+                   (SELECT min(i.v) FROM inner_rows i WHERE i.k = o.k) AS mn,
+                   (SELECT max(i.v) FROM inner_rows i WHERE i.k = o.k) AS mx
+            FROM outer_rows o
+            ORDER BY o.id;
+            """;
+
+        // Row 5 has key 9, which no inner row carries, and row 4 has a NULL key that matches
+        // nothing. Both exercise the empty-input path.
+        AssertMatchesSqlite(Setup, query);
+        AssertRewrites(Setup, query, groupFirst: 6, joinFirst: 0, declines: 0);
+
+        // Typed spot check so a REAL 0.0 answered as INTEGER 0 cannot slip through.
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, Setup);
+        Query(connection, "SELECT (SELECT total(i.v) FROM inner_rows i WHERE i.k = o.k) FROM outer_rows o WHERE o.id = 5;")
+            .Single()[0].Kind.Should().Be(SqlValueKind.Real);
+        Query(connection, "SELECT (SELECT count(*) FROM inner_rows i WHERE i.k = o.k) FROM outer_rows o WHERE o.id = 5;")
+            .Single()[0].Kind.Should().Be(SqlValueKind.Integer);
+    }
+
+    /// <summary>
+    /// Several outer rows asking for the same key must each get their own copy of the one
+    /// grouped row, and none of them may be duplicated by the join.
+    /// </summary>
+    [Test]
+    public void GroupFirstHandlesDuplicateAndMissingOuterKeys()
+    {
+        const string setup =
+            """
+            CREATE TABLE o(id INTEGER PRIMARY KEY, k INTEGER);
+            CREATE TABLE i(id INTEGER PRIMARY KEY, k INTEGER, v INTEGER);
+            INSERT INTO o VALUES (1,7),(2,7),(3,7),(4,8),(5,99);
+            INSERT INTO i VALUES (1,7,1),(2,7,2),(3,7,3),(4,8,10);
+            """;
+
+        const string query =
+            """
+            SELECT o.id, (SELECT avg(i.v) FROM i WHERE i.k = o.k) AS a
+            FROM o
+            ORDER BY o.id;
+            """;
+
+        AssertMatchesSqlite(setup, query);
+        AssertRewrites(setup, query, groupFirst: 1, joinFirst: 0, declines: 0);
+
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, setup);
+        Query(connection, query).Should().HaveCount(5, "the join must not multiply outer rows");
+    }
+
+    /// <summary>
+    /// A NULL correlation key matches nothing on either side of the rewrite: the subquery's
+    /// <c>i.k = o.k</c> is NULL for every inner row, and the rewritten join condition is NULL for
+    /// every grouped row — including the group the inner NULL keys form.
+    /// </summary>
+    [Test]
+    public void GroupFirstNeverMatchesANullCorrelationKey()
+    {
+        const string setup =
+            """
+            CREATE TABLE o(id INTEGER PRIMARY KEY, k INTEGER);
+            CREATE TABLE i(id INTEGER PRIMARY KEY, k INTEGER, v INTEGER);
+            INSERT INTO o VALUES (1,NULL),(2,1);
+            INSERT INTO i VALUES (1,NULL,5),(2,NULL,6),(3,1,9);
+            """;
+
+        const string query =
+            """
+            SELECT o.id,
+                   (SELECT count(*) FROM i WHERE i.k = o.k) AS c,
+                   (SELECT avg(i.v) FROM i WHERE i.k = o.k) AS a
+            FROM o
+            ORDER BY o.id;
+            """;
+
+        AssertMatchesSqlite(setup, query);
+        AssertRewrites(setup, query, groupFirst: 2, joinFirst: 0, declines: 0);
+    }
+
+    [Test]
+    public void GroupFirstSupportsSeveralCorrelationColumns()
+    {
+        const string setup =
+            """
+            CREATE TABLE o(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER);
+            CREATE TABLE i(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER, v INTEGER);
+            INSERT INTO o VALUES (1,1,1),(2,1,2),(3,2,1),(4,9,9);
+            INSERT INTO i VALUES (1,1,1,10),(2,1,1,20),(3,1,2,30),(4,2,1,40);
+            """;
+
+        const string query =
+            """
+            SELECT o.id, (SELECT avg(i.v) FROM i WHERE i.a = o.a AND i.b = o.b) AS a
+            FROM o
+            ORDER BY o.id;
+            """;
+
+        AssertMatchesSqlite(setup, query);
+        AssertRewrites(setup, query, groupFirst: 1, joinFirst: 0, declines: 0);
+    }
+
+    /// <summary>
+    /// A WHERE term that only reads the inner table stays inside the grouped derived table, so
+    /// the group it forms is exactly the set the subquery would have aggregated.
+    /// </summary>
+    [Test]
+    public void GroupFirstKeepsInnerOnlyFiltersInsideTheGroupedTable()
+    {
+        const string query =
+            """
+            SELECT o.id, (SELECT count(*) FROM inner_rows i WHERE i.k = o.k AND i.v > 50) AS c
+            FROM outer_rows o
+            ORDER BY o.id;
+            """;
+
+        AssertMatchesSqlite(Setup, query);
+        AssertRewrites(Setup, query, groupFirst: 1, joinFirst: 0, declines: 0);
+    }
+
+    /// <summary>
+    /// The correlation may be written either way round, and the aggregate may sit inside a larger
+    /// NULL-propagating expression whose empty-input value is still known.
+    /// </summary>
+    [Test]
+    public void GroupFirstAcceptsReversedCorrelationAndAggregateExpressions()
+    {
+        const string reversed =
+            """
+            SELECT o.id, (SELECT avg(i.v) FROM inner_rows i WHERE o.k = i.k) AS a
+            FROM outer_rows o
+            ORDER BY o.id;
+            """;
+        AssertMatchesSqlite(Setup, reversed);
+        AssertRewrites(Setup, reversed, groupFirst: 1, joinFirst: 0, declines: 0);
+
+        const string expression =
+            """
+            SELECT o.id, (SELECT avg(i.v) * 2 + 1 FROM inner_rows i WHERE i.k = o.k) AS a
+            FROM outer_rows o
+            ORDER BY o.id;
+            """;
+        AssertMatchesSqlite(Setup, expression);
+        AssertRewrites(Setup, expression, groupFirst: 1, joinFirst: 0, declines: 0);
+
+        const string casted =
+            """
+            SELECT o.id, (SELECT CAST(max(i.v) AS TEXT) FROM inner_rows i WHERE i.k = o.k) AS a
+            FROM outer_rows o
+            ORDER BY o.id;
+            """;
+        AssertMatchesSqlite(Setup, casted);
+        AssertRewrites(Setup, casted, groupFirst: 1, joinFirst: 0, declines: 0);
+    }
+
+    /// <summary>
+    /// <c>count(*) + 0</c> is 0 for an empty input, not NULL, so its empty-input value is not
+    /// known to the NULL-propagation analysis and the rewrite must decline rather than answer
+    /// NULL where SQLite answers 0.
+    /// </summary>
+    [Test]
+    public void DeclinesAnExpressionWhoseEmptyInputValueIsNotKnown()
+    {
+        const string query =
+            """
+            SELECT o.id, (SELECT count(*) + 0 FROM inner_rows i WHERE i.k = o.k) AS c
+            FROM outer_rows o
+            ORDER BY o.id;
+            """;
+
+        AssertMatchesSqlite(Setup, query);
+        AssertRewrites(Setup, query, groupFirst: 0, joinFirst: 0, declines: 1);
+    }
+
+    [Test]
+    public void GroupFirstComposesWithOuterGroupingAndAggregates()
+    {
+        const string query =
+            """
+            SELECT o.k, count(*) AS n
+            FROM outer_rows o
+            WHERE o.v < (SELECT avg(i.v) FROM inner_rows i WHERE i.k = o.k)
+            GROUP BY o.k
+            ORDER BY o.k;
+            """;
+
+        AssertMatchesSqlite(Setup, query);
+        AssertRewrites(Setup, query, groupFirst: 1, joinFirst: 0, declines: 0);
+    }
+
+    [Test]
+    public void GroupFirstSupportsAnAliasedOuterStarProjection()
+    {
+        const string query =
+            """
+            SELECT o.*
+            FROM outer_rows o
+            WHERE o.v < (SELECT avg(i.v) FROM inner_rows i WHERE i.k = o.k)
+            ORDER BY o.id;
+            """;
+
+        AssertMatchesSqlite(Setup, query);
+        AssertRewrites(Setup, query, groupFirst: 1, joinFirst: 0, declines: 0);
+    }
+
+    /// <summary>
+    /// A bare <c>*</c> publishes every FROM column, so the grouped table would leak two synthetic
+    /// columns into the result. Expanding the star here would mean reimplementing SQLite's
+    /// result-column naming, so the rewrite declines.
+    /// </summary>
+    [Test]
+    public void DeclinesABareOuterStarProjection()
+    {
+        const string query =
+            """
+            SELECT *
+            FROM outer_rows o
+            WHERE o.v < (SELECT avg(i.v) FROM inner_rows i WHERE i.k = o.k)
+            ORDER BY o.id;
+            """;
+
+        AssertMatchesSqlite(Setup, query);
+        AssertRewrites(Setup, query, groupFirst: 0, joinFirst: 0, declines: 1);
+    }
+
+    // ------------------------------------------------------------------------------------
+    // Join-first: aggregates that must not run for an unused key.
+    // ------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// <c>sum</c> can overflow, so group-first is not allowed to compute it for a key no outer
+    /// row asks for. Join-first reaches only the keys the outer rows ask for.
+    /// </summary>
+    [Test]
+    public void JoinFirstDecorrelatesSum()
+    {
+        const string query =
+            """
+            SELECT o.id, o.v
+            FROM outer_rows o
+            WHERE o.v > (SELECT sum(i.v) FROM inner_rows i WHERE i.k = o.k);
+            """;
+
+        AssertMatchesSqliteUnordered(Setup, query);
+        AssertRewrites(Setup, query, groupFirst: 0, joinFirst: 1, declines: 0);
+    }
+
+    /// <summary>
+    /// The exact regression the <c>FILTER (WHERE i.rowid IS NOT NULL)</c> guard exists for: an
+    /// outer row with no matching inner row is null-padded by the left join, and an unguarded
+    /// <c>count(*)</c> would count that invented row as 1 where the subquery answers 0.
+    /// </summary>
+    [Test]
+    public void JoinFirstDoesNotCountTheNullPaddedRow()
+    {
+        const string setup =
+            """
+            CREATE TABLE o(id INTEGER PRIMARY KEY, k INTEGER, v INTEGER);
+            CREATE TABLE i(id INTEGER PRIMARY KEY, k INTEGER, v INTEGER, j TEXT);
+            INSERT INTO o VALUES (1,1,5),(2,9,5),(3,NULL,5);
+            INSERT INTO i VALUES (1,1,1,'{"a":1}');
+            """;
+
+        // json_extract makes the aggregate input fallible, which forces the join-first route
+        // even for count().
+        const string query =
+            """
+            SELECT o.id
+            FROM o
+            WHERE o.v > (SELECT count(json_extract(i.j, '$.a')) FROM i WHERE i.k = o.k);
+            """;
+
+        AssertMatchesSqliteUnordered(setup, query);
+        AssertRewrites(setup, query, groupFirst: 0, joinFirst: 1, declines: 0);
+
+        const string sumQuery =
+            """
+            SELECT o.id
+            FROM o
+            WHERE o.v > (SELECT sum(i.v) FROM i WHERE i.k = o.k);
+            """;
+
+        // sum() over no rows is NULL, and `5 > NULL` is NULL, so rows 2 and 3 must be dropped.
+        AssertMatchesSqliteUnordered(setup, sumQuery);
+        AssertRewrites(setup, sumQuery, groupFirst: 0, joinFirst: 1, declines: 0);
+    }
+
+    [Test]
+    public void JoinFirstKeepsRemainingWhereTermsAndInnerOnlyFilters()
+    {
+        const string query =
+            """
+            SELECT o.id, o.k
+            FROM outer_rows o
+            WHERE o.id <> 3 AND o.v > (SELECT sum(i.v) FROM inner_rows i WHERE i.k = o.k AND i.v < 200);
+            """;
+
+        AssertMatchesSqliteUnordered(Setup, query);
+        AssertRewrites(Setup, query, groupFirst: 0, joinFirst: 1, declines: 0);
+    }
+
+    /// <summary>
+    /// An outer row that matches several inner rows appears once per match after the join, so the
+    /// grouping by the outer rowid has to collapse them back into exactly one output row.
+    /// </summary>
+    [Test]
+    public void JoinFirstEmitsOneRowPerOuterRow()
+    {
+        const string setup =
+            """
+            CREATE TABLE o(id INTEGER PRIMARY KEY, k INTEGER, v INTEGER);
+            CREATE TABLE i(id INTEGER PRIMARY KEY, k INTEGER, v INTEGER);
+            INSERT INTO o VALUES (1,7,100),(2,7,100);
+            INSERT INTO i VALUES (1,7,1),(2,7,2),(3,7,3),(4,7,4);
+            """;
+
+        const string query = "SELECT o.id FROM o WHERE o.v > (SELECT sum(i.v) FROM i WHERE i.k = o.k);";
+
+        AssertMatchesSqliteUnordered(setup, query);
+        AssertRewrites(setup, query, groupFirst: 0, joinFirst: 1, declines: 0);
+
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, setup);
+        Query(connection, query).Should().HaveCount(2);
+    }
+
+    [TestCase("<")]
+    [TestCase("<=")]
+    [TestCase(">")]
+    [TestCase(">=")]
+    [TestCase("=")]
+    [TestCase("<>")]
+    public void JoinFirstMovesEveryComparisonOperatorToHaving(string @operator)
+    {
+        var query =
+            $"""
+            SELECT o.id
+            FROM outer_rows o
+            WHERE o.v {@operator} (SELECT sum(i.v) FROM inner_rows i WHERE i.k = o.k);
+            """;
+
+        AssertMatchesSqliteUnordered(Setup, query);
+        AssertRewrites(Setup, query, groupFirst: 0, joinFirst: 1, declines: 0);
+    }
+
+    [Test]
+    public void JoinFirstAcceptsTheSubqueryOnEitherSideOfTheComparison()
+    {
+        const string query =
+            """
+            SELECT o.id
+            FROM outer_rows o
+            WHERE (SELECT sum(i.v) FROM inner_rows i WHERE i.k = o.k) < o.v;
+            """;
+
+        AssertMatchesSqliteUnordered(Setup, query);
+        AssertRewrites(Setup, query, groupFirst: 0, joinFirst: 1, declines: 0);
+    }
+
+    /// <summary>
+    /// Join-first only knows how to move one whole WHERE comparison. Every other placement of the
+    /// value — a select-list reference, an operand of a larger expression, a second WHERE term —
+    /// would leave a use of a subquery the rewrite is about to delete.
+    /// </summary>
+    [TestCase("SELECT o.id, (SELECT sum(i.v) FROM inner_rows i WHERE i.k = o.k) AS s FROM outer_rows o ORDER BY o.id;")]
+    [TestCase("SELECT o.id FROM outer_rows o WHERE o.v > 1 + (SELECT sum(i.v) FROM inner_rows i WHERE i.k = o.k) ORDER BY o.id;")]
+    [TestCase("SELECT o.id FROM outer_rows o WHERE o.v > (SELECT sum(i.v) FROM inner_rows i WHERE i.k = o.k) OR o.id = 1 ORDER BY o.id;")]
+    [TestCase("SELECT o.id FROM outer_rows o WHERE (SELECT sum(i.v) FROM inner_rows i WHERE i.k = o.k) IS NULL ORDER BY o.id;")]
+    public void DeclinesJoinFirstWhenTheValueIsNotOneWholeComparison(string query)
+    {
+        AssertMatchesSqlite(Setup, query);
+        AssertRewrites(Setup, query, groupFirst: 0, joinFirst: 0, declines: 1);
+    }
+
+    /// <summary>
+    /// Join-first cannot preserve these outer clauses around the grouping step it introduces, so
+    /// each of them declines the rewrite and the subquery keeps its per-row evaluation.
+    /// </summary>
+    [TestCase("SELECT DISTINCT o.k FROM outer_rows o WHERE o.v > (SELECT sum(i.v) FROM inner_rows i WHERE i.k = o.k);")]
+    [TestCase("SELECT o.id FROM outer_rows o WHERE o.v > (SELECT sum(i.v) FROM inner_rows i WHERE i.k = o.k) ORDER BY o.id;")]
+    [TestCase("SELECT o.id FROM outer_rows o WHERE o.v > (SELECT sum(i.v) FROM inner_rows i WHERE i.k = o.k) LIMIT 2;")]
+    [TestCase("SELECT count(*) FROM outer_rows o WHERE o.v > (SELECT sum(i.v) FROM inner_rows i WHERE i.k = o.k);")]
+    [TestCase("SELECT o.k FROM outer_rows o WHERE o.v > (SELECT sum(i.v) FROM inner_rows i WHERE i.k = o.k) GROUP BY o.k;")]
+    public void DeclinesJoinFirstForOuterClausesItCannotPreserve(string query)
+    {
+        AssertMatchesSqlite(Setup, query);
+        AssertRewrites(Setup, query, groupFirst: 0, joinFirst: 0, declines: 1);
+    }
+
+    /// <summary>
+    /// After the join an outer row appears once per matching inner row, so a surviving WHERE term
+    /// runs once per copy. A nondeterministic term could then keep some copies and drop others,
+    /// leaving the aggregate to see only part of the row's inner rows.
+    /// </summary>
+    [Test]
+    public void DeclinesJoinFirstWhenAnotherWhereTermIsNondeterministic()
+    {
+        const string query =
+            """
+            SELECT o.id
+            FROM outer_rows o
+            WHERE o.v > (SELECT sum(i.v) FROM inner_rows i WHERE i.k = o.k) AND random() <> 0;
+            """;
+
+        AssertRewrites(Setup, query, groupFirst: 0, joinFirst: 0, declines: 1);
+    }
+
+    [Test]
+    public void DeclinesJoinFirstWhenAnotherWhereTermReadsACorrelatedSubquery()
+    {
+        const string query =
+            """
+            SELECT o.id
+            FROM outer_rows o
+            WHERE o.v > (SELECT sum(i.v) FROM inner_rows i WHERE i.k = o.k)
+              AND EXISTS (SELECT 1 FROM inner_rows x WHERE x.k = o.k AND x.v > 1000);
+            """;
+
+        AssertMatchesSqlite(Setup, query);
+        AssertRewrites(Setup, query, groupFirst: 0, joinFirst: 0, declines: 1);
+    }
+
+    /// <summary>
+    /// Join-first moves a real table into the enclosing scope, so a name that resolved to
+    /// exactly one column before the rewrite must still resolve to exactly one after it. An
+    /// unqualified enclosing reference that the inner table also answers to, and an unqualified
+    /// reference inside the subquery that the outer table also answers to, both decline.
+    /// </summary>
+    [Test]
+    public void DeclinesJoinFirstWhenAddingTheInnerTableWouldMakeANameAmbiguous()
+    {
+        // `id` and `v` exist on both tables, so the unqualified outer references would become
+        // ambiguous once inner_rows joins the enclosing FROM clause.
+        const string unqualifiedOuter =
+            """
+            SELECT id FROM outer_rows o WHERE v > (SELECT sum(i.v) FROM inner_rows i WHERE i.k = o.k);
+            """;
+        AssertMatchesSqlite(Setup, unqualifiedOuter);
+        AssertRewrites(Setup, unqualifiedOuter, groupFirst: 0, joinFirst: 0, declines: 1);
+
+        // The mirror image: `sum(v)` and `k` resolve to the subquery's only table today, but
+        // would have two candidates in the joined scope.
+        const string unqualifiedInner =
+            """
+            SELECT o.id FROM outer_rows o WHERE o.v > (SELECT sum(v) FROM inner_rows i WHERE k = o.k);
+            """;
+        AssertMatchesSqlite(Setup, unqualifiedInner);
+        AssertRewrites(Setup, unqualifiedInner, groupFirst: 0, joinFirst: 0, declines: 1);
+
+        // An unqualified reference whose name the inner table does not carry is unaffected.
+        const string setup =
+            """
+            CREATE TABLE o(id INTEGER PRIMARY KEY, k INTEGER, budget INTEGER);
+            CREATE TABLE i(id INTEGER PRIMARY KEY, k INTEGER, amount INTEGER);
+            INSERT INTO o VALUES (1,1,500),(2,1,5),(3,9,5);
+            INSERT INTO i VALUES (1,1,10),(2,1,20);
+            """;
+        const string safe = "SELECT budget FROM o WHERE budget > (SELECT sum(i.amount) FROM i WHERE i.k = o.k);";
+        AssertMatchesSqliteUnordered(setup, safe);
+        AssertRewrites(setup, safe, groupFirst: 0, joinFirst: 1, declines: 0);
+    }
+
+    [Test]
+    public void DeclinesJoinFirstWhenANestedQueryCouldResolveAgainstTheMovedTable()
+    {
+        const string setup =
+            """
+            CREATE TABLE o(id INTEGER PRIMARY KEY, k INTEGER, v INTEGER);
+            CREATE TABLE i(id INTEGER PRIMARY KEY, k INTEGER, v INTEGER);
+            CREATE TABLE z(q INTEGER, w INTEGER);
+            INSERT INTO o VALUES (1,1,5),(2,9,5);
+            INSERT INTO i VALUES (1,1,1),(2,1,2);
+            INSERT INTO z VALUES (1,7),(9,7);
+            """;
+        var queries = new[]
+        {
+            """
+            SELECT o.id FROM o
+            WHERE o.v > (SELECT sum(i.v) FROM i WHERE i.k = o.k)
+              AND (SELECT z.w FROM z WHERE z.q = k) > 0;
+            """,
+            """
+            SELECT (SELECT z.w FROM z WHERE z.q = k) AS w FROM o
+            WHERE o.v > (SELECT sum(i.v) FROM i WHERE i.k = o.k);
+            """,
+            """
+            SELECT o.id FROM o
+            WHERE o.v > (SELECT sum(i.v) FROM i WHERE i.k = o.k)
+              AND EXISTS (SELECT 1 FROM z WHERE z.q = k);
+            """,
+        };
+
+        foreach (var query in queries)
+        {
+            AssertMatchesSqliteUnordered(setup, query);
+            AssertRewrites(setup, query, groupFirst: 0, joinFirst: 0, declines: 1);
+        }
+    }
+
+    [Test]
+    public void DeclinesJoinFirstWhenTheMovedQualifierWouldCaptureAnOuterScope()
+    {
+        const string setup =
+            """
+            CREATE TABLE i(id INTEGER PRIMARY KEY, k INTEGER, v INTEGER, z INTEGER);
+            CREATE TABLE o(id INTEGER PRIMARY KEY, k INTEGER, v INTEGER);
+            INSERT INTO i VALUES (1,1,10,1),(2,1,20,0);
+            INSERT INTO o VALUES (1,1,25);
+            """;
+        const string query =
+            """
+            SELECT i.id,
+                   (SELECT o.id FROM o
+                    WHERE o.v > (SELECT sum(i.v) FROM i WHERE i.k = o.k)
+                      AND i.z = 1)
+            FROM i
+            ORDER BY i.id;
+            """;
+
+        AssertMatchesSqlite(setup, query);
+        AssertRewrites(setup, query, groupFirst: 0, joinFirst: 0, declines: 2);
+
+        const string delete =
+            """
+            DELETE FROM i
+            WHERE i.id IN (SELECT o.id FROM o
+                           WHERE o.v > (SELECT sum(i.v) FROM i WHERE i.k = o.k)
+                             AND i.z = 1);
+            """;
+        AssertMatchesSqlite(
+            setup + Environment.NewLine + delete,
+            "SELECT id, k, v, z FROM i ORDER BY id;");
+
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, setup);
+        database.ResetRewriteDiagnostics();
+        Execute(connection, delete);
+        database.RewriteDiagnostics.AggregateGroupFirstRewrites.Should().Be(0);
+        database.RewriteDiagnostics.AggregateJoinFirstRewrites.Should().Be(0);
+        database.RewriteDiagnostics.AggregateDecorrelationDeclines.Should().Be(2);
+    }
+
+    /// <summary>
+    /// Join-first needs a rowid on both sides: <c>GROUP BY o.rowid</c> makes one group per outer
+    /// row, and <c>i.rowid IS NOT NULL</c> is how the NULL-padded row is recognized.
+    /// </summary>
+    [Test]
+    public void DeclinesJoinFirstForWithoutRowidTables()
+    {
+        const string setup =
+            """
+            CREATE TABLE o(k INTEGER, v INTEGER, PRIMARY KEY(k, v)) WITHOUT ROWID;
+            CREATE TABLE i(id INTEGER PRIMARY KEY, k INTEGER, v INTEGER);
+            INSERT INTO o VALUES (1,5),(9,5);
+            INSERT INTO i VALUES (1,1,1),(2,1,2);
+            """;
+
+        const string query = "SELECT o.k FROM o WHERE o.v > (SELECT sum(i.v) FROM i WHERE i.k = o.k);";
+
+        AssertMatchesSqlite(setup, query);
+        AssertRewrites(setup, query, groupFirst: 0, joinFirst: 0, declines: 1);
+
+        const string innerSetup =
+            """
+            CREATE TABLE o(id INTEGER PRIMARY KEY, k INTEGER, v INTEGER);
+            CREATE TABLE i(k INTEGER, v INTEGER, PRIMARY KEY(k, v)) WITHOUT ROWID;
+            INSERT INTO o VALUES (1,1,5),(2,9,5);
+            INSERT INTO i VALUES (1,1),(1,2);
+            """;
+
+        const string innerQuery = "SELECT o.id FROM o WHERE o.v > (SELECT sum(i.v) FROM i WHERE i.k = o.k);";
+        AssertMatchesSqlite(innerSetup, innerQuery);
+        AssertRewrites(innerSetup, innerQuery, groupFirst: 0, joinFirst: 0, declines: 1);
+    }
+
+    /// <summary>
+    /// A declared <c>rowid</c> column shadows the pseudo-column, so <c>o.rowid</c> would name an
+    /// ordinary value that need not be unique and need not be non-NULL.
+    /// </summary>
+    [Test]
+    public void DeclinesJoinFirstWhenARowidSpellingIsShadowed()
+    {
+        const string setup =
+            """
+            CREATE TABLE o(id INTEGER PRIMARY KEY, k INTEGER, v INTEGER);
+            CREATE TABLE i(id INTEGER PRIMARY KEY, k INTEGER, v INTEGER, rowid TEXT);
+            INSERT INTO o VALUES (1,1,5),(2,9,5);
+            INSERT INTO i VALUES (1,1,1,NULL),(2,1,2,NULL);
+            """;
+
+        const string query = "SELECT o.id FROM o WHERE o.v > (SELECT sum(i.v) FROM i WHERE i.k = o.k);";
+
+        AssertMatchesSqlite(setup, query);
+        AssertRewrites(setup, query, groupFirst: 0, joinFirst: 0, declines: 1);
+    }
+
+    // ------------------------------------------------------------------------------------
+    // Unused-key safety: which route an expression forces.
+    // ------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Group-first evaluates the aggregate for every key, including keys no outer row asks for.
+    /// A fallible input would then raise an error the original statement never raises, so those
+    /// shapes must take the join-first route — and when join-first does not apply, no route.
+    /// </summary>
+    [Test]
+    public void AFallibleAggregateInputForcesJoinFirstAndNeverInventsAnError()
+    {
+        const string setup =
+            """
+            CREATE TABLE o(id INTEGER PRIMARY KEY, k INTEGER, v INTEGER);
+            CREATE TABLE i(id INTEGER PRIMARY KEY, k INTEGER, j TEXT);
+            INSERT INTO o VALUES (1,1,5);
+            INSERT INTO i VALUES (1,1,'{"a":1}'),(2,99,'not json at all');
+            """;
+
+        // Key 99 holds malformed JSON, and no outer row asks for it. The original statement
+        // therefore never parses it, and neither may the rewrite.
+        const string query =
+            """
+            SELECT o.id
+            FROM o
+            WHERE o.v > (SELECT avg(json_extract(i.j, '$.a')) FROM i WHERE i.k = o.k);
+            """;
+
+        AssertMatchesSqliteUnordered(setup, query);
+        AssertRewrites(setup, query, groupFirst: 0, joinFirst: 1, declines: 0);
+
+        // Same fallible input in the select list: join-first cannot move a select-list value, so
+        // the subquery stays as it is rather than taking the unsafe group-first route.
+        const string projected =
+            """
+            SELECT o.id, (SELECT avg(json_extract(i.j, '$.a')) FROM i WHERE i.k = o.k) AS a
+            FROM o
+            ORDER BY o.id;
+            """;
+        AssertMatchesSqlite(setup, projected);
+        AssertRewrites(setup, projected, groupFirst: 0, joinFirst: 0, declines: 1);
+    }
+
+    /// <summary>
+    /// A fallible inner WHERE term cannot take either route. Group-first would evaluate it against
+    /// unused keys, while join-first would move it into an ON condition whose key-first evaluation
+    /// could hide an error from a non-matching row.
+    /// </summary>
+    [Test]
+    public void AFallibleInnerWhereTermDeclinesBothRoutes()
+    {
+        const string setup =
+            """
+            CREATE TABLE o(id INTEGER PRIMARY KEY, k INTEGER, v INTEGER);
+            CREATE TABLE i(id INTEGER PRIMARY KEY, k INTEGER, v INTEGER, j TEXT);
+            INSERT INTO o VALUES (1,1,500);
+            INSERT INTO i VALUES (1,1,7,'{"a":1}'),(2,99,8,'nope');
+            """;
+
+        const string query =
+            """
+            SELECT o.id
+            FROM o
+            WHERE o.v > (SELECT count(*) FROM i WHERE i.k = o.k AND json_extract(i.j, '$.a') = 1);
+            """;
+
+        AssertMatchesSqliteUnordered(setup, query);
+        AssertRewrites(setup, query, groupFirst: 0, joinFirst: 0, declines: 1);
+
+        // With the fallible term first, SQLite evaluates it for the non-matching malformed row
+        // before the correlation equality can short-circuit. The declined rewrite must preserve
+        // that runtime error instead of silently returning the matching outer row.
+        const string fallibleFirst =
+            """
+            SELECT o.id
+            FROM o
+            WHERE o.v > (SELECT count(*) FROM i WHERE json_extract(i.j, '$.a') = 1 AND i.k = o.k);
+            """;
+
+        AssertFailsLikeSqlite(setup, fallibleFirst, "malformed JSON");
+    }
+
+    /// <summary>
+    /// The string aggregates can outgrow the largest SQL value for an unused key, and an
+    /// extension aggregate has no known empty-input value at all. Neither may take group-first;
+    /// <c>group_concat</c> in a comparison can still take join-first, but a registered aggregate
+    /// declines outright.
+    /// </summary>
+    [Test]
+    public void StringAndExtensionAggregatesDoNotTakeGroupFirst()
+    {
+        const string setup =
+            """
+            CREATE TABLE o(id INTEGER PRIMARY KEY, k INTEGER, v TEXT);
+            CREATE TABLE i(id INTEGER PRIMARY KEY, k INTEGER, v TEXT);
+            INSERT INTO o VALUES (1,1,'zzz'),(2,9,'a');
+            INSERT INTO i VALUES (1,1,'b'),(2,1,'c');
+            """;
+
+        const string concat =
+            """
+            SELECT o.id FROM o WHERE o.v > (SELECT group_concat(i.v) FROM i WHERE i.k = o.k);
+            """;
+        AssertMatchesSqliteUnordered(setup, concat);
+        AssertRewrites(setup, concat, groupFirst: 0, joinFirst: 1, declines: 0);
+
+        const string projected =
+            """
+            SELECT o.id, (SELECT group_concat(i.v) FROM i WHERE i.k = o.k) AS g FROM o ORDER BY o.id;
+            """;
+        AssertMatchesSqlite(setup, projected);
+        AssertRewrites(setup, projected, groupFirst: 0, joinFirst: 0, declines: 1);
+    }
+
+    // ------------------------------------------------------------------------------------
+    // Comparison compatibility between the grouping key and the join key.
+    // ------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// An inner BINARY key puts <c>'A'</c> and <c>'a'</c> in two groups, while a NOCASE outer key
+    /// joins to both — the outer row would come back twice. The rewrite must decline whenever the
+    /// two keys do not compare identically.
+    /// </summary>
+    [Test]
+    public void DeclinesWhenTheCorrelationKeysUseDifferentCollations()
+    {
+        const string setup =
+            """
+            CREATE TABLE o(id INTEGER PRIMARY KEY, k TEXT COLLATE NOCASE);
+            CREATE TABLE i(id INTEGER PRIMARY KEY, k TEXT, v INTEGER);
+            INSERT INTO o VALUES (1,'a');
+            INSERT INTO i VALUES (1,'A',10),(2,'a',20);
+            """;
+
+        const string query =
+            """
+            SELECT o.id, (SELECT avg(i.v) FROM i WHERE i.k = o.k) AS a FROM o ORDER BY o.id;
+            """;
+
+        AssertMatchesSqlite(setup, query);
+        AssertRewrites(setup, query, groupFirst: 0, joinFirst: 0, declines: 1);
+    }
+
+    /// <summary>
+    /// A BLOB-affinity inner key stores <c>1</c> and <c>'1'</c> as two groups, while a numeric
+    /// outer key converts the text and joins to both.
+    /// </summary>
+    [Test]
+    public void DeclinesWhenTheCorrelationKeysUseDifferentAffinities()
+    {
+        const string setup =
+            """
+            CREATE TABLE o(id INTEGER PRIMARY KEY, k INTEGER);
+            CREATE TABLE i(id INTEGER PRIMARY KEY, k BLOB, v INTEGER);
+            INSERT INTO o VALUES (1,1);
+            INSERT INTO i VALUES (1,1,10),(2,'1',20);
+            """;
+
+        const string query =
+            """
+            SELECT o.id, (SELECT avg(i.v) FROM i WHERE i.k = o.k) AS a FROM o ORDER BY o.id;
+            """;
+
+        AssertMatchesSqlite(setup, query);
+        AssertRewrites(setup, query, groupFirst: 0, joinFirst: 0, declines: 1);
+    }
+
+    /// <summary>
+    /// Matching declared collations are fine: the grouping and the join then partition the key
+    /// space the same way, so at most one grouped row can match an outer row.
+    /// </summary>
+    [Test]
+    public void AcceptsMatchingCollationsAndAffinities()
+    {
+        const string setup =
+            """
+            CREATE TABLE o(id INTEGER PRIMARY KEY, k TEXT COLLATE NOCASE);
+            CREATE TABLE i(id INTEGER PRIMARY KEY, k TEXT COLLATE NOCASE, v INTEGER);
+            INSERT INTO o VALUES (1,'a'),(2,'B');
+            INSERT INTO i VALUES (1,'A',10),(2,'a',20),(3,'b',30);
+            """;
+
+        const string query =
+            """
+            SELECT o.id, (SELECT avg(i.v) FROM i WHERE i.k = o.k) AS a FROM o ORDER BY o.id;
+            """;
+
+        AssertMatchesSqlite(setup, query);
+        AssertRewrites(setup, query, groupFirst: 1, joinFirst: 0, declines: 0);
+    }
+
+    /// <summary>
+    /// A registered collation is ordinary managed code, and group-first would run it while
+    /// forming groups for keys no outer row asks for. Only the built-in sequences are safe there.
+    /// </summary>
+    [Test]
+    public void DeclinesGroupFirstForAKeyWithAnApplicationRegisteredCollation()
+    {
+        const string setup =
+            """
+            CREATE TABLE o(id INTEGER PRIMARY KEY, k TEXT COLLATE REVERSED);
+            CREATE TABLE i(id INTEGER PRIMARY KEY, k TEXT COLLATE REVERSED, v INTEGER);
+            INSERT INTO o VALUES (1,'a');
+            INSERT INTO i VALUES (1,'a',10),(2,'b',20);
+            """;
+
+        const string query =
+            """
+            SELECT o.id, (SELECT avg(i.v) FROM i WHERE i.k = o.k) AS a FROM o ORDER BY o.id;
+            """;
+
+        using var database = new EmbeddedDatabase();
+        database.RegisterCollation("REVERSED", static (left, right) => string.CompareOrdinal(right, left));
+        using var connection = database.Connect();
+        Execute(connection, setup);
+        database.ResetRewriteDiagnostics();
+        Query(connection, query);
+
+        var diagnostics = database.RewriteDiagnostics;
+        diagnostics.AggregateGroupFirstRewrites.Should().Be(0);
+        diagnostics.AggregateJoinFirstRewrites.Should().Be(0);
+        diagnostics.AggregateDecorrelationDeclines.Should().Be(1);
+    }
+
+    // ------------------------------------------------------------------------------------
+    // Shapes that are never eligible.
+    // ------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// An uncorrelated aggregate subquery already evaluates once for the whole statement, so
+    /// there is nothing to decorrelate and no candidate to count.
+    /// </summary>
+    [Test]
+    public void DoesNotTouchUncorrelatedAggregateSubqueries()
+    {
+        const string query =
+            """
+            SELECT o.id FROM outer_rows o WHERE o.v < (SELECT avg(i.v) FROM inner_rows i) ORDER BY o.id;
+            """;
+
+        AssertMatchesSqlite(Setup, query);
+        AssertRewrites(Setup, query, groupFirst: 0, joinFirst: 0, declines: 0);
+    }
+
+    /// <summary>
+    /// A scalar subquery with no aggregate is not a candidate at all: its value depends on which
+    /// row the subquery happens to return, which no grouping reproduces.
+    /// </summary>
+    [Test]
+    public void DoesNotTouchNonAggregateScalarSubqueries()
+    {
+        const string query =
+            """
+            SELECT o.id, (SELECT i.v FROM inner_rows i WHERE i.k = o.k) AS v FROM outer_rows o ORDER BY o.id;
+            """;
+
+        AssertMatchesSqlite(Setup, query);
+        AssertRewrites(Setup, query, groupFirst: 0, joinFirst: 0, declines: 0);
+    }
+
+    /// <summary>
+    /// Each of these inner clauses changes which rows the aggregate sees or how many results the
+    /// subquery yields, and neither rewrite preserves it around the grouping it introduces.
+    /// </summary>
+    [TestCase("SELECT avg(i.v) FROM inner_rows i WHERE i.k = o.k GROUP BY i.v")]
+    [TestCase("SELECT avg(i.v) FROM inner_rows i WHERE i.k = o.k LIMIT 1")]
+    [TestCase("SELECT avg(i.v) FROM inner_rows i WHERE i.k = o.k ORDER BY i.v")]
+    [TestCase("SELECT avg(DISTINCT i.v) FROM inner_rows i WHERE i.k = o.k LIMIT 1 OFFSET 0")]
+    public void DeclinesInnerClausesThatChangeTheAggregatedRows(string inner)
+    {
+        var query = $"SELECT o.id, ({inner}) AS a FROM outer_rows o ORDER BY o.id;";
+
+        AssertMatchesSqlite(Setup, query);
+        AssertRewrites(Setup, query, groupFirst: 0, joinFirst: 0, declines: 1);
+    }
+
+    /// <summary>
+    /// A column read outside an aggregate makes the value depend on which row of the group the
+    /// engine keeps, and a nested subquery keeps a correlation scope neither rewrite moves.
+    /// </summary>
+    [TestCase("SELECT avg(i.v) + i.id FROM inner_rows i WHERE i.k = o.k")]
+    [TestCase("SELECT avg(i.v) + (SELECT 1) FROM inner_rows i WHERE i.k = o.k")]
+    [TestCase("SELECT avg(i.v + random()) FROM inner_rows i WHERE i.k = o.k")]
+    [TestCase("SELECT avg(i.v) FROM inner_rows i WHERE i.k = o.k AND random() > 0")]
+    public void DeclinesInnerExpressionsItCannotModel(string inner)
+    {
+        var query = $"SELECT o.id, ({inner}) AS a FROM outer_rows o ORDER BY o.id;";
+
+        AssertRewrites(Setup, query, groupFirst: 0, joinFirst: 0, declines: 1);
+    }
+
+    /// <summary>
+    /// The correlation has to be a plain equality between one inner and one outer column. A
+    /// range or expression correlation cannot become a grouping key.
+    /// </summary>
+    [TestCase("SELECT avg(i.v) FROM inner_rows i WHERE i.k > o.k")]
+    [TestCase("SELECT avg(i.v) FROM inner_rows i WHERE i.k = o.k + 1")]
+    [TestCase("SELECT avg(i.v) FROM inner_rows i WHERE i.k + 0 = o.k")]
+    [TestCase("SELECT avg(i.v) FROM inner_rows i WHERE i.k IS o.k")]
+    public void DeclinesCorrelationsThatAreNotPlainColumnEqualities(string inner)
+    {
+        var query = $"SELECT o.id, ({inner}) AS a FROM outer_rows o ORDER BY o.id;";
+
+        AssertMatchesSqlite(Setup, query);
+        AssertRewrites(Setup, query, groupFirst: 0, joinFirst: 0, declines: 1);
+    }
+
+    /// <summary>
+    /// The subquery must read one ordinary base table: a view, CTE or joined inner source cannot
+    /// be grouped in place or moved into the enclosing query.
+    /// </summary>
+    [Test]
+    public void DeclinesInnerSourcesThatAreNotOneBaseTable()
+    {
+        const string setup = Setup + "\nCREATE VIEW iv AS SELECT * FROM inner_rows;";
+
+        const string view =
+            "SELECT o.id, (SELECT avg(x.v) FROM iv x WHERE x.k = o.k) AS a FROM outer_rows o ORDER BY o.id;";
+        AssertMatchesSqlite(setup, view);
+        AssertRewrites(setup, view, groupFirst: 0, joinFirst: 0, declines: 1);
+
+        const string joined =
+            """
+            SELECT o.id,
+                   (SELECT avg(a.v) FROM inner_rows a, inner_rows b WHERE a.k = o.k AND b.id = a.id) AS a
+            FROM outer_rows o
+            ORDER BY o.id;
+            """;
+        AssertMatchesSqlite(Setup, joined);
+        AssertRewrites(Setup, joined, groupFirst: 0, joinFirst: 0, declines: 1);
+
+        const string cte =
+            """
+            WITH c AS (SELECT * FROM inner_rows)
+            SELECT o.id, (SELECT avg(x.v) FROM c x WHERE x.k = o.k) AS a
+            FROM outer_rows o
+            ORDER BY o.id;
+            """;
+        AssertMatchesSqlite(Setup, cte);
+        AssertRewrites(Setup, cte, groupFirst: 0, joinFirst: 0, declines: 1);
+    }
+
+    /// <summary>
+    /// A correlation that reaches two levels out belongs to a scope neither rewrite can add a
+    /// join to, so the middle SELECT must decline.
+    /// </summary>
+    [Test]
+    public void DeclinesACorrelationToAGrandparentScope()
+    {
+        const string query =
+            """
+            SELECT g.id,
+                   (SELECT (SELECT avg(i.v) FROM inner_rows i WHERE i.k = g.k) FROM outer_rows m WHERE m.id = g.id) AS a
+            FROM outer_rows g
+            ORDER BY g.id;
+            """;
+
+        AssertMatchesSqlite(Setup, query);
+
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, Setup);
+        database.ResetRewriteDiagnostics();
+        Query(connection, query);
+        database.RewriteDiagnostics.AggregateGroupFirstRewrites.Should().Be(0);
+        database.RewriteDiagnostics.AggregateJoinFirstRewrites.Should().Be(0);
+    }
+
+    /// <summary>
+    /// A pre-existing outer join already decides which rows are NULL-padded; adding another one
+    /// in front of that decision would change the padding.
+    /// </summary>
+    [Test]
+    public void DeclinesWhenTheOuterQueryAlreadyHasAnOuterJoin()
+    {
+        const string query =
+            """
+            SELECT o.id, (SELECT avg(i.v) FROM inner_rows i WHERE i.k = o.k) AS a
+            FROM outer_rows o LEFT JOIN inner_rows p ON p.id = o.id
+            ORDER BY o.id;
+            """;
+
+        AssertMatchesSqlite(Setup, query);
+        AssertRewrites(Setup, query, groupFirst: 0, joinFirst: 0, declines: 1);
+    }
+
+    /// <summary>
+    /// The rewrite runs after every prepare-time validation, so a statement the original engine
+    /// rejects must still be rejected with the same diagnostic.
+    /// </summary>
+    [Test]
+    public void PreservesPrepareTimeDiagnostics()
+    {
+        AssertFailsLikeSqlite(
+            Setup,
+            "SELECT o.id, (SELECT avg(i.nope) FROM inner_rows i WHERE i.k = o.k) FROM outer_rows o;",
+            "no such column");
+        AssertFailsLikeSqlite(
+            Setup,
+            "SELECT o.id, (SELECT avg(i.v) FROM inner_rows i WHERE i.k = o.missing) FROM outer_rows o;",
+            "no such column");
+        AssertFailsLikeSqlite(
+            Setup,
+            "SELECT o.id, (SELECT avg(i.v) FROM no_such_table i WHERE i.k = o.k) FROM outer_rows o;",
+            "no such table");
+    }
+
+    /// <summary>
+    /// A runtime error the original statement raises must survive the rewrite: the group-first
+    /// form still evaluates the same fallible expression over the same rows.
+    /// </summary>
+    [Test]
+    public void PreservesRuntimeErrorsTheOriginalStatementRaises()
+    {
+        const string setup =
+            """
+            CREATE TABLE o(id INTEGER PRIMARY KEY, k INTEGER, v INTEGER);
+            CREATE TABLE i(id INTEGER PRIMARY KEY, k INTEGER, j TEXT);
+            INSERT INTO o VALUES (1,1,5);
+            INSERT INTO i VALUES (1,1,'not json');
+            """;
+
+        AssertFailsLikeSqlite(
+            setup,
+            "SELECT o.id FROM o WHERE o.v > (SELECT avg(json_extract(i.j, '$.a')) FROM i WHERE i.k = o.k);",
+            "malformed JSON");
+    }
+
+    /// <summary>
+    /// Trigger bodies skip <c>ValidateQuerySchema</c>, so no rewrite may run there.
+    /// </summary>
+    [Test]
+    public void DoesNotRewriteInsideTriggerBodies()
+    {
+        const string setup =
+            """
+            CREATE TABLE o(id INTEGER PRIMARY KEY, k INTEGER, v INTEGER);
+            CREATE TABLE i(id INTEGER PRIMARY KEY, k INTEGER, v INTEGER);
+            CREATE TABLE log(n REAL);
+            INSERT INTO i VALUES (1,1,10),(2,1,20);
+            CREATE TRIGGER t AFTER INSERT ON o BEGIN
+                INSERT INTO log
+                SELECT (SELECT avg(x.v) FROM i x WHERE x.k = c.k) FROM o c WHERE c.id = NEW.id;
+            END;
+            """;
+
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, setup);
+        database.ResetRewriteDiagnostics();
+        Execute(connection, "INSERT INTO o VALUES (1,1,5);");
+
+        database.RewriteDiagnostics.AggregateGroupFirstRewrites.Should().Be(0);
+        database.RewriteDiagnostics.AggregateJoinFirstRewrites.Should().Be(0);
+        Query(connection, "SELECT n FROM log;").Single()[0].AsReal().Should().Be(15.0);
+    }
+
+    /// <summary>
+    /// Decorrelation is a plan-shape change, not a result change: whichever route runs, the
+    /// answer has to be the one the per-row subquery produced.
+    /// </summary>
+    [Test]
+    public void GroupFirstDoesNotDegradeToAPerRowScan()
+    {
+        const int rows = 400;
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(
+            connection,
+            """
+            CREATE TABLE o(id INTEGER PRIMARY KEY, k INTEGER, v INTEGER);
+            CREATE TABLE i(id INTEGER PRIMARY KEY, k INTEGER, v INTEGER);
+            """);
+
+        Execute(connection, "BEGIN;");
+        for (var index = 1; index <= rows; index++)
+        {
+            Execute(
+                connection,
+                $"INSERT INTO o VALUES ({index}, {index}, {index}); INSERT INTO i VALUES ({index}, {index}, {index * 2});");
+        }
+
+        Execute(connection, "COMMIT;");
+
+        database.ResetRewriteDiagnostics();
+        var started = DateTime.UtcNow;
+        var result = Query(connection, "SELECT count(*) FROM o WHERE o.v < (SELECT avg(i.v) FROM i WHERE i.k = o.k);");
+        var elapsed = DateTime.UtcNow - started;
+
+        database.RewriteDiagnostics.AggregateGroupFirstRewrites.Should().Be(1);
+        result.Single()[0].AsInteger().Should().Be(rows);
+        elapsed.Should().BeLessThan(
+            TimeSpan.FromSeconds(20),
+            $"the grouped rewrite took {elapsed.TotalSeconds:F1}s at {rows} x {rows} rows");
+    }
+
+    // ------------------------------------------------------------------------------------
+    // Helpers.
+    // ------------------------------------------------------------------------------------
+
+    private static void AssertRewrites(
+        string setup,
+        string query,
+        long groupFirst = -1,
+        long joinFirst = -1,
+        long declines = -1)
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, setup);
+        database.ResetRewriteDiagnostics();
+        Query(connection, query);
+
+        var diagnostics = database.RewriteDiagnostics;
+        if (groupFirst >= 0)
+            diagnostics.AggregateGroupFirstRewrites.Should().Be(groupFirst, $"of query {query}");
+        if (joinFirst >= 0)
+            diagnostics.AggregateJoinFirstRewrites.Should().Be(joinFirst, $"of query {query}");
+        if (declines >= 0)
+            diagnostics.AggregateDecorrelationDeclines.Should().Be(declines, $"of query {query}");
+    }
+
+    private static void AssertFailsLikeSqlite(string setup, string query, string expectedMessagePart)
+    {
+        var managed = Record(() => RunManaged(setup, query));
+        var sqlite = Record(() => RunSqlite(setup, query));
+
+        sqlite.Should().NotBeNull($"of query {query}, which SQLite is expected to reject");
+        sqlite!.Message.Should().ContainEquivalentOf(expectedMessagePart, $"of query {query}");
+        managed.Should().NotBeNull($"of query {query}, which the managed engine must reject too");
+        managed!.Message.Should().ContainEquivalentOf(expectedMessagePart, $"of query {query}");
+    }
+
+    private static Exception? Record(Action action)
+    {
+        try
+        {
+            action();
+            return null;
+        }
+        catch (Exception exception)
+        {
+            return exception;
+        }
+    }
+
+    private static void AssertMatchesSqlite(string setup, string query)
+    {
+        var managed = RunManaged(setup, query);
+        var sqlite = RunSqlite(setup, query);
+        managed.Columns.Should().Equal(sqlite.Columns, $"of query {query}");
+        managed.Rows.Should().HaveCount(sqlite.Rows.Count, $"of query {query}");
+        for (var index = 0; index < sqlite.Rows.Count; index++)
+            managed.Rows[index].Should().Equal(sqlite.Rows[index], $"of row {index} of query {query}");
+    }
+
+    /// <summary>
+    /// The join-first route declines an outer ORDER BY, so its queries have no defined row order.
+    /// Compare the two result multisets instead, which still catches a dropped, duplicated or
+    /// altered row.
+    /// </summary>
+    private static void AssertMatchesSqliteUnordered(string setup, string query)
+    {
+        var managed = RunManaged(setup, query);
+        var sqlite = RunSqlite(setup, query);
+        managed.Columns.Should().Equal(sqlite.Columns, $"of query {query}");
+        Flatten(managed).Should().Equal(Flatten(sqlite), $"of query {query}");
+
+        static IEnumerable<string> Flatten(QueryOutput output)
+            => output.Rows.Select(row => string.Join('\u001f', row)).Order(StringComparer.Ordinal);
+    }
+
+    private static QueryOutput RunManaged(string setup, string query)
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, setup);
+        using var statement = connection.Prepare(query);
+        var columns = Enumerable.Range(0, statement.GetColumnCount())
+            .Select(statement.GetColumnName)
+            .ToArray();
+        var rows = new List<string[]>();
+        while (statement.Step() == StatementStepResult.Row)
+        {
+            rows.Add(Enumerable.Range(0, statement.GetColumnCount())
+                .Select(index => Normalize(statement.GetValue(index)))
+                .ToArray());
+        }
+
+        return new QueryOutput(columns, rows);
+    }
+
+    private static QueryOutput RunSqlite(string setup, string query)
+    {
+        using var connection = new MsData.SqliteConnection("Data Source=:memory:");
+        connection.Open();
+        using (var setupCommand = connection.CreateCommand())
+        {
+            setupCommand.CommandText = setup;
+            setupCommand.ExecuteNonQuery();
+        }
+
+        using var command = connection.CreateCommand();
+        command.CommandText = query;
+        using var reader = command.ExecuteReader();
+        var columns = Enumerable.Range(0, reader.FieldCount).Select(reader.GetName).ToArray();
+        var rows = new List<string[]>();
+        while (reader.Read())
+        {
+            rows.Add(Enumerable.Range(0, reader.FieldCount)
+                .Select(index => Normalize(reader.GetValue(index)))
+                .ToArray());
+        }
+
+        return new QueryOutput(columns, rows);
+    }
+
+    private static IReadOnlyList<SqlValue[]> Query(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        var rows = new List<SqlValue[]>();
+        while (statement.Step() == StatementStepResult.Row)
+        {
+            rows.Add(Enumerable.Range(0, statement.GetColumnCount())
+                .Select(statement.GetValue)
+                .ToArray());
+        }
+
+        return rows;
+    }
+
+    private static void Execute(EmbeddedConnection connection, string sql)
+    {
+        foreach (var statement in connection.PrepareScript(sql))
+        {
+            using (statement)
+            {
+                while (statement.Step() == StatementStepResult.Row)
+                {
+                }
+            }
+        }
+    }
+
+    private static string Normalize(SqlValue value)
+        => value.Kind switch
+        {
+            SqlValueKind.Null => "N:",
+            SqlValueKind.Integer => $"I:{value.AsInteger()}",
+            SqlValueKind.Real => $"R:{value.AsReal():R}",
+            SqlValueKind.Text => $"T:{value.AsText()}",
+            SqlValueKind.Blob => $"B:{Convert.ToBase64String(value.AsBlob().Span)}",
+            _ => throw new InvalidOperationException($"Unknown managed value kind {value.Kind}."),
+        };
+
+    private static string Normalize(object value)
+        => value switch
+        {
+            DBNull => "N:",
+            long integer => $"I:{integer}",
+            double real => $"R:{real:R}",
+            string text => $"T:{text}",
+            byte[] blob => $"B:{Convert.ToBase64String(blob)}",
+            _ => throw new InvalidOperationException($"Unknown SQLite value type {value.GetType().Name}."),
+        };
+
+    private sealed record QueryOutput(string[] Columns, IReadOnlyList<string[]> Rows);
+}


### PR DESCRIPTION
## Summary

- port Turso's conservative scalar aggregate-subquery decorrelation into Ahtola's AST rewrite stage
- add both group-first (`GROUP BY` derived table + `LEFT JOIN`) and join-first (`LEFT JOIN` + outer-row grouping + `HAVING`) execution forms
- preserve empty-input aggregate values and decline unsafe affinity, collation, name-binding, nested-scope, nondeterministic, and error-timing shapes
- add route diagnostics and 79 SQLite-differential regression tests, including DML/name-capture and runtime-error cases
- close the final live Turso gap inventory entry and reconcile the inventory to 216 closed / 0 open with 0 conformance expected failures

## Validation

- `pwsh ./build.ps1 test`
- `pwsh ./scripts/Invoke-ManagedTestSuite.ps1 -Framework net10.0 -Filter "FullyQualifiedName~AggregateSubqueryDecorrelationTests" -MinimumExecutedTests 1`
- changed-file formatting: `dotnet format .\Ahtola.slnx --verify-no-changes --include .\src\Ahtola.Core\EmbeddedDatabase.SubqueryRewrites.cs .\src\Ahtola.Tests\AggregateSubqueryDecorrelationTests.cs --verbosity minimal`

The repository-wide `pwsh ./build.ps1 format-check` still reports pre-existing whitespace findings in unrelated files; both files changed by this PR pass the formatter.