### PR TITLE
Expand managed testing infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,10 @@ jobs:
         shell: pwsh
         run: ./scripts/tests/Test-AssertExactPackageVersion.ps1
 
+      - name: Test code coverage assertion
+        shell: pwsh
+        run: ./scripts/tests/Test-AssertCodeCoverage.ps1
+
       - name: Test managed package closure validator
         shell: pwsh
         run: ./scripts/tests/Test-ValidateManagedPackageClosure.ps1
@@ -119,6 +123,13 @@ jobs:
         # job focused on the managed suite instead of repeating that full gate.
         run: ./scripts/Invoke-ManagedTestSuite.ps1 -Framework net10.0 -MinimumExecutedTests $env:MINIMUM_EXECUTED_TESTS
 
+      - name: Collect and validate code coverage
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        # Windows is the canonical coverage lane; merging reports from different
+        # operating-system branches would make the ratchet nondeterministic.
+        run: ./build.ps1 test-coverage -Framework net10.0 -MinimumExecutedTests $env:MINIMUM_EXECUTED_TESTS
+
       - name: Report Ubuntu cross-process WAL gap
         if: always() && steps.managed-test.outcome == 'failure'
         shell: pwsh
@@ -132,7 +143,7 @@ jobs:
           name: test-results-${{ matrix.os }}
           path: |
             **/*.trx
-            artifacts/
+            artifacts/test-results/**
           if-no-files-found: ignore
           retention-days: 7
 

--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ Requires the .NET SDK and PowerShell 7+:
 ```powershell
 ./build.ps1 build
 ./build.ps1 test
+./build.ps1 test-coverage     # managed suite + per-assembly coverage ratchet
 ./build.ps1 pack              # -> ./artifacts/managed-packages
 ./build.ps1 pack-powershell   # -> ./artifacts/powershell-modules
 ./build.ps1 validate-runtime  # packed consumer trim + NativeAOT publish
@@ -430,7 +431,8 @@ Requires the .NET SDK and PowerShell 7+:
 ```
 
 Contributor details — the full task list, validation gates, conformance suite,
-and repo layout — live in [AGENTS.md](AGENTS.md) and [docs/](docs).
+repo layout, and [managed testing capabilities](docs/testing-capabilities.md)
+live in [AGENTS.md](AGENTS.md) and [docs/](docs).
 
 ## License
 

--- a/build.ps1
+++ b/build.ps1
@@ -24,6 +24,7 @@ param(
         'restore',
         'build',
         'test',
+        'test-coverage',
         'pack',
                 'pack-powershell',
                 'test-powershell',
@@ -91,6 +92,14 @@ $BrowserTrimAnalysisRunner = Join-Path $RepoRoot 'scripts/Invoke-TrimAnalysisGat
 $ConsumerNugetConfig = './samples/ManagedPackageConsumer/obj/managed-package-consumer.nuget.config'
 $ClosureValidator = Join-Path $RepoRoot 'scripts/Validate-ManagedPackageClosure.ps1'
 $TestRunner = Join-Path $RepoRoot 'scripts/Invoke-ManagedTestSuite.ps1'
+$CoverageValidator = Join-Path $RepoRoot 'scripts/Assert-CodeCoverage.ps1'
+$CoverageSettings = Join-Path $RepoRoot 'coverage.runsettings'
+$CoverageBaseline = Join-Path $RepoRoot 'code-coverage-baseline.json'
+$CoverageResultsDirectory = Join-Path $RepoRoot 'artifacts/test-results/coverage'
+# Coverlet changes the timing of migration stress, and instrumenting generated
+# 10,000-row sqltest fixtures is prohibitively slow. The ordinary Windows test
+# leg still runs every class in this explicit category.
+$CoverageFilter = 'TestCategory!=CoverageExcluded'
 $ConsumerFrameworks = @('net8.0', 'net9.0', 'net10.0')
 
 $NativeLeakPattern = '(?i)(Ahtola\.(Raw|Data\.(Native|Sync)|Data\.Sqlite\.(Native[^"]*|Sync))|cargo|rustc|cargo-ndk|turso_sdk_kit|DirectPInvoke|NativeLibrary|DllImport|LibraryImport|TursoUseStaticNativeLibrary)'
@@ -619,6 +628,23 @@ function Invoke-Test {
     )
 }
 
+function Invoke-TestCoverage {
+    Write-Step "Running managed test suite with coverage ($Framework)"
+    Invoke-PwshScript -Path $TestRunner -Arguments @(
+        '-Framework', $Framework,
+        '-MinimumExecutedTests', "$MinimumExecutedTests",
+        '-CollectCoverage',
+        '-CoverageSettings', $CoverageSettings,
+        '-ResultsDirectory', $CoverageResultsDirectory,
+        '-Filter', $CoverageFilter,
+        '-HangTimeoutMinutes', '10'
+    )
+    Invoke-PwshScript -Path $CoverageValidator -Arguments @(
+        '-CoveragePath', (Join-Path $CoverageResultsDirectory "$Framework/coverage.cobertura.xml"),
+        '-BaselinePath', $CoverageBaseline
+    )
+}
+
 function Invoke-FormatCheck {
     Write-Step 'Checking formatting'
     Invoke-DotNet @('format', $Solution, '--verify-no-changes')
@@ -648,6 +674,7 @@ switch ($Task) {
             Assert-ExactPackageVersion -Directory $PackageOutput -ExpectedVersion $PackageVersion
         }
         'test' { Invoke-Test }
+        'test-coverage' { Invoke-TestCoverage }
         'format-check' { Invoke-FormatCheck }
         default { throw "Unknown task '$Task'" }
     }

--- a/code-coverage-baseline.json
+++ b/code-coverage-baseline.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "framework": "net10.0",
+  "platform": "windows",
+  "assemblies": [
+    {
+      "name": "Devolutions.Ahtola.Core",
+      "minimumLineRate": 0.81,
+      "minimumBranchRate": 0.74
+    },
+    {
+      "name": "Devolutions.Ahtola.Data",
+      "minimumLineRate": 0.83,
+      "minimumBranchRate": 0.70
+    },
+    {
+      "name": "Devolutions.Ahtola.Data.Sqlite",
+      "minimumLineRate": 0.72,
+      "minimumBranchRate": 0.63
+    },
+    {
+      "name": "Devolutions.Ahtola.Data.Sqlite.Browser",
+      "minimumLineRate": 0.47,
+      "minimumBranchRate": 0.56
+    },
+    {
+      "name": "Devolutions.Ahtola.EntityFrameworkCore.Sqlite",
+      "minimumLineRate": 0.66,
+      "minimumBranchRate": 0.56
+    }
+  ]
+}

--- a/coverage.runsettings
+++ b/coverage.runsettings
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <Include>[Devolutions.Ahtola.Core]*,[Devolutions.Ahtola.Data]*,[Devolutions.Ahtola.Data.Sqlite]*,[Devolutions.Ahtola.Data.Sqlite.Browser]*,[Devolutions.Ahtola.EntityFrameworkCore.Sqlite]*</Include>
+          <ExcludeByAttribute>GeneratedCodeAttribute,ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
+          <IncludeTestAssembly>false</IncludeTestAssembly>
+          <DeterministicReport>true</DeterministicReport>
+          <ExcludeAssembliesWithoutSources>MissingAll</ExcludeAssembliesWithoutSources>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/docs/testing-capabilities.md
+++ b/docs/testing-capabilities.md
@@ -1,0 +1,111 @@
+# Managed testing capabilities
+
+Ahtola's managed test suite includes deterministic differential, conformance,
+storage-fault, model-based, and concurrency testing derived from the testing
+architecture in the pinned Turso source.
+
+## Running the suite
+
+Use the wrapper so an empty or unexpectedly small run fails:
+
+```powershell
+pwsh ./scripts/Invoke-ManagedTestSuite.ps1 `
+    -Framework net10.0 `
+    -MinimumExecutedTests 2500
+```
+
+Run the coverage ratchet with:
+
+```powershell
+pwsh ./build.ps1 test-coverage -Framework net10.0
+```
+
+The normal Windows test lane remains authoritative for the complete corpus
+and migration stress coverage. The duplicate instrumented lane excludes the
+`CoverageExcluded` category because Coverlet changes lock-test timing and
+instrumenting the deterministic 10,000-row sqltest fixtures is prohibitively
+slow. Those exclusions are category-based and remain fully executed by the
+ordinary managed suite.
+
+## Deterministic seeds and replay
+
+Generated tests use a stable SplitMix64 implementation rather than
+`System.Random`, so a seed produces the same operation sequence across .NET
+runtime versions. Override the root seed when reproducing a failure:
+
+```powershell
+$env:AHTOLA_TEST_SEED = '0x1234'
+pwsh ./scripts/Invoke-ManagedTestSuite.ps1 `
+    -Framework net10.0 `
+    -Filter 'FullyQualifiedName~OracleFoundationTests' `
+    -MinimumExecutedTests 6
+```
+
+On failure, generated tests write JSON and SQL replay artifacts below the
+NUnit work directory and register them as test attachments. The JSON records
+the root and derived seeds, SQL operations, actor and dependency metadata,
+and deterministic schedule choices. The dependency-aware minimizer can remove
+irrelevant operations while retaining the same normalized failure.
+
+## Differential and metamorphic testing
+
+`src/Ahtola.Tests/Oracle/` provides:
+
+- typed SQLite values for NULL, INTEGER, REAL, TEXT, and BLOB;
+- ordered and duplicate-preserving unordered row comparison;
+- normalized SQLite error categories and codes;
+- table, schema, and `integrity_check` snapshots;
+- stable seeded streams and replay artifacts.
+
+`OracleFoundationTests` compares generated SQL against
+`Microsoft.Data.Sqlite` in the host test process. Pure-managed metamorphic
+tests cover ternary-logic partitioning, indexed versus `NOT INDEXED` scans,
+failed-statement atomicity, savepoint restoration, and `UNION ALL`
+cardinality.
+
+## SQL conformance
+
+The sqltest runner supports Turso's deterministic `:default:` and
+`:default-no-rowidalias:` fixtures, multiple database variants, and
+`@cross-check-integrity`. The vendored corpus remains read-only. Engine gaps
+are recorded in
+`src/Ahtola.Tests/Conformance/managed-sqltest-expected-failures.txt`.
+
+## Storage and crash testing
+
+Reusable test infrastructure under `src/Ahtola.Tests/Infrastructure/`
+includes:
+
+- deterministic queued async I/O with selectable completion order;
+- path- and occurrence-specific I/O failures plus operation history;
+- separate live and durable file images;
+- power-loss restoration and deterministic torn flushes.
+
+The storage reliability tests verify durable WAL commits, rejection of
+volatile/uncommitted tails, checkpoint committed-prefix atomicity, sidecar
+lifecycle, and out-of-order asynchronous completion.
+
+## Model and concurrency testing
+
+The model suites include:
+
+- a bounded independent LRU model for pager-cache operations;
+- a three-actor transaction shadow model with snapshots, pending changes,
+  savepoints, checkpoints, and reopen;
+- deterministic cooperative scheduling with replayable named yield points;
+- bounded depth-first and stable-random schedule exploration;
+- observer checks for commit persistence, rollback invisibility, snapshot
+  consistency, completion, and livelock.
+
+These tests control only explicit test actors and test I/O. They do not depend
+on timing sleeps or attempt to intercept arbitrary CLR synchronization.
+
+## Logical database fingerprints and processes
+
+The logical fingerprint utility hashes canonical user schema and typed,
+ordered table contents independently of physical page layout. It is suitable
+for backup, vacuum, migration, and replication assertions.
+
+The process lifecycle trace records child-process start, operation, exit,
+timeout, and restart events as JSON Lines with deterministic sequence numbers.
+Process tests use bounded waits and attach the trace when they fail.

--- a/scripts/Assert-CodeCoverage.ps1
+++ b/scripts/Assert-CodeCoverage.ps1
@@ -1,0 +1,139 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$CoveragePath,
+    [string]$BaselinePath = './code-coverage-baseline.json'
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 3.0
+
+function Fail([string]$Message) {
+    throw "Code coverage validation failed: $Message"
+}
+
+function Get-Rate(
+    [System.Xml.XmlElement]$Element,
+    [string]$Attribute,
+    [string]$Context
+) {
+    $raw = $Element.GetAttribute($Attribute)
+    [decimal]$rate = 0
+    if ([string]::IsNullOrWhiteSpace($raw) -or
+        -not [decimal]::TryParse(
+            $raw,
+            [System.Globalization.NumberStyles]::Float,
+            [System.Globalization.CultureInfo]::InvariantCulture,
+            [ref]$rate
+        ) -or
+        $rate -lt 0 -or
+        $rate -gt 1) {
+        Fail "$Context has invalid $Attribute '$raw'; expected a decimal from 0 through 1."
+    }
+    return $rate
+}
+
+function Get-MinimumRate(
+    [object]$Assembly,
+    [string]$Property
+) {
+    $propertyValue = $Assembly.PSObject.Properties[$Property]
+    if ($null -eq $propertyValue) {
+        Fail "baseline assembly '$($Assembly.name)' is missing '$Property'."
+    }
+
+    [decimal]$rate = 0
+    $raw = [string]$propertyValue.Value
+    if (-not [decimal]::TryParse(
+            $raw,
+            [System.Globalization.NumberStyles]::Float,
+            [System.Globalization.CultureInfo]::InvariantCulture,
+            [ref]$rate
+        ) -or
+        $rate -lt 0 -or
+        $rate -gt 1) {
+        Fail "baseline assembly '$($Assembly.name)' has invalid $Property '$raw'; expected a decimal from 0 through 1."
+    }
+    return $rate
+}
+
+if (-not (Test-Path -LiteralPath $CoveragePath -PathType Leaf)) {
+    Fail "Cobertura report '$CoveragePath' does not exist."
+}
+if (-not (Test-Path -LiteralPath $BaselinePath -PathType Leaf)) {
+    Fail "baseline '$BaselinePath' does not exist."
+}
+
+try {
+    [xml]$coverage = Get-Content -LiteralPath $CoveragePath -Raw
+} catch {
+    Fail "Cobertura report '$CoveragePath' is not valid XML: $($_.Exception.Message)"
+}
+
+try {
+    $baseline = Get-Content -LiteralPath $BaselinePath -Raw | ConvertFrom-Json
+} catch {
+    Fail "baseline '$BaselinePath' is not valid JSON: $($_.Exception.Message)"
+}
+
+if ($baseline.version -ne 1) {
+    Fail "baseline '$BaselinePath' has unsupported version '$($baseline.version)'."
+}
+
+$packages = @($coverage.SelectNodes("/coverage/packages/package"))
+if ($packages.Count -eq 0) {
+    Fail "Cobertura report '$CoveragePath' contains no package coverage."
+}
+
+$packagesByName = @{}
+foreach ($package in $packages) {
+    $name = $package.GetAttribute('name')
+    if ([string]::IsNullOrWhiteSpace($name)) {
+        Fail "Cobertura report '$CoveragePath' contains an unnamed package."
+    }
+    if ($packagesByName.ContainsKey($name)) {
+        Fail "Cobertura report '$CoveragePath' contains duplicate package '$name'."
+    }
+    $packagesByName[$name] = $package
+}
+
+$assemblies = @($baseline.assemblies)
+if ($assemblies.Count -eq 0) {
+    Fail "baseline '$BaselinePath' contains no assemblies."
+}
+
+$failures = [System.Collections.Generic.List[string]]::new()
+foreach ($assembly in $assemblies) {
+    $name = [string]$assembly.name
+    if ([string]::IsNullOrWhiteSpace($name)) {
+        Fail "baseline '$BaselinePath' contains an assembly without a name."
+    }
+    if (-not $packagesByName.ContainsKey($name)) {
+        $failures.Add("$name is absent from the coverage report")
+        continue
+    }
+
+    $package = $packagesByName[$name]
+    $lineRate = Get-Rate $package 'line-rate' "coverage package '$name'"
+    $branchRate = Get-Rate $package 'branch-rate' "coverage package '$name'"
+    $minimumLineRate = Get-MinimumRate $assembly 'minimumLineRate'
+    $minimumBranchRate = Get-MinimumRate $assembly 'minimumBranchRate'
+
+    Write-Host ("{0}: line {1:P2} (minimum {2:P2}), branch {3:P2} (minimum {4:P2})" -f `
+            $name, $lineRate, $minimumLineRate, $branchRate, $minimumBranchRate)
+
+    if ($lineRate -lt $minimumLineRate) {
+        $failures.Add("$name line coverage $($lineRate.ToString('P2')) is below $($minimumLineRate.ToString('P2'))")
+    }
+    if ($branchRate -lt $minimumBranchRate) {
+        $failures.Add("$name branch coverage $($branchRate.ToString('P2')) is below $($minimumBranchRate.ToString('P2'))")
+    }
+}
+
+if ($failures.Count -gt 0) {
+    Fail ($failures -join '; ')
+}
+
+Write-Host "Code coverage satisfies all $($assemblies.Count) assembly baselines." -ForegroundColor Green
+exit 0

--- a/scripts/Invoke-ManagedTestSuite.ps1
+++ b/scripts/Invoke-ManagedTestSuite.ps1
@@ -43,6 +43,10 @@ param(
     # reports as a cancelled job with no indication of which test stalled.
     [int]$HangTimeoutMinutes = 0,
     [switch]$NoBuild,
+    # Collects shipped-assembly coverage through the existing Coverlet VSTest
+    # collector and normalizes its GUID-scoped report to the results root.
+    [switch]$CollectCoverage,
+    [string]$CoverageSettings = './coverage.runsettings',
     # Reproduces the managed lane's "must not shell out to Rust" invariant by
     # putting failing cargo/rustc shims ahead of the real toolchain on PATH.
     [switch]$DenyNativeToolchain
@@ -170,6 +174,12 @@ if ($NoBuild) { $arguments += '--no-build' }
 if ($HangTimeoutMinutes -gt 0) {
     $arguments += @('--blame-hang', '--blame-hang-timeout', "${HangTimeoutMinutes}m", '--blame-hang-dump-type', 'none')
 }
+if ($CollectCoverage) {
+    if (-not (Test-Path -LiteralPath $CoverageSettings -PathType Leaf)) {
+        Fail "coverage settings file '$CoverageSettings' does not exist."
+    }
+    $arguments += @('--collect', 'XPlat Code Coverage', '--settings', $CoverageSettings)
+}
 
 $denyDirectory = $null
 $originalPath = $env:PATH
@@ -213,6 +223,31 @@ if ($sequenceFiles.Count -gt 0) {
 
 if (-not (Test-Path -LiteralPath $trxPath -PathType Leaf)) {
     Fail "the run produced no TRX report at '$trxPath', so it cannot be proven to have executed any test (dotnet test exit code $testExitCode)."
+}
+
+if ($CollectCoverage) {
+    $coverageReports = @(
+        Get-ChildItem -LiteralPath $resultsRoot -Recurse -Filter 'coverage.cobertura.xml' |
+            Where-Object { $_.DirectoryName -ne (Resolve-Path -LiteralPath $resultsRoot).Path }
+    )
+    if ($coverageReports.Count -eq 0) {
+        Fail "coverage collection produced no Cobertura report under '$resultsRoot'."
+    }
+
+    $coverageHashes = @(
+        $coverageReports |
+            Group-Object -Property { (Get-FileHash -LiteralPath $_.FullName -Algorithm SHA256).Hash }
+    )
+    if ($coverageHashes.Count -ne 1) {
+        Fail "coverage collection produced $($coverageHashes.Count) distinct Cobertura reports under '$resultsRoot'; one logical report was expected."
+    }
+
+    $normalizedCoveragePath = Join-Path $resultsRoot 'coverage.cobertura.xml'
+    $sourceCoveragePath = $coverageReports |
+        Sort-Object { $_.FullName.Length } |
+        Select-Object -First 1 -ExpandProperty FullName
+    Copy-Item -LiteralPath $sourceCoveragePath -Destination $normalizedCoveragePath
+    Write-Host "coverage report: $normalizedCoveragePath"
 }
 
 $summary = Get-TrxSummary -TrxPath $trxPath

--- a/scripts/tests/Test-AssertCodeCoverage.ps1
+++ b/scripts/tests/Test-AssertCodeCoverage.ps1
@@ -63,6 +63,7 @@ function Invoke-Validator(
     $exitCode = $LASTEXITCODE
     $renderedOutput = ($output -join [Environment]::NewLine) `
         -replace '\x1B\[[0-?]*[ -/]*[@-~]', '' `
+        -replace '\s*\|\s*', ' ' `
         -replace '\s+', ' '
     if ($ShouldSucceed -and $exitCode -ne 0) {
         Fail "validator unexpectedly failed: $renderedOutput"

--- a/scripts/tests/Test-AssertCodeCoverage.ps1
+++ b/scripts/tests/Test-AssertCodeCoverage.ps1
@@ -61,7 +61,9 @@ function Invoke-Validator(
             -CoveragePath $CoveragePath -BaselinePath $BaselinePath 2>&1
     )
     $exitCode = $LASTEXITCODE
-    $renderedOutput = ($output -join [Environment]::NewLine) -replace '\s+', ' '
+    $renderedOutput = ($output -join [Environment]::NewLine) `
+        -replace '\x1B\[[0-?]*[ -/]*[@-~]', '' `
+        -replace '\s+', ' '
     if ($ShouldSucceed -and $exitCode -ne 0) {
         Fail "validator unexpectedly failed: $renderedOutput"
     }

--- a/scripts/tests/Test-AssertCodeCoverage.ps1
+++ b/scripts/tests/Test-AssertCodeCoverage.ps1
@@ -1,0 +1,112 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 3.0
+
+$repoRoot = Split-Path -Parent $PSScriptRoot | Split-Path -Parent
+$validator = Join-Path $repoRoot 'scripts/Assert-CodeCoverage.ps1'
+$scratchRoot = Join-Path ([System.IO.Path]::GetTempPath()) "ahtola-coverage-$([Guid]::NewGuid().ToString('N'))"
+
+function Fail([string]$Message) {
+    throw "Test-AssertCodeCoverage failed: $Message"
+}
+
+function Write-Baseline(
+    [string]$Path,
+    [decimal]$LineRate = 0.80,
+    [decimal]$BranchRate = 0.70
+) {
+    @{
+        version = 1
+        assemblies = @(
+            @{
+                name = 'Devolutions.Ahtola.Core'
+                minimumLineRate = $LineRate
+                minimumBranchRate = $BranchRate
+            }
+        )
+    } | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $Path -Encoding utf8NoBOM
+}
+
+function Write-Coverage(
+    [string]$Path,
+    [decimal]$LineRate = 0.85,
+    [decimal]$BranchRate = 0.75,
+    [string]$PackageName = 'Devolutions.Ahtola.Core'
+) {
+    $line = $LineRate.ToString([System.Globalization.CultureInfo]::InvariantCulture)
+    $branch = $BranchRate.ToString([System.Globalization.CultureInfo]::InvariantCulture)
+    @"
+<?xml version="1.0" encoding="utf-8"?>
+<coverage line-rate="$line" branch-rate="$branch">
+  <packages>
+    <package name="$PackageName" line-rate="$line" branch-rate="$branch">
+      <classes />
+    </package>
+  </packages>
+</coverage>
+"@ | Set-Content -LiteralPath $Path -Encoding utf8NoBOM
+}
+
+function Invoke-Validator(
+    [string]$CoveragePath,
+    [string]$BaselinePath,
+    [bool]$ShouldSucceed,
+    [string]$ExpectedFailure = ''
+) {
+    $output = @(
+        & pwsh -NoLogo -NoProfile -File $validator `
+            -CoveragePath $CoveragePath -BaselinePath $BaselinePath 2>&1
+    )
+    $exitCode = $LASTEXITCODE
+    $renderedOutput = ($output -join [Environment]::NewLine) -replace '\s+', ' '
+    if ($ShouldSucceed -and $exitCode -ne 0) {
+        Fail "validator unexpectedly failed: $renderedOutput"
+    }
+    if (-not $ShouldSucceed -and $exitCode -eq 0) {
+        Fail 'validator unexpectedly accepted an invalid coverage report.'
+    }
+    if (-not $ShouldSucceed -and $renderedOutput -notmatch [regex]::Escape($ExpectedFailure)) {
+        Fail "validator failure did not contain '$ExpectedFailure': $renderedOutput"
+    }
+}
+
+$passed = 0
+try {
+    New-Item -ItemType Directory -Path $scratchRoot -Force | Out-Null
+    $coveragePath = Join-Path $scratchRoot 'coverage.cobertura.xml'
+    $baselinePath = Join-Path $scratchRoot 'coverage-baseline.json'
+
+    Write-Baseline $baselinePath
+    Write-Coverage $coveragePath
+    Invoke-Validator $coveragePath $baselinePath $true
+    $passed++
+    Write-Host 'PASS: coverage at or above both floors succeeds' -ForegroundColor Green
+
+    Write-Coverage $coveragePath -LineRate 0.79
+    Invoke-Validator $coveragePath $baselinePath $false 'line coverage'
+    $passed++
+    Write-Host 'PASS: line coverage regression fails' -ForegroundColor Green
+
+    Write-Coverage $coveragePath -BranchRate 0.69
+    Invoke-Validator $coveragePath $baselinePath $false 'branch coverage'
+    $passed++
+    Write-Host 'PASS: branch coverage regression fails' -ForegroundColor Green
+
+    Write-Coverage $coveragePath -PackageName 'Unexpected.Assembly'
+    Invoke-Validator $coveragePath $baselinePath $false 'absent from the coverage report'
+    $passed++
+    Write-Host 'PASS: missing required assembly fails' -ForegroundColor Green
+
+    Set-Content -LiteralPath $coveragePath -Value '<coverage><packages /></coverage>' -Encoding utf8NoBOM
+    Invoke-Validator $coveragePath $baselinePath $false 'contains no package coverage'
+    $passed++
+    Write-Host 'PASS: empty report fails' -ForegroundColor Green
+} finally {
+    Remove-Item -LiteralPath $scratchRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "Test-AssertCodeCoverage passed ($passed checks)." -ForegroundColor Green
+exit 0

--- a/src/Ahtola.Data/AhtolaParameterCollection.cs
+++ b/src/Ahtola.Data/AhtolaParameterCollection.cs
@@ -40,7 +40,9 @@ public class AhtolaParameterCollection : DbParameterCollection
 
     public override bool Contains(object value)
     {
-        return _parameters.Any(p => value is AhtolaParameter ? p == value : p.Value == value);
+        return value is AhtolaParameter parameter
+            ? _parameters.Contains(parameter)
+            : _parameters.Any(p => Equals(p.Value, value));
     }
 
     public override bool Contains(string value)
@@ -62,7 +64,9 @@ public class AhtolaParameterCollection : DbParameterCollection
 
     public override int IndexOf(object value)
     {
-        return _parameters.FindIndex(p => value is AhtolaParameter ? p == value : p.Value == value);
+        return value is AhtolaParameter parameter
+            ? _parameters.IndexOf(parameter)
+            : _parameters.FindIndex(p => Equals(p.Value, value));
     }
 
     public override int IndexOf(string parameterName)

--- a/src/Ahtola.Tests/Ahtola.Tests.csproj
+++ b/src/Ahtola.Tests/Ahtola.Tests.csproj
@@ -51,5 +51,7 @@
                  CopyToOutputDirectory="PreserveNewest" />
         <Content Include="Conformance\managed-sqltest-expected-failures.txt"
                  CopyToOutputDirectory="PreserveNewest" />
+        <Content Include="Conformance\managed-sqltest-harness-exclusions.txt"
+                 CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
 </Project>

--- a/src/Ahtola.Tests/AsyncFileSystemAdapterTests.cs
+++ b/src/Ahtola.Tests/AsyncFileSystemAdapterTests.cs
@@ -399,6 +399,73 @@ public sealed class DeterministicAsyncFileSystemTests
         physicalController.GetOperationCount(FileSystemOperation.OpenTemporary).Should().Be(1);
     }
 
+    [Test]
+    public async Task PendingOperationsCanBeReleasedOutOfOrderExactlyOnce()
+    {
+        var controller = new DeterministicAsyncIoController(forceYield: true);
+        var fileSystem = DeterministicAsyncFileSystem.Create(
+            AsyncFileSystemAdapter.Create(new InMemoryFileSystem()),
+            controller);
+        var first = await CompleteYieldAsync(
+            fileSystem.OpenFileAsync("first.db", FileOpenMode.CreateNew),
+            controller);
+        var second = await CompleteYieldAsync(
+            fileSystem.OpenFileAsync("second.db", FileOpenMode.CreateNew),
+            controller);
+
+        var firstWrite = first.WriteAsync(0, new byte[] { 1 });
+        var secondWrite = second.WriteAsync(0, new byte[] { 2 });
+        var pending = controller.PendingOperations;
+        pending.Select(operation => operation.Path).Should().Equal("first.db", "second.db");
+
+        controller.Release(pending[1].Id);
+        await secondWrite;
+        firstWrite.IsCompleted.Should().BeFalse();
+        controller.PendingOperations.Should().ContainSingle()
+            .Which.Id.Should().Be(pending[0].Id);
+
+        controller.Release(pending[0].Id);
+        await firstWrite;
+        Assert.Throws<InvalidOperationException>(() => controller.Release(pending[0].Id));
+        controller.History
+            .Where(@event => @event.Kind == DeterministicAsyncIoEventKind.Released)
+            .TakeLast(2)
+            .Select(@event => @event.Operation.Id)
+            .Should().Equal(pending[1].Id, pending[0].Id);
+    }
+
+    [Test]
+    public async Task PathAndOccurrenceFaultTargetsOnlyTheSelectedIo()
+    {
+        var expected = new IOException("second beta write");
+        var controller = new DeterministicAsyncIoController(forceYield: true);
+        var fileSystem = DeterministicAsyncFileSystem.Create(
+            AsyncFileSystemAdapter.Create(new InMemoryFileSystem()),
+            controller);
+        var alpha = await CompleteYieldAsync(
+            fileSystem.OpenFileAsync("alpha.db", FileOpenMode.CreateNew),
+            controller);
+        var beta = await CompleteYieldAsync(
+            fileSystem.OpenFileAsync("beta.db", FileOpenMode.CreateNew),
+            controller);
+        controller.FailOnOccurrence(FileSystemOperation.Write, "beta.db", 2, expected);
+
+        await CompleteYieldAsync(alpha.WriteAsync(0, new byte[] { 1 }), controller);
+        await CompleteYieldAsync(beta.WriteAsync(0, new byte[] { 2 }), controller);
+        var failed = beta.WriteAsync(1, new byte[] { 3 });
+        controller.ReleaseNext();
+
+        var exception = Assert.ThrowsAsync<IOException>(async () => await failed);
+        exception.Should().BeSameAs(expected);
+        controller.GetOperationCount(FileSystemOperation.Write, "alpha.db").Should().Be(1);
+        controller.GetOperationCount(FileSystemOperation.Write, "beta.db").Should().Be(2);
+        controller.History.Should().ContainSingle(@event =>
+            @event.Kind == DeterministicAsyncIoEventKind.Faulted
+            && @event.Operation.Path == "beta.db"
+            && @event.Operation.PathOccurrence == 2);
+        (await CompleteYieldAsync(beta.GetLengthAsync(), controller)).Should().Be(1);
+    }
+
     private static async Task CompleteYieldAsync(
         ValueTask operation,
         DeterministicAsyncIoController controller)
@@ -417,330 +484,5 @@ public sealed class DeterministicAsyncFileSystemTests
         controller.PendingYieldCount.Should().Be(1);
         controller.ReleaseNext();
         return await operation;
-    }
-}
-
-internal sealed class DeterministicAsyncIoController(bool forceYield)
-{
-    private readonly object _gate = new();
-    private readonly Dictionary<FileSystemOperation, long> _counts = new();
-    private readonly Dictionary<(FileSystemOperation Operation, long Occurrence), Exception> _faults = new();
-    private readonly Queue<TaskCompletionSource> _pendingYields = new();
-
-    internal int PendingYieldCount
-    {
-        get
-        {
-            lock (_gate)
-                return _pendingYields.Count;
-        }
-    }
-
-    internal void FailNext(FileSystemOperation operation, Exception exception)
-    {
-        ArgumentNullException.ThrowIfNull(exception);
-        lock (_gate)
-        {
-            var occurrence = _counts.GetValueOrDefault(operation) + 1;
-            _faults[(operation, occurrence)] = exception;
-        }
-    }
-
-    internal long GetOperationCount(FileSystemOperation operation)
-    {
-        lock (_gate)
-            return _counts.GetValueOrDefault(operation);
-    }
-
-    internal void ReleaseNext()
-    {
-        TaskCompletionSource completion;
-        lock (_gate)
-            completion = _pendingYields.Dequeue();
-        completion.SetResult();
-    }
-
-    internal async ValueTask BeforeOperationAsync(
-        FileSystemOperation operation,
-        CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        TaskCompletionSource? completion = null;
-        Exception? fault;
-        lock (_gate)
-        {
-            var occurrence = _counts.GetValueOrDefault(operation) + 1;
-            _counts[operation] = occurrence;
-            _faults.Remove((operation, occurrence), out fault);
-            if (forceYield)
-            {
-                completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-                _pendingYields.Enqueue(completion);
-            }
-        }
-
-        if (completion is not null)
-            await completion.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-
-        cancellationToken.ThrowIfCancellationRequested();
-        if (fault is not null)
-            ExceptionDispatchInfo.Capture(fault).Throw();
-    }
-}
-
-internal class DeterministicAsyncFileSystem : IAsyncFileSystem
-{
-    protected DeterministicAsyncFileSystem(
-        IAsyncFileSystem inner,
-        DeterministicAsyncIoController controller)
-    {
-        Inner = inner;
-        Controller = controller;
-    }
-
-    protected IAsyncFileSystem Inner { get; }
-
-    protected DeterministicAsyncIoController Controller { get; }
-
-    internal static IAsyncFileSystem Create(
-        IAsyncFileSystem inner,
-        DeterministicAsyncIoController controller)
-    {
-        ArgumentNullException.ThrowIfNull(inner);
-        ArgumentNullException.ThrowIfNull(controller);
-        return (inner is IAsyncAtomicFileSystem, inner is IAsyncTemporaryFileSystem) switch
-        {
-            (true, true) => new AtomicTemporaryFileSystem(inner, controller),
-            (true, false) => new AtomicFileSystem(inner, controller),
-            (false, true) => new TemporaryFileSystem(inner, controller),
-            _ => new DeterministicAsyncFileSystem(inner, controller),
-        };
-    }
-
-    public async ValueTask<bool> FileExistsAsync(
-        string path,
-        CancellationToken cancellationToken = default)
-    {
-        await Controller.BeforeOperationAsync(
-            FileSystemOperation.FileExists,
-            cancellationToken).ConfigureAwait(false);
-        return await Inner.FileExistsAsync(path, cancellationToken).ConfigureAwait(false);
-    }
-
-    public async ValueTask<IAsyncFile> OpenFileAsync(
-        string path,
-        FileOpenMode mode,
-        bool readOnly = false,
-        CancellationToken cancellationToken = default)
-    {
-        await Controller.BeforeOperationAsync(
-            FileSystemOperation.Open,
-            cancellationToken).ConfigureAwait(false);
-        var file = await Inner.OpenFileAsync(path, mode, readOnly, cancellationToken).ConfigureAwait(false);
-        return DeterministicAsyncFile.Create(file, Controller);
-    }
-
-    public async ValueTask DeleteFileAsync(
-        string path,
-        CancellationToken cancellationToken = default)
-    {
-        await Controller.BeforeOperationAsync(
-            FileSystemOperation.Delete,
-            cancellationToken).ConfigureAwait(false);
-        await Inner.DeleteFileAsync(path, cancellationToken).ConfigureAwait(false);
-    }
-
-    public async ValueTask<FileWriteStamp?> GetWriteStampAsync(
-        string path,
-        CancellationToken cancellationToken = default)
-    {
-        await Controller.BeforeOperationAsync(
-            FileSystemOperation.GetWriteStamp,
-            cancellationToken).ConfigureAwait(false);
-        return await Inner.GetWriteStampAsync(path, cancellationToken).ConfigureAwait(false);
-    }
-
-    private sealed class AtomicFileSystem(
-        IAsyncFileSystem inner,
-        DeterministicAsyncIoController controller) :
-        DeterministicAsyncFileSystem(inner, controller),
-        IAsyncAtomicFileSystem
-    {
-        public async ValueTask ReplaceFileAtomicallyAsync(
-            string sourcePath,
-            string destinationPath,
-            bool replaceEmptyDestination,
-            CancellationToken cancellationToken = default)
-        {
-            await Controller.BeforeOperationAsync(
-                FileSystemOperation.AtomicReplace,
-                cancellationToken).ConfigureAwait(false);
-            await ((IAsyncAtomicFileSystem)Inner).ReplaceFileAtomicallyAsync(
-                sourcePath,
-                destinationPath,
-                replaceEmptyDestination,
-                cancellationToken).ConfigureAwait(false);
-        }
-    }
-
-    private sealed class TemporaryFileSystem(
-        IAsyncFileSystem inner,
-        DeterministicAsyncIoController controller) :
-        DeterministicAsyncFileSystem(inner, controller),
-        IAsyncTemporaryFileSystem
-    {
-        public async ValueTask<IAsyncFile> OpenTemporaryFileAsync(
-            string path,
-            CancellationToken cancellationToken = default)
-        {
-            await Controller.BeforeOperationAsync(
-                FileSystemOperation.OpenTemporary,
-                cancellationToken).ConfigureAwait(false);
-            var file = await ((IAsyncTemporaryFileSystem)Inner)
-                .OpenTemporaryFileAsync(path, cancellationToken).ConfigureAwait(false);
-            return DeterministicAsyncFile.Create(file, Controller);
-        }
-    }
-
-    private sealed class AtomicTemporaryFileSystem(
-        IAsyncFileSystem inner,
-        DeterministicAsyncIoController controller) :
-        DeterministicAsyncFileSystem(inner, controller),
-        IAsyncAtomicFileSystem,
-        IAsyncTemporaryFileSystem
-    {
-        public async ValueTask ReplaceFileAtomicallyAsync(
-            string sourcePath,
-            string destinationPath,
-            bool replaceEmptyDestination,
-            CancellationToken cancellationToken = default)
-        {
-            await Controller.BeforeOperationAsync(
-                FileSystemOperation.AtomicReplace,
-                cancellationToken).ConfigureAwait(false);
-            await ((IAsyncAtomicFileSystem)Inner).ReplaceFileAtomicallyAsync(
-                sourcePath,
-                destinationPath,
-                replaceEmptyDestination,
-                cancellationToken).ConfigureAwait(false);
-        }
-
-        public async ValueTask<IAsyncFile> OpenTemporaryFileAsync(
-            string path,
-            CancellationToken cancellationToken = default)
-        {
-            await Controller.BeforeOperationAsync(
-                FileSystemOperation.OpenTemporary,
-                cancellationToken).ConfigureAwait(false);
-            var file = await ((IAsyncTemporaryFileSystem)Inner)
-                .OpenTemporaryFileAsync(path, cancellationToken).ConfigureAwait(false);
-            return DeterministicAsyncFile.Create(file, Controller);
-        }
-    }
-}
-
-internal class DeterministicAsyncFile : IAsyncFile
-{
-    protected DeterministicAsyncFile(
-        IAsyncFile inner,
-        DeterministicAsyncIoController controller)
-    {
-        Inner = inner;
-        Controller = controller;
-    }
-
-    protected IAsyncFile Inner { get; }
-
-    protected DeterministicAsyncIoController Controller { get; }
-
-    internal static IAsyncFile Create(
-        IAsyncFile inner,
-        DeterministicAsyncIoController controller)
-    {
-        ArgumentNullException.ThrowIfNull(inner);
-        ArgumentNullException.ThrowIfNull(controller);
-        return inner is IAsyncPageMaterializingFile
-            ? new MaterializingFile(inner, controller)
-            : new DeterministicAsyncFile(inner, controller);
-    }
-
-    public bool IsReadOnly => Inner.IsReadOnly;
-
-    public async ValueTask<long> GetLengthAsync(CancellationToken cancellationToken = default)
-    {
-        await Controller.BeforeOperationAsync(
-            FileSystemOperation.GetLength,
-            cancellationToken).ConfigureAwait(false);
-        return await Inner.GetLengthAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    public async ValueTask<int> ReadAsync(
-        long position,
-        Memory<byte> destination,
-        CancellationToken cancellationToken = default)
-    {
-        await Controller.BeforeOperationAsync(
-            FileSystemOperation.Read,
-            cancellationToken).ConfigureAwait(false);
-        return await Inner.ReadAsync(position, destination, cancellationToken).ConfigureAwait(false);
-    }
-
-    public async ValueTask WriteAsync(
-        long position,
-        ReadOnlyMemory<byte> source,
-        CancellationToken cancellationToken = default)
-    {
-        await Controller.BeforeOperationAsync(
-            FileSystemOperation.Write,
-            cancellationToken).ConfigureAwait(false);
-        await Inner.WriteAsync(position, source, cancellationToken).ConfigureAwait(false);
-    }
-
-    public async ValueTask SetLengthAsync(
-        long length,
-        CancellationToken cancellationToken = default)
-    {
-        await Controller.BeforeOperationAsync(
-            FileSystemOperation.SetLength,
-            cancellationToken).ConfigureAwait(false);
-        await Inner.SetLengthAsync(length, cancellationToken).ConfigureAwait(false);
-    }
-
-    public async ValueTask FlushToDiskAsync(CancellationToken cancellationToken = default)
-    {
-        await Controller.BeforeOperationAsync(
-            FileSystemOperation.FlushToDisk,
-            cancellationToken).ConfigureAwait(false);
-        await Inner.FlushToDiskAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        await Controller.BeforeOperationAsync(
-            FileSystemOperation.Dispose,
-            CancellationToken.None).ConfigureAwait(false);
-        await Inner.DisposeAsync().ConfigureAwait(false);
-    }
-
-    private sealed class MaterializingFile(
-        IAsyncFile inner,
-        DeterministicAsyncIoController controller) :
-        DeterministicAsyncFile(inner, controller),
-        IAsyncPageMaterializingFile
-    {
-        public async ValueTask EnsureMaterializedAsync(
-            long position,
-            int length,
-            CancellationToken cancellationToken = default)
-        {
-            await Controller.BeforeOperationAsync(
-                FileSystemOperation.EnsureMaterialized,
-                cancellationToken).ConfigureAwait(false);
-            await ((IAsyncPageMaterializingFile)Inner).EnsureMaterializedAsync(
-                position,
-                length,
-                cancellationToken).ConfigureAwait(false);
-        }
     }
 }

--- a/src/Ahtola.Tests/ConcurrencyModelTests.cs
+++ b/src/Ahtola.Tests/ConcurrencyModelTests.cs
@@ -1,0 +1,253 @@
+using System.Globalization;
+using AwesomeAssertions;
+using Ahtola.Data.Sqlite;
+using Ahtola.Tests.Oracle;
+
+namespace Ahtola.Tests;
+
+/// <summary>
+/// Bounded cooperative interleavings derived from Turso's concurrent simulator,
+/// stress shuttle tests, and MVCC fixed-yield tests.
+/// </summary>
+public sealed class ConcurrencyModelTests
+{
+    private const int ExhaustiveScheduleLimit = 32;
+    private const int RandomScheduleCount = 4;
+
+    [Test]
+    public async Task TransactionInterleavingsPreserveCommitRollbackAndSnapshots()
+    {
+        var root = StableTestSeed.Create(0xc011ab1eUL);
+        var runNumber = 0;
+        var sawRollbackPendingRead = false;
+        var sawReaderSpanCommit = false;
+
+        var exploration = await CooperativeScheduleExplorer.ExploreDepthFirstAsync(
+            prefix => RunTransactionScheduleAsync(
+                root.Derive($"transaction-dfs-{runNumber++}"),
+                replayChoices: prefix,
+                allowReplayPrefix: true),
+            ExhaustiveScheduleLimit);
+
+        exploration.Exhaustive.Should().BeTrue(
+            because: "the two bounded actor scripts have only fifteen order-preserving interleavings");
+        exploration.Runs.Should().HaveCount(15);
+        foreach (var run in exploration.Runs)
+            RecordCoverage(run, ref sawRollbackPendingRead, ref sawReaderSpanCommit);
+
+        for (var index = 0; index < RandomScheduleCount; index++)
+        {
+            var stream = root.Derive($"transaction-random-{index}");
+            var run = await RunTransactionScheduleAsync(
+                stream,
+                choose: (_, enabled) => stream.Random.NextInt32(enabled));
+            RecordCoverage(run, ref sawRollbackPendingRead, ref sawReaderSpanCommit);
+        }
+
+        sawRollbackPendingRead.Should().BeTrue(
+            because: "at least one explored reader ran while the rollback transaction was pending");
+        sawReaderSpanCommit.Should().BeTrue(
+            because: "at least one explored snapshot straddled the writer's commit");
+    }
+
+    private static async Task<CooperativeScheduleResult> RunTransactionScheduleAsync(
+        StableRandomStream stream,
+        IReadOnlyList<int>? replayChoices = null,
+        Func<int, int, int>? choose = null,
+        bool allowReplayPrefix = false)
+    {
+        var path = DatabasePath(stream.Seed);
+        var trace = ReplayTrace.Create(TestContext.CurrentContext.Test.Name, stream);
+        try
+        {
+            using (var setup = Open(path))
+            {
+                Execute(
+                    setup,
+                    "CREATE TABLE schedule_rows(id INTEGER PRIMARY KEY, value INTEGER NOT NULL);"
+                    + "INSERT INTO schedule_rows VALUES(1, 0);"
+                    + "INSERT INTO schedule_rows VALUES(2, 0);",
+                    trace,
+                    actor: -1,
+                    action: "setup");
+            }
+
+            using var writer = Open(path);
+            using var reader = Open(path);
+            var observations = new List<ReaderObservation>();
+            var scheduler = new DeterministicCooperativeScheduler(
+                maxSteps: 16,
+                maxStepsWithoutProgress: 8);
+
+            scheduler.AddActor("writer", async actor =>
+            {
+                await actor.YieldAsync("writer.before-rollback");
+                Execute(writer, "BEGIN;", trace, actor.ActorId, "rollback.begin");
+                Execute(
+                    writer,
+                    "INSERT INTO schedule_rows VALUES(99, 99);",
+                    trace,
+                    actor.ActorId,
+                    "rollback.write");
+                actor.NoteProgress();
+
+                await actor.YieldAsync("writer.rollback-pending");
+                Execute(writer, "ROLLBACK;", trace, actor.ActorId, "rollback.finish");
+                Execute(writer, "BEGIN;", trace, actor.ActorId, "commit.begin");
+                Execute(writer, "UPDATE schedule_rows SET value = 1;", trace, actor.ActorId, "commit.update");
+                Execute(
+                    writer,
+                    "INSERT INTO schedule_rows VALUES(10, 10);",
+                    trace,
+                    actor.ActorId,
+                    "commit.insert");
+                actor.NoteProgress();
+
+                await actor.YieldAsync("writer.commit-pending");
+                Execute(writer, "COMMIT;", trace, actor.ActorId, "commit.finish");
+                actor.NoteProgress();
+
+                await actor.YieldAsync("writer.after-commit");
+            });
+
+            scheduler.AddActor("reader", async actor =>
+            {
+                await actor.YieldAsync("reader.before-snapshot");
+                Execute(reader, "BEGIN;", trace, actor.ActorId, "snapshot.begin");
+                var first = Scalar(reader, "SELECT value FROM schedule_rows WHERE id = 1;", trace, actor.ActorId);
+                var rollbackFirst = Scalar(
+                    reader,
+                    "SELECT COUNT(*) FROM schedule_rows WHERE id = 99;",
+                    trace,
+                    actor.ActorId);
+                actor.NoteProgress();
+
+                await actor.YieldAsync("reader.between-snapshot-reads");
+                var second = Scalar(reader, "SELECT value FROM schedule_rows WHERE id = 2;", trace, actor.ActorId);
+                var rollbackSecond = Scalar(
+                    reader,
+                    "SELECT COUNT(*) FROM schedule_rows WHERE id = 99;",
+                    trace,
+                    actor.ActorId);
+                Execute(reader, "COMMIT;", trace, actor.ActorId, "snapshot.finish");
+                observations.Add(new ReaderObservation(first, second, rollbackFirst, rollbackSecond));
+                actor.NoteProgress();
+            });
+
+            var result = await scheduler.RunAsync(replayChoices, choose, allowReplayPrefix);
+            foreach (var step in result.Steps)
+                trace.AddScheduleStep(step);
+
+            OracleFailureArtifacts.Run(trace, () =>
+            {
+                result.EnsureSuccessful();
+                result.Actors.Should().HaveCount(2)
+                    .And.OnlyContain(static actor => actor.Completed && actor.Crash == null);
+                result.Steps.Should().HaveCount(6);
+                observations.Should().ContainSingle();
+                observations[0].FirstValue.Should().Be(observations[0].SecondValue,
+                    because: "both reads belong to one snapshot");
+                observations[0].FirstValue.Should().BeOneOf(0L, 1L);
+                observations[0].RollbackCountBeforeYield.Should().Be(0);
+                observations[0].RollbackCountAfterYield.Should().Be(0);
+
+                using var verify = Open(path);
+                Scalar(verify, "SELECT COUNT(*) FROM schedule_rows WHERE id = 10;", trace, -1)
+                    .Should().Be(1, because: "a successfully committed key cannot disappear");
+                Scalar(verify, "SELECT COUNT(*) FROM schedule_rows WHERE id = 99;", trace, -1)
+                    .Should().Be(0, because: "a rolled-back key must never become externally visible");
+                Scalar(verify, "SELECT COUNT(*) FROM schedule_rows WHERE id IN (1, 2) AND value = 1;", trace, -1)
+                    .Should().Be(2, because: "the committed multi-row update is atomic");
+            });
+
+            return result;
+        }
+        finally
+        {
+            DeleteDatabaseFiles(path);
+        }
+    }
+
+    private static void RecordCoverage(
+        CooperativeScheduleResult result,
+        ref bool sawRollbackPendingRead,
+        ref bool sawReaderSpanCommit)
+    {
+        result.EnsureSuccessful();
+        var points = result.Steps.Select(static step => step.YieldPoint).ToArray();
+        sawRollbackPendingRead |= Ordered(
+            points,
+            "writer.before-rollback",
+            "reader.before-snapshot",
+            "writer.rollback-pending");
+        sawReaderSpanCommit |= Ordered(
+            points,
+            "reader.before-snapshot",
+            "writer.commit-pending",
+            "reader.between-snapshot-reads");
+    }
+
+    private static bool Ordered(string[] points, string first, string second, string third)
+    {
+        var firstIndex = Array.IndexOf(points, first);
+        var secondIndex = Array.IndexOf(points, second);
+        var thirdIndex = Array.IndexOf(points, third);
+        return firstIndex < secondIndex && secondIndex < thirdIndex;
+    }
+
+    private static SqliteConnection Open(string path)
+    {
+        var connection = new SqliteConnection(
+            $"Data Source={path};Local Provider=Managed;Pooling=False;Default Timeout=1");
+        connection.Open();
+        return connection;
+    }
+
+    private static void Execute(
+        SqliteConnection connection,
+        string sql,
+        ReplayTrace trace,
+        int actor,
+        string action)
+    {
+        trace.Add(sql, comparison: "cooperative schedule", actor: actor, action: action);
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.ExecuteNonQuery();
+    }
+
+    private static long Scalar(
+        SqliteConnection connection,
+        string sql,
+        ReplayTrace trace,
+        int actor)
+    {
+        trace.Add(sql, comparison: "cooperative schedule", actor: actor, action: "observe");
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        return Convert.ToInt64(command.ExecuteScalar(), CultureInfo.InvariantCulture);
+    }
+
+    private static string DatabasePath(ulong seed)
+    {
+        var directory = Path.Combine(TestContext.CurrentContext.WorkDirectory, "concurrency-model");
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, $"schedule-{seed:x16}-{Guid.NewGuid():N}.db");
+    }
+
+    private static void DeleteDatabaseFiles(string path)
+    {
+        foreach (var suffix in new[] { string.Empty, "-wal", "-shm", "-journal" })
+        {
+            var candidate = path + suffix;
+            if (File.Exists(candidate))
+                File.Delete(candidate);
+        }
+    }
+
+    private sealed record ReaderObservation(
+        long FirstValue,
+        long SecondValue,
+        long RollbackCountBeforeYield,
+        long RollbackCountAfterYield);
+}

--- a/src/Ahtola.Tests/Conformance/managed-sqltest-expected-failures.txt
+++ b/src/Ahtola.Tests/Conformance/managed-sqltest-expected-failures.txt
@@ -12,3 +12,138 @@
 # Intentional SQLite-compatible extensions beyond the pinned Turso baseline.
 gencol.sqltest::gencol_stored_rejected | STORED generated columns are supported instead of returning Turso's expected rejection
 gencol.sqltest::gencol_stored_generated_always_rejected | GENERATED ALWAYS AS ... STORED is supported instead of returning Turso's expected rejection
+
+# Engine gaps exposed by the now-managed deterministic :default: fixtures.
+agg-functions/default.sqltest::select-with-group-by-and-agg-1 | grouped aggregation exceeds the managed execution memory limit
+agg-functions/default.sqltest::select-max-star | aggregate star argument validation differs
+agg-functions/default.sqltest::select-max-star-in-expression | aggregate star argument validation differs
+agg-functions/default.sqltest::select-scalar-func-star | scalar star argument validation differs
+agg-functions/default.sqltest::select-scalar-func-star-in-expression | scalar star argument validation differs
+agg-functions/default.sqltest::select-nested-agg-func | nested aggregate validation differs
+agg-functions/default.sqltest::select-nested-agg-func-in-expression | nested aggregate validation differs
+concat.sqltest::concat-ws-one-arg-error | concat_ws arity validation differs
+groupby/default.sqltest::group_by | grouped aggregation exceeds the managed execution memory limit
+groupby/default.sqltest::group_by_without_aggs | grouped query exceeds the managed execution memory limit
+groupby/default.sqltest::group_by_multiple_aggregates_2 | grouped aggregation differs
+groupby/default.sqltest::group_by_and_binary_expression_that_depends_on_two_aggregates | grouped aggregate expression differs
+groupby/default.sqltest::group_by_function_expression | grouped function expression differs
+groupby/default.sqltest::group_by_count_star | grouped count star differs
+groupby/default.sqltest::group_by_count_star_in_expression | grouped count star expression differs
+groupby/default.sqltest::group_by_count_no_args_in_expression | grouped count expression differs
+groupby/default.sqltest::having | HAVING aggregation differs
+groupby/default.sqltest::having_with_scalar_fn_over_aggregate | HAVING scalar aggregate expression differs
+groupby/default.sqltest::having_with_multiple_conditions | HAVING condition evaluation differs
+groupby/default.sqltest::group_by_column_number | ordinal GROUP BY differs
+groupby/default.sqltest::group_by_no_sorting_required | grouped no-sort plan differs
+groupby/default.sqltest::group_by_no_sorting_required_and_const_agg_arg | grouped constant argument plan differs
+groupby/default.sqltest::distinct_agg_functions | distinct aggregate execution differs
+groupby/default.sqltest::proper-sort-order | grouped sort order differs
+join/default.sqltest::left-join-constant-condition-true-inner-join-constant-condition-false | mixed outer and inner join semantics differ
+join/default.sqltest::join-using-multiple | multi-table USING semantics differ
+join/default.sqltest::join-using-multiple-with-quoting | quoted multi-table USING semantics differ
+join/default.sqltest::natural-join-multiple | multi-table NATURAL JOIN semantics differ
+json/default.sqltest::json_extract_empty | json_extract arity validation differs
+json/default.sqltest::json_extract_with_escaping_2 | JSON path escaping differs
+json/default.sqltest::json_arrow_implicit_real_cast | JSON arrow numeric coercion differs
+json/default.sqltest::json_arrow_shift_implicit_real_cast | JSON arrow and shift coercion differs
+json/default.sqltest::json_extract_overflow_int32_1 | JSON integer overflow handling differs
+json/default.sqltest::json_extract_overflow_int32_2 | JSON integer overflow handling differs
+json/default.sqltest::json_extract_overflow_int32_3 | JSON integer overflow handling differs
+json/default.sqltest::json_extract_overflow_int32_3-2 | JSON integer overflow handling differs
+json/default.sqltest::json_extract_overflow_int64 | JSON integer overflow handling differs
+json/default.sqltest::json_type_blob_with_trailing_bytes | JSONB trailing-byte validation differs
+json/default.sqltest::json_error_position_valid | json_error_position differs
+json/default.sqltest::json_error_position_valid_ws | json_error_position whitespace handling differs
+json/default.sqltest::json_error_position_array_valid | json_error_position array handling differs
+json/default.sqltest::json_error_position_array_valid_ws | json_error_position array whitespace handling differs
+json/default.sqltest::json_error_position_complex | json_error_position complex input handling differs
+json/default.sqltest::json_set_notation | JSON set notation differs
+json/default.sqltest::json_insert_notation | JSON insert notation differs
+json/default.sqltest::json_hex_values | JSON hexadecimal number handling differs
+json/default.sqltest::json_mixed_escaping | JSON mixed escaping differs
+json/default.sqltest::jsonb-oversized-child-remove | oversized JSONB child removal differs
+json/default.sqltest::json-subtype-query-materialization-boundaries | JSON subtype materialization differs
+like.sqltest::like-complexity-1 | LIKE complexity limit is not enforced
+like.sqltest::like-complexity-2 | LIKE complexity boundary differs
+offset/default.sqltest::select-offset-0-groupby | grouped OFFSET query exceeds the managed execution memory limit
+offset/default.sqltest::select-offset-1-groupby | grouped OFFSET query exceeds the managed execution memory limit
+orderby/default.sqltest::order-by-case-insensitive-aggregate | aggregate tie ordering differs
+orderby/default.sqltest::order-by-agg-not-mentioned-in-select | hidden aggregate ordering differs
+pragma/default.sqltest::pragma-table-info-equal-syntax | PRAGMA table_info equals syntax differs
+pragma/default.sqltest::pragma-table-info-call-syntax | PRAGMA table_info call syntax differs
+pragma/default.sqltest::pragma-table-xinfo-call-syntax | PRAGMA table_xinfo call syntax differs
+pragma/default.sqltest::pragma-table-info-alt-name-equal-syntax | PRAGMA alias equals syntax differs
+pragma/default.sqltest::pragma-table-info-alt-name-call-syntax | PRAGMA alias call syntax differs
+pragma/default.sqltest::pragma-function-table-info-alt-name | pragma_table_info alias differs
+pragma/default.sqltest::pragma-function-table-info | pragma_table_info table-valued function differs
+pragma/default.sqltest::pragma-vtab-table-info | PRAGMA virtual table metadata differs
+pragma/default.sqltest::pragma-function-legacy-file-format | pragma function legacy_file_format differs
+pragma/default.sqltest::pragma-function-update | pragma function update behavior differs
+pragma/default.sqltest::pragma-function-nontext-argument | pragma function argument coercion differs
+pragma/default.sqltest::pragma-vtab-nontext-argument | PRAGMA virtual table argument coercion differs
+pragma/default.sqltest::pragma-vtab-join | PRAGMA virtual table join differs
+pragma/default.sqltest::pragma-vtab-reversed-join-order | PRAGMA virtual table reversed join differs
+pragma/default.sqltest::pragma-module-list-nonempty | pragma_module_list differs
+pragma/default.sqltest::pragma-function-list-has-abs | pragma_function_list differs
+pragma/default.sqltest::pragma-function-list-has-count | pragma_function_list differs
+pragma/default.sqltest::pragma-function-list-scalar | pragma_function_list flags differ
+pragma/default.sqltest::pragma-function-list-aggregate | pragma_function_list flags differ
+pragma/default.sqltest::pragma-function-list-window-row-number | pragma_function_list window metadata differs
+pragma/default.sqltest::pragma-function-list-window-rank | pragma_function_list window metadata differs
+pragma/default.sqltest::pragma-function-list-window-dense-rank | pragma_function_list window metadata differs
+pragma/default.sqltest::pragma-function-list-window-first-value | pragma_function_list window metadata differs
+pragma/default.sqltest::pragma-function-list-window-last-value | pragma_function_list window metadata differs
+pragma/default.sqltest::pragma-function-list-window-nth-value | pragma_function_list window metadata differs
+pragma/default.sqltest::pragma-function-list-window-lag | pragma_function_list window metadata differs
+pragma/default.sqltest::pragma-function-list-window-lead | pragma_function_list window metadata differs
+pragma/default.sqltest::pragma-function-list-window-ntile | pragma_function_list window metadata differs
+pragma/default.sqltest::pragma-function-list-omits-unimplemented-window-functions | pragma_function_list exposes different window functions
+scalar-functions-datetime.sqltest::time_date-overflow-issue-5251 | TIME_DATE function is unavailable
+scalar-functions-datetime.sqltest::unixepoch-out-of-range-strftime-utc | out-of-range unixepoch handling differs
+scalar-functions.sqltest::substr-embedded-nul | embedded NUL substring handling differs
+scalar-functions.sqltest::unicode-char0 | char zero formatting differs
+scalar-functions.sqltest::quote-string-embedded-nul | quote embedded NUL handling differs
+scalar-functions.sqltest::quote-float-scientific-format | quote floating-point formatting differs
+scalar-functions.sqltest::cast-text-exp-to-integer | exponent text integer cast differs
+scalar-functions.sqltest::cast-without-type-integer | typeless CAST syntax is rejected
+scalar-functions.sqltest::cast-without-type-text-numeric | typeless CAST syntax is rejected
+scalar-functions.sqltest::cast-without-type-text-integer-string | typeless CAST syntax is rejected
+scalar-functions.sqltest::cast-without-type-text-real-string | typeless CAST syntax is rejected
+scalar-functions.sqltest::cast-without-type-null | typeless CAST syntax is rejected
+scalar-functions.sqltest::cast-without-type-in-expression | typeless CAST syntax is rejected
+scalar-functions.sqltest::length-999123 | numeric length coercion differs
+scalar-functions.sqltest::iif-2-args-true | variadic iif is unavailable
+scalar-functions.sqltest::iif-2-args-false-is-null | variadic iif is unavailable
+scalar-functions.sqltest::iif-multi-args-finds-first-true | variadic iif is unavailable
+scalar-functions.sqltest::iif-multi-args-falls-to-else | variadic iif is unavailable
+scalar-functions.sqltest::if-alias-2-args-true | variadic if alias is unavailable
+scalar-functions.sqltest::if-alias-multi-args-finds-first-true | variadic if alias is unavailable
+scalar-functions.sqltest::if-alias-multi-args-falls-to-else | variadic if alias is unavailable
+scalar-functions.sqltest::if-alias-multi-args-no-else-is-null | variadic if alias is unavailable
+scalar-functions.sqltest::func3-5-8 | function argument validation differs
+scalar-functions.sqltest::func3-5-9 | function argument validation differs
+scalar-functions.sqltest::func3-5-10 | function argument validation differs
+scalar-functions.sqltest::func9-160 | function argument validation differs
+scalar-functions.sqltest::uuid7-str-negative-timestamp | negative uuid7 timestamp validation differs
+scalar-functions.sqltest::uuid7-negative-timestamp | negative uuid7 timestamp validation differs
+select/default.sqltest::select-limit-true | boolean LIMIT expression differs
+select/default.sqltest::select-limit-false | boolean LIMIT expression differs
+select/default.sqltest::select-star-no-from | star without FROM validation differs
+select/default.sqltest::select-star-and-constant-no-from | star without FROM validation differs
+select/default.sqltest::select-star-subquery | star subquery validation differs
+select/default.sqltest::limit-complex-exprs-limit-text-2 | text LIMIT coercion differs
+select/default.sqltest::limit-complex-exprs-limit-bool-true | boolean LIMIT coercion differs
+select/default.sqltest::limit-complex-exprs-limit-bool-add | boolean LIMIT expression differs
+select/default.sqltest::limit-complex-exprs-limit-bool-false-add | boolean LIMIT expression differs
+select/default.sqltest::select-param-zero-invalid | zero-index parameter validation differs
+subquery/default.sqltest::subquery-inner-grouping | grouped subquery exceeds the managed execution memory limit
+subquery/default.sqltest::subquery-inner-grouping-cte | grouped CTE subquery differs
+subquery/default.sqltest::subquery-outer-grouping | outer grouped subquery differs
+window/default.sqltest::window-multiple-functions | window peer ordering differs
+window/default.sqltest::window-with-group-by | window grouping differs
+window/default.sqltest::window-nonexistent-function | window function validation differs
+window/default.sqltest::window-function-without-over | window function validation differs
+window/default.sqltest::window-scalar-function-star | window scalar star validation differs
+window/default.sqltest::window-nonexistent-function-star | window function star validation differs
+window/default.sqltest::window-aggregate-with-group-by-as-argument | grouped window aggregate argument differs
+window/default.sqltest::window-row-number-with-peers | window peer ordering differs

--- a/src/Ahtola.Tests/Conformance/managed-sqltest-harness-exclusions.txt
+++ b/src/Ahtola.Tests/Conformance/managed-sqltest-harness-exclusions.txt
@@ -1,0 +1,3 @@
+# Cases that cannot be safely bounded by the in-process managed sqltest harness.
+# Format: <relative path>::<test name> | <reviewable harness limitation>
+join/default.sqltest::four-way-inner-join | query planning does not observe the managed sqltest cancellation token, so this known gap cannot be bounded in-process

--- a/src/Ahtola.Tests/DeterministicCooperativeSchedulerTests.cs
+++ b/src/Ahtola.Tests/DeterministicCooperativeSchedulerTests.cs
@@ -1,0 +1,152 @@
+using AwesomeAssertions;
+using Ahtola.Tests.Oracle;
+
+namespace Ahtola.Tests;
+
+public sealed class DeterministicCooperativeSchedulerTests
+{
+    [Test]
+    public async Task ChoiceVectorReplaysTheSameNamedYieldTrace()
+    {
+        var random = new StablePrng(0x5cedUL);
+        var first = await RunTwoActorProbeAsync((_, enabled) => random.NextInt32(enabled));
+        first.EnsureSuccessful();
+
+        var replay = await RunTwoActorProbeAsync(replayChoices: first.Choices);
+        replay.EnsureSuccessful();
+
+        replay.Steps.Select(Identity).Should().Equal(first.Steps.Select(Identity));
+        replay.Choices.Should().Equal(first.Choices);
+
+        var stream = StableTestSeed.Create(0x5cedUL).Derive("cooperative-replay");
+        var trace = ReplayTrace.Create(TestContext.CurrentContext.Test.Name, stream);
+        foreach (var step in first.Steps)
+            trace.AddScheduleStep(step);
+
+        var restored = ReplayTrace.FromJson(trace.ToJson());
+        restored.ScheduleChoices.Should().Equal(first.Choices);
+        restored.Schedule.Should().BeEquivalentTo(trace.Schedule, options => options.WithStrictOrdering());
+        restored.ToSql().Should().Contain("schedule choices=[").And.Contain("yield=right.first#0");
+    }
+
+    [Test]
+    public async Task DepthFirstExplorerEnumeratesEverySmallInterleaving()
+    {
+        var exploration = await CooperativeScheduleExplorer.ExploreDepthFirstAsync(
+            prefix => RunTwoActorProbeAsync(replayChoices: prefix, allowReplayPrefix: true),
+            maxSchedules: 8);
+
+        exploration.Exhaustive.Should().BeTrue();
+        exploration.Runs.Should().HaveCount(6, because: "two actors with two yield points have 4!/(2!*2!) schedules");
+        exploration.Runs.Should().OnlyContain(static run => run.CompletedSuccessfully);
+        exploration.Runs.Select(static run => string.Join(",", run.Steps.Select(step => step.ActorId)))
+            .Should().OnlyHaveUniqueItems();
+    }
+
+    [Test]
+    public async Task ObserverReceivesStartCrashAndFinalizationExactlyOnce()
+    {
+        var observer = new RecordingObserver();
+        var scheduler = new DeterministicCooperativeScheduler(observers: observer);
+        scheduler.AddActor("healthy", async actor =>
+        {
+            await actor.YieldAsync("healthy.ready");
+            actor.NoteProgress();
+        });
+        scheduler.AddActor("crash", async actor =>
+        {
+            await actor.YieldAsync("crash.ready");
+            throw new InvalidOperationException("synthetic actor crash");
+        });
+
+        var result = await scheduler.RunAsync();
+
+        result.Failure.Should().BeOfType<InvalidOperationException>();
+        observer.Started.Should().BeEquivalentTo(["healthy", "crash"]);
+        observer.Finished.Should().ContainSingle().Which.Should().Be("healthy");
+        observer.Crashed.Should().ContainSingle().Which.Should().Be("crash");
+        observer.Finalized.Should().Be(1);
+    }
+
+    [Test]
+    public async Task MaxStepBoundReportsCooperativeLivelock()
+    {
+        var scheduler = new DeterministicCooperativeScheduler(
+            maxSteps: 4,
+            maxStepsWithoutProgress: 4);
+        scheduler.AddActor("spinner", async actor =>
+        {
+            while (true)
+                await actor.YieldAsync("spinner.no-progress");
+        });
+
+        var result = await scheduler.RunAsync();
+
+        result.Failure.Should().BeOfType<CooperativeLivelockException>();
+        result.Steps.Should().HaveCount(4);
+        result.Actors.Should().ContainSingle().Which.Completed.Should().BeFalse();
+    }
+
+    private static Task<CooperativeScheduleResult> RunTwoActorProbeAsync(
+        Func<int, int, int>? choose = null,
+        IReadOnlyList<int>? replayChoices = null,
+        bool allowReplayPrefix = false)
+    {
+        var scheduler = new DeterministicCooperativeScheduler();
+        scheduler.AddActor("left", async actor =>
+        {
+            await actor.YieldAsync("left.first");
+            actor.NoteProgress();
+            await actor.YieldAsync("left.second");
+            actor.NoteProgress();
+        });
+        scheduler.AddActor("right", async actor =>
+        {
+            await actor.YieldAsync("right.first");
+            actor.NoteProgress();
+            await actor.YieldAsync("right.second");
+            actor.NoteProgress();
+        });
+        return scheduler.RunAsync(replayChoices, choose, allowReplayPrefix);
+    }
+
+    private static string Identity(CooperativeScheduleStep step)
+        => $"{step.ActorId}:{step.ActorName}:{step.YieldPoint}:{step.YieldOrdinal}";
+
+    private sealed class RecordingObserver : CooperativeScheduleObserver
+    {
+        private readonly object _gate = new();
+
+        internal List<string> Started { get; } = [];
+
+        internal List<string> Finished { get; } = [];
+
+        internal List<string> Crashed { get; } = [];
+
+        internal int Finalized { get; private set; }
+
+        public override void OnStart(CooperativeActorInfo actor)
+        {
+            lock (_gate)
+                Started.Add(actor.Name);
+        }
+
+        public override void OnFinish(CooperativeActorResult actor)
+        {
+            lock (_gate)
+                Finished.Add(actor.Actor.Name);
+        }
+
+        public override void OnCrash(CooperativeActorInfo actor, Exception exception)
+        {
+            lock (_gate)
+                Crashed.Add(actor.Name);
+        }
+
+        public override void FinalizeRun(CooperativeScheduleResult result)
+        {
+            lock (_gate)
+                Finalized++;
+        }
+    }
+}

--- a/src/Ahtola.Tests/Infrastructure/DeterministicAsyncFileSystem.cs
+++ b/src/Ahtola.Tests/Infrastructure/DeterministicAsyncFileSystem.cs
@@ -1,0 +1,483 @@
+using System.Runtime.ExceptionServices;
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Tests;
+
+internal enum DeterministicAsyncIoEventKind
+{
+    Observed,
+    Pending,
+    Released,
+    Canceled,
+    Faulted,
+}
+
+internal readonly record struct DeterministicAsyncIoOperation(
+    long Id,
+    FileSystemOperation Type,
+    string Path,
+    long Occurrence,
+    long PathOccurrence);
+
+internal readonly record struct DeterministicAsyncIoEvent(
+    DeterministicAsyncIoOperation Operation,
+    DeterministicAsyncIoEventKind Kind);
+
+internal sealed class DeterministicAsyncIoController(bool forceYield)
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<FileSystemOperation, long> _counts = new();
+    private readonly Dictionary<(FileSystemOperation Operation, string Path), long> _pathCounts = new();
+    private readonly Dictionary<(FileSystemOperation Operation, long Occurrence), Exception> _globalFaults = new();
+    private readonly Dictionary<
+        (FileSystemOperation Operation, string Path, long Occurrence),
+        Exception> _pathFaults = new();
+    private readonly List<PendingOperation> _pending = [];
+    private readonly List<DeterministicAsyncIoEvent> _history = [];
+    private long _nextId;
+
+    internal int PendingYieldCount
+    {
+        get
+        {
+            lock (_gate)
+                return _pending.Count;
+        }
+    }
+
+    internal IReadOnlyList<DeterministicAsyncIoOperation> PendingOperations
+    {
+        get
+        {
+            lock (_gate)
+                return [.. _pending.Select(static item => item.Operation)];
+        }
+    }
+
+    internal IReadOnlyList<DeterministicAsyncIoEvent> History
+    {
+        get
+        {
+            lock (_gate)
+                return [.. _history];
+        }
+    }
+
+    internal void FailNext(FileSystemOperation operation, Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        lock (_gate)
+        {
+            var occurrence = _counts.GetValueOrDefault(operation) + 1;
+            _globalFaults[(operation, occurrence)] = exception;
+        }
+    }
+
+    internal void FailOnOccurrence(
+        FileSystemOperation operation,
+        string path,
+        long occurrence,
+        Exception exception)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        ArgumentOutOfRangeException.ThrowIfLessThan(occurrence, 1);
+        ArgumentNullException.ThrowIfNull(exception);
+        lock (_gate)
+            _pathFaults[(operation, path, occurrence)] = exception;
+    }
+
+    internal long GetOperationCount(FileSystemOperation operation)
+    {
+        lock (_gate)
+            return _counts.GetValueOrDefault(operation);
+    }
+
+    internal long GetOperationCount(FileSystemOperation operation, string path)
+    {
+        lock (_gate)
+            return _pathCounts.GetValueOrDefault((operation, path));
+    }
+
+    internal long ReleaseNext()
+    {
+        long id;
+        lock (_gate)
+        {
+            if (_pending.Count == 0)
+                throw new InvalidOperationException("There are no pending asynchronous I/O operations.");
+            id = _pending[0].Operation.Id;
+        }
+
+        Release(id);
+        return id;
+    }
+
+    internal void Release(long operationId)
+    {
+        PendingOperation pending;
+        lock (_gate)
+        {
+            var index = _pending.FindIndex(item => item.Operation.Id == operationId);
+            if (index < 0)
+                throw new InvalidOperationException($"Operation {operationId} is not pending.");
+            pending = _pending[index];
+            _pending.RemoveAt(index);
+            _history.Add(new DeterministicAsyncIoEvent(
+                pending.Operation,
+                DeterministicAsyncIoEventKind.Released));
+        }
+
+        pending.Completion.SetResult();
+    }
+
+    internal async ValueTask BeforeOperationAsync(
+        FileSystemOperation operation,
+        string path,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        DeterministicAsyncIoOperation scheduledOperation;
+        TaskCompletionSource? completion = null;
+        Exception? fault;
+        lock (_gate)
+        {
+            var occurrence = _counts.GetValueOrDefault(operation) + 1;
+            _counts[operation] = occurrence;
+            var pathKey = (operation, path);
+            var pathOccurrence = _pathCounts.GetValueOrDefault(pathKey) + 1;
+            _pathCounts[pathKey] = pathOccurrence;
+            scheduledOperation = new DeterministicAsyncIoOperation(
+                ++_nextId,
+                operation,
+                path,
+                occurrence,
+                pathOccurrence);
+            _history.Add(new DeterministicAsyncIoEvent(
+                scheduledOperation,
+                DeterministicAsyncIoEventKind.Observed));
+            if (!_pathFaults.Remove((operation, path, pathOccurrence), out fault))
+                _globalFaults.Remove((operation, occurrence), out fault);
+            if (forceYield)
+            {
+                completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                _pending.Add(new PendingOperation(scheduledOperation, completion));
+                _history.Add(new DeterministicAsyncIoEvent(
+                    scheduledOperation,
+                    DeterministicAsyncIoEventKind.Pending));
+            }
+        }
+
+        if (completion is not null)
+        {
+            try
+            {
+                await completion.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                lock (_gate)
+                {
+                    _history.Add(new DeterministicAsyncIoEvent(
+                        scheduledOperation,
+                        DeterministicAsyncIoEventKind.Canceled));
+                }
+                throw;
+            }
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        if (fault is not null)
+        {
+            lock (_gate)
+            {
+                _history.Add(new DeterministicAsyncIoEvent(
+                    scheduledOperation,
+                    DeterministicAsyncIoEventKind.Faulted));
+            }
+            ExceptionDispatchInfo.Capture(fault).Throw();
+        }
+    }
+
+    private sealed record PendingOperation(
+        DeterministicAsyncIoOperation Operation,
+        TaskCompletionSource Completion);
+}
+
+internal class DeterministicAsyncFileSystem : IAsyncFileSystem
+{
+    protected DeterministicAsyncFileSystem(
+        IAsyncFileSystem inner,
+        DeterministicAsyncIoController controller)
+    {
+        Inner = inner;
+        Controller = controller;
+    }
+
+    protected IAsyncFileSystem Inner { get; }
+
+    protected DeterministicAsyncIoController Controller { get; }
+
+    internal static IAsyncFileSystem Create(
+        IAsyncFileSystem inner,
+        DeterministicAsyncIoController controller)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        ArgumentNullException.ThrowIfNull(controller);
+        return (inner is IAsyncAtomicFileSystem, inner is IAsyncTemporaryFileSystem) switch
+        {
+            (true, true) => new AtomicTemporaryFileSystem(inner, controller),
+            (true, false) => new AtomicFileSystem(inner, controller),
+            (false, true) => new TemporaryFileSystem(inner, controller),
+            _ => new DeterministicAsyncFileSystem(inner, controller),
+        };
+    }
+
+    public async ValueTask<bool> FileExistsAsync(
+        string path,
+        CancellationToken cancellationToken = default)
+    {
+        await Controller.BeforeOperationAsync(
+            FileSystemOperation.FileExists,
+            path,
+            cancellationToken).ConfigureAwait(false);
+        return await Inner.FileExistsAsync(path, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask<IAsyncFile> OpenFileAsync(
+        string path,
+        FileOpenMode mode,
+        bool readOnly = false,
+        CancellationToken cancellationToken = default)
+    {
+        await Controller.BeforeOperationAsync(
+            FileSystemOperation.Open,
+            path,
+            cancellationToken).ConfigureAwait(false);
+        var file = await Inner.OpenFileAsync(path, mode, readOnly, cancellationToken).ConfigureAwait(false);
+        return DeterministicAsyncFile.Create(file, Controller, path);
+    }
+
+    public async ValueTask DeleteFileAsync(
+        string path,
+        CancellationToken cancellationToken = default)
+    {
+        await Controller.BeforeOperationAsync(
+            FileSystemOperation.Delete,
+            path,
+            cancellationToken).ConfigureAwait(false);
+        await Inner.DeleteFileAsync(path, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask<FileWriteStamp?> GetWriteStampAsync(
+        string path,
+        CancellationToken cancellationToken = default)
+    {
+        await Controller.BeforeOperationAsync(
+            FileSystemOperation.GetWriteStamp,
+            path,
+            cancellationToken).ConfigureAwait(false);
+        return await Inner.GetWriteStampAsync(path, cancellationToken).ConfigureAwait(false);
+    }
+
+    private sealed class AtomicFileSystem(
+        IAsyncFileSystem inner,
+        DeterministicAsyncIoController controller) :
+        DeterministicAsyncFileSystem(inner, controller),
+        IAsyncAtomicFileSystem
+    {
+        public async ValueTask ReplaceFileAtomicallyAsync(
+            string sourcePath,
+            string destinationPath,
+            bool replaceEmptyDestination,
+            CancellationToken cancellationToken = default)
+        {
+            await Controller.BeforeOperationAsync(
+                FileSystemOperation.AtomicReplace,
+                destinationPath,
+                cancellationToken).ConfigureAwait(false);
+            await ((IAsyncAtomicFileSystem)Inner).ReplaceFileAtomicallyAsync(
+                sourcePath,
+                destinationPath,
+                replaceEmptyDestination,
+                cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private sealed class TemporaryFileSystem(
+        IAsyncFileSystem inner,
+        DeterministicAsyncIoController controller) :
+        DeterministicAsyncFileSystem(inner, controller),
+        IAsyncTemporaryFileSystem
+    {
+        public async ValueTask<IAsyncFile> OpenTemporaryFileAsync(
+            string path,
+            CancellationToken cancellationToken = default)
+        {
+            await Controller.BeforeOperationAsync(
+                FileSystemOperation.OpenTemporary,
+                path,
+                cancellationToken).ConfigureAwait(false);
+            var file = await ((IAsyncTemporaryFileSystem)Inner)
+                .OpenTemporaryFileAsync(path, cancellationToken).ConfigureAwait(false);
+            return DeterministicAsyncFile.Create(file, Controller, path);
+        }
+    }
+
+    private sealed class AtomicTemporaryFileSystem(
+        IAsyncFileSystem inner,
+        DeterministicAsyncIoController controller) :
+        DeterministicAsyncFileSystem(inner, controller),
+        IAsyncAtomicFileSystem,
+        IAsyncTemporaryFileSystem
+    {
+        public async ValueTask ReplaceFileAtomicallyAsync(
+            string sourcePath,
+            string destinationPath,
+            bool replaceEmptyDestination,
+            CancellationToken cancellationToken = default)
+        {
+            await Controller.BeforeOperationAsync(
+                FileSystemOperation.AtomicReplace,
+                destinationPath,
+                cancellationToken).ConfigureAwait(false);
+            await ((IAsyncAtomicFileSystem)Inner).ReplaceFileAtomicallyAsync(
+                sourcePath,
+                destinationPath,
+                replaceEmptyDestination,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        public async ValueTask<IAsyncFile> OpenTemporaryFileAsync(
+            string path,
+            CancellationToken cancellationToken = default)
+        {
+            await Controller.BeforeOperationAsync(
+                FileSystemOperation.OpenTemporary,
+                path,
+                cancellationToken).ConfigureAwait(false);
+            var file = await ((IAsyncTemporaryFileSystem)Inner)
+                .OpenTemporaryFileAsync(path, cancellationToken).ConfigureAwait(false);
+            return DeterministicAsyncFile.Create(file, Controller, path);
+        }
+    }
+}
+
+internal class DeterministicAsyncFile : IAsyncFile
+{
+    protected DeterministicAsyncFile(
+        IAsyncFile inner,
+        DeterministicAsyncIoController controller,
+        string path)
+    {
+        Inner = inner;
+        Controller = controller;
+        Path = path;
+    }
+
+    protected IAsyncFile Inner { get; }
+
+    protected DeterministicAsyncIoController Controller { get; }
+
+    protected string Path { get; }
+
+    internal static IAsyncFile Create(
+        IAsyncFile inner,
+        DeterministicAsyncIoController controller,
+        string path = "<direct>")
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        ArgumentNullException.ThrowIfNull(controller);
+        return inner is IAsyncPageMaterializingFile
+            ? new MaterializingFile(inner, controller, path)
+            : new DeterministicAsyncFile(inner, controller, path);
+    }
+
+    public bool IsReadOnly => Inner.IsReadOnly;
+
+    public async ValueTask<long> GetLengthAsync(CancellationToken cancellationToken = default)
+    {
+        await Controller.BeforeOperationAsync(
+            FileSystemOperation.GetLength,
+            Path,
+            cancellationToken).ConfigureAwait(false);
+        return await Inner.GetLengthAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask<int> ReadAsync(
+        long position,
+        Memory<byte> destination,
+        CancellationToken cancellationToken = default)
+    {
+        await Controller.BeforeOperationAsync(
+            FileSystemOperation.Read,
+            Path,
+            cancellationToken).ConfigureAwait(false);
+        return await Inner.ReadAsync(position, destination, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask WriteAsync(
+        long position,
+        ReadOnlyMemory<byte> source,
+        CancellationToken cancellationToken = default)
+    {
+        await Controller.BeforeOperationAsync(
+            FileSystemOperation.Write,
+            Path,
+            cancellationToken).ConfigureAwait(false);
+        await Inner.WriteAsync(position, source, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask SetLengthAsync(
+        long length,
+        CancellationToken cancellationToken = default)
+    {
+        await Controller.BeforeOperationAsync(
+            FileSystemOperation.SetLength,
+            Path,
+            cancellationToken).ConfigureAwait(false);
+        await Inner.SetLengthAsync(length, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask FlushToDiskAsync(CancellationToken cancellationToken = default)
+    {
+        await Controller.BeforeOperationAsync(
+            FileSystemOperation.FlushToDisk,
+            Path,
+            cancellationToken).ConfigureAwait(false);
+        await Inner.FlushToDiskAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await Controller.BeforeOperationAsync(
+            FileSystemOperation.Dispose,
+            Path,
+            CancellationToken.None).ConfigureAwait(false);
+        await Inner.DisposeAsync().ConfigureAwait(false);
+    }
+
+    private sealed class MaterializingFile(
+        IAsyncFile inner,
+        DeterministicAsyncIoController controller,
+        string path) :
+        DeterministicAsyncFile(inner, controller, path),
+        IAsyncPageMaterializingFile
+    {
+        public async ValueTask EnsureMaterializedAsync(
+            long position,
+            int length,
+            CancellationToken cancellationToken = default)
+        {
+            await Controller.BeforeOperationAsync(
+                FileSystemOperation.EnsureMaterialized,
+                Path,
+                cancellationToken).ConfigureAwait(false);
+            await ((IAsyncPageMaterializingFile)Inner).EnsureMaterializedAsync(
+                position,
+                length,
+                cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Ahtola.Tests/Infrastructure/DeterministicCooperativeScheduler.cs
+++ b/src/Ahtola.Tests/Infrastructure/DeterministicCooperativeScheduler.cs
@@ -1,0 +1,511 @@
+namespace Ahtola.Tests;
+
+internal sealed record CooperativeActorInfo(int Id, string Name);
+
+internal sealed record CooperativeScheduleStep(
+    int Step,
+    int Choice,
+    int ActorId,
+    string ActorName,
+    string YieldPoint,
+    int YieldOrdinal,
+    IReadOnlyList<int> EnabledActors,
+    long ProgressCount);
+
+internal sealed record CooperativeActorResult(
+    CooperativeActorInfo Actor,
+    bool Completed,
+    int YieldCount,
+    long ProgressCount,
+    Exception? Crash);
+
+internal sealed class CooperativeScheduleResult
+{
+    internal CooperativeScheduleResult(
+        IReadOnlyList<CooperativeScheduleStep> steps,
+        IReadOnlyList<CooperativeActorResult> actors,
+        Exception? failure)
+    {
+        Steps = steps;
+        Actors = actors;
+        Failure = failure;
+    }
+
+    internal IReadOnlyList<CooperativeScheduleStep> Steps { get; }
+
+    internal IReadOnlyList<CooperativeActorResult> Actors { get; }
+
+    internal Exception? Failure { get; }
+
+    internal IReadOnlyList<int> Choices => [.. Steps.Select(static step => step.Choice)];
+
+    internal bool CompletedSuccessfully =>
+        Failure is null
+        && Actors.Count > 0
+        && Actors.All(static actor => actor.Completed && actor.Crash is null);
+
+    internal void EnsureSuccessful()
+    {
+        if (Failure is not null)
+            throw new AssertionException($"Cooperative schedule failed: {Failure.Message}", Failure);
+        if (!CompletedSuccessfully)
+            throw new AssertionException("Cooperative schedule did not complete every actor exactly once.");
+    }
+}
+
+internal interface ICooperativeScheduleObserver
+{
+    void OnStart(CooperativeActorInfo actor);
+
+    void OnFinish(CooperativeActorResult actor);
+
+    void OnCrash(CooperativeActorInfo actor, Exception exception);
+
+    void FinalizeRun(CooperativeScheduleResult result);
+}
+
+internal abstract class CooperativeScheduleObserver : ICooperativeScheduleObserver
+{
+    public virtual void OnStart(CooperativeActorInfo actor)
+    {
+    }
+
+    public virtual void OnFinish(CooperativeActorResult actor)
+    {
+    }
+
+    public virtual void OnCrash(CooperativeActorInfo actor, Exception exception)
+    {
+    }
+
+    public virtual void FinalizeRun(CooperativeScheduleResult result)
+    {
+    }
+}
+
+internal sealed class CooperativeActorContext
+{
+    private readonly DeterministicCooperativeScheduler _scheduler;
+    private readonly DeterministicCooperativeScheduler.ActorState _state;
+
+    internal CooperativeActorContext(
+        DeterministicCooperativeScheduler scheduler,
+        DeterministicCooperativeScheduler.ActorState state)
+    {
+        _scheduler = scheduler;
+        _state = state;
+    }
+
+    internal int ActorId => _state.Info.Id;
+
+    internal string ActorName => _state.Info.Name;
+
+    internal CancellationToken CancellationToken => _scheduler.CancellationToken;
+
+    internal ValueTask YieldAsync(string name)
+        => _scheduler.YieldAsync(_state, name);
+
+    internal void NoteProgress()
+        => _scheduler.NoteProgress(_state);
+}
+
+/// <summary>
+/// Test-only scheduler for async actors that cooperate at explicit, named yield
+/// points. It intentionally does not attempt to intercept CLR synchronization.
+/// </summary>
+internal sealed class DeterministicCooperativeScheduler
+{
+    private static readonly TimeSpan StateChangeTimeout = TimeSpan.FromSeconds(10);
+
+    private readonly object _gate = new();
+    private readonly int _maxSteps;
+    private readonly int _maxStepsWithoutProgress;
+    private readonly IReadOnlyList<ICooperativeScheduleObserver> _observers;
+    private readonly List<ActorState> _actors = [];
+    private readonly List<CooperativeScheduleStep> _steps = [];
+    private readonly SemaphoreSlim _stateChanged = new(0);
+    private readonly CancellationTokenSource _shutdown = new();
+    private Exception? _observerFailure;
+    private long _progressCount;
+    private bool _started;
+
+    internal DeterministicCooperativeScheduler(
+        int maxSteps = 256,
+        int maxStepsWithoutProgress = 64,
+        params ICooperativeScheduleObserver[] observers)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxSteps);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxStepsWithoutProgress);
+        _maxSteps = maxSteps;
+        _maxStepsWithoutProgress = maxStepsWithoutProgress;
+        _observers = observers ?? throw new ArgumentNullException(nameof(observers));
+    }
+
+    internal CancellationToken CancellationToken => _shutdown.Token;
+
+    internal void AddActor(string name, Func<CooperativeActorContext, Task> action)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(action);
+        if (_started)
+            throw new InvalidOperationException("Actors cannot be added after the schedule starts.");
+        if (_actors.Any(actor => string.Equals(actor.Info.Name, name, StringComparison.Ordinal)))
+            throw new ArgumentException($"An actor named '{name}' is already registered.", nameof(name));
+
+        _actors.Add(new ActorState(new CooperativeActorInfo(_actors.Count, name), action));
+    }
+
+    internal async Task<CooperativeScheduleResult> RunAsync(
+        IReadOnlyList<int>? replayChoices = null,
+        Func<int, int, int>? choose = null,
+        bool allowReplayPrefix = false)
+    {
+        if (_started)
+            throw new InvalidOperationException("A cooperative scheduler can only run once.");
+        if (_actors.Count == 0)
+            throw new InvalidOperationException("At least one actor is required.");
+        if (replayChoices is not null && choose is not null)
+            throw new ArgumentException("A replay vector and a choice function are mutually exclusive.");
+
+        _started = true;
+        foreach (var actor in _actors)
+            actor.Task = ExecuteActorAsync(actor);
+
+        Exception? failure = null;
+        var stepsWithoutProgress = 0;
+        var lastProgress = 0L;
+        try
+        {
+            while (true)
+            {
+                await WaitForQuiescenceAsync().ConfigureAwait(false);
+
+                ActorState[] waiting;
+                lock (_gate)
+                {
+                    failure = _observerFailure
+                        ?? _actors.Select(static actor => actor.Crash).FirstOrDefault(static crash => crash is not null);
+                    if (failure is not null)
+                        break;
+                    if (_actors.All(static actor => actor.Status == ActorStatus.Completed))
+                    {
+                        if (!allowReplayPrefix
+                            && replayChoices is { } replay
+                            && replay.Count != _steps.Count)
+                        {
+                            failure = new InvalidOperationException(
+                                $"Replay supplied {replay.Count} choices but the schedule completed after {_steps.Count} steps.");
+                        }
+                        break;
+                    }
+
+                    waiting = [.. _actors
+                        .Where(static actor => actor.Status == ActorStatus.Waiting)
+                        .OrderBy(static actor => actor.Info.Id)];
+                }
+
+                if (_steps.Count >= _maxSteps)
+                {
+                    failure = new CooperativeLivelockException(
+                        $"Schedule exceeded the {_maxSteps}-step bound without completing.");
+                    break;
+                }
+
+                var choice = replayChoices is { } choices && _steps.Count < choices.Count
+                    ? choices[_steps.Count]
+                    : choose?.Invoke(_steps.Count, waiting.Length) ?? 0;
+                if ((uint)choice >= (uint)waiting.Length)
+                {
+                    failure = new InvalidOperationException(
+                        $"Schedule choice {choice} at step {_steps.Count} is outside the enabled range [0, {waiting.Length}).");
+                    break;
+                }
+
+                var selected = waiting[choice];
+                ResumeRequest request;
+                lock (_gate)
+                {
+                    request = selected.Waiting
+                        ?? throw new InvalidOperationException($"Actor {selected.Info.Name} is no longer waiting.");
+                    selected.Waiting = null;
+                    selected.Status = ActorStatus.Running;
+                    _steps.Add(new CooperativeScheduleStep(
+                        _steps.Count,
+                        choice,
+                        selected.Info.Id,
+                        selected.Info.Name,
+                        request.Name,
+                        request.Ordinal,
+                        [.. waiting.Select(static actor => actor.Info.Id)],
+                        _progressCount));
+                }
+
+                request.Resume.TrySetResult();
+                await WaitForActorTransitionAsync(selected).ConfigureAwait(false);
+
+                var progress = Interlocked.Read(ref _progressCount);
+                if (progress == lastProgress)
+                {
+                    stepsWithoutProgress++;
+                    if (stepsWithoutProgress >= _maxStepsWithoutProgress)
+                    {
+                        failure = new CooperativeLivelockException(
+                            $"Schedule made no reported progress for {stepsWithoutProgress} consecutive steps.");
+                        break;
+                    }
+                }
+                else
+                {
+                    lastProgress = progress;
+                    stepsWithoutProgress = 0;
+                }
+            }
+        }
+        catch (Exception exception)
+        {
+            failure = exception;
+        }
+
+        if (failure is not null)
+            await StopActorsAsync().ConfigureAwait(false);
+
+        var result = CreateResult(failure ?? _observerFailure);
+        Notify(static (observer, state) => observer.FinalizeRun(state), result);
+        if (_observerFailure is not null && result.Failure is null)
+            result = CreateResult(_observerFailure);
+        return result;
+    }
+
+    internal ValueTask YieldAsync(ActorState actor, string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        _shutdown.Token.ThrowIfCancellationRequested();
+
+        TaskCompletionSource resume;
+        lock (_gate)
+        {
+            if (actor.Status != ActorStatus.Running)
+                throw new InvalidOperationException($"Actor {actor.Info.Name} attempted to yield while {actor.Status}.");
+
+            resume = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            actor.Waiting = new ResumeRequest(name, actor.YieldCount++, resume);
+            actor.Status = ActorStatus.Waiting;
+        }
+
+        _stateChanged.Release();
+        return new ValueTask(resume.Task.WaitAsync(_shutdown.Token));
+    }
+
+    internal void NoteProgress(ActorState actor)
+    {
+        lock (_gate)
+        {
+            if (actor.Status == ActorStatus.Completed || actor.Status == ActorStatus.Crashed)
+                throw new InvalidOperationException($"Actor {actor.Info.Name} reported progress after completion.");
+            actor.ProgressCount++;
+            Interlocked.Increment(ref _progressCount);
+        }
+    }
+
+    private async Task ExecuteActorAsync(ActorState actor)
+    {
+        Notify(static (observer, state) => observer.OnStart(state), actor.Info);
+        try
+        {
+            await actor.Action(new CooperativeActorContext(this, actor)).ConfigureAwait(false);
+            lock (_gate)
+            {
+                if (actor.Status == ActorStatus.Completed || actor.Status == ActorStatus.Crashed)
+                    throw new InvalidOperationException($"Actor {actor.Info.Name} completed more than once.");
+                actor.Status = ActorStatus.Completed;
+                actor.CompletionCount++;
+            }
+
+            Notify(
+                static (observer, state) => observer.OnFinish(state),
+                CreateActorResult(actor));
+        }
+        catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
+        {
+            lock (_gate)
+                actor.Status = ActorStatus.Canceled;
+        }
+        catch (Exception exception)
+        {
+            lock (_gate)
+            {
+                actor.Status = ActorStatus.Crashed;
+                actor.Crash = exception;
+            }
+            Notify(
+                static (observer, state) => observer.OnCrash(state.Actor, state.Exception),
+                (Actor: actor.Info, Exception: exception));
+        }
+        finally
+        {
+            _stateChanged.Release();
+        }
+    }
+
+    private async Task WaitForQuiescenceAsync()
+    {
+        while (true)
+        {
+            lock (_gate)
+            {
+                if (_actors.All(static actor => actor.Status != ActorStatus.Running))
+                    return;
+            }
+
+            if (!await _stateChanged.WaitAsync(StateChangeTimeout).ConfigureAwait(false))
+            {
+                throw new CooperativeLivelockException(
+                    "Actors did not reach another named yield point or terminal state within the bounded wait.");
+            }
+        }
+    }
+
+    private async Task WaitForActorTransitionAsync(ActorState actor)
+    {
+        while (true)
+        {
+            lock (_gate)
+            {
+                if (actor.Status != ActorStatus.Running)
+                    return;
+            }
+
+            if (!await _stateChanged.WaitAsync(StateChangeTimeout).ConfigureAwait(false))
+            {
+                throw new CooperativeLivelockException(
+                    $"Actor {actor.Info.Name} did not reach another named yield point or terminal state.");
+            }
+        }
+    }
+
+    private async Task StopActorsAsync()
+    {
+        _shutdown.Cancel();
+        TaskCompletionSource[] pending;
+        lock (_gate)
+        {
+            pending = [.. _actors
+                .Where(static actor => actor.Waiting is not null)
+                .Select(static actor => actor.Waiting!.Resume)];
+        }
+        foreach (var completion in pending)
+            completion.TrySetCanceled(_shutdown.Token);
+
+        var tasks = _actors.Select(static actor => actor.Task!).ToArray();
+        await Task.WhenAll(tasks).WaitAsync(StateChangeTimeout).ConfigureAwait(false);
+    }
+
+    private CooperativeScheduleResult CreateResult(Exception? failure)
+        => new(
+            [.. _steps],
+            [.. _actors.Select(CreateActorResult)],
+            failure);
+
+    private static CooperativeActorResult CreateActorResult(ActorState actor)
+        => new(
+            actor.Info,
+            actor.Status == ActorStatus.Completed && actor.CompletionCount == 1,
+            actor.YieldCount,
+            actor.ProgressCount,
+            actor.Crash);
+
+    private void Notify<TState>(
+        Action<ICooperativeScheduleObserver, TState> callback,
+        TState state)
+    {
+        foreach (var observer in _observers)
+        {
+            try
+            {
+                callback(observer, state);
+            }
+            catch (Exception exception)
+            {
+                Interlocked.CompareExchange(ref _observerFailure, exception, null);
+            }
+        }
+    }
+
+    internal sealed class ActorState(
+        CooperativeActorInfo info,
+        Func<CooperativeActorContext, Task> action)
+    {
+        internal CooperativeActorInfo Info { get; } = info;
+
+        internal Func<CooperativeActorContext, Task> Action { get; } = action;
+
+        internal ActorStatus Status { get; set; } = ActorStatus.Running;
+
+        internal ResumeRequest? Waiting { get; set; }
+
+        internal Task? Task { get; set; }
+
+        internal Exception? Crash { get; set; }
+
+        internal int YieldCount { get; set; }
+
+        internal long ProgressCount { get; set; }
+
+        internal int CompletionCount { get; set; }
+    }
+
+    internal sealed record ResumeRequest(string Name, int Ordinal, TaskCompletionSource Resume);
+
+    internal enum ActorStatus
+    {
+        Running,
+        Waiting,
+        Completed,
+        Crashed,
+        Canceled,
+    }
+}
+
+internal sealed class CooperativeLivelockException(string message) : TimeoutException(message);
+
+internal sealed record CooperativeExplorationResult(
+    IReadOnlyList<CooperativeScheduleResult> Runs,
+    bool Exhaustive);
+
+internal static class CooperativeScheduleExplorer
+{
+    internal static async Task<CooperativeExplorationResult> ExploreDepthFirstAsync(
+        Func<IReadOnlyList<int>, Task<CooperativeScheduleResult>> run,
+        int maxSchedules)
+    {
+        ArgumentNullException.ThrowIfNull(run);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxSchedules);
+
+        var pending = new Stack<int[]>();
+        var seen = new HashSet<string>(StringComparer.Ordinal) { string.Empty };
+        var results = new List<CooperativeScheduleResult>();
+        pending.Push([]);
+
+        while (pending.Count > 0 && results.Count < maxSchedules)
+        {
+            var prefix = pending.Pop();
+            var result = await run(prefix).ConfigureAwait(false);
+            results.Add(result);
+            result.EnsureSuccessful();
+
+            for (var step = result.Steps.Count - 1; step >= prefix.Length; step--)
+            {
+                var decision = result.Steps[step];
+                for (var alternative = decision.EnabledActors.Count - 1; alternative >= 1; alternative--)
+                {
+                    var candidate = result.Choices.Take(step).Append(alternative).ToArray();
+                    var key = string.Join(",", candidate);
+                    if (seen.Add(key))
+                        pending.Push(candidate);
+                }
+            }
+        }
+
+        return new CooperativeExplorationResult(results, pending.Count == 0);
+    }
+}

--- a/src/Ahtola.Tests/Infrastructure/LiveDurableFileSystem.cs
+++ b/src/Ahtola.Tests/Infrastructure/LiveDurableFileSystem.cs
@@ -1,0 +1,381 @@
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Tests;
+
+internal sealed record PowerLossSnapshot(
+    IReadOnlyDictionary<string, byte[]> Files,
+    int SelectedMutationCount = 0,
+    int DroppedMutationCount = 0);
+
+/// <summary>
+/// Test storage with separate process-visible and fsync-acknowledged images.
+/// It follows Turso's <c>UnreliableIo</c> model: writes and truncations are
+/// volatile until the affected file is flushed.
+/// </summary>
+internal sealed class LiveDurableFileSystem :
+    IFileSystem,
+    IAtomicFileSystem,
+    IStoragePathResolver
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<string, FileState> _files = new(StringComparer.Ordinal);
+    private TornFlushPlan? _tornFlush;
+    private PowerLossSnapshot? _tornFlushSnapshot;
+    private long _writeStamp;
+
+    public StringComparer PathComparer => StringComparer.Ordinal;
+
+    public string GetCanonicalPath(string path)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        return path;
+    }
+
+    public bool FileExists(string path)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        lock (_gate)
+            return _files.ContainsKey(path);
+    }
+
+    public IFile OpenFile(string path, FileOpenMode mode, bool readOnly = false)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        if (readOnly && mode == FileOpenMode.CreateNew)
+            throw new ArgumentException("A newly created file cannot be opened read-only.", nameof(readOnly));
+
+        lock (_gate)
+        {
+            var exists = _files.TryGetValue(path, out var state);
+            switch (mode)
+            {
+                case FileOpenMode.OpenExisting when !exists:
+                    throw new FileNotFoundException("The requested crash-test file does not exist.", path);
+                case FileOpenMode.CreateNew when exists:
+                    throw new IOException($"The crash-test file '{path}' already exists.");
+            }
+
+            if (!exists)
+            {
+                state = new FileState();
+                _files.Add(path, state);
+            }
+
+            return new FileView(this, path, state!, readOnly);
+        }
+    }
+
+    public void DeleteFile(string path)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        lock (_gate)
+        {
+            if (_files.Remove(path))
+                _writeStamp++;
+        }
+    }
+
+    public FileWriteStamp? GetWriteStamp(string path)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        lock (_gate)
+        {
+            return _files.TryGetValue(path, out var state)
+                ? new FileWriteStamp(state.Live.LongLength, DateTimeOffset.UnixEpoch.AddTicks(state.Stamp))
+                : null;
+        }
+    }
+
+    void IAtomicFileSystem.ReplaceFileAtomically(
+        string sourcePath,
+        string destinationPath,
+        bool replaceEmptyDestination)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(sourcePath);
+        ArgumentException.ThrowIfNullOrEmpty(destinationPath);
+        if (string.Equals(sourcePath, destinationPath, StringComparison.Ordinal))
+            throw new IOException("Atomic file replacement requires distinct paths.");
+
+        lock (_gate)
+        {
+            if (!_files.TryGetValue(sourcePath, out var source))
+                throw new FileNotFoundException("The atomic replacement source does not exist.", sourcePath);
+            if (_files.TryGetValue(destinationPath, out var destination)
+                && (!replaceEmptyDestination || destination.Live.Length != 0))
+            {
+                throw new IOException("output file already exists");
+            }
+
+            _files.Remove(sourcePath);
+            _files[destinationPath] = source;
+            source.Stamp = ++_writeStamp;
+        }
+    }
+
+    internal IReadOnlyList<string> EnumerateFilePaths()
+    {
+        lock (_gate)
+            return [.. _files.Keys];
+    }
+
+    internal void MarkAllDurable()
+    {
+        lock (_gate)
+        {
+            foreach (var state in _files.Values)
+                state.PromoteAll();
+        }
+    }
+
+    internal PowerLossSnapshot CaptureDurableSnapshot()
+    {
+        lock (_gate)
+            return BuildDurableSnapshot();
+    }
+
+    internal void ArmTornFlush(string path, params int[] selectedMutationOccurrences)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        ArgumentNullException.ThrowIfNull(selectedMutationOccurrences);
+        if (selectedMutationOccurrences.Any(static occurrence => occurrence < 1))
+            throw new ArgumentOutOfRangeException(
+                nameof(selectedMutationOccurrences),
+                "Mutation occurrences are one-based.");
+
+        lock (_gate)
+        {
+            _tornFlush = new TornFlushPlan(path, selectedMutationOccurrences.ToHashSet());
+            _tornFlushSnapshot = null;
+        }
+    }
+
+    internal PowerLossSnapshot TakeTornFlushSnapshot()
+    {
+        lock (_gate)
+        {
+            var snapshot = _tornFlushSnapshot
+                ?? throw new InvalidOperationException("The armed file has not flushed pending mutations.");
+            _tornFlushSnapshot = null;
+            return snapshot;
+        }
+    }
+
+    internal void RestoreAfterPowerLoss()
+        => RestoreAfterPowerLoss(CaptureDurableSnapshot());
+
+    internal void RestoreAfterPowerLoss(PowerLossSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        lock (_gate)
+        {
+            _files.Clear();
+            foreach (var (path, bytes) in snapshot.Files)
+            {
+                var image = bytes.ToArray();
+                _files.Add(path, new FileState
+                {
+                    Live = image.ToArray(),
+                    Durable = image,
+                    DurableExists = true,
+                    Stamp = ++_writeStamp,
+                });
+            }
+
+            _tornFlush = null;
+            _tornFlushSnapshot = null;
+        }
+    }
+
+    private PowerLossSnapshot BuildDurableSnapshot(
+        string? tornPath = null,
+        IReadOnlySet<int>? selectedOccurrences = null)
+    {
+        var files = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+        var selected = 0;
+        var dropped = 0;
+        foreach (var (path, state) in _files)
+        {
+            var include = state.DurableExists;
+            var image = state.Durable.ToArray();
+            if (string.Equals(path, tornPath, StringComparison.Ordinal))
+            {
+                for (var index = 0; index < state.Pending.Count; index++)
+                {
+                    if (selectedOccurrences!.Contains(index + 1))
+                    {
+                        state.Pending[index].Apply(ref image);
+                        include = true;
+                        selected++;
+                    }
+                    else
+                    {
+                        dropped++;
+                    }
+                }
+            }
+
+            if (include)
+                files.Add(path, image);
+        }
+
+        return new PowerLossSnapshot(files, selected, dropped);
+    }
+
+    private void Write(FileState state, long position, ReadOnlySpan<byte> source)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(position);
+        lock (_gate)
+        {
+            var data = source.ToArray();
+            var end = checked((int)position + data.Length);
+            if (state.Live.Length < end)
+                Array.Resize(ref state.Live, end);
+            data.CopyTo(state.Live.AsSpan((int)position));
+            state.Pending.Add(new WriteMutation(position, data));
+            state.Stamp = ++_writeStamp;
+        }
+    }
+
+    private int Read(FileState state, long position, Span<byte> destination)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(position);
+        lock (_gate)
+        {
+            if (position >= state.Live.LongLength || destination.IsEmpty)
+                return 0;
+            var count = (int)Math.Min(destination.Length, state.Live.LongLength - position);
+            state.Live.AsSpan((int)position, count).CopyTo(destination);
+            return count;
+        }
+    }
+
+    private void SetLength(FileState state, long length)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(length);
+        if (length > int.MaxValue)
+            throw new IOException("The crash-test file cannot exceed two gigabytes.");
+
+        lock (_gate)
+        {
+            Array.Resize(ref state.Live, (int)length);
+            state.Pending.Add(new SetLengthMutation(length));
+            state.Stamp = ++_writeStamp;
+        }
+    }
+
+    private void Flush(string path, FileState state)
+    {
+        lock (_gate)
+        {
+            if (_tornFlush is { } plan
+                && string.Equals(plan.Path, path, StringComparison.Ordinal)
+                && state.Pending.Count > 0)
+            {
+                _tornFlushSnapshot = BuildDurableSnapshot(path, plan.SelectedOccurrences);
+                _tornFlush = null;
+            }
+
+            state.PromoteAll();
+        }
+    }
+
+    private sealed class FileView(
+        LiveDurableFileSystem owner,
+        string path,
+        FileState state,
+        bool readOnly) : IFile
+    {
+        private bool _disposed;
+
+        public long Length
+        {
+            get
+            {
+                ThrowIfDisposed();
+                lock (owner._gate)
+                    return state.Live.LongLength;
+            }
+        }
+
+        public bool IsReadOnly { get; } = readOnly;
+
+        public int Read(long position, Span<byte> destination)
+        {
+            ThrowIfDisposed();
+            return owner.Read(state, position, destination);
+        }
+
+        public void Write(long position, ReadOnlySpan<byte> source)
+        {
+            ThrowIfDisposed();
+            ThrowIfReadOnly();
+            owner.Write(state, position, source);
+        }
+
+        public void SetLength(long length)
+        {
+            ThrowIfDisposed();
+            ThrowIfReadOnly();
+            owner.SetLength(state, length);
+        }
+
+        public void FlushToDisk()
+        {
+            ThrowIfDisposed();
+            if (!IsReadOnly)
+                owner.Flush(path, state);
+        }
+
+        public void Dispose() => _disposed = true;
+
+        private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposed, this);
+
+        private void ThrowIfReadOnly()
+        {
+            if (IsReadOnly)
+                throw new InvalidOperationException("Cannot mutate a file opened read-only.");
+        }
+    }
+
+    private sealed class FileState
+    {
+        internal byte[] Live = [];
+        internal byte[] Durable = [];
+        internal bool DurableExists;
+        internal long Stamp;
+        internal List<FileMutation> Pending { get; } = [];
+
+        internal void PromoteAll()
+        {
+            Durable = Live.ToArray();
+            DurableExists = true;
+            Pending.Clear();
+        }
+    }
+
+    private abstract record FileMutation
+    {
+        internal abstract void Apply(ref byte[] image);
+    }
+
+    private sealed record WriteMutation(long Position, byte[] Data) : FileMutation
+    {
+        internal override void Apply(ref byte[] image)
+        {
+            var end = checked((int)Position + Data.Length);
+            if (image.Length < end)
+                Array.Resize(ref image, end);
+            Data.CopyTo(image.AsSpan((int)Position));
+        }
+    }
+
+    private sealed record SetLengthMutation(long Length) : FileMutation
+    {
+        internal override void Apply(ref byte[] image)
+            => Array.Resize(ref image, checked((int)Length));
+    }
+
+    private sealed record TornFlushPlan(
+        string Path,
+        IReadOnlySet<int> SelectedOccurrences);
+}

--- a/src/Ahtola.Tests/Infrastructure/LogicalDatabaseFingerprint.cs
+++ b/src/Ahtola.Tests/Infrastructure/LogicalDatabaseFingerprint.cs
@@ -1,0 +1,194 @@
+using System.Buffers.Binary;
+using System.Data;
+using System.Data.Common;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Ahtola.Tests.Infrastructure;
+
+internal sealed record LogicalDatabaseFingerprintResult(
+    string Sha256,
+    int SchemaObjects,
+    int Tables,
+    long Rows)
+{
+    public override string ToString()
+        => $"{Sha256} (schema={SchemaObjects}, tables={Tables}, rows={Rows})";
+}
+
+/// <summary>
+/// Test-only logical database fingerprint inspired by Turso's tools/dbhash.
+/// The encoding is independent of pages, rowids, insertion history, and provider object types.
+/// </summary>
+internal static class LogicalDatabaseFingerprint
+{
+    private const byte FormatVersion = 1;
+
+    internal static LogicalDatabaseFingerprintResult Compute(DbConnection connection)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        if (connection.State != ConnectionState.Open)
+            throw new InvalidOperationException("The connection must be open before it can be fingerprinted.");
+
+        using var canonical = new MemoryStream();
+        canonical.WriteByte(FormatVersion);
+
+        var schemaRows = ReadRows(
+            connection,
+            """
+            SELECT type, name, tbl_name, sql
+            FROM sqlite_schema
+            WHERE name NOT LIKE 'sqlite_%'
+              AND name NOT LIKE '__turso_internal_%'
+              AND name NOT IN ('turso_cdc', 'turso_cdc_version', 'turso_sync_last_change_id')
+            ORDER BY type, name, tbl_name, sql
+            """);
+        WriteCollection(canonical, 0x53, schemaRows);
+
+        var tables = ReadNames(
+            connection,
+            """
+            SELECT name
+            FROM sqlite_schema
+            WHERE type = 'table'
+              AND name NOT LIKE 'sqlite_%'
+              AND name NOT LIKE '__turso_internal_%'
+              AND name NOT IN ('turso_cdc', 'turso_cdc_version', 'turso_sync_last_change_id')
+              AND sql NOT LIKE 'CREATE VIRTUAL TABLE%'
+            ORDER BY name
+            """);
+
+        long rowCount = 0;
+        foreach (var table in tables)
+        {
+            canonical.WriteByte(0x54);
+            WriteBytes(canonical, Encoding.UTF8.GetBytes(table));
+
+            var rows = ReadRows(connection, $"SELECT * FROM {QuoteIdentifier(table)}");
+            rows.Sort(ByteArrayComparer.Instance);
+            WriteInt64(canonical, rows.Count);
+            for (var ordinal = 0; ordinal < rows.Count; ordinal++)
+            {
+                canonical.WriteByte(0x52);
+                WriteInt64(canonical, ordinal);
+                WriteBytes(canonical, rows[ordinal]);
+            }
+
+            rowCount += rows.Count;
+        }
+
+        var digest = SHA256.HashData(canonical.GetBuffer().AsSpan(0, checked((int)canonical.Length)));
+        return new LogicalDatabaseFingerprintResult(
+            Convert.ToHexString(digest).ToLowerInvariant(),
+            schemaRows.Count,
+            tables.Count,
+            rowCount);
+    }
+
+    private static List<string> ReadNames(DbConnection connection, string sql)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        using var reader = command.ExecuteReader();
+        var values = new List<string>();
+        while (reader.Read())
+            values.Add(reader.GetString(0));
+        return values;
+    }
+
+    private static List<byte[]> ReadRows(DbConnection connection, string sql)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        using var reader = command.ExecuteReader();
+        var rows = new List<byte[]>();
+        while (reader.Read())
+        {
+            using var encoded = new MemoryStream();
+            WriteInt64(encoded, reader.FieldCount);
+            for (var ordinal = 0; ordinal < reader.FieldCount; ordinal++)
+                WriteValue(encoded, reader.GetValue(ordinal));
+            rows.Add(encoded.ToArray());
+        }
+        return rows;
+    }
+
+    private static void WriteCollection(Stream destination, byte marker, IReadOnlyList<byte[]> values)
+    {
+        destination.WriteByte(marker);
+        WriteInt64(destination, values.Count);
+        foreach (var value in values)
+            WriteBytes(destination, value);
+    }
+
+    private static void WriteValue(Stream destination, object value)
+    {
+        switch (value)
+        {
+            case DBNull:
+                destination.WriteByte(0);
+                return;
+            case byte or sbyte or short or ushort or int or uint or long:
+                destination.WriteByte(1);
+                WriteInt64(destination, Convert.ToInt64(value, System.Globalization.CultureInfo.InvariantCulture));
+                return;
+            case ulong unsigned when unsigned <= long.MaxValue:
+                destination.WriteByte(1);
+                WriteInt64(destination, checked((long)unsigned));
+                return;
+            case float or double:
+                destination.WriteByte(2);
+                WriteInt64(destination, BitConverter.DoubleToInt64Bits(Convert.ToDouble(
+                    value,
+                    System.Globalization.CultureInfo.InvariantCulture)));
+                return;
+            case string text:
+                destination.WriteByte(3);
+                WriteBytes(destination, Encoding.UTF8.GetBytes(text));
+                return;
+            case byte[] blob:
+                destination.WriteByte(4);
+                WriteBytes(destination, blob);
+                return;
+            case ReadOnlyMemory<byte> blob:
+                destination.WriteByte(4);
+                WriteBytes(destination, blob.Span);
+                return;
+            default:
+                throw new InvalidDataException(
+                    $"Unsupported logical SQLite value type '{value.GetType().FullName}'.");
+        }
+    }
+
+    private static void WriteInt64(Stream destination, long value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(long)];
+        BinaryPrimitives.WriteInt64BigEndian(bytes, value);
+        destination.Write(bytes);
+    }
+
+    private static void WriteBytes(Stream destination, ReadOnlySpan<byte> value)
+    {
+        WriteInt64(destination, value.Length);
+        destination.Write(value);
+    }
+
+    private static string QuoteIdentifier(string value)
+        => '"' + value.Replace("\"", "\"\"", StringComparison.Ordinal) + '"';
+
+    private sealed class ByteArrayComparer : IComparer<byte[]>
+    {
+        internal static readonly ByteArrayComparer Instance = new();
+
+        public int Compare(byte[]? left, byte[]? right)
+        {
+            if (ReferenceEquals(left, right))
+                return 0;
+            if (left is null)
+                return -1;
+            if (right is null)
+                return 1;
+            return left.AsSpan().SequenceCompareTo(right);
+        }
+    }
+}

--- a/src/Ahtola.Tests/Infrastructure/ProcessLifecycleTrace.cs
+++ b/src/Ahtola.Tests/Infrastructure/ProcessLifecycleTrace.cs
@@ -1,0 +1,146 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+
+namespace Ahtola.Tests.Infrastructure;
+
+internal sealed record ProcessLifecycleEvent(
+    long Sequence,
+    string Kind,
+    string Actor,
+    string? Operation,
+    int? ExitCode,
+    string? Detail);
+
+/// <summary>
+/// JSONL lifecycle trace for child-process tests. Sequence numbers are logical timestamps so
+/// traces remain comparable without depending on wall-clock scheduling.
+/// </summary>
+internal sealed class ProcessLifecycleTrace
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<string, int> _starts = new(StringComparer.Ordinal);
+    private readonly List<ProcessLifecycleEvent> _events = [];
+    private long _sequence;
+
+    internal ProcessLifecycleTrace(string path)
+    {
+        Path = path;
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(path)!);
+    }
+
+    internal string Path { get; }
+
+    internal IReadOnlyList<ProcessLifecycleEvent> Events
+    {
+        get
+        {
+            lock (_gate)
+                return _events.ToArray();
+        }
+    }
+
+    internal void RecordStart(string actor, string operation)
+    {
+        lock (_gate)
+        {
+            if (_starts.TryGetValue(actor, out var starts) && starts > 0)
+                AppendLocked("restart", actor, operation, null, $"attempt={starts + 1}");
+
+            _starts[actor] = starts + 1;
+            AppendLocked("start", actor, operation, null, null);
+        }
+    }
+
+    internal void RecordOperation(string actor, string operation, string? detail = null)
+        => Append("operation", actor, operation, null, detail);
+
+    internal void RecordExit(string actor, string operation, int exitCode)
+        => Append("exit", actor, operation, exitCode, null);
+
+    internal void RecordTimeout(string actor, string operation, string? detail = null)
+        => Append("timeout", actor, operation, null, detail);
+
+    internal void WaitForExit(
+        Process process,
+        TimeSpan timeout,
+        string actor,
+        string operation,
+        Func<string>? output = null)
+    {
+        RecordOperation(actor, "wait-for-exit", operation);
+        if (!process.WaitForExit(timeout))
+        {
+            var detail = output?.Invoke();
+            RecordTimeout(actor, operation, detail);
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+            process.WaitForExit();
+            throw new TimeoutException(
+                $"Process '{actor}' timed out during '{operation}'.{Environment.NewLine}{ReplayDiagnostics()}");
+        }
+
+        process.WaitForExit();
+        RecordExit(actor, operation, process.ExitCode);
+    }
+
+    internal void WaitUntil(
+        Func<bool> predicate,
+        TimeSpan timeout,
+        string actor,
+        string operation,
+        Process? process = null,
+        Func<string>? output = null)
+    {
+        RecordOperation(actor, operation);
+        var stopwatch = Stopwatch.StartNew();
+        while (!predicate())
+        {
+            if (process?.HasExited == true)
+            {
+                process.WaitForExit();
+                RecordExit(actor, operation, process.ExitCode);
+                throw new InvalidOperationException(
+                    $"Process '{actor}' exited before '{operation}'.{Environment.NewLine}{ReplayDiagnostics()}"
+                    + Environment.NewLine
+                    + output?.Invoke());
+            }
+
+            if (stopwatch.Elapsed >= timeout)
+            {
+                var detail = output?.Invoke();
+                RecordTimeout(actor, operation, detail);
+                if (process is { HasExited: false })
+                    process.Kill(entireProcessTree: true);
+                throw new TimeoutException(
+                    $"Process '{actor}' timed out during '{operation}'.{Environment.NewLine}{ReplayDiagnostics()}");
+            }
+
+            Thread.Sleep(TimeSpan.FromMilliseconds(10));
+        }
+    }
+
+    internal string ReplayDiagnostics()
+    {
+        lock (_gate)
+        {
+            var result = new StringBuilder($"Replay trace: {Path}");
+            foreach (var item in _events)
+                result.AppendLine().Append(JsonSerializer.Serialize(item));
+            return result.ToString();
+        }
+    }
+
+    private void Append(string kind, string actor, string? operation, int? exitCode, string? detail)
+    {
+        lock (_gate)
+            AppendLocked(kind, actor, operation, exitCode, detail);
+    }
+
+    private void AppendLocked(string kind, string actor, string? operation, int? exitCode, string? detail)
+    {
+        var item = new ProcessLifecycleEvent(++_sequence, kind, actor, operation, exitCode, detail);
+        _events.Add(item);
+        File.AppendAllText(Path, JsonSerializer.Serialize(item) + Environment.NewLine, Encoding.UTF8);
+    }
+}

--- a/src/Ahtola.Tests/Infrastructure/ProcessLifecycleTraceTests.cs
+++ b/src/Ahtola.Tests/Infrastructure/ProcessLifecycleTraceTests.cs
@@ -1,0 +1,76 @@
+using System.Text.Json;
+using AwesomeAssertions;
+
+namespace Ahtola.Tests.Infrastructure;
+
+public sealed class ProcessLifecycleTraceTests
+{
+    [Test]
+    public void JsonlTraceUsesDeterministicSequencesAndRecordsRestarts()
+    {
+        var root = Path.Combine(
+            TestContext.CurrentContext.WorkDirectory,
+            "process-lifecycle-trace",
+            Guid.NewGuid().ToString("N"));
+        var path = Path.Combine(root, "trace.jsonl");
+
+        try
+        {
+            var trace = new ProcessLifecycleTrace(path);
+            trace.RecordStart("worker", "write");
+            trace.RecordOperation("worker", "publish");
+            trace.RecordExit("worker", "write", 0);
+            trace.RecordStart("worker", "recover");
+
+            var events = File.ReadLines(path)
+                .Select(line => JsonSerializer.Deserialize<ProcessLifecycleEvent>(line))
+                .ToArray();
+
+            events.Should().NotContainNulls();
+            events.Select(item => item!.Sequence).Should().Equal(1, 2, 3, 4, 5);
+            events.Select(item => item!.Kind).Should().Equal(
+                "start",
+                "operation",
+                "exit",
+                "restart",
+                "start");
+            trace.ReplayDiagnostics().Should().Contain("\"Kind\":\"restart\"");
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
+    public void BoundedWaitRecordsTimeoutAndIncludesReplayDiagnostics()
+    {
+        var root = Path.Combine(
+            TestContext.CurrentContext.WorkDirectory,
+            "process-lifecycle-trace",
+            Guid.NewGuid().ToString("N"));
+        var path = Path.Combine(root, "trace.jsonl");
+
+        try
+        {
+            var trace = new ProcessLifecycleTrace(path);
+            trace.RecordStart("worker", "wait");
+
+            Action wait = () => trace.WaitUntil(
+                () => false,
+                TimeSpan.FromMilliseconds(20),
+                "worker",
+                "never-signaled");
+
+            wait.Should().Throw<TimeoutException>()
+                .WithMessage("*process-lifecycle*\"Kind\":\"timeout\"*");
+            trace.Events.Select(item => item.Kind).Should().ContainInOrder("start", "operation", "timeout");
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/src/Ahtola.Tests/LogicalDatabaseFingerprintTests.cs
+++ b/src/Ahtola.Tests/LogicalDatabaseFingerprintTests.cs
@@ -1,0 +1,112 @@
+using Ahtola.Data.Sqlite;
+using Ahtola.Tests.Infrastructure;
+using AwesomeAssertions;
+
+namespace Ahtola.Tests;
+
+public sealed class LogicalDatabaseFingerprintTests
+{
+    [Test]
+    public void TypedGoldenVectorIsStableAndExcludesSqliteInternalObjects()
+    {
+        using var connection = Open(":memory:");
+        Execute(
+            connection,
+            """
+            CREATE TABLE typed(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                nil,
+                integer_value,
+                real_value,
+                text_value,
+                blob_value);
+            INSERT INTO typed(nil, integer_value, real_value, text_value, blob_value)
+            VALUES(NULL, -7, 1.5, 'héllo', X'00FF');
+            """);
+
+        var fingerprint = LogicalDatabaseFingerprint.Compute(connection);
+        TestContext.Out.WriteLine($"logical fingerprint: {fingerprint}");
+
+        fingerprint.SchemaObjects.Should().Be(1, "sqlite_sequence is an internal SQLite object");
+        fingerprint.Tables.Should().Be(1);
+        fingerprint.Rows.Should().Be(1);
+        fingerprint.Sha256.Should().Be("7a0f724474204a7cd7e26c2f18d7bba7623da6f378eb63161b1fd5b87b6f2b86");
+    }
+
+    [Test]
+    public void EqualLogicalStatesWithDifferentPhysicalHistoriesHaveTheSameFingerprint()
+    {
+        var root = Path.Combine(
+            TestContext.CurrentContext.WorkDirectory,
+            "logical-database-fingerprint",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        var firstPath = Path.Combine(root, "first.db");
+        var secondPath = Path.Combine(root, "second.db");
+
+        try
+        {
+            using var first = Open(firstPath);
+            Execute(
+                first,
+                """
+                PRAGMA page_size=512;
+                VACUUM;
+                CREATE TABLE items(id INTEGER PRIMARY KEY, label TEXT, payload BLOB);
+                CREATE INDEX items_label ON items(label);
+                INSERT INTO items VALUES(3, 'three', X'03');
+                INSERT INTO items VALUES(1, 'one', X'01');
+                INSERT INTO items VALUES(2, 'discarded', X'FF');
+                DELETE FROM items WHERE id = 2;
+                INSERT INTO items VALUES(2, 'two', X'02');
+                """);
+
+            using var second = Open(secondPath);
+            Execute(
+                second,
+                """
+                PRAGMA page_size=4096;
+                VACUUM;
+                CREATE TABLE items(id INTEGER PRIMARY KEY, label TEXT, payload BLOB);
+                CREATE INDEX items_label ON items(label);
+                INSERT INTO items VALUES(1, 'one', X'01');
+                INSERT INTO items VALUES(2, 'two', X'02');
+                INSERT INTO items VALUES(3, 'three', X'03');
+                """);
+
+            var firstFingerprint = LogicalDatabaseFingerprint.Compute(first);
+            var secondFingerprint = LogicalDatabaseFingerprint.Compute(second);
+
+            firstFingerprint.Should().Be(
+                secondFingerprint,
+                $"logical fingerprints should ignore page layout and mutation history; first={firstFingerprint}, second={secondFingerprint}");
+
+            Execute(second, "UPDATE items SET label = 'changed' WHERE id = 2;");
+            var changedFingerprint = LogicalDatabaseFingerprint.Compute(second);
+            changedFingerprint.Sha256.Should().NotBe(
+                firstFingerprint.Sha256,
+                $"one typed value changed; before={firstFingerprint}, after={changedFingerprint}");
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static SqliteConnection Open(string dataSource)
+    {
+        var connection = new SqliteConnection(
+            $"Data Source={dataSource};Local Provider=Managed;Pooling=False");
+        connection.Open();
+        return connection;
+    }
+
+    private static void Execute(SqliteConnection connection, string sql)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.ExecuteNonQuery();
+    }
+}

--- a/src/Ahtola.Tests/ManagedEmbeddedReplicaConnectionTests.cs
+++ b/src/Ahtola.Tests/ManagedEmbeddedReplicaConnectionTests.cs
@@ -3295,6 +3295,8 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
     [TestCase(PullResponseFailure.InvalidPage)]
     [TestCase(PullResponseFailure.Non4KiBPage)]
     [TestCase(PullResponseFailure.LogicalStream)]
+    [TestCase(PullResponseFailure.UnknownStream)]
+    [TestCase(PullResponseFailure.UnknownApplyMode)]
     public void CreateReplicaRejectsInvalidBootstrapStreamsWithoutInstallingFiles(PullResponseFailure failure)
     {
         var path = Path.Combine(
@@ -3306,6 +3308,8 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
             PullResponseFailure.InvalidPage => CreatePullResponse("revision-page", new byte[1]),
             PullResponseFailure.Non4KiBPage => CreatePullResponse("revision-non-4k", new byte[4095]),
             PullResponseFailure.LogicalStream => CreatePullResponse("revision-logical", new byte[4096], streamKind: 1),
+            PullResponseFailure.UnknownStream => CreatePullResponse("revision-unknown-stream", new byte[4096], streamKind: 99),
+            PullResponseFailure.UnknownApplyMode => CreatePullResponse("revision-unknown-mode", new byte[4096], applyMode: 99),
             _ => throw new ArgumentOutOfRangeException(nameof(failure)),
         };
         var handler = new PullUpdatesHandler(response);
@@ -6058,6 +6062,8 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
         InvalidPage,
         Non4KiBPage,
         LogicalStream,
+        UnknownStream,
+        UnknownApplyMode,
     }
 
     public enum UnsupportedReplicaMode

--- a/src/Ahtola.Tests/ManagedMigrationsLockConcurrencyTests.cs
+++ b/src/Ahtola.Tests/ManagedMigrationsLockConcurrencyTests.cs
@@ -29,6 +29,7 @@ namespace Ahtola.Tests;
 /// implicit-write-transaction semantics. The one-shot EF-faithful gate now rotates
 /// 24/24 racers in ~1.3s (native reference: 1.03s).
 /// </summary>
+[Category("CoverageExcluded")]
 public class ManagedMigrationsLockConcurrencyTests
 {
     /// <summary>

--- a/src/Ahtola.Tests/ManagedProviderReaderLifecycleTests.cs
+++ b/src/Ahtola.Tests/ManagedProviderReaderLifecycleTests.cs
@@ -22,4 +22,32 @@ public sealed class ManagedProviderReaderLifecycleTests
         reader.Invoking(static value => value.Read()).Should().Throw<InvalidOperationException>();
         connection.ExecuteNonQuery("CREATE TABLE data(value INTEGER);").Should().Be(0);
     }
+
+    [Test]
+    public void ManagedCommandCanBeReusedAfterItsReaderIsExhaustedAndDisposed()
+    {
+        using var connection = new AhtolaConnection("Data Source=:memory:;Local Provider=Managed");
+        connection.Open();
+        connection.ExecuteNonQuery("CREATE TABLE data(value INTEGER);");
+        connection.ExecuteNonQuery("INSERT INTO data VALUES (1), (2);");
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT value FROM data ORDER BY value;";
+
+        using (var first = command.ExecuteReader())
+        {
+            first.Read().Should().BeTrue();
+            first.GetInt64(0).Should().Be(1);
+            first.Read().Should().BeTrue();
+            first.GetInt64(0).Should().Be(2);
+            first.Read().Should().BeFalse();
+        }
+
+        using var second = command.ExecuteReader();
+        second.Read().Should().BeTrue();
+        second.GetInt64(0).Should().Be(1);
+        second.Read().Should().BeTrue();
+        second.GetInt64(0).Should().Be(2);
+        second.Read().Should().BeFalse();
+    }
 }

--- a/src/Ahtola.Tests/ManagedReplicaLogicalReplayerTests.cs
+++ b/src/Ahtola.Tests/ManagedReplicaLogicalReplayerTests.cs
@@ -454,6 +454,37 @@ public sealed class ManagedReplicaLogicalReplayerTests
     }
 
     [Test]
+    public void KeyChangingReplayDeletesTheOldCompositeKeyBeforeUpsertingTheNewKey()
+    {
+        using var connection = OpenConnection();
+        Exec(connection, "CREATE TABLE t(tenant TEXT, code TEXT, value TEXT, PRIMARY KEY(tenant, code))");
+        Exec(connection, "INSERT INTO t VALUES ('a', 'old', 'local'), ('a', 'keep', 'untouched')");
+
+        var oldKey = SqliteRecordCodecTestHelper.EncodeRow(SqlValue.Text("a"), SqlValue.Text("old"));
+        var newRecord = SqliteRecordCodecTestHelper.EncodeRow(
+            SqlValue.Text("a"),
+            SqlValue.Text("new"),
+            SqlValue.Text("remote"));
+        var txn = new ManagedReplicaLogicalTxn(
+            2,
+            1,
+            [
+                RowOp(ManagedReplicaLogicalOpType.DeleteRow, "t", rowId: 999, oldKey),
+                RowOp(ManagedReplicaLogicalOpType.UpsertRow, "t", rowId: 999, newRecord),
+            ],
+            string.Empty);
+
+        Apply(connection, [txn]);
+
+        Scalar(connection, "SELECT COUNT(*) FROM t WHERE tenant = 'a' AND code = 'old'").AsInteger()
+            .Should().Be(0);
+        Scalar(connection, "SELECT value FROM t WHERE tenant = 'a' AND code = 'new'").AsText()
+            .Should().Be("remote");
+        Scalar(connection, "SELECT value FROM t WHERE tenant = 'a' AND code = 'keep'").AsText()
+            .Should().Be("untouched");
+    }
+
+    [Test]
     public void HeaderUpdateReplaysBothPragmasWhenBothArePresent()
     {
         using var connection = OpenConnection();

--- a/src/Ahtola.Tests/ManagedSqltestConformanceTests.cs
+++ b/src/Ahtola.Tests/ManagedSqltestConformanceTests.cs
@@ -10,6 +10,7 @@ namespace Ahtola.Tests;
 /// currently satisfy are listed in <c>Conformance/managed-sqltest-expected-failures.txt</c>
 /// so both coverage and known gaps stay visible instead of being silently omitted.
 /// </summary>
+[Category("CoverageExcluded")]
 public class ManagedSqltestConformanceTests
 {
     public static IEnumerable<TestCaseData> CorpusFiles()
@@ -55,7 +56,8 @@ public class ManagedSqltestConformanceTests
             }
         }
 
-        problems.Should().BeEmpty();
+        if (problems.Count != 0)
+            Assert.Fail(string.Join(Environment.NewLine, problems));
     }
 
     [Test]
@@ -135,6 +137,22 @@ public class ManagedSqltestConformanceTests
             .Where(id => !runnable.Contains(id))
             .Should()
             .BeEmpty("stale expected-failure entries hide corpus coverage changes");
+    }
+
+    [Test]
+    public void HarnessExclusionsAreReviewableAndReferToUnsupportedCases()
+    {
+        var unsupported = SqltestCorpus.Cases
+            .Where(static discovered => discovered.Status == SqltestCaseStatus.UnsupportedHarness)
+            .ToDictionary(static discovered => discovered.Id, StringComparer.Ordinal);
+
+        SqltestCorpus.HarnessExclusions.Should().ContainSingle(
+            "in-process exclusions must stay exceptional and individually reviewed");
+        foreach (var (id, reason) in SqltestCorpus.HarnessExclusions)
+        {
+            unsupported.Should().ContainKey(id, "stale exclusions silently shrink conformance coverage");
+            reason.Should().NotBeNullOrWhiteSpace();
+        }
     }
 
     [Test]

--- a/src/Ahtola.Tests/ManagedSurfaceContractCoverageTests.cs
+++ b/src/Ahtola.Tests/ManagedSurfaceContractCoverageTests.cs
@@ -1,0 +1,52 @@
+using System.Reflection;
+using AwesomeAssertions;
+
+namespace Ahtola.Tests;
+
+public sealed class ManagedSurfaceContractCoverageTests
+{
+    private static readonly ContractMapping[] Mappings =
+    [
+        new("composite/null primary-key predicate", typeof(ManagedReplicaLogicalReplayerTests), nameof(ManagedReplicaLogicalReplayerTests.DeleteWithANullPrimaryKeyValueMatchesTheNullRowNullSafely), "turso-src/sync/engine/src/database_replay_generator.rs::identity_predicate"),
+        new("shadowed rowid predicate", typeof(ManagedReplicaLogicalReplayerTests), nameof(ManagedReplicaLogicalReplayerTests.UpsertHandlesATableWithAGenuineRowidNamedColumnThatIsNotTheAlias), "turso-src/sync/engine/src/database_replay_generator.rs::implicit_rowid_alias"),
+        new("key-changing update/delete replay", typeof(ManagedReplicaLogicalReplayerTests), nameof(ManagedReplicaLogicalReplayerTests.KeyChangingReplayDeletesTheOldCompositeKeyBeforeUpsertingTheNewKey), "turso-src/sync/engine/src/database_replay_generator.rs::replay_values"),
+        new("CRC stream rejection", typeof(ManagedReplicaLml3DecoderTests), nameof(ManagedReplicaLml3DecoderTests.RejectsATransactionChecksumMismatch), "turso-src/sync/engine/src/database_sync_operations.rs::apply_logical_transactions_file"),
+        new("truncated stream rejection", typeof(ManagedReplicaLml3DecoderTests), nameof(ManagedReplicaLml3DecoderTests.RejectsATruncatedFrame), "turso-src/sync/engine/src/database_sync_operations.rs::apply_logical_transactions_file"),
+        new("unknown stream rejection", typeof(ManagedEmbeddedReplicaConnectionTests), nameof(ManagedEmbeddedReplicaConnectionTests.CreateReplicaRejectsInvalidBootstrapStreamsWithoutInstallingFiles), "turso-src/sync/engine/src/database_sync_operations.rs::pull_updates_stream_kind"),
+        new("revision metadata compatibility", typeof(ManagedEmbeddedReplicaConnectionTests), nameof(ManagedEmbeddedReplicaConnectionTests.ZeroTransactionRevisionAdvancePublishesMetadataSoTheNextSyncIsUpToDate), "turso-src/sync/engine/src/database_sync_engine.rs::update_metadata"),
+        new("ack metadata compatibility", typeof(ManagedReplicaLogicalReplayerTests), nameof(ManagedReplicaLogicalReplayerTests.TransactionsAcknowledgedViaTheTursoSyncLastChangeIdFallbackAreSkipped), "turso-src/sync/engine/src/database_sync_operations.rs::logical_txn_acknowledges_client"),
+        new("replace-base publication failure recovery", typeof(ManagedEmbeddedReplicaConnectionTests), nameof(ManagedEmbeddedReplicaConnectionTests.FailedPublicationReopenRecoversAPreSwapReplacementIntent), "turso-src/sync/engine/src/database_sync_engine.rs::ReplaceBaseApplyGuard"),
+        new("provider state transition", typeof(ManagedProviderReaderLifecycleTests), nameof(ManagedProviderReaderLifecycleTests.ClosingAndReopeningManagedConnectionPermanentlyClosesActiveAhtolaReader), "turso-src/bindings/rust/tests/integration_tests.rs::test_invalid_transaction_state_on_rows_drop"),
+        new("provider reader reuse", typeof(ManagedProviderReaderLifecycleTests), nameof(ManagedProviderReaderLifecycleTests.ManagedCommandCanBeReusedAfterItsReaderIsExhaustedAndDisposed), "turso-src/bindings/rust/tests/integration_tests.rs::test_statement_query_resets_before_execution"),
+        new("provider missing parameter", typeof(ManagedCoreParameterContractRegressionTests), nameof(ManagedCoreParameterContractRegressionTests.ManagedSqliteFacadeBindsTypedNumberedNamedAndPositionalValuesAfterRebind), "turso-src/bindings/go/driver_db_test.go::TestQueryMissingParameterReturnsError"),
+        new("provider interruption", typeof(ManagedProviderAsyncParityTests), nameof(ManagedProviderAsyncParityTests.ManagedSqliteCancelInterruptsActiveCommand), "turso-src/bindings/python/tests/test_interrupt.py::test_interrupt_from_watchdog_thread_aborts_query"),
+        new("provider read-only", typeof(ForeignReadOnlyOpenTests), nameof(ForeignReadOnlyOpenTests.ForeignReadOnlyRejectsWrites), "turso-src/bindings/rust/tests/integration_tests.rs::test_builder_read_only_rejects_writes_without_modifying_files"),
+        new("provider disposal", typeof(ManagedProviderAsyncParityTests), nameof(ManagedProviderAsyncParityTests.ManagedSqliteReaderAsyncOperationsReturnFaultedTasksAfterDisposal), "turso-src/bindings/rust/tests/integration_tests.rs::test_invalid_transaction_state_on_rows_drop"),
+        new("provider concurrent execution", typeof(ManagedProviderAsyncParityTests), nameof(ManagedProviderAsyncParityTests.ManagedSqliteAsyncLockWaitIsCancellable), "turso-src/bindings/rust/tests/integration_tests.rs::test_concurrent_unique_constraint_regression"),
+    ];
+
+    [TestCaseSource(nameof(CoverageCases))]
+    public void HarvestedTursoContractMapsToAnExecutableManagedCase(ContractMapping mapping)
+    {
+        mapping.UpstreamReference.Should().StartWith("turso-src/");
+        var method = mapping.TestType.GetMethod(
+            mapping.TestMethod,
+            BindingFlags.Instance | BindingFlags.Public);
+        method.Should().NotBeNull($"{mapping.Contract} must map to an existing executable test");
+        method!.GetCustomAttributes(inherit: false)
+            .Any(attribute => attribute is TestAttribute or TestCaseAttribute or TestCaseSourceAttribute)
+            .Should().BeTrue($"{mapping.TestType.Name}.{mapping.TestMethod} must remain executable");
+    }
+
+    private static IEnumerable<TestCaseData> CoverageCases()
+        => Mappings.Select(mapping => new TestCaseData(mapping).SetName($"Turso contract: {mapping.Contract}"));
+
+    public sealed record ContractMapping(
+        string Contract,
+        Type TestType,
+        string TestMethod,
+        string UpstreamReference)
+    {
+        public override string ToString() => Contract;
+    }
+}

--- a/src/Ahtola.Tests/ModelBasedStorageTests.cs
+++ b/src/Ahtola.Tests/ModelBasedStorageTests.cs
@@ -1,0 +1,168 @@
+using AwesomeAssertions;
+using Ahtola.Core.Storage;
+using Ahtola.Tests.Oracle;
+
+namespace Ahtola.Tests;
+
+/// <summary>
+/// Bounded reference-model checks corresponding to Turso's randomized
+/// <c>core/storage/page_cache.rs::test_page_cache_fuzz</c>.
+/// </summary>
+public sealed class ModelBasedStorageTests
+{
+    private const int OperationCount = 256;
+
+    [TestCase(17)]
+    [TestCase(0x5eed)]
+    public void PagerReadCacheMatchesIndependentLruModelAfterEveryOperation(int defaultSeed)
+    {
+        var stream = StableTestSeed.Create((ulong)defaultSeed)
+            .Derive($"pager-read-cache-{defaultSeed:x}");
+        var trace = ReplayTrace.Create(TestContext.CurrentContext.Test.Name, stream);
+
+        OracleFailureArtifacts.Run(trace, () =>
+        {
+            const int capacity = 4;
+            var actual = new SqlitePagerReadCache(capacity);
+            var model = new ReferenceReadCache(capacity);
+
+            for (var step = 0; step < OperationCount; step++)
+            {
+                var pageNumber = checked((uint)(stream.Random.NextInt32(7) + 1));
+                var generation = stream.Random.NextInt32(5);
+                switch (stream.Random.NextInt32(100))
+                {
+                    case < 43:
+                        {
+                            var page = stream.Random.NextBytes(24);
+                            Log(trace, step, $"ADD page={pageNumber} generation={generation} bytes={Convert.ToHexString(page)}");
+                            actual.Add(pageNumber, generation, page);
+                            model.Add(pageNumber, generation, page);
+                            break;
+                        }
+                    case < 76:
+                        {
+                            Log(trace, step, $"GET page={pageNumber} generation={generation}");
+                            var actualFound = actual.TryGetValue(pageNumber, generation, out var actualPage);
+                            var expectedFound = model.TryGetValue(pageNumber, generation, out var expectedPage);
+                            actualFound.Should().Be(expectedFound, because: Diagnostics(trace, step));
+                            if (expectedFound)
+                                actualPage.Should().Equal(expectedPage, because: Diagnostics(trace, step));
+                            break;
+                        }
+                    case < 92:
+                        Log(trace, step, $"REMOVE page={pageNumber}");
+                        actual.Remove(pageNumber);
+                        model.Remove(pageNumber);
+                        break;
+                    default:
+                        Log(trace, step, "CLEAR");
+                        actual.Clear();
+                        model.Clear();
+                        break;
+                }
+
+                AssertEquivalent(actual, model, step, trace);
+            }
+        });
+    }
+
+    private static void AssertEquivalent(
+        SqlitePagerReadCache actual,
+        ReferenceReadCache model,
+        int step,
+        ReplayTrace trace)
+    {
+        actual.Capacity.Should().Be(model.Capacity, because: Diagnostics(trace, step));
+        actual.Count.Should().Be(model.Count, because: Diagnostics(trace, step));
+        actual.Count.Should().BeLessThanOrEqualTo(actual.Capacity, because: Diagnostics(trace, step));
+
+        // Touch the same keys in the same order on both caches. Count equality plus
+        // finding every modeled key proves exact membership without inspecting internals.
+        var keys = model.PageNumbers.Order().ToArray();
+        foreach (var pageNumber in keys)
+        {
+            var generation = model.Generation(pageNumber);
+            var expectedFound = model.TryGetValue(pageNumber, generation, out var expectedPage);
+            var actualFound = actual.TryGetValue(pageNumber, generation, out var actualPage);
+            expectedFound.Should().BeTrue(because: Diagnostics(trace, step));
+            actualFound.Should().BeTrue(because: Diagnostics(trace, step));
+            actualPage.Should().Equal(expectedPage, because: Diagnostics(trace, step));
+        }
+
+        actual.Count.Should().Be(model.Count, because: Diagnostics(trace, step));
+    }
+
+    private static void Log(ReplayTrace trace, int step, string operation)
+        => trace.Add(
+            $"-- cache step={step}: {operation}",
+            comparison: "independent bounded LRU model",
+            action: "pager-cache");
+
+    private static string Diagnostics(ReplayTrace trace, int step)
+        => $"{trace.SeedDiagnostics}; step={step}{Environment.NewLine}{trace.ToSql()}";
+
+    private sealed class ReferenceReadCache(int capacity)
+    {
+        private readonly Dictionary<uint, CacheEntry> _entries = [];
+        private readonly List<uint> _leastToMostRecent = [];
+
+        internal int Capacity { get; } = capacity;
+
+        internal int Count => _entries.Count;
+
+        internal IEnumerable<uint> PageNumbers => _entries.Keys;
+
+        internal long Generation(uint pageNumber) => _entries[pageNumber].Generation;
+
+        internal void Add(uint pageNumber, long generation, byte[] page)
+        {
+            Remove(pageNumber);
+            if (_entries.Count == Capacity)
+            {
+                var evicted = _leastToMostRecent[0];
+                _leastToMostRecent.RemoveAt(0);
+                _entries.Remove(evicted);
+            }
+
+            _entries.Add(pageNumber, new CacheEntry(generation, page.ToArray()));
+            _leastToMostRecent.Add(pageNumber);
+        }
+
+        internal bool TryGetValue(uint pageNumber, long generation, out byte[] page)
+        {
+            if (!_entries.TryGetValue(pageNumber, out var entry))
+            {
+                page = null!;
+                return false;
+            }
+
+            if (entry.Generation != generation)
+            {
+                Remove(pageNumber);
+                page = null!;
+                return false;
+            }
+
+            _leastToMostRecent.Remove(pageNumber);
+            _leastToMostRecent.Add(pageNumber);
+            page = entry.Page.ToArray();
+            return true;
+        }
+
+        internal void Remove(uint pageNumber)
+        {
+            if (!_entries.Remove(pageNumber))
+                return;
+            _leastToMostRecent.Remove(pageNumber);
+        }
+
+        internal void Clear()
+        {
+            _entries.Clear();
+            _leastToMostRecent.Clear();
+        }
+
+        private sealed record CacheEntry(long Generation, byte[] Page);
+    }
+}

--- a/src/Ahtola.Tests/Oracle/DependencyAwareTraceMinimizer.cs
+++ b/src/Ahtola.Tests/Oracle/DependencyAwareTraceMinimizer.cs
@@ -1,0 +1,115 @@
+using System.Text.RegularExpressions;
+
+namespace Ahtola.Tests.Oracle;
+
+internal static partial class DependencyAwareTraceMinimizer
+{
+    public static IReadOnlyList<ReplayOperation> Minimize(
+        IReadOnlyList<ReplayOperation> operations,
+        Func<IReadOnlyList<ReplayOperation>, string?> classifyFailure)
+    {
+        ArgumentNullException.ThrowIfNull(operations);
+        ArgumentNullException.ThrowIfNull(classifyFailure);
+        ValidateDependencies(operations);
+
+        var expectedFingerprint = classifyFailure(operations)
+            ?? throw new ArgumentException("The original replay trace does not fail.", nameof(operations));
+        var current = operations.ToList();
+        var granularity = 2;
+
+        while (current.Count > 1)
+        {
+            var chunkSize = (int)Math.Ceiling(current.Count / (double)granularity);
+            var reduced = false;
+            for (var start = 0; start < current.Count; start += chunkSize)
+            {
+                var removedIds = current
+                    .Skip(start)
+                    .Take(chunkSize)
+                    .Select(static operation => operation.Index)
+                    .ToHashSet();
+                var candidate = RemoveOperationsAndDependents(current, removedIds);
+                if (candidate.Count == current.Count
+                    || classifyFailure(candidate) != expectedFingerprint)
+                {
+                    continue;
+                }
+
+                current = candidate;
+                granularity = Math.Max(2, granularity - 1);
+                reduced = true;
+                break;
+            }
+
+            if (reduced)
+                continue;
+            if (granularity >= current.Count)
+                break;
+            granularity = Math.Min(current.Count, granularity * 2);
+        }
+
+        ValidateDependencies(current);
+        return current;
+    }
+
+    public static string NormalizeFailure(Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        var firstLine = exception.Message.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
+            .FirstOrDefault() ?? string.Empty;
+        var normalized = GuidPattern().Replace(firstLine, "<guid>");
+        normalized = HexPattern().Replace(normalized, "0x<number>");
+        normalized = IntegerPattern().Replace(normalized, "<number>");
+        return $"{exception.GetType().FullName}:{normalized}";
+    }
+
+    internal static void ValidateDependencies(IReadOnlyList<ReplayOperation> operations)
+    {
+        var seen = new HashSet<int>();
+        foreach (var operation in operations)
+        {
+            if (!seen.Add(operation.Index))
+                throw new InvalidOperationException($"Replay operation id {operation.Index} is duplicated.");
+            foreach (var dependency in operation.Dependencies ?? [])
+            {
+                if (!seen.Contains(dependency))
+                {
+                    throw new InvalidOperationException(
+                        $"Replay operation {operation.Index} depends on missing or later operation {dependency}.");
+                }
+            }
+        }
+    }
+
+    private static List<ReplayOperation> RemoveOperationsAndDependents(
+        IReadOnlyList<ReplayOperation> operations,
+        HashSet<int> removedIds)
+    {
+        var changed = true;
+        while (changed)
+        {
+            changed = false;
+            foreach (var operation in operations)
+            {
+                if (removedIds.Contains(operation.Index)
+                    || !(operation.Dependencies?.Any(removedIds.Contains) ?? false))
+                {
+                    continue;
+                }
+
+                changed = removedIds.Add(operation.Index) || changed;
+            }
+        }
+
+        return operations.Where(operation => !removedIds.Contains(operation.Index)).ToList();
+    }
+
+    [GeneratedRegex(@"(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b")]
+    private static partial Regex GuidPattern();
+
+    [GeneratedRegex(@"(?i)\b0x[0-9a-f]+\b")]
+    private static partial Regex HexPattern();
+
+    [GeneratedRegex(@"(?<![A-Za-z_])\d+(?![A-Za-z_])")]
+    private static partial Regex IntegerPattern();
+}

--- a/src/Ahtola.Tests/Oracle/ReplayTrace.cs
+++ b/src/Ahtola.Tests/Oracle/ReplayTrace.cs
@@ -1,0 +1,168 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Ahtola.Tests.Oracle;
+
+internal sealed record ReplayOperation(
+    int Index,
+    string Sql,
+    string Comparison,
+    bool Ordered,
+    int? Actor = null,
+    string? Action = null,
+    IReadOnlyList<int>? Dependencies = null);
+
+internal sealed record ReplayScheduleStep(
+    int Step,
+    int Choice,
+    int Actor,
+    string ActorName,
+    string YieldPoint,
+    int YieldOrdinal,
+    IReadOnlyList<int> EnabledActors,
+    long ProgressCount);
+
+internal sealed class ReplayTrace
+{
+    public string TestName { get; init; } = string.Empty;
+
+    public ulong RootSeed { get; init; }
+
+    public ulong StreamSeed { get; init; }
+
+    public string StreamName { get; init; } = string.Empty;
+
+    public string SeedDiagnostics { get; init; } = string.Empty;
+
+    public List<ReplayOperation> Operations { get; init; } = [];
+
+    public List<int> ScheduleChoices { get; init; } = [];
+
+    public List<ReplayScheduleStep> Schedule { get; init; } = [];
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Failure { get; set; }
+
+    public static ReplayTrace Create(string testName, StableRandomStream stream)
+        => new()
+        {
+            TestName = testName,
+            RootSeed = stream.RootSeed,
+            StreamSeed = stream.Seed,
+            StreamName = stream.Name,
+            SeedDiagnostics = stream.Diagnostics,
+        };
+
+    public void Add(
+        string sql,
+        string comparison = "ordered",
+        bool ordered = true,
+        int? actor = null,
+        string? action = null,
+        IReadOnlyList<int>? dependencies = null)
+        => Operations.Add(
+            new ReplayOperation(
+                Operations.Count,
+                sql,
+                comparison,
+                ordered,
+                actor,
+                action,
+                dependencies is null ? null : [.. dependencies]));
+
+    public void AddScheduleStep(CooperativeScheduleStep step)
+    {
+        ArgumentNullException.ThrowIfNull(step);
+        ScheduleChoices.Add(step.Choice);
+        Schedule.Add(new ReplayScheduleStep(
+            step.Step,
+            step.Choice,
+            step.ActorId,
+            step.ActorName,
+            step.YieldPoint,
+            step.YieldOrdinal,
+            [.. step.EnabledActors],
+            step.ProgressCount));
+    }
+
+    public string ToJson()
+        => JsonSerializer.Serialize(this, SerializerOptions);
+
+    public static ReplayTrace FromJson(string json)
+        => JsonSerializer.Deserialize<ReplayTrace>(json, SerializerOptions)
+            ?? throw new InvalidOperationException("The replay trace contained no value.");
+
+    public string ToSql()
+    {
+        var writer = new StringWriter();
+        writer.WriteLine($"-- {TestName}");
+        writer.WriteLine($"-- {SeedDiagnostics}");
+        if (ScheduleChoices.Count > 0)
+        {
+            writer.WriteLine($"-- schedule choices=[{string.Join(",", ScheduleChoices)}]");
+            foreach (var step in Schedule)
+            {
+                writer.WriteLine(
+                    $"-- schedule {step.Step}; choice={step.Choice}; actor={step.Actor}:{step.ActorName}; "
+                    + $"yield={step.YieldPoint}#{step.YieldOrdinal}; "
+                    + $"enabled=[{string.Join(",", step.EnabledActors)}]; progress={step.ProgressCount}");
+            }
+        }
+
+        foreach (var operation in Operations)
+        {
+            writer.WriteLine();
+            var actor = operation.Actor is { } actorId ? $"; actor={actorId}" : string.Empty;
+            var action = operation.Action is { Length: > 0 } actionName ? $"; action={actionName}" : string.Empty;
+            var dependencies = operation.Dependencies is { Count: > 0 } required
+                ? $"; depends=[{string.Join(",", required)}]"
+                : string.Empty;
+            writer.WriteLine(
+                $"-- operation {operation.Index}; comparison={operation.Comparison}; ordered={operation.Ordered}"
+                + actor
+                + action
+                + dependencies);
+            writer.WriteLine(operation.Sql.TrimEnd().EndsWith(';') ? operation.Sql.TrimEnd() : operation.Sql.TrimEnd() + ";");
+        }
+
+        return writer.ToString();
+    }
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+}
+
+internal static class OracleFailureArtifacts
+{
+    public static void Run(ReplayTrace trace, Action action)
+    {
+        try
+        {
+            action();
+        }
+        catch (Exception exception)
+        {
+            Write(trace, exception);
+            throw;
+        }
+    }
+
+    private static void Write(ReplayTrace trace, Exception exception)
+    {
+        trace.Failure = exception.ToString();
+        var safeName = string.Concat(trace.TestName.Select(character =>
+            Path.GetInvalidFileNameChars().Contains(character) ? '_' : character));
+        var directory = Path.Combine(TestContext.CurrentContext.WorkDirectory, "oracle-failures");
+        Directory.CreateDirectory(directory);
+        var stem = $"{safeName}-{trace.StreamSeed:x16}-{Guid.NewGuid():N}";
+        var jsonPath = Path.Combine(directory, stem + ".json");
+        var sqlPath = Path.Combine(directory, stem + ".sql");
+        File.WriteAllText(jsonPath, trace.ToJson());
+        File.WriteAllText(sqlPath, trace.ToSql());
+        TestContext.AddTestAttachment(jsonPath, $"Oracle replay trace ({trace.SeedDiagnostics})");
+        TestContext.AddTestAttachment(sqlPath, "Oracle replay SQL");
+    }
+}

--- a/src/Ahtola.Tests/Oracle/StableTestRandom.cs
+++ b/src/Ahtola.Tests/Oracle/StableTestRandom.cs
@@ -1,0 +1,162 @@
+using System.Globalization;
+using System.Text;
+
+namespace Ahtola.Tests.Oracle;
+
+internal sealed class StableTestSeed
+{
+    private const string EnvironmentVariable = "AHTOLA_TEST_SEED";
+
+    private StableTestSeed(ulong rootSeed, string source)
+    {
+        RootSeed = rootSeed;
+        Source = source;
+    }
+
+    public ulong RootSeed { get; }
+
+    public string Source { get; }
+
+    public static StableTestSeed Create(ulong defaultSeed)
+    {
+        var text = Environment.GetEnvironmentVariable(EnvironmentVariable);
+        if (string.IsNullOrWhiteSpace(text))
+            return new StableTestSeed(defaultSeed, "test default");
+
+        if (!TryParseSeed(text, out var seed))
+        {
+            throw new InvalidOperationException(
+                $"{EnvironmentVariable} must be an unsigned 64-bit integer in decimal or 0x-prefixed hexadecimal form; received '{text}'.");
+        }
+
+        return new StableTestSeed(seed, EnvironmentVariable);
+    }
+
+    public StableRandomStream Derive(string streamName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(streamName);
+        var streamSeed = Mix(RootSeed ^ StableHash(streamName));
+        return new StableRandomStream(
+            new StablePrng(streamSeed),
+            RootSeed,
+            streamSeed,
+            streamName,
+            Source);
+    }
+
+    private static bool TryParseSeed(string text, out ulong seed)
+    {
+        text = text.Trim();
+        return text.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
+            ? ulong.TryParse(text.AsSpan(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out seed)
+            : ulong.TryParse(text, NumberStyles.None, CultureInfo.InvariantCulture, out seed);
+    }
+
+    private static ulong StableHash(string value)
+    {
+        const ulong offset = 14695981039346656037;
+        const ulong prime = 1099511628211;
+        var hash = offset;
+        foreach (var octet in Encoding.UTF8.GetBytes(value))
+        {
+            hash ^= octet;
+            hash *= prime;
+        }
+
+        return hash;
+    }
+
+    private static ulong Mix(ulong value)
+    {
+        value ^= value >> 30;
+        value *= 0xbf58476d1ce4e5b9;
+        value ^= value >> 27;
+        value *= 0x94d049bb133111eb;
+        return value ^ (value >> 31);
+    }
+}
+
+internal sealed class StableRandomStream
+{
+    internal StableRandomStream(StablePrng random, ulong rootSeed, ulong seed, string name, string source)
+    {
+        Random = random;
+        RootSeed = rootSeed;
+        Seed = seed;
+        Name = name;
+        Source = source;
+    }
+
+    public StablePrng Random { get; }
+
+    public ulong RootSeed { get; }
+
+    public ulong Seed { get; }
+
+    public string Name { get; }
+
+    public string Source { get; }
+
+    public string Diagnostics =>
+        $"root seed={RootSeed} ({Source}), stream='{Name}', stream seed={Seed}; replay with AHTOLA_TEST_SEED={RootSeed}";
+}
+
+/// <summary>
+/// SplitMix64 with explicitly fixed output and range-selection algorithms.
+/// </summary>
+internal sealed class StablePrng
+{
+    private ulong _state;
+
+    public StablePrng(ulong seed)
+    {
+        _state = seed;
+    }
+
+    public ulong NextUInt64()
+    {
+        var value = _state += 0x9e3779b97f4a7c15;
+        value = (value ^ (value >> 30)) * 0xbf58476d1ce4e5b9;
+        value = (value ^ (value >> 27)) * 0x94d049bb133111eb;
+        return value ^ (value >> 31);
+    }
+
+    public int NextInt32(int exclusiveMaximum)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(exclusiveMaximum);
+        var bound = (uint)exclusiveMaximum;
+        var threshold = unchecked((0u - bound) % bound);
+
+        while (true)
+        {
+            var candidate = (uint)NextUInt64();
+            if (candidate >= threshold)
+                return (int)(candidate % bound);
+        }
+    }
+
+    public int NextInt32(int inclusiveMinimum, int exclusiveMaximum)
+    {
+        if (exclusiveMaximum <= inclusiveMinimum)
+            throw new ArgumentOutOfRangeException(nameof(exclusiveMaximum));
+
+        return inclusiveMinimum + NextInt32(exclusiveMaximum - inclusiveMinimum);
+    }
+
+    public bool NextBoolean() => (NextUInt64() & 1) != 0;
+
+    public byte[] NextBytes(int length)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(length);
+        var bytes = new byte[length];
+        var offset = 0;
+        while (offset < bytes.Length)
+        {
+            var value = NextUInt64();
+            for (var shift = 0; shift < 64 && offset < bytes.Length; shift += 8)
+                bytes[offset++] = (byte)(value >> shift);
+        }
+
+        return bytes;
+    }
+}

--- a/src/Ahtola.Tests/Oracle/TypedSqliteOracle.cs
+++ b/src/Ahtola.Tests/Oracle/TypedSqliteOracle.cs
@@ -1,0 +1,341 @@
+using System.Data.Common;
+using System.Globalization;
+using AhtolaSqliteException = Ahtola.Data.Sqlite.SqliteException;
+using MicrosoftSqliteException = Microsoft.Data.Sqlite.SqliteException;
+
+namespace Ahtola.Tests.Oracle;
+
+internal enum OracleValueKind
+{
+    Null,
+    Integer,
+    Real,
+    Text,
+    Blob,
+}
+
+internal readonly struct OracleValue : IEquatable<OracleValue>
+{
+    private readonly long _integer;
+    private readonly long _realBits;
+    private readonly string? _text;
+    private readonly byte[]? _blob;
+
+    private OracleValue(OracleValueKind kind, long integer = 0, long realBits = 0, string? text = null, byte[]? blob = null)
+    {
+        Kind = kind;
+        _integer = integer;
+        _realBits = realBits;
+        _text = text;
+        _blob = blob;
+    }
+
+    public OracleValueKind Kind { get; }
+
+    public static OracleValue Null => new(OracleValueKind.Null);
+
+    public static OracleValue Integer(long value) => new(OracleValueKind.Integer, integer: value);
+
+    public static OracleValue Real(double value) => new(OracleValueKind.Real, realBits: BitConverter.DoubleToInt64Bits(value));
+
+    public static OracleValue Text(string value) => new(OracleValueKind.Text, text: value);
+
+    public static OracleValue Blob(byte[] value) => new(OracleValueKind.Blob, blob: [.. value]);
+
+    public bool Equals(OracleValue other)
+    {
+        if (Kind != other.Kind)
+            return false;
+
+        return Kind switch
+        {
+            OracleValueKind.Null => true,
+            OracleValueKind.Integer => _integer == other._integer,
+            OracleValueKind.Real => _realBits == other._realBits,
+            OracleValueKind.Text => string.Equals(_text, other._text, StringComparison.Ordinal),
+            OracleValueKind.Blob => _blob!.AsSpan().SequenceEqual(other._blob),
+            _ => false,
+        };
+    }
+
+    public override bool Equals(object? obj) => obj is OracleValue other && Equals(other);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(Kind);
+        switch (Kind)
+        {
+            case OracleValueKind.Integer:
+                hash.Add(_integer);
+                break;
+            case OracleValueKind.Real:
+                hash.Add(_realBits);
+                break;
+            case OracleValueKind.Text:
+                hash.Add(_text, StringComparer.Ordinal);
+                break;
+            case OracleValueKind.Blob:
+                foreach (var octet in _blob!)
+                    hash.Add(octet);
+                break;
+        }
+
+        return hash.ToHashCode();
+    }
+
+    public override string ToString()
+        => Kind switch
+        {
+            OracleValueKind.Null => "NULL",
+            OracleValueKind.Integer => $"INTEGER({_integer.ToString(CultureInfo.InvariantCulture)})",
+            OracleValueKind.Real => $"REAL({BitConverter.Int64BitsToDouble(_realBits).ToString("R", CultureInfo.InvariantCulture)}, bits=0x{_realBits:x16})",
+            OracleValueKind.Text => $"TEXT({JsonString(_text!)})",
+            OracleValueKind.Blob => $"BLOB({Convert.ToHexString(_blob!)})",
+            _ => Kind.ToString(),
+        };
+
+    public static bool operator ==(OracleValue left, OracleValue right) => left.Equals(right);
+
+    public static bool operator !=(OracleValue left, OracleValue right) => !left.Equals(right);
+
+    private static string JsonString(string value)
+        => System.Text.Json.JsonSerializer.Serialize(value);
+}
+
+internal sealed class OracleRow : IEquatable<OracleRow>
+{
+    public OracleRow(IEnumerable<OracleValue> values)
+    {
+        Values = [.. values];
+    }
+
+    public IReadOnlyList<OracleValue> Values { get; }
+
+    public bool Equals(OracleRow? other)
+        => other is not null && Values.SequenceEqual(other.Values);
+
+    public override bool Equals(object? obj) => Equals(obj as OracleRow);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        foreach (var value in Values)
+            hash.Add(value);
+        return hash.ToHashCode();
+    }
+
+    public override string ToString() => $"[{string.Join(", ", Values)}]";
+}
+
+internal enum OracleExecutionKind
+{
+    Success,
+    Error,
+}
+
+internal sealed record OracleError(string Category, int? SqliteErrorCode, string Message);
+
+internal sealed record OracleExecutionResult(
+    OracleExecutionKind Kind,
+    bool HasResultSet,
+    IReadOnlyList<string> Columns,
+    IReadOnlyList<OracleRow> Rows,
+    OracleError? Error)
+{
+    public static OracleExecutionResult Success(bool hasResultSet, IReadOnlyList<string> columns, IReadOnlyList<OracleRow> rows)
+        => new(OracleExecutionKind.Success, hasResultSet, columns, rows, null);
+
+    public static OracleExecutionResult Failure(OracleError error)
+        => new(OracleExecutionKind.Error, false, [], [], error);
+}
+
+internal static class TypedSqliteOracle
+{
+    public static OracleExecutionResult Execute(DbConnection connection, string sql)
+    {
+        try
+        {
+            using var command = connection.CreateCommand();
+            command.CommandText = sql;
+            using var reader = command.ExecuteReader();
+            var hasResultSet = reader.FieldCount != 0;
+            var columns = Enumerable.Range(0, reader.FieldCount).Select(reader.GetName).ToArray();
+            var rows = new List<OracleRow>();
+            while (reader.Read())
+            {
+                var values = new OracleValue[reader.FieldCount];
+                for (var index = 0; index < values.Length; index++)
+                    values[index] = Normalize(reader.GetValue(index));
+                rows.Add(new OracleRow(values));
+            }
+
+            return OracleExecutionResult.Success(hasResultSet, columns, rows);
+        }
+        catch (Exception exception)
+        {
+            return OracleExecutionResult.Failure(NormalizeError(exception));
+        }
+    }
+
+    public static void AssertEquivalent(
+        OracleExecutionResult managed,
+        OracleExecutionResult reference,
+        bool ordered,
+        string diagnostics)
+    {
+        if (managed.Kind != reference.Kind)
+            Fail($"success/error mismatch: managed={Describe(managed)}, SQLite={Describe(reference)}", diagnostics);
+
+        if (managed.Kind == OracleExecutionKind.Error)
+        {
+            if (!string.Equals(managed.Error!.Category, reference.Error!.Category, StringComparison.Ordinal))
+                Fail($"error category mismatch: managed={Describe(managed)}, SQLite={Describe(reference)}", diagnostics);
+
+            if (managed.Error.SqliteErrorCode is { } managedCode
+                && reference.Error.SqliteErrorCode is { } referenceCode
+                && managedCode != referenceCode)
+            {
+                Fail($"SQLite error code mismatch: managed={managedCode}, SQLite={referenceCode}", diagnostics);
+            }
+
+            return;
+        }
+
+        if (managed.HasResultSet != reference.HasResultSet)
+            Fail($"result-set category mismatch: managed={managed.HasResultSet}, SQLite={reference.HasResultSet}", diagnostics);
+        if (!managed.Columns.SequenceEqual(reference.Columns, StringComparer.Ordinal))
+            Fail($"column mismatch: managed=[{string.Join(", ", managed.Columns)}], SQLite=[{string.Join(", ", reference.Columns)}]", diagnostics);
+
+        var mismatch = ordered
+            ? OrderedMismatch(managed.Rows, reference.Rows)
+            : BagMismatch(managed.Rows, reference.Rows);
+        if (mismatch is not null)
+            Fail(mismatch, diagnostics);
+    }
+
+    public static void AssertEquivalent(
+        DbConnection managed,
+        DbConnection reference,
+        string sql,
+        bool ordered,
+        string diagnostics)
+        => AssertEquivalent(Execute(managed, sql), Execute(reference, sql), ordered, $"{diagnostics}; SQL={sql}");
+
+    public static OracleExecutionResult TableSnapshot(DbConnection connection, string table, bool includeRowId = true)
+    {
+        var quoted = QuoteIdentifier(table);
+        var projection = includeRowId ? "rowid AS __oracle_rowid, *" : "*";
+        var ordering = includeRowId ? " ORDER BY rowid" : string.Empty;
+        return Execute(connection, $"SELECT {projection} FROM {quoted}{ordering};");
+    }
+
+    public static OracleExecutionResult SchemaSnapshot(DbConnection connection)
+        => Execute(
+            connection,
+            "SELECT type, name, tbl_name, sql FROM sqlite_schema "
+            + "WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name;");
+
+    public static void AssertIntegrity(DbConnection connection, string diagnostics)
+    {
+        var result = Execute(connection, "PRAGMA integrity_check;");
+        if (result.Kind != OracleExecutionKind.Success
+            || result.Rows.Count != 1
+            || result.Rows[0].Values.Count != 1
+            || result.Rows[0].Values[0] != OracleValue.Text("ok"))
+        {
+            Fail($"integrity_check did not return one TEXT(\"ok\") row: {Describe(result)}", diagnostics);
+        }
+    }
+
+    private static OracleValue Normalize(object value)
+        => value switch
+        {
+            null or DBNull => OracleValue.Null,
+            long integer => OracleValue.Integer(integer),
+            int integer => OracleValue.Integer(integer),
+            short integer => OracleValue.Integer(integer),
+            byte integer => OracleValue.Integer(integer),
+            double real => OracleValue.Real(real),
+            float real => OracleValue.Real(real),
+            string text => OracleValue.Text(text),
+            byte[] blob => OracleValue.Blob(blob),
+            _ => throw new InvalidOperationException(
+                $"Unexpected SQLite storage value type {value.GetType().FullName}; value={value}."),
+        };
+
+    private static OracleError NormalizeError(Exception exception)
+    {
+        var (code, message) = exception switch
+        {
+            AhtolaSqliteException sqlite => ((int?)sqlite.SqliteErrorCode, sqlite.Message),
+            MicrosoftSqliteException sqlite => ((int?)sqlite.SqliteErrorCode, sqlite.Message),
+            _ => ((int?)null, exception.Message),
+        };
+
+        return new OracleError(code is { } value ? PrimaryErrorCategory(value) : exception.GetType().Name, code, message);
+    }
+
+    private static string PrimaryErrorCategory(int code)
+        => (code & 0xff) switch
+        {
+            1 => "SQLITE_ERROR",
+            5 => "SQLITE_BUSY",
+            6 => "SQLITE_LOCKED",
+            8 => "SQLITE_READONLY",
+            9 => "SQLITE_INTERRUPT",
+            10 => "SQLITE_IOERR",
+            11 => "SQLITE_CORRUPT",
+            13 => "SQLITE_FULL",
+            14 => "SQLITE_CANTOPEN",
+            17 => "SQLITE_SCHEMA",
+            18 => "SQLITE_TOOBIG",
+            19 => "SQLITE_CONSTRAINT",
+            20 => "SQLITE_MISMATCH",
+            21 => "SQLITE_MISUSE",
+            23 => "SQLITE_AUTH",
+            25 => "SQLITE_RANGE",
+            26 => "SQLITE_NOTADB",
+            var value => $"SQLITE_{value}",
+        };
+
+    private static string? OrderedMismatch(IReadOnlyList<OracleRow> managed, IReadOnlyList<OracleRow> reference)
+    {
+        if (managed.Count != reference.Count)
+            return $"row count mismatch: managed={managed.Count}, SQLite={reference.Count}";
+
+        for (var index = 0; index < managed.Count; index++)
+        {
+            if (!managed[index].Equals(reference[index]))
+                return $"ordered row mismatch at {index}: managed={managed[index]}, SQLite={reference[index]}";
+        }
+
+        return null;
+    }
+
+    private static string? BagMismatch(IReadOnlyList<OracleRow> managed, IReadOnlyList<OracleRow> reference)
+    {
+        var counts = new Dictionary<OracleRow, int>();
+        foreach (var row in managed)
+            counts[row] = counts.GetValueOrDefault(row) + 1;
+        foreach (var row in reference)
+            counts[row] = counts.GetValueOrDefault(row) - 1;
+
+        var differences = counts.Where(pair => pair.Value != 0).ToArray();
+        return differences.Length == 0
+            ? null
+            : "unordered row-bag mismatch (signed count is managed minus SQLite): "
+                + string.Join(", ", differences.Select(pair => $"{pair.Key} => {pair.Value}"));
+    }
+
+    private static string Describe(OracleExecutionResult result)
+        => result.Kind == OracleExecutionKind.Error
+            ? $"error(category={result.Error!.Category}, code={result.Error.SqliteErrorCode}, message={result.Error.Message})"
+            : $"success(resultSet={result.HasResultSet}, rows=[{string.Join(", ", result.Rows)}])";
+
+    private static string QuoteIdentifier(string identifier)
+        => '"' + identifier.Replace("\"", "\"\"", StringComparison.Ordinal) + '"';
+
+    private static void Fail(string message, string diagnostics)
+        => throw new AssertionException($"{message}{Environment.NewLine}{diagnostics}");
+}

--- a/src/Ahtola.Tests/OracleFoundationTests.cs
+++ b/src/Ahtola.Tests/OracleFoundationTests.cs
@@ -1,0 +1,348 @@
+using System.Data.Common;
+using System.Globalization;
+using AwesomeAssertions;
+using Ahtola.Data.Sqlite;
+using Ahtola.Tests.Oracle;
+using ReferenceSqliteConnection = Microsoft.Data.Sqlite.SqliteConnection;
+
+namespace Ahtola.Tests;
+
+public sealed class OracleFoundationTests
+{
+    private const ulong DefaultRootSeed = 0xa4701a20260827UL;
+
+    [Test]
+    public void GeneratedTypedSequenceMatchesSqlite()
+    {
+        var stream = Stream();
+        var trace = ReplayTrace.Create(TestContext.CurrentContext.Test.Name, stream);
+
+        OracleFailureArtifacts.Run(trace, () =>
+        {
+            using var managed = OpenManaged();
+            using var reference = OpenReference();
+            Differential(
+                managed,
+                reference,
+                trace,
+                """
+                CREATE TABLE generated_values(
+                    id INTEGER PRIMARY KEY,
+                    bucket INTEGER,
+                    score REAL,
+                    label TEXT,
+                    payload BLOB
+                );
+                """);
+
+            for (var id = 1; id <= 24; id++)
+            {
+                var bucket = stream.Random.NextInt32(5) == 0
+                    ? "NULL"
+                    : stream.Random.NextInt32(-3, 4).ToString(CultureInfo.InvariantCulture);
+                var score = (stream.Random.NextInt32(-4096, 4097) / 8d)
+                    .ToString("R", CultureInfo.InvariantCulture);
+                var labels = new[] { "alpha", "βeta", "quote's", string.Empty, "repeat" };
+                var label = SqlText(labels[stream.Random.NextInt32(labels.Length)]);
+                var payload = stream.Random.NextInt32(4) == 0
+                    ? "NULL"
+                    : $"X'{Convert.ToHexString(stream.Random.NextBytes(stream.Random.NextInt32(0, 7)))}'";
+                Differential(
+                    managed,
+                    reference,
+                    trace,
+                    $"INSERT INTO generated_values VALUES ({id}, {bucket}, {score}, {label}, {payload});");
+
+                if (id % 6 == 0)
+                {
+                    Differential(
+                        managed,
+                        reference,
+                        trace,
+                        "SELECT bucket, score, label, payload FROM generated_values "
+                        + $"WHERE id <= {id} AND (bucket IS NULL OR bucket >= 0);",
+                        ordered: false);
+                }
+            }
+
+            var selectedBucket = stream.Random.NextInt32(-3, 4);
+            Differential(
+                managed,
+                reference,
+                trace,
+                $"UPDATE generated_values SET score = score + 0.5 WHERE bucket = {selectedBucket};");
+            Differential(
+                managed,
+                reference,
+                trace,
+                "SELECT id, bucket, score, label, payload, "
+                + "typeof(bucket), typeof(score), typeof(label), typeof(payload) "
+                + "FROM generated_values ORDER BY id;");
+
+            Differential(
+                managed,
+                reference,
+                trace,
+                "SELECT missing_column FROM generated_values;");
+
+            trace.Add(
+                "SELECT rowid AS __oracle_rowid, * FROM generated_values ORDER BY rowid;",
+                "ordered table snapshot");
+            TypedSqliteOracle.AssertEquivalent(
+                TypedSqliteOracle.TableSnapshot(managed, "generated_values"),
+                TypedSqliteOracle.TableSnapshot(reference, "generated_values"),
+                ordered: true,
+                stream.Diagnostics);
+
+            trace.Add(
+                "SELECT type, name, tbl_name, sql FROM sqlite_schema "
+                + "WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name;",
+                "ordered schema snapshot");
+            TypedSqliteOracle.AssertEquivalent(
+                TypedSqliteOracle.SchemaSnapshot(managed),
+                TypedSqliteOracle.SchemaSnapshot(reference),
+                ordered: true,
+                stream.Diagnostics);
+
+            trace.Add("PRAGMA integrity_check;", "integrity");
+            TypedSqliteOracle.AssertIntegrity(managed, stream.Diagnostics);
+            TypedSqliteOracle.AssertIntegrity(reference, stream.Diagnostics);
+        });
+    }
+
+    [Test]
+    public void TernaryLogicPartitionsEveryGeneratedRow()
+    {
+        var stream = Stream();
+        var trace = ReplayTrace.Create(TestContext.CurrentContext.Test.Name, stream);
+
+        OracleFailureArtifacts.Run(trace, () =>
+        {
+            using var connection = OpenManaged();
+            Execute(connection, trace, "CREATE TABLE tlp(id INTEGER PRIMARY KEY, left_value INTEGER, right_value INTEGER, label TEXT);");
+            SeedRows(connection, trace, stream, "tlp", 32);
+
+            const string predicate = "(left_value < right_value OR label = 'hit')";
+            var all = Query(connection, trace, "SELECT id FROM tlp;", "row bag", ordered: false);
+            var partitions = Query(
+                connection,
+                trace,
+                $"""
+                SELECT id FROM tlp WHERE {predicate}
+                UNION ALL
+                SELECT id FROM tlp WHERE NOT ({predicate})
+                UNION ALL
+                SELECT id FROM tlp WHERE ({predicate}) IS NULL;
+                """,
+                "TLP row bag",
+                ordered: false);
+
+            TypedSqliteOracle.AssertEquivalent(all, partitions, ordered: false, stream.Diagnostics);
+        });
+    }
+
+    [Test]
+    public void IndexedAndNotIndexedPlansReturnTheSameRowBag()
+    {
+        var stream = Stream();
+        var trace = ReplayTrace.Create(TestContext.CurrentContext.Test.Name, stream);
+
+        OracleFailureArtifacts.Run(trace, () =>
+        {
+            using var connection = OpenManaged();
+            Execute(connection, trace, "CREATE TABLE indexed_rows(id INTEGER PRIMARY KEY, bucket INTEGER, value INTEGER, label TEXT);");
+            SeedRows(connection, trace, stream, "indexed_rows", 40);
+            Execute(connection, trace, "CREATE INDEX ix_indexed_rows_bucket_value ON indexed_rows(bucket, value);");
+
+            var bucket = stream.Random.NextInt32(-3, 4);
+            var indexed = Query(
+                connection,
+                trace,
+                $"SELECT bucket, value, label FROM indexed_rows INDEXED BY ix_indexed_rows_bucket_value WHERE bucket = {bucket};",
+                "indexed row bag",
+                ordered: false);
+            var scanned = Query(
+                connection,
+                trace,
+                $"SELECT bucket, value, label FROM indexed_rows NOT INDEXED WHERE bucket = {bucket};",
+                "NOT INDEXED row bag",
+                ordered: false);
+
+            TypedSqliteOracle.AssertEquivalent(indexed, scanned, ordered: false, stream.Diagnostics);
+        });
+    }
+
+    [Test]
+    public void FailedWriteLeavesThePreStatementSnapshot()
+    {
+        var stream = Stream();
+        var trace = ReplayTrace.Create(TestContext.CurrentContext.Test.Name, stream);
+
+        OracleFailureArtifacts.Run(trace, () =>
+        {
+            using var connection = OpenManaged();
+            Execute(connection, trace, "CREATE TABLE atomic_rows(id INTEGER PRIMARY KEY, code TEXT UNIQUE);");
+            Execute(connection, trace, "INSERT INTO atomic_rows VALUES (1, 'one'), (2, 'two');");
+            var before = Query(connection, trace, "SELECT id, code FROM atomic_rows ORDER BY id;", "before failed write");
+
+            var failed = Query(
+                connection,
+                trace,
+                "INSERT INTO atomic_rows VALUES (3, 'three'), (4, 'one');",
+                "expected constraint error");
+            failed.Kind.Should().Be(OracleExecutionKind.Error, because: stream.Diagnostics);
+
+            var after = Query(connection, trace, "SELECT id, code FROM atomic_rows ORDER BY id;", "after failed write");
+            TypedSqliteOracle.AssertEquivalent(before, after, ordered: true, stream.Diagnostics);
+        });
+    }
+
+    [Test]
+    public void SavepointRollbackRestoresTheOriginalRows()
+    {
+        var stream = Stream();
+        var trace = ReplayTrace.Create(TestContext.CurrentContext.Test.Name, stream);
+
+        OracleFailureArtifacts.Run(trace, () =>
+        {
+            using var connection = OpenManaged();
+            Execute(
+                connection,
+                trace,
+                "CREATE TABLE savepoint_rows(id INTEGER PRIMARY KEY, value INTEGER, other_value INTEGER, label TEXT);");
+            SeedRows(connection, trace, stream, "savepoint_rows", 20);
+            var before = Query(
+                connection,
+                trace,
+                "SELECT id, value, other_value, label FROM savepoint_rows ORDER BY id;",
+                "before savepoint");
+
+            Execute(connection, trace, "SAVEPOINT generated_changes;");
+            Execute(connection, trace, "UPDATE savepoint_rows SET value = value * -3 WHERE id % 2 = 0;");
+            Execute(connection, trace, "DELETE FROM savepoint_rows WHERE id % 5 = 0;");
+            Execute(connection, trace, "INSERT INTO savepoint_rows VALUES (1001, 42, 84, 'temporary');");
+            Execute(connection, trace, "ROLLBACK TO generated_changes;");
+            Execute(connection, trace, "RELEASE generated_changes;");
+
+            var after = Query(
+                connection,
+                trace,
+                "SELECT id, value, other_value, label FROM savepoint_rows ORDER BY id;",
+                "after rollback");
+            TypedSqliteOracle.AssertEquivalent(before, after, ordered: true, stream.Diagnostics);
+        });
+    }
+
+    [Test]
+    public void UnionAllCardinalityIsTheSumOfItsGeneratedTerms()
+    {
+        var stream = Stream();
+        var trace = ReplayTrace.Create(TestContext.CurrentContext.Test.Name, stream);
+
+        OracleFailureArtifacts.Run(trace, () =>
+        {
+            using var connection = OpenManaged();
+            Execute(connection, trace, "CREATE TABLE union_rows(id INTEGER PRIMARY KEY, bucket INTEGER, value INTEGER, label TEXT);");
+            SeedRows(connection, trace, stream, "union_rows", 36);
+
+            for (var iteration = 0; iteration < 8; iteration++)
+            {
+                var firstBucket = stream.Random.NextInt32(-3, 4);
+                var threshold = stream.Random.NextInt32(-20, 21);
+                var firstSql = $"SELECT id, label FROM union_rows WHERE bucket = {firstBucket}";
+                var secondSql = $"SELECT id, label FROM union_rows WHERE value >= {threshold}";
+                var first = Query(connection, trace, firstSql + ";", "UNION ALL first term", ordered: false);
+                var second = Query(connection, trace, secondSql + ";", "UNION ALL second term", ordered: false);
+                var union = Query(
+                    connection,
+                    trace,
+                    firstSql + " UNION ALL " + secondSql + ";",
+                    "UNION ALL result",
+                    ordered: false);
+
+                union.Kind.Should().Be(OracleExecutionKind.Success, because: stream.Diagnostics);
+                union.Rows.Count.Should().Be(first.Rows.Count + second.Rows.Count, because: stream.Diagnostics);
+            }
+        });
+    }
+
+    private static StableRandomStream Stream()
+        => StableTestSeed.Create(DefaultRootSeed).Derive(TestContext.CurrentContext.Test.Name);
+
+    private static SqliteConnection OpenManaged()
+    {
+        var connection = new SqliteConnection("Data Source=:memory:;Local Provider=Managed");
+        connection.Open();
+        return connection;
+    }
+
+    private static ReferenceSqliteConnection OpenReference()
+    {
+        var connection = new ReferenceSqliteConnection("Data Source=:memory:");
+        connection.Open();
+        return connection;
+    }
+
+    private static void Differential(
+        DbConnection managed,
+        DbConnection reference,
+        ReplayTrace trace,
+        string sql,
+        bool ordered = true)
+    {
+        trace.Add(sql, ordered ? "typed ordered differential" : "typed unordered row-bag differential", ordered);
+        TypedSqliteOracle.AssertEquivalent(
+            TypedSqliteOracle.Execute(managed, sql),
+            TypedSqliteOracle.Execute(reference, sql),
+            ordered,
+            $"{trace.SeedDiagnostics}; operation={trace.Operations.Count - 1}; SQL={sql}");
+    }
+
+    private static void Execute(DbConnection connection, ReplayTrace trace, string sql)
+    {
+        var result = Query(connection, trace, sql, "managed execution");
+        if (result.Kind != OracleExecutionKind.Success)
+        {
+            throw new AssertionException(
+                $"Managed setup failed: category={result.Error!.Category}, code={result.Error.SqliteErrorCode}, "
+                + $"message={result.Error.Message}{Environment.NewLine}{trace.SeedDiagnostics}{Environment.NewLine}SQL={sql}");
+        }
+    }
+
+    private static OracleExecutionResult Query(
+        DbConnection connection,
+        ReplayTrace trace,
+        string sql,
+        string comparison,
+        bool ordered = true)
+    {
+        trace.Add(sql, comparison, ordered);
+        return TypedSqliteOracle.Execute(connection, sql);
+    }
+
+    private static void SeedRows(
+        DbConnection connection,
+        ReplayTrace trace,
+        StableRandomStream stream,
+        string table,
+        int count)
+    {
+        for (var id = 1; id <= count; id++)
+        {
+            var left = stream.Random.NextInt32(5) == 0
+                ? "NULL"
+                : stream.Random.NextInt32(-12, 13).ToString(CultureInfo.InvariantCulture);
+            var right = stream.Random.NextInt32(5) == 0
+                ? "NULL"
+                : stream.Random.NextInt32(-12, 13).ToString(CultureInfo.InvariantCulture);
+            var label = stream.Random.NextInt32(6) == 0 ? "hit" : $"group-{stream.Random.NextInt32(4)}";
+            Execute(
+                connection,
+                trace,
+                $"INSERT INTO \"{table}\" VALUES ({id}, {left}, {right}, {SqlText(label)});");
+        }
+    }
+
+    private static string SqlText(string value)
+        => "'" + value.Replace("'", "''", StringComparison.Ordinal) + "'";
+}

--- a/src/Ahtola.Tests/OracleInfrastructureTests.cs
+++ b/src/Ahtola.Tests/OracleInfrastructureTests.cs
@@ -1,0 +1,63 @@
+using AwesomeAssertions;
+using Ahtola.Tests.Oracle;
+
+namespace Ahtola.Tests;
+
+public sealed class OracleInfrastructureTests
+{
+    [Test]
+    public void StablePrngMatchesItsCrossRuntimeGoldenSequence()
+    {
+        var random = new StablePrng(0x0123456789abcdefUL);
+
+        new[] { random.NextUInt64(), random.NextUInt64(), random.NextUInt64(), random.NextUInt64() }
+            .Should().Equal(
+                0x157a3807a48faa9dUL,
+                0xd573529b34a1d093UL,
+                0x2f90b72e996dccbeUL,
+                0xa2d419334c4667ecUL);
+    }
+
+    [Test]
+    public void ReplayTraceRoundTripsWithoutLosingSqlOrSeedDiagnostics()
+    {
+        var stream = StableTestSeed.Create(42).Derive("trace-round-trip");
+        var trace = ReplayTrace.Create(TestContext.CurrentContext.Test.Name, stream);
+        trace.Add("SELECT 1;", "typed ordered differential");
+        trace.AddScheduleStep(new CooperativeScheduleStep(
+            0,
+            1,
+            7,
+            "reader",
+            "reader.before-read",
+            0,
+            [2, 7],
+            3));
+
+        var restored = ReplayTrace.FromJson(trace.ToJson());
+
+        restored.RootSeed.Should().Be(stream.RootSeed, because: stream.Diagnostics);
+        restored.StreamSeed.Should().Be(stream.Seed, because: stream.Diagnostics);
+        restored.SeedDiagnostics.Should().Be(stream.Diagnostics);
+        restored.Operations.Should().Equal(trace.Operations);
+        restored.ScheduleChoices.Should().Equal(1);
+        restored.Schedule.Should().BeEquivalentTo(trace.Schedule, options => options.WithStrictOrdering());
+        restored.ToSql().Should().Contain("SELECT 1;")
+            .And.Contain("AHTOLA_TEST_SEED")
+            .And.Contain("schedule choices=[1]")
+            .And.Contain("yield=reader.before-read#0");
+    }
+
+    [Test]
+    public void UnorderedComparisonDetectsMissingDuplicateRows()
+    {
+        var duplicate = new OracleRow([OracleValue.Integer(7), OracleValue.Text("same")]);
+        var twoRows = OracleExecutionResult.Success(true, ["value", "label"], [duplicate, duplicate]);
+        var oneRow = OracleExecutionResult.Success(true, ["value", "label"], [duplicate]);
+
+        var error = Assert.Throws<AssertionException>(
+            () => TypedSqliteOracle.AssertEquivalent(twoRows, oneRow, ordered: false, "multiplicity probe"));
+
+        error!.Message.Should().Contain("row-bag mismatch").And.Contain("=> 1");
+    }
+}

--- a/src/Ahtola.Tests/ParameterCollectionContractTests.cs
+++ b/src/Ahtola.Tests/ParameterCollectionContractTests.cs
@@ -1,0 +1,122 @@
+using System.Data.Common;
+using Ahtola.Data.Sqlite;
+using AwesomeAssertions;
+
+namespace Ahtola.Tests;
+
+public sealed class ParameterCollectionContractTests
+{
+    [Test]
+    public void AhtolaCollectionSupportsLookupCopyInsertionAndRemoval()
+    {
+        var collection = new AhtolaParameterCollection();
+        var first = new AhtolaParameter("@first", 1L);
+        var third = new AhtolaParameter("@third", 3L);
+
+        collection.Add(first).Should().Be(0);
+        collection.Add(2L).Should().Be(1);
+        collection.AddRange(new object[] { third, 4L });
+        var fifth = collection.AddWithValue("@fifth", 5L);
+        collection.Insert(1, new AhtolaParameter("@inserted", 10L));
+
+        collection.Count.Should().Be(6);
+        collection.SyncRoot.Should().NotBeNull();
+        collection.Contains(first).Should().BeTrue();
+        collection.Contains(2L).Should().BeTrue();
+        collection.Contains("@FIRST").Should().BeFalse();
+        collection.Contains("@first").Should().BeTrue();
+        collection.IndexOf(first).Should().Be(0);
+        collection.IndexOf(2L).Should().Be(2);
+        collection.IndexOf("@third").Should().Be(3);
+
+        var copied = new AhtolaParameter[collection.Count + 1];
+        collection.CopyTo(copied, 1);
+        copied[1].Should().BeSameAs(first);
+        copied[^1].Should().BeSameAs(fifth);
+        collection.Cast<AhtolaParameter>().Should().HaveCount(6);
+
+        collection.Remove(2L);
+        collection.RemoveAt("@inserted");
+        collection.RemoveAt(collection.IndexOf(fifth));
+        collection.Cast<AhtolaParameter>().Select(static parameter => parameter.Value)
+            .Should().Equal(1L, 3L, 4L);
+
+        collection.Clear();
+        collection.Count.Should().Be(0);
+    }
+
+    [Test]
+    public void AhtolaCollectionRejectsMissingAndWrongProviderParameters()
+    {
+        DbParameterCollection collection = new AhtolaParameterCollection
+        {
+            new AhtolaParameter("@value", 1L),
+        };
+
+        collection[0] = new AhtolaParameter("@replacement", 2L);
+        collection["@replacement"] = new AhtolaParameter("@renamed", 3L);
+        collection[0].Value.Should().Be(3L);
+
+        Assert.Throws<ArgumentException>(() => collection[0] = new SqliteParameter("@wrong", 4L));
+        Assert.Throws<ArgumentException>(() => collection["@missing"] = new AhtolaParameter("@value", 5L));
+        Assert.Throws<ArgumentException>(() => collection.Remove("@missing-value"));
+        Assert.Throws<ArgumentException>(() => collection.RemoveAt("@missing"));
+        Assert.Throws<ArgumentException>(() => _ = collection["@missing"]);
+        Assert.Throws<ArgumentNullException>(() => collection.CopyTo(null!, 0));
+    }
+
+    [Test]
+    public void SqliteCollectionSupportsTypedOverloadsAndCaseInsensitiveLookup()
+    {
+        var collection = new SqliteParameterCollection();
+        var id = collection.Add("$id", SqliteType.Integer);
+        var payload = collection.Add("$payload", SqliteType.Blob, 128);
+        var name = collection.AddWithValue("$name", "ahtola");
+
+        collection.AddRange(new object[] { new SqliteParameter("$rank", 4L), 5L });
+        collection.Insert(1, new SqliteParameter("$inserted", 10L));
+
+        collection.Count.Should().Be(6);
+        collection.SyncRoot.Should().NotBeNull();
+        id.SqliteType.Should().Be(SqliteType.Integer);
+        payload.SqliteType.Should().Be(SqliteType.Blob);
+        payload.Size.Should().Be(128);
+        collection["$NAME"].Should().BeSameAs(name);
+        collection.Contains("$ID").Should().BeTrue();
+        collection.Contains(id).Should().BeTrue();
+        collection.Contains(5L).Should().BeTrue();
+        collection.IndexOf("$PAYLOAD").Should().Be(2);
+        collection.IndexOf(4L).Should().Be(4);
+
+        var copied = new SqliteParameter[collection.Count];
+        collection.CopyTo(copied, 0);
+        copied.Should().Equal(collection.Cast<SqliteParameter>());
+
+        collection.Remove(5L);
+        collection.RemoveAt("$INSERTED");
+        collection.RemoveAt(collection.IndexOf("$rank"));
+        collection.Cast<SqliteParameter>().Select(static parameter => parameter.ParameterName)
+            .Should().Equal("$id", "$payload", "$name");
+    }
+
+    [Test]
+    public void SqliteCollectionRejectsMissingAndWrongProviderParameters()
+    {
+        DbParameterCollection collection = new SqliteParameterCollection
+        {
+            new SqliteParameter("$value", 1L),
+        };
+
+        collection[0] = new SqliteParameter("$replacement", 2L);
+        collection["$REPLACEMENT"] = new SqliteParameter("$renamed", 3L);
+        collection[0].Value.Should().Be(3L);
+
+        Assert.Throws<ArgumentException>(() => collection[0] = new AhtolaParameter("@wrong", 4L));
+        Assert.Throws<ArgumentException>(() => collection["$missing"] = new SqliteParameter("$value", 5L));
+        Assert.Throws<ArgumentException>(() => collection.Remove("$missing-value"));
+        Assert.Throws<ArgumentException>(() => collection.RemoveAt("$missing"));
+        Assert.Throws<ArgumentException>(() => _ = collection["$missing"]);
+        Assert.Throws<ArgumentNullException>(() => collection.AddRange(null!));
+        Assert.Throws<ArgumentNullException>(() => collection.CopyTo(null!, 0));
+    }
+}

--- a/src/Ahtola.Tests/SqliteWalProcessIsolationHarnessTests.cs
+++ b/src/Ahtola.Tests/SqliteWalProcessIsolationHarnessTests.cs
@@ -6,6 +6,7 @@ using AwesomeAssertions;
 using Microsoft.Data.Sqlite;
 using Ahtola.Core;
 using Ahtola.Core.Storage;
+using Ahtola.Tests.Infrastructure;
 
 namespace Ahtola.Tests;
 
@@ -504,7 +505,14 @@ public sealed class SqliteWalProcessIsolationHarnessTests
         long? lockOffset = null,
         bool holdLease = true,
         CheckpointWindow? checkpointWindow = null)
-        => new(artifact.WorkDirectory, artifact.DatabasePath, operation, lockOffset, holdLease, checkpointWindow);
+        => new(
+            artifact.WorkDirectory,
+            artifact.DatabasePath,
+            operation,
+            lockOffset,
+            holdLease,
+            checkpointWindow,
+            artifact.ProcessTrace);
 
     private static CommittedWritePages ReadCommittedWritePages(string databasePath)
     {
@@ -770,11 +778,14 @@ public sealed class SqliteWalProcessIsolationHarnessTests
         {
             WorkDirectory = workDirectory;
             DatabasePath = databasePath;
+            ProcessTrace = new ProcessLifecycleTrace(Path.Combine(workDirectory, "process-lifecycle.jsonl"));
         }
 
         internal string WorkDirectory { get; }
 
         internal string DatabasePath { get; }
+
+        internal ProcessLifecycleTrace ProcessTrace { get; }
 
         internal static DetachedSqliteWalArtifact Create()
         {
@@ -939,6 +950,8 @@ public sealed class SqliteWalProcessIsolationHarnessTests
         private readonly string _pausePath;
         private readonly string _resultPath;
         private readonly StringBuilder _output = new();
+        private readonly ProcessLifecycleTrace _trace;
+        private readonly string _operation;
         private bool _completed;
         private bool _released;
 
@@ -948,8 +961,11 @@ public sealed class SqliteWalProcessIsolationHarnessTests
             string operation,
             long? lockOffset,
             bool holdLease,
-            CheckpointWindow? checkpointWindow)
+            CheckpointWindow? checkpointWindow,
+            ProcessLifecycleTrace trace)
         {
+            _trace = trace;
+            _operation = operation;
             var token = Guid.NewGuid().ToString("N");
             _readyPath = Path.Combine(workDirectory, $"wal-process-ready-{token}");
             _releasePath = Path.Combine(workDirectory, $"wal-process-release-{token}");
@@ -987,6 +1003,7 @@ public sealed class SqliteWalProcessIsolationHarnessTests
 
             _process = Process.Start(startInfo)
                 ?? throw new InvalidOperationException("Failed to start the WAL process harness worker.");
+            _trace.RecordStart("wal-worker", operation);
             _process.OutputDataReceived += AppendOutput;
             _process.ErrorDataReceived += AppendOutput;
             _process.BeginOutputReadLine();
@@ -997,11 +1014,15 @@ public sealed class SqliteWalProcessIsolationHarnessTests
         internal string ReadResult()
         {
             WaitForSignal(_resultPath, "The WAL process harness worker did not report a result.");
+            _trace.RecordOperation("wal-worker", "read-result", _operation);
             return File.ReadAllText(_resultPath);
         }
 
         internal void SignalGo()
-            => File.WriteAllText(_goPath, string.Empty);
+        {
+            _trace.RecordOperation("wal-worker", "signal-go", _operation);
+            File.WriteAllText(_goPath, string.Empty);
+        }
 
         internal void WaitForPause()
             => WaitForSignal(_pausePath, "The WAL process harness worker did not reach its pause point.");
@@ -1010,6 +1031,7 @@ public sealed class SqliteWalProcessIsolationHarnessTests
         {
             if (!_released)
             {
+                _trace.RecordOperation("wal-worker", "release", _operation);
                 File.WriteAllText(_releasePath, string.Empty);
                 _released = true;
             }
@@ -1019,12 +1041,10 @@ public sealed class SqliteWalProcessIsolationHarnessTests
 
         internal void Abort()
         {
+            _trace.RecordOperation("wal-worker", "abort", _operation);
             if (!_process.HasExited)
                 _process.Kill(entireProcessTree: true);
-            if (!_process.WaitForExit(WorkerTimeout))
-                Assert.Fail($"The WAL process harness worker did not terminate:{Environment.NewLine}{DrainOutput()}");
-            // Drain async stdout/stderr callbacks after the kill so Dispose is quiet.
-            _process.WaitForExit();
+            _trace.WaitForExit(_process, WorkerTimeout, "wal-worker", _operation, DrainOutput);
             _completed = true;
             // Windows can retain byte-range locks and section objects briefly after the
             // process image exits; give the kernel a moment before the parent reopens.
@@ -1037,14 +1057,10 @@ public sealed class SqliteWalProcessIsolationHarnessTests
             if (_completed)
                 return;
 
-            if (!_process.WaitForExit(WorkerTimeout))
-            {
-                _process.Kill(entireProcessTree: true);
-                Assert.Fail($"The WAL process harness worker did not exit:{Environment.NewLine}{DrainOutput()}");
-            }
-
-            _process.WaitForExit();
-            _process.ExitCode.Should().Be(0, $"worker output:{Environment.NewLine}{DrainOutput()}");
+            _trace.WaitForExit(_process, WorkerTimeout, "wal-worker", _operation, DrainOutput);
+            _process.ExitCode.Should().Be(
+                0,
+                $"worker output:{Environment.NewLine}{DrainOutput()}{Environment.NewLine}{_trace.ReplayDiagnostics()}");
             _completed = true;
         }
 
@@ -1063,21 +1079,20 @@ public sealed class SqliteWalProcessIsolationHarnessTests
 
         private void WaitForSignal(string path, string failureMessage)
         {
-            var stopwatch = Stopwatch.StartNew();
-            while (!File.Exists(path))
+            try
             {
-                if (_process.HasExited)
-                {
-                    _process.WaitForExit();
-                    Assert.Fail($"{failureMessage}{Environment.NewLine}{DrainOutput()}");
-                }
-                if (stopwatch.Elapsed >= WorkerTimeout)
-                {
-                    _process.Kill(entireProcessTree: true);
-                    Assert.Fail($"{failureMessage}{Environment.NewLine}{DrainOutput()}");
-                }
-
-                Thread.Sleep(TimeSpan.FromMilliseconds(10));
+                _trace.WaitUntil(
+                    () => File.Exists(path),
+                    WorkerTimeout,
+                    "wal-worker",
+                    System.IO.Path.GetFileName(path),
+                    _process,
+                    DrainOutput);
+            }
+            catch (Exception exception) when (exception is TimeoutException or InvalidOperationException)
+            {
+                Assert.Fail(
+                    $"{failureMessage}{Environment.NewLine}{DrainOutput()}{Environment.NewLine}{_trace.ReplayDiagnostics()}");
             }
         }
 

--- a/src/Ahtola.Tests/Sqltest/SqltestCorpus.cs
+++ b/src/Ahtola.Tests/Sqltest/SqltestCorpus.cs
@@ -33,6 +33,7 @@ internal sealed record SqltestDiscoveredCase(
 internal static class SqltestCorpus
 {
     private const string ExpectedFailuresFileName = "managed-sqltest-expected-failures.txt";
+    private const string HarnessExclusionsFileName = "managed-sqltest-harness-exclusions.txt";
 
     private static readonly HashSet<string> ManagedCapabilities =
         new(StringComparer.Ordinal) { "trigger", "strict" };
@@ -42,12 +43,18 @@ internal static class SqltestCorpus
     private static readonly Lazy<IReadOnlyDictionary<string, string>> LazyExpectedFailures =
         new(LoadExpectedFailures);
 
+    private static readonly Lazy<IReadOnlyDictionary<string, string>> LazyHarnessExclusions =
+        new(() => LoadReasonFile(HarnessExclusionsFileName));
+
     private static readonly ConcurrentDictionary<string, SqltestFile> ParsedFiles = new(StringComparer.Ordinal);
 
     public static IReadOnlyList<SqltestDiscoveredCase> Cases => LazyCases.Value;
 
     /// <summary>Case id to the reason the managed engine currently fails it.</summary>
     public static IReadOnlyDictionary<string, string> ExpectedFailures => LazyExpectedFailures.Value;
+
+    /// <summary>Case id to a reviewed reason it cannot be bounded by the in-process harness.</summary>
+    public static IReadOnlyDictionary<string, string> HarnessExclusions => LazyHarnessExclusions.Value;
 
     public static string ExpectedFailuresSourcePath =>
         Path.Combine(ResolveTestProjectDirectory(), "Conformance", ExpectedFailuresFileName);
@@ -87,10 +94,9 @@ internal static class SqltestCorpus
                 continue;
             }
 
-            var fileReason = DescribeFileLimitation(file);
             foreach (var test in file.Tests)
             {
-                var (status, reason) = Classify(file, test, fileReason);
+                var (status, reason) = Classify(file, test);
                 discovered.Add(new SqltestDiscoveredCase(relativePath, fullPath, test.Name, status, reason));
             }
         }
@@ -98,30 +104,33 @@ internal static class SqltestCorpus
         return discovered;
     }
 
-    private static string? DescribeFileLimitation(SqltestFile file)
+    internal static string? DescribeFileLimitation(SqltestFile file)
     {
         if (file.Databases.Count == 0)
             return "the file declares no @database";
 
-        if (file.Databases.Count > 1)
-            return "the managed harness runs one @database configuration per file";
-
-        var database = file.Databases[0];
-        return database.Kind switch
+        foreach (var database in file.Databases)
         {
-            SqltestDatabaseKind.Default or SqltestDatabaseKind.DefaultNoRowidAlias =>
-                "the generated :default: fixture is produced by the Rust runner's seeded data generator",
-            SqltestDatabaseKind.Path =>
-                "the fixture database is produced by the Rust runner's generator",
-            _ => null,
-        };
+            if (database.Kind == SqltestDatabaseKind.Path)
+            {
+                return
+                    $"path fixture '{database.Path}' has no equivalent managed generator; " +
+                    "Turso's integrity fixtures are produced by explicit page-corruption routines";
+            }
+        }
+
+        return null;
     }
 
-    private static (SqltestCaseStatus Status, string? Reason) Classify(
+    internal static (SqltestCaseStatus Status, string? Reason) Classify(
         SqltestFile file,
-        SqltestCase test,
-        string? fileLimitation)
+        SqltestCase test)
     {
+        var id = $"{file.RelativePath}::{test.Name}";
+        if (HarnessExclusions.TryGetValue(id, out var exclusionReason))
+            return (SqltestCaseStatus.UnsupportedHarness, exclusionReason);
+
+        var fileLimitation = DescribeFileLimitation(file);
         if (fileLimitation is not null)
             return (SqltestCaseStatus.UnsupportedHarness, fileLimitation);
 
@@ -147,8 +156,11 @@ internal static class SqltestCorpus
     }
 
     private static IReadOnlyDictionary<string, string> LoadExpectedFailures()
+        => LoadReasonFile(ExpectedFailuresFileName);
+
+    private static IReadOnlyDictionary<string, string> LoadReasonFile(string fileName)
     {
-        var path = ResolveExpectedFailuresPath();
+        var path = ResolveReasonFilePath(fileName);
         var entries = new Dictionary<string, string>(StringComparer.Ordinal);
         foreach (var line in File.ReadLines(path))
         {
@@ -169,13 +181,14 @@ internal static class SqltestCorpus
         return entries;
     }
 
-    private static string ResolveExpectedFailuresPath()
+    private static string ResolveReasonFilePath(string fileName)
     {
         var copied = Path.Combine(
             TestContext.CurrentContext.TestDirectory,
             "Conformance",
-            ExpectedFailuresFileName);
-        return File.Exists(copied) ? copied : ExpectedFailuresSourcePath;
+            fileName);
+        var source = Path.Combine(ResolveTestProjectDirectory(), "Conformance", fileName);
+        return File.Exists(copied) ? copied : source;
     }
 
     private static string ResolveCorpusRoot()

--- a/src/Ahtola.Tests/Sqltest/SqltestDefaultDatabaseGenerator.cs
+++ b/src/Ahtola.Tests/Sqltest/SqltestDefaultDatabaseGenerator.cs
@@ -1,0 +1,422 @@
+using System.Buffers.Binary;
+using System.Globalization;
+using System.Numerics;
+using System.Text;
+using Ahtola.Core;
+
+namespace Ahtola.Tests.Sqltest;
+
+internal sealed record SqltestGeneratedUser(
+    string FirstName,
+    string LastName,
+    string Email,
+    string PhoneNumber,
+    string Address,
+    string City,
+    string State,
+    string Zipcode,
+    long Age);
+
+internal sealed record SqltestGeneratedProduct(string Name, double Price);
+
+internal sealed record SqltestGeneratedData(
+    IReadOnlyList<SqltestGeneratedUser> Users,
+    IReadOnlyList<SqltestGeneratedProduct> Products);
+
+/// <summary>
+/// Managed port of Turso's deterministic default sqltest database generator.
+/// The seed, schema, generation order, fake-data providers, and ChaCha8 stream
+/// mirror <c>testing/sqltest/src/generator/mod.rs</c>.
+/// </summary>
+internal static class SqltestDefaultDatabaseGenerator
+{
+    internal const ulong DefaultSeed = 42;
+    internal const int DefaultUserCount = 10_000;
+
+    private static readonly string[] ProductNames =
+    [
+        "hat", "cap", "shirt", "sweater", "sweatshirt", "shorts",
+        "jeans", "sneakers", "boots", "coat", "accessories",
+    ];
+
+    private static readonly Lazy<string> DefaultPath =
+        new(() => GenerateCached(noRowidAlias: false), LazyThreadSafetyMode.ExecutionAndPublication);
+
+    private static readonly Lazy<string> NoRowidAliasPath =
+        new(() => GenerateCached(noRowidAlias: true), LazyThreadSafetyMode.ExecutionAndPublication);
+
+    private static readonly string FixtureDirectory = Path.Combine(
+        TestContext.CurrentContext.WorkDirectory,
+        ".sqltest-default-fixtures",
+        Environment.ProcessId.ToString(CultureInfo.InvariantCulture));
+
+    static SqltestDefaultDatabaseGenerator()
+        => AppDomain.CurrentDomain.ProcessExit += static (_, _) => TryDeleteFixtureDirectory();
+
+    public static string GetDefaultPath(bool noRowidAlias)
+        => noRowidAlias ? NoRowidAliasPath.Value : DefaultPath.Value;
+
+    internal static SqltestGeneratedData GenerateData(int userCount, ulong seed = DefaultSeed)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(userCount);
+        var random = new ChaCha8Random(seed);
+        var users = new SqltestGeneratedUser[userCount];
+        for (var index = 0; index < users.Length; index++)
+            users[index] = GenerateUser(random);
+
+        var products = ProductNames
+            .Select(name => new SqltestGeneratedProduct(name, random.NextDoubleInclusive(1.0, 100.0)))
+            .ToArray();
+        return new SqltestGeneratedData(users, products);
+    }
+
+    internal static void GenerateDatabase(
+        string path,
+        bool noRowidAlias,
+        int userCount = DefaultUserCount,
+        ulong seed = DefaultSeed)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        DeleteDatabase(path);
+        var data = GenerateData(userCount, seed);
+
+        using var database = EmbeddedDatabase.OpenFile(path);
+        using var connection = database.Connect();
+        Execute(connection, "BEGIN");
+        try
+        {
+            var primaryKey = noRowidAlias ? "INT PRIMARY KEY" : "INTEGER PRIMARY KEY";
+            Execute(
+                connection,
+                $"""
+                 CREATE TABLE users (
+                     id {primaryKey},
+                     first_name TEXT,
+                     last_name TEXT,
+                     email TEXT,
+                     phone_number TEXT,
+                     address TEXT,
+                     city TEXT,
+                     state TEXT,
+                     zipcode TEXT,
+                     age INTEGER
+                 );
+                 CREATE TABLE products (
+                     id {primaryKey},
+                     name TEXT,
+                     price REAL
+                 );
+                 """);
+            if (!noRowidAlias)
+                Execute(connection, "CREATE INDEX age_idx ON users (age);");
+
+            var userSql = noRowidAlias
+                ? """
+                  INSERT INTO users
+                    (id, first_name, last_name, email, phone_number, address, city, state, zipcode, age)
+                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+                  """
+                : """
+                  INSERT INTO users
+                    (first_name, last_name, email, phone_number, address, city, state, zipcode, age)
+                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+                  """;
+            using (var insertUser = connection.Prepare(userSql))
+            {
+                for (var index = 0; index < data.Users.Count; index++)
+                {
+                    var user = data.Users[index];
+                    var offset = noRowidAlias ? 1 : 0;
+                    if (noRowidAlias)
+                        insertUser.Bind(1, SqlValue.Integer(index + 1));
+                    insertUser.Bind(offset + 1, SqlValue.Text(user.FirstName));
+                    insertUser.Bind(offset + 2, SqlValue.Text(user.LastName));
+                    insertUser.Bind(offset + 3, SqlValue.Text(user.Email));
+                    insertUser.Bind(offset + 4, SqlValue.Text(user.PhoneNumber));
+                    insertUser.Bind(offset + 5, SqlValue.Text(user.Address));
+                    insertUser.Bind(offset + 6, SqlValue.Text(user.City));
+                    insertUser.Bind(offset + 7, SqlValue.Text(user.State));
+                    insertUser.Bind(offset + 8, SqlValue.Text(user.Zipcode));
+                    insertUser.Bind(offset + 9, SqlValue.Integer(user.Age));
+                    _ = insertUser.Step();
+                    insertUser.Reset();
+                }
+            }
+
+            var productSql = noRowidAlias
+                ? "INSERT INTO products (id, name, price) VALUES (?1, ?2, ?3)"
+                : "INSERT INTO products (name, price) VALUES (?1, ?2)";
+            using (var insertProduct = connection.Prepare(productSql))
+            {
+                for (var index = 0; index < data.Products.Count; index++)
+                {
+                    var product = data.Products[index];
+                    var offset = noRowidAlias ? 1 : 0;
+                    if (noRowidAlias)
+                        insertProduct.Bind(1, SqlValue.Integer(index + 1));
+                    insertProduct.Bind(offset + 1, SqlValue.Text(product.Name));
+                    insertProduct.Bind(offset + 2, SqlValue.Real(product.Price));
+                    _ = insertProduct.Step();
+                    insertProduct.Reset();
+                }
+            }
+
+            Execute(connection, "COMMIT");
+        }
+        catch
+        {
+            try
+            {
+                Execute(connection, "ROLLBACK");
+            }
+            catch (Exception)
+            {
+                // Preserve the generation failure.
+            }
+
+            throw;
+        }
+    }
+
+    private static string GenerateCached(bool noRowidAlias)
+    {
+        var path = Path.Combine(
+            FixtureDirectory,
+            noRowidAlias ? "database-no-rowidalias.db" : "database.db");
+        GenerateDatabase(path, noRowidAlias);
+        return path;
+    }
+
+    private static void TryDeleteFixtureDirectory()
+    {
+        try
+        {
+            if (Directory.Exists(FixtureDirectory))
+                Directory.Delete(FixtureDirectory, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    private static SqltestGeneratedUser GenerateUser(ChaCha8Random random)
+    {
+        var firstName = random.Choose(SqltestFakeEnglishData.FirstNames);
+        var lastName = random.Choose(SqltestFakeEnglishData.LastNames);
+        var emailName = random.Choose(SqltestFakeEnglishData.FirstNames).ToLowerInvariant();
+        var email = $"{emailName}@example.{random.Choose(SqltestFakeEnglishData.SafeEmailDomains)}";
+        var phone = Numerify(random.Choose(SqltestFakeEnglishData.PhoneNumberFormats), random);
+
+        var streetName = random.NextBoolean()
+            ? random.Choose(SqltestFakeEnglishData.FirstNames)
+            : random.Choose(SqltestFakeEnglishData.LastNames);
+        var address = $"{streetName} {random.Choose(SqltestFakeEnglishData.StreetSuffixes)}";
+
+        string city;
+        switch (random.NextUInt32Inclusive(0, 4))
+        {
+            case 0:
+                city =
+                    $"{random.Choose(SqltestFakeEnglishData.CityPrefixes)} " +
+                    $"{random.Choose(SqltestFakeEnglishData.FirstNames)} " +
+                    $"{random.Choose(SqltestFakeEnglishData.LastNames)} " +
+                    $"{random.Choose(SqltestFakeEnglishData.CitySuffixes)}";
+                break;
+            case 1:
+                city =
+                    $"{random.Choose(SqltestFakeEnglishData.FirstNames)} " +
+                    $"{random.Choose(SqltestFakeEnglishData.CitySuffixes)}";
+                break;
+            default:
+                city =
+                    $"{random.Choose(SqltestFakeEnglishData.LastNames)} " +
+                    $"{random.Choose(SqltestFakeEnglishData.CitySuffixes)}";
+                break;
+        }
+
+        return new SqltestGeneratedUser(
+            firstName,
+            lastName,
+            email,
+            phone,
+            address,
+            city,
+            random.Choose(SqltestFakeEnglishData.StateAbbreviations),
+            Numerify(random.Choose(SqltestFakeEnglishData.ZipFormats), random),
+            checked((long)random.NextUInt64Inclusive(1, 100)));
+    }
+
+    private static string Numerify(string format, ChaCha8Random random)
+    {
+        var result = new StringBuilder(format.Length);
+        foreach (var character in format)
+        {
+            result.Append(character switch
+            {
+                '^' => (char)('0' + random.NextUInt32Inclusive(1, 9)),
+                '#' => (char)('0' + random.NextUInt32Inclusive(0, 9)),
+                _ => character,
+            });
+        }
+
+        return result.ToString();
+    }
+
+    private static void Execute(EmbeddedConnection connection, string sql)
+    {
+        foreach (var statement in connection.PrepareScript(sql))
+        {
+            using (statement)
+            {
+                while (statement.Step() == StatementStepResult.Row)
+                {
+                }
+            }
+        }
+    }
+
+    private static void DeleteDatabase(string path)
+    {
+        foreach (var suffix in new[] { string.Empty, "-wal", "-shm" })
+            File.Delete(path + suffix);
+    }
+
+    private sealed class ChaCha8Random
+    {
+        private readonly uint[] _key = new uint[8];
+        private readonly uint[] _buffer = new uint[64];
+        private ulong _counter;
+        private int _index = 64;
+
+        public ChaCha8Random(ulong seed)
+        {
+            Span<byte> key = stackalloc byte[32];
+            var state = seed;
+            for (var offset = 0; offset < key.Length; offset += sizeof(uint))
+            {
+                state = unchecked(state * 6_364_136_223_846_793_005UL + 11_634_580_027_462_260_723UL);
+                var xorshifted = (uint)(((state >> 18) ^ state) >> 27);
+                var rotation = (int)(state >> 59);
+                BinaryPrimitives.WriteUInt32LittleEndian(
+                    key[offset..],
+                    BitOperations.RotateRight(xorshifted, rotation));
+            }
+
+            for (var index = 0; index < _key.Length; index++)
+                _key[index] = BinaryPrimitives.ReadUInt32LittleEndian(key[(index * sizeof(uint))..]);
+        }
+
+        public T Choose<T>(IReadOnlyList<T> values)
+            => values[checked((int)NextUInt32Inclusive(0, checked((uint)values.Count - 1)))];
+
+        public bool NextBoolean() => unchecked((int)NextUInt32()) < 0;
+
+        public uint NextUInt32Inclusive(uint low, uint high)
+        {
+            var range = unchecked(high - low + 1);
+            if (range == 0)
+                return NextUInt32();
+            var product = (ulong)NextUInt32() * range;
+            var result = (uint)(product >> 32);
+            var lowOrder = (uint)product;
+            if (lowOrder > unchecked(0U - range))
+            {
+                var newProduct = (ulong)NextUInt32() * range;
+                if (unchecked(lowOrder + (uint)(newProduct >> 32)) < lowOrder)
+                    result++;
+            }
+
+            return unchecked(low + result);
+        }
+
+        public ulong NextUInt64Inclusive(ulong low, ulong high)
+        {
+            var range = unchecked(high - low + 1);
+            if (range == 0)
+                return NextUInt64();
+            var product = (UInt128)NextUInt64() * range;
+            var result = (ulong)(product >> 64);
+            var lowOrder = (ulong)product;
+            if (lowOrder > unchecked(0UL - range))
+            {
+                var newProduct = (UInt128)NextUInt64() * range;
+                if (unchecked(lowOrder + (ulong)(newProduct >> 64)) < lowOrder)
+                    result++;
+            }
+
+            return unchecked(low + result);
+        }
+
+        public double NextDoubleInclusive(double low, double high)
+        {
+            var bits = (NextUInt64() >> 12) | 0x3FF0_0000_0000_0000UL;
+            var zeroToOne = BitConverter.UInt64BitsToDouble(bits) - 1.0;
+            return zeroToOne * (high - low) + low;
+        }
+
+        private uint NextUInt32()
+        {
+            if (_index == _buffer.Length)
+                Refill();
+            return _buffer[_index++];
+        }
+
+        private ulong NextUInt64()
+        {
+            var low = NextUInt32();
+            var high = NextUInt32();
+            return ((ulong)high << 32) | low;
+        }
+
+        private void Refill()
+        {
+            Span<uint> state = stackalloc uint[16];
+            Span<uint> working = stackalloc uint[16];
+            for (var block = 0; block < 4; block++)
+            {
+                state[0] = 0x61707865;
+                state[1] = 0x3320646E;
+                state[2] = 0x79622D32;
+                state[3] = 0x6B206574;
+                _key.CopyTo(state[4..12]);
+                state[12] = (uint)(_counter + (ulong)block);
+                state[13] = (uint)((_counter + (ulong)block) >> 32);
+                state[14] = 0;
+                state[15] = 0;
+                state.CopyTo(working);
+                for (var round = 0; round < 4; round++)
+                {
+                    QuarterRound(working, 0, 4, 8, 12);
+                    QuarterRound(working, 1, 5, 9, 13);
+                    QuarterRound(working, 2, 6, 10, 14);
+                    QuarterRound(working, 3, 7, 11, 15);
+                    QuarterRound(working, 0, 5, 10, 15);
+                    QuarterRound(working, 1, 6, 11, 12);
+                    QuarterRound(working, 2, 7, 8, 13);
+                    QuarterRound(working, 3, 4, 9, 14);
+                }
+
+                for (var word = 0; word < 16; word++)
+                    _buffer[(block * 16) + word] = unchecked(working[word] + state[word]);
+            }
+
+            _counter += 4;
+            _index = 0;
+        }
+
+        private static void QuarterRound(Span<uint> state, int a, int b, int c, int d)
+        {
+            state[a] = unchecked(state[a] + state[b]);
+            state[d] = BitOperations.RotateLeft(state[d] ^ state[a], 16);
+            state[c] = unchecked(state[c] + state[d]);
+            state[b] = BitOperations.RotateLeft(state[b] ^ state[c], 12);
+            state[a] = unchecked(state[a] + state[b]);
+            state[d] = BitOperations.RotateLeft(state[d] ^ state[a], 8);
+            state[c] = unchecked(state[c] + state[d]);
+            state[b] = BitOperations.RotateLeft(state[b] ^ state[c], 7);
+        }
+    }
+}

--- a/src/Ahtola.Tests/Sqltest/SqltestFakeEnglishData.cs
+++ b/src/Ahtola.Tests/Sqltest/SqltestFakeEnglishData.cs
@@ -1,0 +1,180 @@
+using System.IO.Compression;
+using System.Text.Json;
+
+namespace Ahtola.Tests.Sqltest;
+
+/*
+ * English locale data below:
+ * Copyright (c) 2016 cksac
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to inclusion of this copyright and permission
+ * notice. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ */
+
+/// <summary>
+/// The English provider arrays used by fake 4.4.0. The compressed data is a
+/// mechanical copy of fake's MIT/Apache-2.0 <c>src/locales/mod.rs</c>; keeping
+/// the original ordering is required because Turso selects by seeded index.
+/// </summary>
+internal static class SqltestFakeEnglishData
+{
+    private static readonly Lazy<IReadOnlyDictionary<string, string[]>> Data = new(Load);
+
+    public static string[] FirstNames => Data.Value["NAME_FIRST_NAME"];
+    public static string[] LastNames => Data.Value["NAME_LAST_NAME"];
+    public static string[] CityPrefixes => Data.Value["ADDRESS_CITY_PREFIX"];
+    public static string[] CitySuffixes => Data.Value["ADDRESS_CITY_SUFFIX"];
+    public static string[] StreetSuffixes => Data.Value["ADDRESS_STREET_SUFFIX"];
+    public static string[] StateAbbreviations => Data.Value["ADDRESS_STATE_ABBR"];
+    public static string[] ZipFormats => Data.Value["ADDRESS_ZIP_FORMATS"];
+    public static string[] PhoneNumberFormats => Data.Value["PHONE_NUMBER_FORMATS"];
+    public static string[] SafeEmailDomains { get; } = ["com", "net", "org"];
+
+    private static IReadOnlyDictionary<string, string[]> Load()
+    {
+        var compressed = Convert.FromBase64String(CompressedData);
+        using var input = new MemoryStream(compressed);
+        using var gzip = new GZipStream(input, CompressionMode.Decompress);
+        return JsonSerializer.Deserialize<Dictionary<string, string[]>>(gzip)
+               ?? throw new InvalidDataException("Could not load sqltest fake English locale data.");
+    }
+
+    private const string CompressedData =
+        """
+        H4sIALZDkGoC/319a48bO5LlXxl0f+hdYGaB/brf7HqXVI+Wyq62FzMXlMRS8iozqc6HylmD/e8bEecEU/a9Mwasc5Jk8pVkMEgGWf/5l8dPD1e/Xd+t1i+/
+        Kf3L//m/f/kU6jSF6i//KqzLreIm7EOqjW3iBEyROHvBZ5cinndjwRrxbfAO/WMdul02OkcirI7OJtI2doZdqEKjbBfwWwHqTeyGTJ7aCMaQVoLdDvkV7FGm
+        nSRP1LdJIzG5n8cW69rRvRg4DRNccv3mmEmOVSFjD9omkC4k5KNLYSahsEJRW0raQpCptwFF2dfBnvdttLj3Yz8gcjCLqWrCDhgNE+owsYLSDtGnOpI00SJN
+        fYWAE3N3iNFq1rJVB0ZfI5o6lEeUs/aS1GEi2RBY60Zmp2qmGQxFUYTXjoB81nEL8MffQyuVe8b5fjwAGEtEHdax789ewEP2h0Rnz1X8QfBHCY22Cd6duXfx
+        nJ97pJ8e2vNwufDZtdBUSE8yOfmYM/KG39z22dmHs24H0sWZhMIQKuEXzmkbie7QO1ZO0AjrdPIgU8EK5IMOH4jM20odC9IjOXqktckU6T6lOGwqQ8UqPTkg
+        rZN/31PsCuE7J29BJ1bgxNJNXrqpd6ycMCNTT9YE1k0jVe4kATs+d3xGRTQbfJlm0+XeEmxcwChxlwnYpW0ozIrcMAhz36SOwEemkq1MzTGgETWID54tfyl6
+        jUB8taFKQNRJG/ohbFMunH1AmxdrwJu2Nev2jM68d/IOYnlp90x9T9GrhKU12p7RWOhQXJGpfaIfJGqbNgHRpgNCpr4n4ausodYbZPt7QCunaGrnikHNnNFI
+        Lk3SaRNm1jEzrcPANJXRjUF6JtHXGELbQRo1WU5zeBHqM/HowIt7Kq7pPIjXoFJU1vCOviaEHw91ceww3qINdWEbUSPGLFPdtiJoBZu46Mro11H4djL6IZi/
+        hVgS28U8kEljBqAWFFG33e8jonIp0LFLdPjenfazQooT0pHvQie+2/IpM8dK6DRyWKZOg8FHxpuxAxnRb7oTc3hKO6IXevLCoH1RRvRVjZFSSdpXTieSgm0L
+        xlFbyASCr9n3Y4tP2Q8d0hYhhwTHTYc0lFiEIxWakWPOeNYDlSOQjv+FhMLYvYyjF42diyRjsbAMltHlJTw+fNEwhKAU4zA2RiCQRepaFihqf6BSXYeY2H4m
+        1OxUW2Sfg6mQn0NCjRqBS7eBcBXWulPGO10nXYCMPnyUDlbnJvKBwSfGHYPU8pZ0JEBP/QwR8Jmt/TOb6mfLs/zGXdoOoL+HJtG1ZTYie7ySCci0YxdbT1Ka
+        7o49Gg/4JsZtlCbLpHF+sZoDzI5pJrPbgOyzXqBvfeZw+Nl1LSWdKctgLSOfUAeiBCG+oSIEFktaJ4IMPR1YnGHwVwb3mOBQKliah3WMzyIgTGx/TqjzRCVA
+        CQJ0aOmfRdXsiD0dDsTWBhEjFZ1M1fhstZc5WVFiUWavmeyfKnfWTD/nyQrfBQd8ciHUnZSyTSpzQowlfCK2u+QkF1L8BidTIe7XllB9YQw+olcK+zG43xRA
+        IjqYkTMWwaCwgLTOYmHZmb8ppDgVT+QiOgBTILSOxYGJs6mKZNvzXWODuyYS72xd2qfimz1LUD8FB4oBYQMbZJe3B+BOdSfn9MsHx+ikZm0L7UHe4TAyr5MX
+        Y3KHLWtrQnWMSGXc4Rdpjd5WvLWPXenqY8fWM5bOqzJVG/aFtDZCaxj7APc0IKcXmBorbIgYby6gzyhAzAtDN7oIjUcnCmUmS3VwcsYYvvPwJXjH1JvJA0n7
+        2TrTabw1SH1IxRnzSzD4dnDA2CRIPU0YRLKRgYmynpQkRw+UHXsnA0vdNSaSQGanM5qdMZkGcldYrh3ZZo0XAt2KtLiyZozRsfN8iiOj7L1Q/qU7lK3MPIWy
+        uL3MuztniezoTucv9D7HVJ52kzM4DaHkWBItVMYOz72I7zN+TlmooUKcGKQvYmB7jFvqCsJMizSMTui1Yxe8iDKRpsbhPIMzpNent/fKpK+Co0dVhdQAW7Qz
+        ISKO+VaLb2+kpreIh4mM+iVoX1jxTsU3o7MK7x1LNKOkTGqatOCHQaz7GAqbnDHW2HtK0bt7ZWJQYPL2JjQ6rTMQA5PhUEgorJRUHyB9C59DpZ/4/EI+ntEq
+        /vTQlSfkG6s3F4ndWDq66csXiX0qiZoBHwxnFyK1VAop5dBtGEEQVtFnWfrg6KJB6AFoItYwOkmhsNmtJbUs1FH6eV/YMDPWiD9EPjSMKWYCsxkHx5HRnaJj
+        DY3pok5vFPxKKcekbQ+OdMlDqlmIDO1YyIT3Jnhk01MuMHZd5JqPqCaBBh86Q20W5OqXMncaCO7B5HM9NhsUIktTPspUH+4tFlkvXCdSkuniCL1IiDRB9kDw
+        gam2/cjmkDOFFqtQgD0sdxuG7nyhFbQmK04enh03u4zKog7XiYVQzjdn/yF+kEBNEAZAY87j7GG/orDtge/+DbuYIfesw9XO2MfOepV1mM0conSebrRMdFN5
+        f9IOq2zk2tfFaDq5AlrCtGO+pnaoUBETpuqCVuLLsG9MTl6GCrV3GdLvRExJlUyGhzzAwZqOQB16EvsGQtAuLm0tA35NdCcUVkl04l5E/iIRjkeXmPwLcM1G
+        WLIaUIJxGeyc8hUs4ghBK1SCorQDnyeGOFZMRsnMELrbEJnxzoviqqmy4pcd3YE17WPGJSeblzrZrAspzP0wTBkrTuXFQia+9+6B6CAf7x0uPb/rCYljJUKx
+        JTKu04ysHUbw3tPnh/1OXuapIIJP/PoxOPgn8/nDZdxI162MbWsG22E157IM8pf4AJEZi2iPAnjxd3ceGYFEhA9VNl+EvSWmyGYtWDMCVLU3mFhDRxKSsdYo
+        7FgFJ2lmKGfEqvGlCM5umwvDV1aa6BgHdgJQD5BNwl9G5q9lmNYJi5e9AwgbQmEgXWRNdZHoVceWEUv7ib3qGc7eyVLHSu5LfqjtCeEc6DJyXQbEX1A6e6fC
+        4HbiRzl5H5NBjS6Mi+0slnYWTxNc3r0pxfc04Dv+gH5zmYLn07ucLwZepri3Ck/cClCCJETnHWwN8ZKNAcriJRtWwh7IJWZ6lxlrBILeDnKjSywzCzM9zDSD
+        pnZfmL8k7J8j0mjxi8VPJUMmObkf8qhjJ1qoD55KkLMOIbotBG92QcQVB8HMrQxQvlV8sUZjBF7jnkBRLjoEUsRm6WWHVZFLrL1fjhTGI5ctLsd6C4d2i5yM
+        3TsWlC59UU+JhX2X6aV91Anf6UokIgGCUVly1kZTUcncmequEqu1q43t/11tsPh9tbMfc9qBY9y/wrz1are30c7QJpJXvoV7tWMDEzKStIhoLGFZNhA6pdYR
+        oSdb2jK0lN/ekIM3ruMIQV58c/RK3uyAFmUddomEcbpYu8JupQCyLNjRAXtwSnQhxKgIXfc26q4fSK2O24G+rWPuCqFTLi++yRDH5BN+8RVrLs8r6YHxA1+p
+        TpDZQjzqVOLD4ovhBsuBV9wWMcwklYfy4B8Fy2s1nKAFXXGxQjEPhThDFuv+XTuB8YaZ5R6YkExgTlk9pVKgSQt6EbLnO4+FIUhHZEB69swg659NGZuPV77X
+        KITBTsw0m1r9PgEnRjd53aBqRJ8fTa+48p3BK98ZvOLOoGAHSaSMHaDBIvtVw6CpJvgj41KClqq0eLoL4mgCAasxykquQBltYxNXQxJG2SR3QIxQuq/wMVpT
+        Yq7abPtKgmgCrS3iXLXc7FQC+Xt1rDpM969QuV1ym4ArqB9X3CpVrIgHR3rw2R+t1lRk7Y0gZ0VwUW6FMx4LR8IQ71fdiVHxA2PJ5KrHR7IIdNEmtPi+mLEL
+        xA16oLC3gF28K84JDGdSvFDpwk7+KqYXQjoPh0FCoQUiRsWJLhNcsDJ/NboYGvcU5EqQn7F2qIhsRmNLwCLf1djHDdoQusEpMDXm9BTmrVx9sA99wtPs7lnU
+        PkQJLZRNC4wBIVDZxd7ZGd5ZaR/xgK1FYf8cnVohr8MGgk8Jmt21aWfXPsu45izjOgypgf/o61RGQU4eDcLansZ13PlG/XV0Mwmw4YxOpEd3O0aSH0BIlOvY
+        YT9JiAO3DpTaO2lnhbuWDuwdQrgqNhZ3sm3Ga1GY7LEOqDAjFpaLGYpbNKXrGh46097GmSZ3ZrmV7YKzliGphF5DgF5zLeMa0+hrVcwGkMKoElx3uojQz8x6
+        s/PsPPUzm0OksxBODo7IkHY/Qxtor2nqorhjgIgVeyURMsXpYeZnFJJJH86CMIYSO1dnhLGyuoJxJpRZwgfL5NjhtZtgRnIC3Cons2brHCHkO1oLvQl7OCSE
+        73ZYyhGGbiRENBrrL0K5XnWjatpQCFkXZ+IMRTWGceeGO603AQPyjet2N5yi3gR4T8zpVKM13EDYKHS2IKCstw+sTFrqif4trFiE5VM08XIT4ZDf3rCDILRD
+        wY1ATBjnfMO5P5y0u890KhSMwytIYka70O0KQQa6HeLrquLXhBKeX5F7rjc+VN/o1irWLm9MRNwkz430ZwRJrjSSZVAkl7BmfaP7o0gCA9UNpNRN0oKkwug3
+        lznNZRbFzNuQzHDj0UTRjeiw2OUyZmlBO1NAHmruDBpJCJux9XeTd/5ZMnOcaaF3k2UUNAlzI60ARe2wfaSYZoI2zu3UGzf2vOHOp+KJ21TCJ4+BJlo3HXRz
+        wT3B0fMImgtFMhCHiiIOGUOJM8lcAEzaoXWqMexCPaLOxl1n8/SbEXtcgpK/riEvdTu2mC8oYSw9fiE7b2CmoYA1n5vR8vaO/Lzr3iyGyVvffr51I4lbN5JQ
+        kuBS45e7g8oQoPjXjnQw0XnLZmOIF23MvpV2jvc7j6jD+h8InWByczuLiVuKCcET3+sPGK5vbfuKhHmgbnIbsPpwG2gkcusmG0YmEob9iIjuAyWKwQSSoVW0
+        MEYXN3TYDhkk2d78bawZgLMqI4it3tOhBGkYiU8gbuNsGCe8S46UR8oty7Fj5751GQHiLDFtZemMZtAeKt0tjTdu3Xjj1reTbt3q4jb5fuxtESi3lCKKcQ+x
+        dauLL2dsAmsYDgL9Nh1znQbEBiOR27yBgc2td/Db7O0oc7Z2y4WZ23yEO/u7EeRN1+hbVGHGxtltHjmM3GbO2oWwveTJkhy9QOOOdT6iiY8s4Ni45LwdW9bM
+        hPq+w68akdu04g6i585evOP+w52buN3tW2ZV2YClwDtbWrlDALaSu5rDzV3DXxO4dzJvQ8zzPOquyVS372CpfdfhHZ1O7I1gPnHXh7AFwjAR5IyFmUZQht9h
+        CiwsEawrG7Ek+wQr47u+CYw7eyLZ6qXv3IOxDuhldzYO38HS9u4E+Xl3st+POVcfTPI+bGAIe4+PrzABU4uVFtAMdiD41EB5cgLppwzfXRkjK16inZ3zHmwq
+        adnnuIeVxT2tLAQZ346vRvdIDJ+Kg8eeGkSROmT9wC3yeyy9CeSNocitmgRv1kzMY2pCqEkcO0csTwtlHE30ojesx4bVg3m/Il9OJaQHwWMbCHR0QCNShnUJ
+        ZQMw8dtxAVWJO/TEia8UH+TunyNT1e+SzimCQS2/5xaNYOYz896VANxquXf19L6op8r8tRMz1DO+vmGiXhk0o7gPI+2/7nVuBKcTw/gK931AISYWX5CErWLa
+        +TOTm7whca1UiXt58Sf//hNb0MS6mDyPH94yPjz3H800EwuNzRoFDjJKkxOG2eE37tgZhRT69kaIUNlAnc1udEKriW16Q2W58mfkzK3d96RTceXHiNg5vncl
+        WwmbpjKkg601xeIV3avBSuz9rGsrZU7ZBASb6IQ+3nRiVwJRUbmnin4vbZ4QiVhWuvftFSMHd/J3Jg+Ebsr26KPwPfdM7uM7S8WR7L4o8PfJe2fCgtm9SZMM
+        z8zOmv3TZv+0ufS0TI1eCfGfI+opb10W5h0D7xAED8hU9p6fY29HlYQgVMVcVNBQQALZUHwdzp2C2rWTe0Yrz2jVHsNYk7LR55qh8NTaOKU4BHcp0Z/F3u3C
+        TCJZIpYwkyMd9gjZO7wFJ6l1yqpQwraWezpVYyiETmkmHjiVb8UWlPsReGKeOVm7L7Oye5+I3mf+QvKMbAeCFFojjr0J7gAIhz2Ee1eMhFg8I+aNgik4toXM
+        TsjvyE+h6KEgcml0qogGP/INUVE7EnrQRlwJR49yCu2+GJ/fu7J37zbo925Kfj/qIR5rJCOOLyyoOggmQjTcOSDULgExk1Sc4JDwzCnTwqdMCx/TF2pjmQqj
+        Wx0JGyLmU4vgb9fIDdXfRTGxXBR7yoXbUy7cnnLh9pQLNJcFTKEEcK5Oib/rr3aJUF7xL6a0DU7oUhOiPzO7HfPbeX5h6wjaM3fFxHBBm8TFmdnhQvpkSXCI
+        XmVDqWhjpNVZ0GJrCO6hK26oGS2O3TnjS8V3jn+OfY57YMlOLA0KMCEcB/GFD9oL6m2GFYkHmb/25PU3sf4mrz8O7IsY9oGkHYGoLpmHIiMxeojI2CL2dQRb
+        +iS+gyM1C591GplIkmMkoUefHOnh6dYnZpG/u2DDkDIm1/pi5oLLO4pxlwqbnDFfItULo5+nhtNFhjDJVUo/gts2LIptw4L2BovoeeXXi/7qVIJW0ud2Tqwg
+        EGcLCrOFr/ctaKioSBIRPvpjxzdZuzYplN8NjyYsMCdbpKP98i2zRxSgkDOGXCecdlhkW8BdwIZvgWF3QRu+BWz4Fm4DJwSJYzK1oB3aAtv/C7f1XMyWZ6Bn
+        rPhnKF3k5w80SFu4MeeimKQtikmaMcYGo7SFG6Ut2EuwmrvwLjL3kAkmuAvvF5PV1ZJCWxCwc8OqZXgLE3XXZYAx+tKN15acAwlysr9UQxIQbE8sA08tLCEP
+        l7QmWhbD0SVnEUsuQQmOCDkybyO0TSNtIVsPxFN1SpMnMhapa7yQ4jQ5IsITZpxCsJkDMjvhNR5KNZLImPdT9uTe57zRtGtJ2bXkHGKpRgI6Qi9tMWUZIdiX
+        bse19KnBUtfG4ILsRbimNwBiVTQNZRnpAAm5dHPXJTeql7E5IlyDRY5l9ASp/S0pJpZuo2AEPshwZhIomABWf8gYhpnPLVPJHjvNU0EY0RE6PhljoCeBBtlK
+        GFFf06F3BywgLbFCvIxeb0MaWPYTiv6OX+sty/gjERDLD7R5vJFsDW1JabVMPJqkxBJn9SdqaSCzE8LWHmgOdRaMxeH5qWUqwLAM125zTYcdXXZ9mJxFsjbS
+        k9Wd2vdsM6ll8k8BmwoFHmAX6r07DR+I6ANhPjCICPlAfLVNjNBjuHW4zBgrlxkVyuaReRR4mRsAwvDY0tLbg5tgLWmCteTx9yW/f+44gVxm9nzF4OSjkNmJ
+        ryeCv82XqHMs84hff2K1ZD39g3KoXotm4Ouay4wsToFP6OQjrMUEabehLDqyH488dKGEn3DEiqXh6DE4sZRoKy/4biPNEmJx5OLdckz7BOwJcD4wQwxVW1lh
+        ELDEZsiSknV0i7DlyDX4pdlBL7FyIoAqoPiCNrecsP26nHqKqQeufD6UNU5hxC1+rYk+YErwwCnBA9YRFeTDuRMClrtBjFqTE+bWZELj7B+Lvyu0Qvf0TI4l
+        UMI6h7FcmPvSTvBB99XoixioFAo5weGN1iMPolDWKNd+x9VDp/TfMxf7NkMSK7Vv/RD4nBgXVugewu8mKB/KeqWw6Fk7q646bCukXYuMaMCwAKKkZawUNEqg
+        vQjjYPbAI42CNb8Sl8BBEKYjbAkMoMSjAc+F17Mz24JRFlu5h00e0h2yh/HA+4DVRKfxjJ+7D+H8YQ6Vioe7JSfZ359TGGUC5C973rByYKRx0hZSArXltfbM
+        8cyVRUzeYzrPSCpVneYKS3ORUl1C1ia+jE0l6pKcp5A9e7379NnTHD7o9nuug3ckeSi5+d2bSXcg+KeARmmkLaQ48SXMtZR4LrjIbyydMb4p+mTNzHmBB49j
+        KGUbSlYHJnTyQHye/OtMv5dvMTER789DRBWJyHsnwX6LMZz3EZq8ew+z20DwGAbWl514euCBpwc/5fSgyilraeShWjB+JFdIH1THTJSGJ1bPD/wyph/YyDDi
+        GgcfXKT4Q/HKTvjtfnhqPzikPQRUG2XOtCnOsyCfCA0zMlHjE0ahQFm0LaJqW0TVmWT3ebeSigwVrJIVQVxQxhLiAOmmmuwEssE7NHA14ow9JNKE9MEn1CAM
+        NBXi74kowqgvNPKSDKE1IRIZVdfBclIYv370Vgjd8wGfI225tKWsAlbYrCMLTpGEsBjcO86kePKLpD3FcyoVng6RAA/sajzQDkWQB6UezOSBBJlPkMK+ifzA
+        epKW0p3IWobswpY56GKqC0Xjkc/BxPte1KgEim6ahlIgY6SsvryLmDmDWXZyFXD1lTHchgVKVxEcVjTfzn7gLvYDTOkEsDGgBJZgwrpM0uv5x+Gc02MI/npx
+        QawdG2/2gcDN/oUMPAasFJWIJWsFBOkrPvfM7AcrwYg5jXM5R1qTCSEc7TyBkA4dVm1PbDH8YeKv5WlySTzxw7OHTj5oTYhwgjosiOxOHRd/jRXCKAbL4GOA
+        LvgYDsQGzmwejyE3yREOMp3DNPFRx3i7Euox2OK8gG1/PtpHeLQD0KGwSIY1hkffUABBKwPHQTXy4h4ReMItOY/oU4/WbuTXauQxIuqY4AdJ/0id5ZHf5NEl
+        ipCegPJETGsetblaOXwr6RH2b4++gyQETeIR5ZNunHEWhHSceQQ7EGa/w/xKJtShEPfx94VA83lMuMPpMR2g/gg5JCIiKuDRoJyQAY/ZWtVjhir/mPlbE1Ci
+        HPHZMzcClUyGyGOGLHrMjLMjcL2ILIOi+QppGAp9TMgJXzF3nNE+ZlR0PvlHm/hbAXAs7wlT9qctL7962vJ5CLgB7WmHX3wuQQwKTxjAn95YzKeDaTZPlpT8
+        vhlE/LaAAX57QIJrgiXaE1vSkxXsibeOPUFuPFnVPKEfPR2tpE/HypPu+FsDLF7Mhp+grj3BVv6JKt+TW42CZDAADt49df7GibG6rd5Tv+EtTcIylr2e+q0t
+        8j31p+JHi24Qc8J6iwCeeJzhCVLkaRioviqjiwW0r/gE27mnD37LJy44PMssMhumPZ5h8vQceGPEc2htj/c5ZAZEgxE8WNU+B8l8jXf7f45OB/wmLtQ92/VC
+        KRR6AGPc7NvP2AxVCEToU89+t8uzn9F8jtjYMcTLsZy+eo5YeXl2dedZmn0N66tnUUYSPorSCdgBh0jogNYwnqOnKaqrLX8/VznasvZzNdHG6zmpkkPSkQzI
+        RTJ7QgVkJsHy4pkD6nPmRRjPXfSVCqFckVPG5KnfCrZnpEf41G+5Evbc5ZNa6dhKwLOa2SL430doyoaJLjyr/vdRoppI3GGIhVkGVsHVK2VnxL75KvAX4/hK
+        hk8GeaMmtgoVNvWE9IGhqhGBIBFXZVtR2BHYwLBoxVPWhgir2zeFOEvECQgrrlXITOdYimCMWf/nSMce122syvFjZTHCjVFgf2YVkMLEY3fKRgiDlWviK19v
+        XsUNIW4LKewwEytyxKVVK6YbY49Hj5StWkjiecxVTAS0KSFMN7VVZhA94ckviWFAAUi1aQURu+La7opz41UcNygzBt+VXfy5ikhpMk1IcC7+xMQn3jy3wplO
+        AVPsV5VP3sGQpyrbSLEStRLL3CvV3E2rVoYMCvH6hhBRQEYSDeSU0AGx7LMPgCvubq0wXK84dqzyZkNADJljJ0goLINZlxGcgJhrCiJZGz1X861LQvdMxi/D
+        FTZ7dmkPNzTBvOc9c8o6R6vi7KPNym+2WEFNUoDoUwYP/nL0WHH9d5VFZZYRHaXr4NQHAlYejKXillDdpMWZhe/9XLNSflRhHYvQbzOjdICQMuZRRL85kpy5
+        il7Y3tshDUgUPaUSSU9giHdWw3tkyHeO2avM62SNkCFFrDuvuO68yj5arrz5j2wfo21PKODR7zZewcxkNR7ZfkZka+xx3SUI2YCgQ0WIRCSB/QkFIO6zXdGc
+        bsVtx1XZdlxxX34deDPwWk/HFDaRQesSnIB7QCJSiVKCyKAOCJ7UltbpgB2rtc155DfgqkawymlHkvAe7buUIO4Guv7azSnW8wXAawpwQU6s1yUNGbKC9Rij
+        bXFs3c3WNtcB9zQoJqCH7ZlDE+frcAotQ/pJETI6Qudbb+0+rsFoNXKTd73NAwEqjDHLeQxYFFrDQHEtI4DvWq/Liam1m9mvfZV37Vb169i5l16UyEittawx
+        SAnwnUqmjB2Zu6Ae/R6o9XwP1LriWUsjxWVypxIB5LKxiaS40KFzh5H4XpCxsKEqK07MWsQzN1mF8Fi4MGx6r9VOBnZtSpvCOEVZV4kLouuKHQXE4k8bO+W5
+        tpFRfrErvk5cOVv7FU3rtOeBeWEdQ+9HtLqEedvazCHkF9NtIZmJiG6FvpC4P7o+oGsdsHJkaO75DbUu08cdvl/G2u2aN9iuKaMF8TEyL+8wYpEeVZez2Abu
+        +CghtgTvMYPvNyjDwL+2k7aFIFI/YCvkWLnvsbQS8jjzyWksgT12P00s9MQ3Tv7qO05KrHml73oY6TA2bPIjK2DEcRjD4MQZohs//DtDHVtPmESv9c6gQiaS
+        5AifGoaHSnxbW7mV90UEKGTYi32lF46FLzRXf3HJ9qI3Ahm2jjjOJGSCA8PBBOIFa2ACYwPkRTQvuogdEOQUcHXHS2AUelhQiauUL6YTvtDW6SW6KYQyG8df
+        tFkXN1r8GpsdU3FEJDZKvbgW+ELLoxeIGYVdNFn2UnlloPMKYIAQkgk8S00aQT1vxmY3jwti5KUS5QXJeBx+DvQFIbkP9OLq4wvNml68L7+ktze0zxcpo7/b
+        NLxK5IW2xYLFhRGZbieAclLHe4HZ0otJmxebSbx4HhUDCAa2l4z2JpgAeOroOn8WPfwLN/vlcSBDdyBip0IJagj12UVX94xOTs0syNBDY63FSGKgE12g+ipJ
+        HvqU6YTUE0cdYRgyX2bDq5dieGWMMbA83Jx56XiT/ItZWFmQsWMfeYfUf+FA+oKFVAHrvIYHktrRSc8gXHd+KQZxL9xR/uJrLF/0yv4eBEvFX+x7f/E16y8d
+        7iD4wlXnL1wZ/tL1WIT4CrOlr7rXjAI7PXeO5FBjv7oe9TXgBXz3r+VEydcw7s1a/Cs2aL5yffQrJfFXdivBExCp8bStIuKP3GYVwhe5GvIVRlZfaWKlaPX8
+        tVyT/NWvSVaSGTh7aF/d/8qdg6/yUnvGIhhmXF854xLEai1IQvCdQ23IknENw9DaLdhHmGkGZS55V4FiHAphRrwalNROWmbAKLxZggFRo24TLzIAiYUVGttC
+        4KYX3ECrfYXN9WuA9vnKZieI1bFXvWNuiyD14E7oLq/8iwmvmOO++tVpr2HoGeAEfx6UeWVPf40bDlqvrjK96kK6z+5f9RSmdRZlkyE//6t8TugEr76s9Fr5
+        7cGvdkKykIFstJb0yqnza9nqUoZDSWTZaaKjjg4zQy95xdjzysWq13Lu8tV2VhtnHtYEoJL8TsJcNHy98Syz0nyf7TW1fsxfaCpZbc852rsQrwxRLDukNGEv
+        +pXnJf/hf1LkH35M6h8fzr5JezDx9S30DRbZvvmBK5BojKeYvokAQ9v8psdsSG1yD9ZX2Df4dmID/+a2j991CY6iCnwii84OhOJ1cK/ixJJ8D4wTPfV7PIub
+        Auk7BdJ3CqTvEETfOSH/jqHjO/rVd5vqf8ehme854Qly/nsmWD19V9n67/+Kv7e0/HT+55Y2G1x19GmjoguD9KeN1Ejnf8cIf6xkiO17xIULP/01joOo8lBB
+        P3VNP4ggMz7ij46Mbzu7qcDuvtdbfrHEcna1vt4Z3UXbPNAr9PN7zwvzeQu+Xp2vcif9fI++ZpDXfQe7wuJzGO1KC8FmE0gnpBYD1Gy9dZ93wm+rIWKeIPzA
+        YLuWLnxORNjYKLZh5FX1ey1r8yd34uOdZGfXP3sb+1zzRvCat4TnHW5+j5XFQZtDwdTjao7PosdYTBlXjXzOQ+83e2eWi5eu6RXwA+8VD7Bq0XvaeWN6ki8n
+        33aPp4PfP+53jUe/SdzvAfvp6uhyY/Tw3vE2tp8uhMZVqlVojrz51W//7f3i1+gXw/I+VpWbvP+13PwKGaM3vGaSPu3KbarsT8Iaj4QHlS/0rF65ENUw81ZU
+        /WskILhd/aIb5QuI3mJ7Axc2Awq4Vlc4Dw9eot1c/u0Tr/K69F3Yy8Bn0SMiTHUuqSxeSvsxCXZpt4nYPX9p4/dK6mqplVdZcuTZs0vdssDnvpzr4TJnXpZ3
+        ds0er9cbP4+8H3Dk/v2VX/WmNvfWE650zRaz86uG98819vd8cE3VDgL2qlNDAbtKiFf6hCriaiGfxfCqIZGwkQRX6GCT+ZrTmWvRVnmRT+Bgd63nK3kJTkS5
+        9doZNAq9dKbH9TNje/jlhpaOq+c3qmBZoJu04XUYqa9p8XRTx5lJuXitRe23ZEgcdJLxBW3lJnfbD162IhJP2uPGqJ8E+G8u/ig3e8T2TeQ0ItanCvcc33Sp
+        wfUoY70XAWblvZGJ82F+GM65X7wQwt5A2ojJ4NugB/Rx6UXV/nx3hswV/F6LJvEWi6Zh4BZ3X7S8TqPnzRUdL50I3HUWMqddbsXAXxG4DdhXuI08zmC3WGwz
+        75HYl8sidKuri2hMdjdF999cK+FXKsTuI+9xYUTPqyREpHM0uFXbAF4egZIJ9sCjXyHRWtu+TR0Wbm/zTnTh97Q11xwZ03zX5m0+8vaH9/jTXQ7z3Q3IyAhT
+        iFvqH/dhK5NRJ30hPCF9GDf+Ie9Df8h14TiA2x4g3u5lyuCHT/tfDpxWrv3cZ3xtPeM21gec6hoHXIa4iHFTO+MqzyJy5WYh3WPEC9rrWeULqV2+kmKFY0GE
+        egNNpRwrovXXQvoPkB46QGU7E2RfeJFjfeRhoXi0s0i5Yhq5zcfIClhgQ2CRT6J+W0L5I/JQ0e9bk4oLaTX7chRIQf9OEfbtF6Mdchwrs8MW5FqCMADk4EKU
+        jQj8AB4rnCQaB2R3PAWosMuw4eL7MhwSj+vsCThQq8xvdVyGzkOxn9mRFbJNj9pbRsqVZXx7q8n2XcbJi8r9mgNPcGxxaGUUcuD5hR1hT/N//SsjNQkM6uUD
+        NDyB8A5LdmlyuKdrOYronfkw7BHJ1G4rWqX/fsinRBP1mwny0Oy1YTpJY/LWjYEPxXBVRorhZwvUiS9P6IMP24t67GAYqVeIZ1x+8rC91DuHYEG4vXF79e2i
+        2ElulzpsurXhrhq73s0NP2Bk+PGrJV//i2ldhs1prjpaxNGaMmOcfhA1l/Zqer0U7aRFc0ponQ+d/ZmEh9Hl1cNYiHhZ8/yjUdpjgKw/t0qKrY31sDCiOdPw
+        0eMP/7hp0JPI3U3nty09/e2iXNFLDudbLKY9/U06+FsEg72LKNVYN3riLOsJxyQRvOw6P3WweRnSh5muiOix4j6LxNpWMOnYUfd7Dns7uWAGJdCcz2xKRnTa
+        5zdbUxUNznL7/BZ5kk9tJyDyn/OI9v6c32sXhc86G0Wzm60mciUCkgYS0n9Mi30ecSb+72PaY2gTNnzQ0ABbcwG67Mr+LNZK5uC2xLGKbkMKhv2+8/137t7G
+        5shgrGhui/fYosaO9REybaVNrGxB12XfuS87xaNd5b8S/bzC/mbFfc76rc++I6zm9dj0zBvfSt1gprBCH16NPstYja2+u9MNrLNnRjaiY55tYOopFur93KM8
+        36OTll4u11sHTLrWQa/Fxr4Zz6Yri2/cQavsaOPen7zbKW1w24tSVp5QcSs07QZnvjXXqkZA/+yp5XdffpGHLscSYqyhqRu1fq+saUgwZivzbYLI72o7bdwt
+        qbTEve8LJbCjDaXrA02E1w3Mng2xbzpv5sjXt5a5PnKWtR4C8nC2c4ODAushVgihRhlgScrDIXc95APSG+yvXbC3rYdOtTowKktrnTByu6fLmDqt33Uzg71o
+        /Z7ehvN9ggqTD12nP6KBnK2y5+5IwMK6zOji+Rq3lOOdK9Yb/EESoSMGmxfJyRHLw1v+uZmyUvylrjlV+HJEVXy1BQxRQG0ZMFq7/pprjlJfM3+lje+4oBZr
+        nOE5X5ezIfdsVY6LcANsLXQRDiugr7wq7dXH09eYWNnC+r41W7dXTYLLalxUwwqWGu1weWvnSqnwMuc6Ww9LviOuDw3WvfwP+rzaJVGp50OfDxPJx8GIqa/G
+        bAn1FX9+WcFw1O5uORtbqAG+sPUtW46/jfgDbN83ud0GW0SKTQ2SvHUpi1y/Gd90BefT5eXqar3+7eLu5dtvz6ur67t/6DLOo19ODT2UtbLOsHZ4xBFR3A+l
+        5m9/iGn95ZoxDVgZwJenCYfbUrJxb2TuqdFuckcdYIPTx6dkCR3RUhqm3g+2rfWGc93b8ieI3P8NwSvaecnUX9PCCtRZPtcvq6url7OcfuLFBJ/kvZGrH9CD
+        Pvtaxk9/eK3HHz7bE+xxOoYef8bL+sNF4H0BF+GItZCx1z8yYH8fihe6gdhLqcPxAZDe/wyPIxxMs73ITcO/dNP5X7pR0vPvweAvPWX+PRZF+ODv/AhgDQN7
+        NII9F/EveKvtRaeWOO3eaZfxt3LGjn/Eg3/gpLFVhxOq+LJLpz9gzxujh1iIOf046qYW6uLqh96eh7XIwu2e3MB1A2hw8woBRqhrl9u6UkDof7qtd9f/cmuv
+        fUZD+hwIfBx46+0773zln4YFsTl5GNxzvlC0/3Ve3/slm46cLm9yV0h/fj2kWgENmKPuK8R/m36evGauod+12EAp2LNb/UL6X1mc4X5st0PijTWgPe6m4A0V
+        Ci2W7Qz7ucMr9Ly3gJB8JoRJCRb2ll6kZTZr8CWWKhX6nxB9a0b7O14Pftqt5THPFjX2EMPOqgEETu88xFP/pO73bFJnLA+5Q+0+5LEdHHEd15/Q/hf+iD97
+        8tS5ZeMT7cNlYsSu/4xx/plzIUWkSAbH3iHQbttE1zOOKT3TDDphOv/MLajnGpkz7H8hNmoUzPhDXYa9C+mfoD/HLiTsfM5spadZYC9romxFWbgKR5iqKsJw
+        1PrWiiLSsP/JOBMWuTP0P+E40OAPai20VtPKcqgdexBY6lT88yjrw4SaXR87Wq0Y6X9hY0ewR52Zxj+S/mcmciq53lZYF3xo+IVHKITnJA5/JD2NZdJwTszg
+        AxYElQ2A7+FXs4ID8O0tbYtnqs9RJ4e/kK49ojmd0S+qebGhfmlRLsOe294mAEDMiVuwYTdusWlrI7ICvOsaDfgPzL3h5JvQQFXjCD03WbE9it+eG6KE/udR
+        +9PL1W+fPn9e2ZC91PF6oT/f9WelY9Qn/XnSnxcdhK5Uomu4G/W4vVMheKk/6nb3qD/qsVjrzzcVQPr4oK89aLgHe9TXHjTwg4Z70OgfNPpHDff4VX9u9ede
+        fx70R6N6vNAfjeVJfZ80p0+ayWeNdKWRrjXIWoO8aPQv/9AvojF/tR8N92o/msarvvH67bxCvt89/3b9tHr49LLWGvmr/pNAM2jg59unx6vfHr88fL5anYf+
+        H//x17/+z3+RQP+m4f/lB176E9f/yvmP7uLwv//tP/DwU6x/4vpfOf/RXRz+LM4/jfHP4/tjbP/rr/h/HtvPbn/u+KvrX/79//1/HOqfsnqGAAA=
+        """;
+}

--- a/src/Ahtola.Tests/Sqltest/SqltestManagedRunner.cs
+++ b/src/Ahtola.Tests/Sqltest/SqltestManagedRunner.cs
@@ -7,6 +7,12 @@ namespace Ahtola.Tests.Sqltest;
 
 internal sealed record SqltestOutcome(bool Matched, string Detail);
 
+internal sealed record SqltestIntegrityResult(IReadOnlyList<string> Rows, string? Error);
+
+internal delegate SqltestIntegrityResult SqltestIntegrityCheck(
+    EmbeddedConnection connection,
+    CancellationToken cancellationToken);
+
 /// <summary>
 /// Executes a discovered <c>.sqltest</c> case against the managed engine using the same
 /// execution and comparison rules as the Rust <c>sqltest</c> runner: every statement in the
@@ -20,18 +26,43 @@ internal static class SqltestManagedRunner
     // Mirrors Turso's test-helper-only process-global atomic counter.
     private static long _testNondeterministicCounter;
 
-    public static SqltestOutcome Run(SqltestFile file, SqltestCase test)
+    public static SqltestOutcome Run(
+        SqltestFile file,
+        SqltestCase test,
+        SqltestIntegrityCheck? integrityCheck = null)
     {
-        var database = file.Databases[0];
+        integrityCheck ??= RunManagedIntegrityCheck;
+        var failures = new List<string>();
+        for (var databaseIndex = 0; databaseIndex < file.Databases.Count; databaseIndex++)
+        {
+            var database = file.Databases[databaseIndex];
+            var outcome = RunVariant(file, test, database, integrityCheck);
+            if (!outcome.Matched)
+            {
+                failures.Add(
+                    $"database variant {databaseIndex + 1}/{file.Databases.Count} " +
+                    $"({database.DisplayName}): {outcome.Detail}");
+            }
+        }
+
+        return failures.Count == 0
+            ? new SqltestOutcome(true, string.Empty)
+            : new SqltestOutcome(false, string.Join(Environment.NewLine, failures));
+    }
+
+    private static SqltestOutcome RunVariant(
+        SqltestFile file,
+        SqltestCase test,
+        SqltestDatabase database,
+        SqltestIntegrityCheck integrityCheck)
+    {
         var temporaryPath = database.Kind == SqltestDatabaseKind.TempFile
-            ? Path.Combine(Path.GetTempPath(), $"Ahtola-sqltest-{Guid.NewGuid():N}.db")
+            ? CreateTemporaryDatabasePath()
             : null;
 
         try
         {
-            using var embedded = temporaryPath is null
-                ? new EmbeddedDatabase()
-                : EmbeddedDatabase.OpenFile(temporaryPath);
+            using var embedded = OpenDatabase(database, temporaryPath);
             embedded.RegisterScalarFunction(
                 "test_nondet_counter",
                 0,
@@ -49,12 +80,65 @@ internal static class SqltestManagedRunner
             }
 
             var error = TryExecute(connection, test.Sql, timeout.Token, out var rows);
-            return Compare(test.Expectation, rows, error);
+            var outcome = Compare(test.Expectation, rows, error);
+            // Match Turso's runner: integrity cross-checks apply only to passing,
+            // writable cases that did not intentionally expect an error.
+            if (!outcome.Matched
+                || !test.CrossCheckIntegrity
+                || database.ReadOnly
+                || test.Expectation.Kind == SqltestExpectationKind.Error)
+                return outcome;
+
+            var integrity = integrityCheck(connection, timeout.Token);
+            if (integrity.Error is null
+                && integrity.Rows.Count == 1
+                && string.Equals(integrity.Rows[0], "ok", StringComparison.Ordinal))
+            {
+                return outcome;
+            }
+
+            var actual = integrity.Error is { } integrityError
+                ? $"error: {integrityError}"
+                : $"{integrity.Rows.Count} row(s): [{string.Join(", ", integrity.Rows.Select(static row => $"'{row}'"))}]";
+            return new SqltestOutcome(
+                false,
+                $"integrity_check failed for {file.RelativePath}::{test.Name}: " +
+                $"expected exactly one row 'ok', got {actual}");
         }
         finally
         {
             DeleteTemporaryDatabase(temporaryPath);
         }
+    }
+
+    private static EmbeddedDatabase OpenDatabase(SqltestDatabase database, string? temporaryPath)
+        => database.Kind switch
+        {
+            SqltestDatabaseKind.Memory => new EmbeddedDatabase(),
+            SqltestDatabaseKind.TempFile => EmbeddedDatabase.OpenFile(temporaryPath!),
+            SqltestDatabaseKind.Default => EmbeddedDatabase.OpenFile(
+                SqltestDefaultDatabaseGenerator.GetDefaultPath(noRowidAlias: false),
+                readOnly: true),
+            SqltestDatabaseKind.DefaultNoRowidAlias => EmbeddedDatabase.OpenFile(
+                SqltestDefaultDatabaseGenerator.GetDefaultPath(noRowidAlias: true),
+                readOnly: true),
+            _ => throw new NotSupportedException(
+                $"The managed sqltest harness cannot construct database fixture '{database.DisplayName}'."),
+        };
+
+    private static string CreateTemporaryDatabasePath()
+    {
+        var directory = Path.Combine(TestContext.CurrentContext.WorkDirectory, ".sqltest-temporary");
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, $"Ahtola-sqltest-{Guid.NewGuid():N}.db");
+    }
+
+    private static SqltestIntegrityResult RunManagedIntegrityCheck(
+        EmbeddedConnection connection,
+        CancellationToken cancellationToken)
+    {
+        var error = TryExecute(connection, "PRAGMA integrity_check", cancellationToken, out var rows);
+        return new SqltestIntegrityResult(rows, error);
     }
 
     private static void DeleteTemporaryDatabase(string? path)

--- a/src/Ahtola.Tests/Sqltest/SqltestParser.cs
+++ b/src/Ahtola.Tests/Sqltest/SqltestParser.cs
@@ -12,7 +12,17 @@ internal enum SqltestDatabaseKind
     DefaultNoRowidAlias,
 }
 
-internal sealed record SqltestDatabase(SqltestDatabaseKind Kind, string? Path, bool ReadOnly);
+internal sealed record SqltestDatabase(SqltestDatabaseKind Kind, string? Path, bool ReadOnly)
+{
+    public string DisplayName => Kind switch
+    {
+        SqltestDatabaseKind.Memory => ":memory:",
+        SqltestDatabaseKind.TempFile => ":temp:",
+        SqltestDatabaseKind.Default => ":default:",
+        SqltestDatabaseKind.DefaultNoRowidAlias => ":default-no-rowidalias:",
+        _ => Path ?? "<path>",
+    };
+}
 
 internal enum SqltestExpectationKind
 {
@@ -37,7 +47,8 @@ internal sealed record SqltestCase(
     IReadOnlyList<string> Setups,
     IReadOnlyList<SqltestSkip> Skips,
     string? Backend,
-    IReadOnlyList<string> Requires);
+    IReadOnlyList<string> Requires,
+    bool CrossCheckIntegrity);
 
 internal sealed record SqltestFile(
     string RelativePath,
@@ -347,6 +358,8 @@ internal static class SqltestParser
                     new SqltestDatabase(SqltestDatabaseKind.Default, null, true),
                 { Kind: TokenKind.Location, Value: ":default-no-rowidalias:" } =>
                     new SqltestDatabase(SqltestDatabaseKind.DefaultNoRowidAlias, null, true),
+                { Kind: TokenKind.Location, Value: ":default-no-rowid-alias:" } =>
+                    new SqltestDatabase(SqltestDatabaseKind.DefaultNoRowidAlias, null, true),
                 { Kind: TokenKind.Word } =>
                     new SqltestDatabase(SqltestDatabaseKind.Path, token.Value, ConsumeReadOnly()),
                 _ => throw new SqltestParseException($"Unexpected database specifier '{token.Value}'."),
@@ -367,6 +380,7 @@ internal static class SqltestParser
             var skips = new List<SqltestSkip>();
             var requires = new List<string>();
             string? backend = null;
+            var crossCheckIntegrity = false;
 
             while (Peek() is { Kind: TokenKind.Directive } directive)
             {
@@ -391,6 +405,7 @@ internal static class SqltestParser
                         backend = ExpectWord();
                         break;
                     case "@cross-check-integrity":
+                        crossCheckIntegrity = true;
                         break;
                     default:
                         throw new SqltestParseException($"Unexpected directive '{directive.Value}' in {relativePath}.");
@@ -436,7 +451,15 @@ internal static class SqltestParser
             if (expectation is null)
                 throw new SqltestParseException($"Test '{name}' in {relativePath} has no default expect block.");
 
-            return new SqltestCase(name, sql, expectation, setups, skips, backend, requires);
+            return new SqltestCase(
+                name,
+                sql,
+                expectation,
+                setups,
+                skips,
+                backend,
+                requires,
+                crossCheckIntegrity);
         }
 
         private SqltestExpectation ParseExpectation()

--- a/src/Ahtola.Tests/SqltestHarnessTests.cs
+++ b/src/Ahtola.Tests/SqltestHarnessTests.cs
@@ -1,0 +1,255 @@
+using AwesomeAssertions;
+using Ahtola.Tests.Sqltest;
+
+namespace Ahtola.Tests;
+
+[Category("CoverageExcluded")]
+public class SqltestHarnessTests
+{
+    [Test]
+    public void ParserRetainsCrossCheckIntegrityAsTypedMetadata()
+    {
+        var file = Parse(
+            """
+            @database :memory:
+
+            @cross-check-integrity
+            test checked {
+                SELECT 1
+            }
+            expect {
+                1
+            }
+
+            test unchecked {
+                SELECT 2
+            }
+            expect {
+                2
+            }
+            """);
+
+        file.Tests.Single(test => test.Name == "checked").CrossCheckIntegrity.Should().BeTrue();
+        file.Tests.Single(test => test.Name == "unchecked").CrossCheckIntegrity.Should().BeFalse();
+    }
+
+    [Test]
+    public void DefaultFixtureDataMatchesTursoSeedAndIsDeterministic()
+    {
+        var first = SqltestDefaultDatabaseGenerator.GenerateData(
+            SqltestDefaultDatabaseGenerator.DefaultUserCount);
+        var second = SqltestDefaultDatabaseGenerator.GenerateData(
+            SqltestDefaultDatabaseGenerator.DefaultUserCount);
+
+        first.Should().BeEquivalentTo(second, options => options.WithStrictOrdering());
+        first.Users.Should().HaveCount(10_000);
+        first.Products.Should().HaveCount(11);
+        first.Users[0].Should().Be(
+            new SqltestGeneratedUser(
+                "Dan",
+                "Parker",
+                "caden@example.org",
+                "436.726.1331 x867",
+                "Davonte Mountains",
+                "Hodkiewicz side",
+                "NJ",
+                "758",
+                31));
+        first.Users[1].Should().Be(
+            new SqltestGeneratedUser(
+                "Chaz",
+                "Zemlak",
+                "kip@example.com",
+                "(242) 091-6326 x60303",
+                "Dibbert Street",
+                "Noe mouth",
+                "ND",
+                "656",
+                10));
+        first.Users.Sum(static user => user.Age).Should().Be(504_576);
+        first.Products[0].Name.Should().Be("hat");
+        first.Products[0].Price.Should().BeApproximately(82.9389679823547, 1e-13);
+        first.Products[1].Name.Should().Be("cap");
+        first.Products[1].Price.Should().BeApproximately(32.2475410444338, 1e-13);
+    }
+
+    [Test]
+    public void DefaultDatabaseVariantsHaveEquivalentShapeAndDistinctPrimaryKeyDeclarations()
+    {
+        var defaultPath = SqltestDefaultDatabaseGenerator.GetDefaultPath(noRowidAlias: false);
+        var noAliasPath = SqltestDefaultDatabaseGenerator.GetDefaultPath(noRowidAlias: true);
+
+        Query(defaultPath, "SELECT count(*) FROM users").Should().Equal("10000");
+        Query(noAliasPath, "SELECT count(*) FROM users").Should().Equal("10000");
+        Query(defaultPath, "SELECT count(*) FROM products").Should().Equal("11");
+        Query(noAliasPath, "SELECT count(*) FROM products").Should().Equal("11");
+        Query(defaultPath, "SELECT sql FROM sqlite_schema WHERE name = 'users'").Single()
+            .Should().Contain("id INTEGER PRIMARY KEY");
+        Query(noAliasPath, "SELECT sql FROM sqlite_schema WHERE name = 'users'").Single()
+            .Should().Contain("id INT PRIMARY KEY").And.NotContain("id INTEGER PRIMARY KEY");
+    }
+
+    [Test]
+    public void IntegrityCheckRequiresExactlyOneOkRowAndReportsCaseContext()
+    {
+        var file = Parse(
+            """
+            @database :memory:
+
+            @cross-check-integrity
+            test corrupt {
+                SELECT 1
+            }
+            expect {
+                1
+            }
+            """,
+            "integrity/focused.sqltest");
+
+        var outcome = SqltestManagedRunner.Run(
+            file,
+            file.Tests.Single(),
+            static (_, _) => new SqltestIntegrityResult(["row 2 missing", "ok"], null));
+
+        outcome.Matched.Should().BeFalse();
+        outcome.Detail.Should()
+            .Contain("integrity_check failed for integrity/focused.sqltest::corrupt")
+            .And.Contain("expected exactly one row 'ok'")
+            .And.Contain("2 row(s)");
+    }
+
+    [Test]
+    public void IntegrityCheckSkipsExpectedErrorsAndReadOnlyFixturesLikeTurso()
+    {
+        var expectedError = Parse(
+            """
+            @database :memory:
+
+            @cross-check-integrity
+            test expected-error {
+                SELECT missing_column
+            }
+            expect error {
+            }
+            """);
+        var readOnly = Parse(
+            """
+            @database :default:
+
+            @cross-check-integrity
+            test readonly {
+                SELECT 1
+            }
+            expect {
+                1
+            }
+            """);
+        var checks = 0;
+        SqltestIntegrityCheck integrityCheck = (_, _) =>
+        {
+            checks++;
+            return new SqltestIntegrityResult(["not ok"], null);
+        };
+
+        SqltestManagedRunner.Run(expectedError, expectedError.Tests.Single(), integrityCheck)
+            .Matched.Should().BeTrue();
+        SqltestManagedRunner.Run(readOnly, readOnly.Tests.Single(), integrityCheck)
+            .Matched.Should().BeTrue();
+        checks.Should().Be(0);
+    }
+
+    [Test]
+    public void MultipleDatabaseDeclarationsRunAsIndependentVariants()
+    {
+        var file = Parse(
+            """
+            @database :memory:
+            @database :temp:
+
+            @cross-check-integrity
+            test variants {
+                SELECT 1
+            }
+            expect {
+                1
+            }
+            """);
+        var checks = 0;
+
+        var outcome = SqltestManagedRunner.Run(
+            file,
+            file.Tests.Single(),
+            (_, _) =>
+            {
+                checks++;
+                return new SqltestIntegrityResult(["ok"], null);
+            });
+
+        outcome.Matched.Should().BeTrue();
+        checks.Should().Be(2);
+        SqltestCorpus.Classify(file, file.Tests.Single()).Status.Should().Be(SqltestCaseStatus.Runnable);
+    }
+
+    [Test]
+    public void GeneratedDefaultsAreRunnableButUngeneratedPathsStayExplicitlyUnsupported()
+    {
+        var defaults = Parse(
+            """
+            @database :default:
+            @database :default-no-rowid-alias:
+            test variants { SELECT 1 }
+            expect { 1 }
+            """);
+        var path = Parse(
+            """
+            @database database/custom.db readonly
+            test path { SELECT 1 }
+            expect { 1 }
+            """);
+
+        SqltestCorpus.Classify(defaults, defaults.Tests.Single()).Status
+            .Should().Be(SqltestCaseStatus.Runnable);
+        var pathClassification = SqltestCorpus.Classify(path, path.Tests.Single());
+        pathClassification.Status.Should().Be(SqltestCaseStatus.UnsupportedHarness);
+        pathClassification.Reason.Should().Contain("no equivalent managed generator");
+    }
+
+    [Test]
+    public void UnboundedPlannerGapIsReportedAsAnExplicitHarnessLimitation()
+    {
+        var file = Parse(
+            """
+            @database :default:
+            test four-way-inner-join { SELECT 1 }
+            expect { 1 }
+            """,
+            "join/default.sqltest");
+
+        var classification = SqltestCorpus.Classify(file, file.Tests.Single());
+
+        classification.Status.Should().Be(SqltestCaseStatus.UnsupportedHarness);
+        classification.Reason.Should().Contain("cannot be bounded in-process");
+    }
+
+    private static SqltestFile Parse(string source, string relativePath = "focused.sqltest")
+        => SqltestParser.Parse(relativePath, source);
+
+    private static IReadOnlyList<string> Query(string path, string sql)
+    {
+        using var database = Ahtola.Core.EmbeddedDatabase.OpenFile(path, readOnly: true);
+        using var connection = database.Connect();
+        using var statement = connection.Prepare(sql);
+        var rows = new List<string>();
+        while (statement.Step() == Ahtola.Core.StatementStepResult.Row)
+        {
+            var value = statement.GetValue(0);
+            rows.Add(value.Kind switch
+            {
+                Ahtola.Core.SqlValueKind.Integer => value.AsInteger().ToString(),
+                Ahtola.Core.SqlValueKind.Text => value.AsText(),
+                _ => value.ToString() ?? string.Empty,
+            });
+        }
+        return rows;
+    }
+}

--- a/src/Ahtola.Tests/StorageReliabilityTests.cs
+++ b/src/Ahtola.Tests/StorageReliabilityTests.cs
@@ -1,0 +1,195 @@
+using AwesomeAssertions;
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Tests;
+
+public sealed class StorageReliabilityTests
+{
+    [Test]
+    public void CommittedWalSurvivesPowerLossBeforeFirstCheckpoint()
+    {
+        var fileSystem = new LiveDurableFileSystem();
+        const string databasePath = "before-first-checkpoint.db";
+        const string walPath = databasePath + "-wal";
+        var committedPage = CreatePage(0x42);
+
+        using (var pager = CreatePager(fileSystem, databasePath, walPath))
+        {
+            CommitPage(pager, 2, committedPage, SqliteSynchronousMode.Full);
+            pager.ReadCommittedPage(2).Should().Equal(committedPage);
+            var durable = fileSystem.CaptureDurableSnapshot();
+            durable.Files[databasePath].Length.Should().BeGreaterThanOrEqualTo(SqlitePageSize.Default);
+            durable.Files[walPath].Length.Should().BeGreaterThan(SqliteWalHeader.Size);
+        }
+
+        fileSystem.RestoreAfterPowerLoss();
+
+        using var recovered = SqlitePager.Open(fileSystem, databasePath, walPath);
+        recovered.ReadCommittedPage(2).Should().Equal(committedPage);
+        recovered.RecoveryInfo.LastCommittedFrameNumber.Should().BeGreaterThan(0);
+    }
+
+    [Test]
+    public void UnsyncedCommitAndDurableUncommittedFrameNeverBecomeVisible()
+    {
+        var fileSystem = new LiveDurableFileSystem();
+        const string databasePath = "volatile-tail.db";
+        const string walPath = databasePath + "-wal";
+        var durablePage = CreatePage(0x31);
+        var volatilePage = CreatePage(0x72);
+        var uncommittedPage = CreatePage(0x93);
+
+        using (var pager = CreatePager(fileSystem, databasePath, walPath))
+        {
+            CommitPage(pager, 2, durablePage, SqliteSynchronousMode.Full);
+            pager.CheckpointToMainStoreAndResetWal();
+            CommitPage(pager, 2, volatilePage, SqliteSynchronousMode.Off);
+            pager.ReadCommittedPage(2).Should().Equal(volatilePage);
+        }
+
+        fileSystem.RestoreAfterPowerLoss();
+        using (var recovered = SqlitePager.Open(fileSystem, databasePath, walPath))
+        {
+            recovered.ReadCommittedPage(2).Should().Equal(durablePage);
+            recovered.AppendUncommittedWalFrameForTesting(2, uncommittedPage);
+        }
+
+        fileSystem.RestoreAfterPowerLoss();
+        using var final = SqlitePager.Open(fileSystem, databasePath, walPath);
+        final.ReadCommittedPage(2).Should().Equal(durablePage);
+        final.RecoveryInfo.LastCommittedFrameNumber.Should().Be(0);
+    }
+
+    [Test]
+    public void TornCheckpointRecoversOneCommittedImageWithoutMixedPages()
+    {
+        var fileSystem = new LiveDurableFileSystem();
+        const string databasePath = "torn-checkpoint.db";
+        const string walPath = databasePath + "-wal";
+        var oldPages = Enumerable.Range(2, 4)
+            .ToDictionary(page => (uint)page, page => CreatePage((byte)(0x10 + page)));
+        var newPages = Enumerable.Range(2, 4)
+            .ToDictionary(page => (uint)page, page => CreatePage((byte)(0x70 + page)));
+
+        using (var pager = CreatePager(fileSystem, databasePath, walPath))
+        {
+            CommitPages(pager, oldPages, SqliteSynchronousMode.Full);
+            pager.CheckpointToMainStoreAndResetWal();
+            fileSystem.MarkAllDurable();
+
+            CommitPages(pager, newPages, SqliteSynchronousMode.Full);
+            fileSystem.ArmTornFlush(databasePath, 1, 3);
+            pager.CheckpointToMainStore(synchronousMode: SqliteSynchronousMode.Full);
+        }
+
+        var crash = fileSystem.TakeTornFlushSnapshot();
+        crash.SelectedMutationCount.Should().BeGreaterThan(0);
+        crash.DroppedMutationCount.Should().BeGreaterThan(0);
+        crash.Files.Should().ContainKey(databasePath).WhoseValue.Should().NotBeEmpty();
+        crash.Files.Should().ContainKey(walPath).WhoseValue.Length
+            .Should().BeGreaterThan(SqliteWalHeader.Size);
+        var tornMain = crash.Files[databasePath];
+        oldPages.Any(pair => ContainsPageImage(tornMain, pair.Key, pair.Value)).Should().BeTrue();
+        newPages.Any(pair => ContainsPageImage(tornMain, pair.Key, pair.Value)).Should().BeTrue();
+
+        fileSystem.RestoreAfterPowerLoss(crash);
+        using var recovered = SqlitePager.Open(fileSystem, databasePath, walPath);
+        var recoveredPages = newPages.Keys.ToDictionary(
+            pageNumber => pageNumber,
+            recovered.ReadCommittedPage);
+        var isPriorImage = oldPages.All(pair => recoveredPages[pair.Key].SequenceEqual(pair.Value));
+        var isCommittedImage = newPages.All(pair => recoveredPages[pair.Key].SequenceEqual(pair.Value));
+        (isPriorImage || isCommittedImage).Should().BeTrue(
+            "checkpoint recovery must select a complete committed image, never torn page generations");
+    }
+
+    [Test]
+    public void PowerLossPreservesSidecarsAndOnlyFlushedTruncation()
+    {
+        var fileSystem = new LiveDurableFileSystem();
+        using (var database = fileSystem.OpenFile("state.db", FileOpenMode.CreateNew))
+        {
+            database.Write(0, new byte[] { 1, 2, 3, 4 });
+            database.FlushToDisk();
+            database.SetLength(2);
+        }
+        using (var wal = fileSystem.OpenFile("state.db-wal", FileOpenMode.CreateNew))
+        {
+            wal.Write(0, new byte[] { 5, 6 });
+            wal.FlushToDisk();
+        }
+        using (var sharedMemory = fileSystem.OpenFile("state.db-shm", FileOpenMode.CreateNew))
+        {
+            sharedMemory.Write(0, new byte[] { 7, 8 });
+            sharedMemory.FlushToDisk();
+        }
+
+        fileSystem.DeleteFile("state.db-wal");
+        fileSystem.RestoreAfterPowerLoss();
+
+        ReadAll(fileSystem, "state.db").Should().Equal(1, 2, 3, 4);
+        fileSystem.FileExists("state.db-wal").Should().BeFalse();
+        ReadAll(fileSystem, "state.db-shm").Should().Equal(7, 8);
+
+        using (var database = fileSystem.OpenFile("state.db", FileOpenMode.OpenExisting))
+        {
+            database.SetLength(2);
+            database.FlushToDisk();
+        }
+        fileSystem.RestoreAfterPowerLoss();
+        ReadAll(fileSystem, "state.db").Should().Equal(1, 2);
+    }
+
+    private static SqlitePager CreatePager(
+        IFileSystem fileSystem,
+        string databasePath,
+        string walPath)
+        => SqlitePager.Create(
+            fileSystem,
+            databasePath,
+            walPath,
+            SqliteWalHeader.Create(
+                SqlitePageSize.Default,
+                salt1: 0x1020_3040,
+                salt2: 0x5060_7080,
+                checkpointSequence: 17));
+
+    private static void CommitPage(
+        SqlitePager pager,
+        uint pageNumber,
+        byte[] page,
+        SqliteSynchronousMode synchronousMode)
+        => CommitPages(pager, new Dictionary<uint, byte[]> { [pageNumber] = page }, synchronousMode);
+
+    private static void CommitPages(
+        SqlitePager pager,
+        IReadOnlyDictionary<uint, byte[]> pages,
+        SqliteSynchronousMode synchronousMode)
+    {
+        using var transaction = pager.BeginTransaction(pages.Keys.Max());
+        foreach (var (pageNumber, page) in pages)
+            transaction.WritePage(pageNumber, page);
+        transaction.Commit(synchronousMode);
+    }
+
+    private static byte[] CreatePage(byte fill)
+    {
+        var page = new byte[SqlitePageSize.Default];
+        Array.Fill(page, fill);
+        return page;
+    }
+
+    private static byte[] ReadAll(IFileSystem fileSystem, string path)
+    {
+        using var file = fileSystem.OpenFile(path, FileOpenMode.OpenExisting, readOnly: true);
+        var bytes = new byte[checked((int)file.Length)];
+        file.Read(0, bytes).Should().Be(bytes.Length);
+        return bytes;
+    }
+
+    private static bool ContainsPageImage(byte[] database, uint pageNumber, byte[] expected)
+    {
+        var offset = checked((int)(pageNumber - 1) * SqlitePageSize.Default);
+        return database.AsSpan(offset, SqlitePageSize.Default).SequenceEqual(expected);
+    }
+}

--- a/src/Ahtola.Tests/TraceMinimizerTests.cs
+++ b/src/Ahtola.Tests/TraceMinimizerTests.cs
@@ -1,0 +1,101 @@
+using AwesomeAssertions;
+using Ahtola.Tests.Oracle;
+
+namespace Ahtola.Tests;
+
+public sealed class TraceMinimizerTests
+{
+    [Test]
+    public void DdminRemovesIrrelevantOperationsAndTheirDependents()
+    {
+        var operations = new[]
+        {
+            Operation(0, "setup", "CREATE TABLE t(id INTEGER PRIMARY KEY);"),
+            Operation(1, "begin", "BEGIN;", dependencies: [0]),
+            Operation(2, "observe", "SELECT * FROM t;", dependencies: [0]),
+            Operation(3, "insert", "INSERT INTO t VALUES (13);", dependencies: [0, 1]),
+            Operation(4, "savepoint", "SAVEPOINT irrelevant;", dependencies: [0, 1]),
+            Operation(5, "update", "UPDATE t SET id = 99;", dependencies: [0, 1, 4]),
+            Operation(6, "fault", "SELECT synthetic_failure FROM t;", dependencies: [0, 1, 3]),
+            Operation(7, "commit", "COMMIT;", dependencies: [0, 1]),
+        };
+
+        var minimized = DependencyAwareTraceMinimizer.Minimize(operations, SyntheticFailure);
+
+        minimized.Select(static operation => operation.Action)
+            .Should().Equal("setup", "begin", "insert", "fault");
+        DependencyAwareTraceMinimizer.ValidateDependencies(minimized);
+        SyntheticFailure(minimized).Should().Be("SyntheticFailure:row=13");
+    }
+
+    [Test]
+    public void ReplayTraceRoundTripsActorActionAndDependencies()
+    {
+        var stream = StableTestSeed.Create(91).Derive("dependency-round-trip");
+        var trace = ReplayTrace.Create(TestContext.CurrentContext.Test.Name, stream);
+        trace.Add("CREATE TABLE t(id INTEGER);", actor: 0, action: "setup");
+        trace.Add("BEGIN;", actor: 1, action: "begin", dependencies: [0]);
+
+        var restored = ReplayTrace.FromJson(trace.ToJson());
+
+        restored.Operations[1].Actor.Should().Be(1);
+        restored.Operations[1].Action.Should().Be("begin");
+        restored.Operations[1].Dependencies.Should().Equal(0);
+        restored.ToSql().Should().Contain("actor=1").And.Contain("depends=[0]");
+    }
+
+    [Test]
+    public void FailureFingerprintNormalizesVolatileNumbersAndIdentifiers()
+    {
+        var first = new InvalidOperationException(
+            "operation 19 failed at 0xCAFE for 70b8f95f-46a2-4af2-aacd-ab83dc78d1e1");
+        var second = new InvalidOperationException(
+            "operation 41 failed at 0xBEEF for 8b1a9953-c461-4f9a-827d-0d01bf54c2f4");
+
+        DependencyAwareTraceMinimizer.NormalizeFailure(first)
+            .Should().Be(DependencyAwareTraceMinimizer.NormalizeFailure(second));
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void StableSeedHonorsHexEnvironmentOverride()
+    {
+        const string variable = "AHTOLA_TEST_SEED";
+        var previous = Environment.GetEnvironmentVariable(variable);
+        try
+        {
+            Environment.SetEnvironmentVariable(variable, "0xdecafbad");
+            var seed = StableTestSeed.Create(1);
+
+            seed.RootSeed.Should().Be(0xdecafbadUL);
+            seed.Source.Should().Be(variable);
+            seed.Derive("override").Diagnostics.Should().Contain($"{variable}=3737844653");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(variable, previous);
+        }
+    }
+
+    private static ReplayOperation Operation(
+        int id,
+        string action,
+        string sql,
+        int actor = 0,
+        params int[] dependencies)
+        => new(id, sql, "synthetic", true, actor, action, dependencies);
+
+    private static string? SyntheticFailure(IReadOnlyList<ReplayOperation> operations)
+    {
+        var ids = operations.Select(static operation => operation.Index).ToHashSet();
+        if (operations.Any(static operation => operation.Action == "fault")
+            && operations.Any(static operation =>
+                operation.Action == "insert" && operation.Sql.Contains("13", StringComparison.Ordinal))
+            && operations.All(operation => (operation.Dependencies ?? []).All(ids.Contains)))
+        {
+            return "SyntheticFailure:row=13";
+        }
+
+        return null;
+    }
+}

--- a/src/Ahtola.Tests/TransactionShadowModelTests.cs
+++ b/src/Ahtola.Tests/TransactionShadowModelTests.cs
@@ -1,0 +1,712 @@
+using AwesomeAssertions;
+using Ahtola.Data.Sqlite;
+using Ahtola.Tests.Oracle;
+
+namespace Ahtola.Tests;
+
+/// <summary>
+/// Single-threaded deterministic scheduling modeled after Turso's
+/// <c>tests/integration/fuzz_transaction/ShadowDb</c>.
+/// </summary>
+public sealed class TransactionShadowModelTests
+{
+    private const int ActorCount = 3;
+    private const int RandomOperationCount = 72;
+
+    [TestCase(31)]
+    [TestCase(0x71ce)]
+    public void MultiConnectionReplayMatchesTransactionShadowAfterEveryObservation(int defaultSeed)
+    {
+        var stream = StableTestSeed.Create((ulong)defaultSeed)
+            .Derive($"transaction-shadow-{defaultSeed:x}");
+        var trace = ReplayTrace.Create(TestContext.CurrentContext.Test.Name, stream);
+        var path = DatabasePath(defaultSeed);
+
+        try
+        {
+            OracleFailureArtifacts.Run(trace, () =>
+            {
+                using var runner = new ShadowRunner(path, ActorCount, trace);
+                runner.Initialize();
+                runner.RunRequiredCoverage();
+                runner.RunGenerated(stream.Random, RandomOperationCount);
+                runner.RollBackActiveTransactions();
+                runner.AssertAllVisible();
+            });
+        }
+        finally
+        {
+            DeleteDatabaseFiles(path);
+        }
+    }
+
+    private static string DatabasePath(int seed)
+    {
+        var directory = Path.Combine(TestContext.CurrentContext.WorkDirectory, "model-testing");
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, $"transaction-shadow-{seed:x}-{Guid.NewGuid():N}.db");
+    }
+
+    private static void DeleteDatabaseFiles(string path)
+    {
+        foreach (var suffix in new[] { string.Empty, "-wal", "-shm", "-journal" })
+        {
+            var candidate = path + suffix;
+            if (File.Exists(candidate))
+                File.Delete(candidate);
+        }
+    }
+
+    private enum ShadowAction
+    {
+        Begin,
+        Commit,
+        Rollback,
+        Insert,
+        Update,
+        Delete,
+        Select,
+        Savepoint,
+        RollbackTo,
+        Release,
+        Checkpoint,
+        Reopen,
+    }
+
+    private sealed record ShadowCommand(
+        int Actor,
+        ShadowAction Action,
+        int Key = 0,
+        int Value = 0,
+        string? Savepoint = null);
+
+    private sealed class ShadowRunner : IDisposable
+    {
+        private readonly string _path;
+        private readonly int _actorCount;
+        private readonly ReplayTrace _trace;
+        private readonly TransactionShadow _model;
+        private List<SqliteConnection> _connections = [];
+        private int _savepointNumber;
+
+        internal ShadowRunner(string path, int actorCount, ReplayTrace trace)
+        {
+            _path = path;
+            _actorCount = actorCount;
+            _trace = trace;
+            _model = new TransactionShadow(actorCount);
+        }
+
+        internal void Initialize()
+        {
+            _trace.Add(
+                "CREATE TABLE model_rows(id INTEGER PRIMARY KEY, value INTEGER NOT NULL);",
+                comparison: "shadow setup",
+                actor: 0,
+                action: "setup");
+            using (var setup = OpenConnection())
+            {
+                ExpectSuccess(
+                    TypedSqliteOracle.Execute(
+                        setup,
+                        "CREATE TABLE model_rows(id INTEGER PRIMARY KEY, value INTEGER NOT NULL);"),
+                    "setup");
+            }
+
+            OpenActors();
+            AssertAllVisible();
+        }
+
+        internal void RunRequiredCoverage()
+        {
+            Execute(new ShadowCommand(0, ShadowAction.Begin));
+            Execute(new ShadowCommand(0, ShadowAction.Insert, 1, 10));
+            Execute(new ShadowCommand(0, ShadowAction.Savepoint, Savepoint: "required"));
+            Execute(new ShadowCommand(0, ShadowAction.Update, 1, 99));
+            Execute(new ShadowCommand(0, ShadowAction.RollbackTo, Savepoint: "required"));
+            Execute(new ShadowCommand(0, ShadowAction.Release, Savepoint: "required"));
+            Execute(new ShadowCommand(1, ShadowAction.Select));
+            Execute(new ShadowCommand(0, ShadowAction.Commit));
+            Execute(new ShadowCommand(0, ShadowAction.Insert, 1, 77)); // deterministic constraint error
+            Execute(new ShadowCommand(1, ShadowAction.Begin));
+            Execute(new ShadowCommand(1, ShadowAction.Select));
+            Execute(new ShadowCommand(0, ShadowAction.Insert, 2, 20));
+            Execute(new ShadowCommand(1, ShadowAction.Select));
+            Execute(new ShadowCommand(1, ShadowAction.Commit));
+            Execute(new ShadowCommand(2, ShadowAction.Commit)); // deterministic invalid control
+            Execute(new ShadowCommand(0, ShadowAction.Checkpoint));
+            Execute(new ShadowCommand(2, ShadowAction.Reopen));
+        }
+
+        internal void RunGenerated(StablePrng random, int operationCount)
+        {
+            for (var step = 0; step < operationCount; step++)
+            {
+                var actor = random.NextInt32(_actorCount);
+                Execute(Generate(actor, step, random));
+            }
+        }
+
+        internal void RollBackActiveTransactions()
+        {
+            for (var actor = 0; actor < _actorCount; actor++)
+            {
+                if (_model.IsActive(actor))
+                    Execute(new ShadowCommand(actor, ShadowAction.Rollback));
+            }
+        }
+
+        internal void AssertAllVisible()
+        {
+            for (var actor = 0; actor < _actorCount; actor++)
+            {
+                var expectedRows = _model.VisibleRows(actor)
+                    .Select(static pair => new OracleRow(
+                        [OracleValue.Integer(pair.Key), OracleValue.Integer(pair.Value)]))
+                    .ToArray();
+                var dependencies = _model.Dependencies(actor);
+                const string sql = "SELECT id, value FROM model_rows ORDER BY id;";
+                _trace.Add(
+                    sql,
+                    comparison: "transaction shadow visible rows",
+                    actor: actor,
+                    action: "observe",
+                    dependencies: dependencies);
+                var actual = TypedSqliteOracle.Execute(_connections[actor], sql);
+                var expected = OracleExecutionResult.Success(true, ["id", "value"], expectedRows);
+                TypedSqliteOracle.AssertEquivalent(
+                    actual,
+                    expected,
+                    ordered: true,
+                    $"{_trace.SeedDiagnostics}; actor={actor}; operation={_trace.Operations.Count - 1}");
+            }
+        }
+
+        public void Dispose()
+        {
+            DisposeActors();
+        }
+
+        private ShadowCommand Generate(int actor, int step, StablePrng random)
+        {
+            if (step > 0 && step % 29 == 0)
+                return new ShadowCommand(actor, ShadowAction.Reopen);
+            if (_model.AllInactive && step > 0 && step % 17 == 0)
+                return new ShadowCommand(actor, ShadowAction.Checkpoint);
+
+            var choice = random.NextInt32(100);
+            if (_model.IsActive(actor))
+            {
+                if (choice < 8)
+                    return new ShadowCommand(actor, ShadowAction.Begin);
+                if (choice < 20)
+                    return new ShadowCommand(actor, ShadowAction.Commit);
+                if (choice < 30)
+                    return new ShadowCommand(actor, ShadowAction.Rollback);
+                if (choice < 42)
+                    return new ShadowCommand(
+                        actor,
+                        ShadowAction.Savepoint,
+                        Savepoint: $"sp_{actor}_{_savepointNumber++}");
+                if (choice < 50)
+                {
+                    return new ShadowCommand(
+                        actor,
+                        ShadowAction.RollbackTo,
+                        Savepoint: _model.LastSavepoint(actor) ?? "missing");
+                }
+
+                if (choice < 58)
+                {
+                    return new ShadowCommand(
+                        actor,
+                        ShadowAction.Release,
+                        Savepoint: _model.LastSavepoint(actor) ?? "missing");
+                }
+
+                if (choice < 72 || !_model.CanMutate(actor))
+                    return new ShadowCommand(actor, ShadowAction.Select);
+                return RandomMutation(actor, random);
+            }
+
+            if (choice < 20)
+                return new ShadowCommand(actor, ShadowAction.Begin);
+            if (choice < 27)
+                return new ShadowCommand(actor, ShadowAction.Commit);
+            if (choice < 34)
+                return new ShadowCommand(actor, ShadowAction.Rollback);
+            if (choice < 40)
+                return new ShadowCommand(actor, ShadowAction.Release, Savepoint: "missing");
+            if (choice < 53)
+                return new ShadowCommand(actor, ShadowAction.Select);
+            if (choice < 58 && _model.AllInactive)
+                return new ShadowCommand(actor, ShadowAction.Checkpoint);
+            if (choice < 63)
+                return new ShadowCommand(actor, ShadowAction.Reopen);
+            if (!_model.CanMutate(actor))
+                return new ShadowCommand(actor, ShadowAction.Select);
+            return RandomMutation(actor, random);
+        }
+
+        private static ShadowCommand RandomMutation(int actor, StablePrng random)
+        {
+            var key = random.NextInt32(1, 13);
+            var value = random.NextInt32(-50, 51);
+            return random.NextInt32(3) switch
+            {
+                0 => new ShadowCommand(actor, ShadowAction.Insert, key, value),
+                1 => new ShadowCommand(actor, ShadowAction.Update, key, value),
+                _ => new ShadowCommand(actor, ShadowAction.Delete, key),
+            };
+        }
+
+        private void Execute(ShadowCommand command)
+        {
+            var dependencies = _model.Dependencies(command.Actor);
+            switch (command.Action)
+            {
+                case ShadowAction.Reopen:
+                    Trace("-- close and reopen every actor connection", command, dependencies);
+                    DisposeActors();
+                    _model.RollBackAll();
+                    OpenActors();
+                    break;
+
+                case ShadowAction.Begin:
+                    {
+                        var expectedSuccess = !_model.IsActive(command.Actor);
+                        var operationIndex = Trace("BEGIN;", command, dependencies);
+                        ExpectOutcome(ExecuteSql(command.Actor, "BEGIN;"), expectedSuccess, command);
+                        if (expectedSuccess)
+                            _model.Begin(command.Actor, operationIndex);
+                        break;
+                    }
+
+                case ShadowAction.Commit:
+                    {
+                        var expectedSuccess = _model.IsActive(command.Actor);
+                        Trace("COMMIT;", command, dependencies);
+                        ExpectOutcome(ExecuteSql(command.Actor, "COMMIT;"), expectedSuccess, command);
+                        if (expectedSuccess)
+                            _model.Commit(command.Actor);
+                        break;
+                    }
+
+                case ShadowAction.Rollback:
+                    {
+                        var expectedSuccess = _model.IsActive(command.Actor);
+                        Trace("ROLLBACK;", command, dependencies);
+                        ExpectOutcome(ExecuteSql(command.Actor, "ROLLBACK;"), expectedSuccess, command);
+                        if (expectedSuccess)
+                            _model.Rollback(command.Actor);
+                        break;
+                    }
+
+                case ShadowAction.Insert:
+                    {
+                        _model.EnsureCanMutate(command.Actor);
+                        var expectedSuccess = !_model.Contains(command.Actor, command.Key);
+                        var sql = $"INSERT INTO model_rows VALUES ({command.Key}, {command.Value});";
+                        Trace(sql, command, dependencies);
+                        ExpectOutcome(ExecuteSql(command.Actor, sql), expectedSuccess, command);
+                        if (expectedSuccess)
+                            _model.Insert(command.Actor, command.Key, command.Value);
+                        else
+                            _model.MarkFailedMutation(command.Actor);
+                        break;
+                    }
+
+                case ShadowAction.Update:
+                    {
+                        _model.EnsureCanMutate(command.Actor);
+                        var sql = $"UPDATE model_rows SET value = {command.Value} WHERE id = {command.Key};";
+                        Trace(sql, command, dependencies);
+                        ExpectSuccess(ExecuteSql(command.Actor, sql), command.ToString());
+                        _model.Update(command.Actor, command.Key, command.Value);
+                        break;
+                    }
+
+                case ShadowAction.Delete:
+                    {
+                        _model.EnsureCanMutate(command.Actor);
+                        var sql = $"DELETE FROM model_rows WHERE id = {command.Key};";
+                        Trace(sql, command, dependencies);
+                        ExpectSuccess(ExecuteSql(command.Actor, sql), command.ToString());
+                        _model.Delete(command.Actor, command.Key);
+                        break;
+                    }
+
+                case ShadowAction.Select:
+                    Trace("SELECT id, value FROM model_rows ORDER BY id;", command, dependencies);
+                    ExpectSuccess(
+                        ExecuteSql(command.Actor, "SELECT id, value FROM model_rows ORDER BY id;"),
+                        command.ToString());
+                    break;
+
+                case ShadowAction.Savepoint:
+                    {
+                        var expectedSuccess = _model.IsActive(command.Actor);
+                        var sql = $"SAVEPOINT \"{command.Savepoint}\";";
+                        var operationIndex = Trace(sql, command, dependencies);
+                        ExpectOutcome(ExecuteSql(command.Actor, sql), expectedSuccess, command);
+                        if (expectedSuccess)
+                            _model.Savepoint(command.Actor, command.Savepoint!, operationIndex);
+                        break;
+                    }
+
+                case ShadowAction.RollbackTo:
+                    {
+                        var expectedSuccess = _model.HasSavepoint(command.Actor, command.Savepoint!);
+                        var sql = $"ROLLBACK TO \"{command.Savepoint}\";";
+                        Trace(sql, command, dependencies);
+                        ExpectOutcome(ExecuteSql(command.Actor, sql), expectedSuccess, command);
+                        if (expectedSuccess)
+                            _model.RollbackTo(command.Actor, command.Savepoint!);
+                        break;
+                    }
+
+                case ShadowAction.Release:
+                    {
+                        var expectedSuccess = _model.HasSavepoint(command.Actor, command.Savepoint!);
+                        var sql = $"RELEASE \"{command.Savepoint}\";";
+                        Trace(sql, command, dependencies);
+                        ExpectOutcome(ExecuteSql(command.Actor, sql), expectedSuccess, command);
+                        if (expectedSuccess)
+                            _model.Release(command.Actor, command.Savepoint!);
+                        break;
+                    }
+
+                case ShadowAction.Checkpoint:
+                    _model.AllInactive.Should().BeTrue(because: "generated checkpoints are quiescent");
+                    Trace("PRAGMA wal_checkpoint(PASSIVE);", command, dependencies);
+                    ExpectSuccess(
+                        ExecuteSql(command.Actor, "PRAGMA wal_checkpoint(PASSIVE);"),
+                        command.ToString());
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(command));
+            }
+
+            AssertAllVisible();
+        }
+
+        private int Trace(string sql, ShadowCommand command, IReadOnlyList<int> dependencies)
+        {
+            var index = _trace.Operations.Count;
+            _trace.Add(
+                sql,
+                comparison: "transaction shadow operation",
+                actor: command.Actor,
+                action: command.Action.ToString(),
+                dependencies: dependencies);
+            return index;
+        }
+
+        private OracleExecutionResult ExecuteSql(int actor, string sql)
+            => TypedSqliteOracle.Execute(_connections[actor], sql);
+
+        private void OpenActors()
+        {
+            for (var actor = 0; actor < _actorCount; actor++)
+                _connections.Add(OpenConnection());
+        }
+
+        private SqliteConnection OpenConnection()
+        {
+            var connection = new SqliteConnection(
+                $"Data Source={_path};Local Provider=Managed;Pooling=False;Default Timeout=1");
+            connection.Open();
+            return connection;
+        }
+
+        private void DisposeActors()
+        {
+            foreach (var connection in _connections)
+                connection.Dispose();
+            _connections.Clear();
+        }
+
+        private void ExpectOutcome(
+            OracleExecutionResult result,
+            bool expectedSuccess,
+            ShadowCommand command)
+        {
+            if (expectedSuccess)
+            {
+                ExpectSuccess(result, command.ToString());
+                return;
+            }
+
+            if (result.Kind != OracleExecutionKind.Error)
+            {
+                throw new AssertionException(
+                    $"Expected modeled invalid operation to fail: {command}.{Environment.NewLine}"
+                    + $"{_trace.SeedDiagnostics}{Environment.NewLine}{_trace.ToSql()}");
+            }
+        }
+
+        private void ExpectSuccess(OracleExecutionResult result, string operation)
+        {
+            if (result.Kind != OracleExecutionKind.Success)
+            {
+                throw new AssertionException(
+                    $"Expected modeled operation to succeed: {operation}; "
+                    + $"error={result.Error?.Category}/{result.Error?.SqliteErrorCode}: {result.Error?.Message}"
+                    + $"{Environment.NewLine}{_trace.SeedDiagnostics}{Environment.NewLine}{_trace.ToSql()}");
+            }
+        }
+    }
+
+    private sealed class TransactionShadow
+    {
+        private readonly ActorState[] _actors;
+        private SortedDictionary<int, int> _committed = [];
+        private int _committedVersion;
+
+        internal TransactionShadow(int actorCount)
+        {
+            _actors = Enumerable.Range(0, actorCount).Select(static _ => new ActorState()).ToArray();
+        }
+
+        internal bool AllInactive => _actors.All(static actor => !actor.Active);
+
+        internal bool IsActive(int actor) => _actors[actor].Active;
+
+        internal bool CanMutate(int actor)
+        {
+            var state = _actors[actor];
+            return !_actors.Where((_, index) => index != actor).Any(static other => other.HoldsWriteLease)
+                && (!state.Active || state.SnapshotVersion == _committedVersion);
+        }
+
+        internal void EnsureCanMutate(int actor)
+        {
+            if (!CanMutate(actor))
+                throw new InvalidOperationException($"Actor {actor} was scheduled for an invalid write-lock transition.");
+        }
+
+        internal IReadOnlyList<int> Dependencies(int actor)
+        {
+            var dependencies = new List<int> { 0 };
+            var state = _actors[actor];
+            if (state.Active)
+                dependencies.Add(state.BeginOperation);
+            if (state.Savepoints.Count > 0)
+                dependencies.Add(state.Savepoints[^1].Operation);
+            return dependencies;
+        }
+
+        internal void Begin(int actor, int operation)
+        {
+            var state = _actors[actor];
+            state.Active = true;
+            state.Snapshot = null;
+            state.WorkingView = null;
+            state.SnapshotVersion = -1;
+            state.HoldsWriteLease = false;
+            state.PendingChanges.Clear();
+            state.BeginOperation = operation;
+            state.Savepoints.Clear();
+        }
+
+        internal void Commit(int actor)
+        {
+            var state = _actors[actor];
+            if (state.PendingChanges.Count > 0)
+            {
+                if (state.SnapshotVersion != _committedVersion)
+                    throw new InvalidOperationException("The shadow scheduler allowed a stale writer to commit.");
+                foreach (var change in state.PendingChanges)
+                    change.Apply(_committed);
+                _committedVersion++;
+            }
+
+            Reset(state);
+        }
+
+        internal void Rollback(int actor) => Reset(_actors[actor]);
+
+        internal void RollBackAll()
+        {
+            foreach (var actor in _actors)
+                Reset(actor);
+        }
+
+        internal IEnumerable<KeyValuePair<int, int>> VisibleRows(int actor)
+        {
+            EnsureSnapshot(actor);
+            var state = _actors[actor];
+            return state.Active ? state.WorkingView!.ToArray() : _committed.ToArray();
+        }
+
+        internal bool Contains(int actor, int key)
+        {
+            EnsureSnapshot(actor);
+            return WorkingView(actor).ContainsKey(key);
+        }
+
+        internal void Insert(int actor, int key, int value)
+        {
+            EnsureSnapshot(actor);
+            WorkingView(actor).Add(key, value);
+            PublishOrPend(actor, new PendingMutation(ShadowAction.Insert, key, value), changed: true);
+        }
+
+        internal void Update(int actor, int key, int value)
+        {
+            EnsureSnapshot(actor);
+            var view = WorkingView(actor);
+            var changed = view.ContainsKey(key);
+            if (changed)
+                view[key] = value;
+            PublishOrPend(actor, new PendingMutation(ShadowAction.Update, key, value), changed);
+        }
+
+        internal void Delete(int actor, int key)
+        {
+            EnsureSnapshot(actor);
+            var changed = WorkingView(actor).Remove(key);
+            PublishOrPend(actor, new PendingMutation(ShadowAction.Delete, key, 0), changed);
+        }
+
+        internal void MarkFailedMutation(int actor)
+        {
+            if (_actors[actor].Active)
+                _actors[actor].HoldsWriteLease = true;
+        }
+
+        internal void Savepoint(int actor, string name, int operation)
+        {
+            EnsureSnapshot(actor);
+            var state = _actors[actor];
+            state.Savepoints.Add(
+                new SavepointFrame(name, Clone(state.WorkingView!), state.PendingChanges.Count, operation));
+        }
+
+        internal bool HasSavepoint(int actor, string name)
+            => _actors[actor].Active
+                && _actors[actor].Savepoints.Exists(
+                    savepoint => string.Equals(savepoint.Name, name, StringComparison.OrdinalIgnoreCase));
+
+        internal string? LastSavepoint(int actor)
+            => _actors[actor].Savepoints.LastOrDefault()?.Name;
+
+        internal void RollbackTo(int actor, string name)
+        {
+            var state = _actors[actor];
+            var index = FindSavepoint(state, name);
+            var frame = state.Savepoints[index];
+            state.WorkingView = Clone(frame.WorkingView);
+            state.PendingChanges.RemoveRange(
+                frame.PendingChangeCount,
+                state.PendingChanges.Count - frame.PendingChangeCount);
+            state.Savepoints.RemoveRange(index + 1, state.Savepoints.Count - index - 1);
+        }
+
+        internal void Release(int actor, string name)
+        {
+            var state = _actors[actor];
+            var index = FindSavepoint(state, name);
+            state.Savepoints.RemoveRange(index, state.Savepoints.Count - index);
+        }
+
+        private static int FindSavepoint(ActorState state, string name)
+        {
+            for (var index = state.Savepoints.Count - 1; index >= 0; index--)
+            {
+                if (string.Equals(state.Savepoints[index].Name, name, StringComparison.OrdinalIgnoreCase))
+                    return index;
+            }
+
+            throw new InvalidOperationException($"Savepoint '{name}' does not exist in the shadow state.");
+        }
+
+        private void EnsureSnapshot(int actor)
+        {
+            var state = _actors[actor];
+            if (!state.Active || state.WorkingView is not null)
+                return;
+            state.Snapshot = Clone(_committed);
+            state.WorkingView = Clone(state.Snapshot);
+            state.SnapshotVersion = _committedVersion;
+        }
+
+        private SortedDictionary<int, int> WorkingView(int actor)
+            => _actors[actor].Active ? _actors[actor].WorkingView! : _committed;
+
+        private void PublishOrPend(int actor, PendingMutation mutation, bool changed)
+        {
+            var state = _actors[actor];
+            if (state.Active)
+            {
+                state.HoldsWriteLease = true;
+                state.PendingChanges.Add(mutation);
+                return;
+            }
+
+            if (changed)
+                _committedVersion++;
+        }
+
+        private static SortedDictionary<int, int> Clone(IReadOnlyDictionary<int, int> rows)
+        {
+            var clone = new SortedDictionary<int, int>();
+            foreach (var row in rows)
+                clone.Add(row.Key, row.Value);
+            return clone;
+        }
+
+        private static void Reset(ActorState state)
+        {
+            state.Active = false;
+            state.Snapshot = null;
+            state.WorkingView = null;
+            state.SnapshotVersion = -1;
+            state.HoldsWriteLease = false;
+            state.PendingChanges.Clear();
+            state.BeginOperation = -1;
+            state.Savepoints.Clear();
+        }
+
+        private sealed class ActorState
+        {
+            internal bool Active;
+            internal SortedDictionary<int, int>? Snapshot;
+            internal SortedDictionary<int, int>? WorkingView;
+            internal int SnapshotVersion = -1;
+            internal bool HoldsWriteLease;
+            internal int BeginOperation = -1;
+            internal List<PendingMutation> PendingChanges { get; } = [];
+            internal List<SavepointFrame> Savepoints { get; } = [];
+        }
+
+        private sealed record SavepointFrame(
+            string Name,
+            SortedDictionary<int, int> WorkingView,
+            int PendingChangeCount,
+            int Operation);
+
+        private sealed record PendingMutation(ShadowAction Action, int Key, int Value)
+        {
+            internal void Apply(IDictionary<int, int> rows)
+            {
+                switch (Action)
+                {
+                    case ShadowAction.Insert:
+                        rows.Add(Key, Value);
+                        break;
+                    case ShadowAction.Update:
+                        if (rows.ContainsKey(Key))
+                            rows[Key] = Value;
+                        break;
+                    case ShadowAction.Delete:
+                        rows.Remove(Key);
+                        break;
+                    default:
+                        throw new InvalidOperationException($"Unsupported pending mutation {Action}.");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add stable seeded differential and metamorphic testing with typed SQLite result normalization, replay artifacts, and dependency-aware minimization
- port Turso-style deterministic sqltest fixtures, multi-database variants, and integrity cross-check semantics, unlocking 1,809 logical cases / 3,618 fixture variants
- add reusable queued async I/O, live-vs-durable power-loss simulation, model-based cache/transaction checks, and bounded cooperative schedule exploration
- add logical database fingerprints, process lifecycle traces, sync/provider contract coverage, and per-assembly Cobertura ratchets in CI
- fix boxed value lookup/removal in `AhtolaParameterCollection`, discovered by the new contract tests

## Validation

- net10 managed suite: 6,753 passed
- net10 coverage lane: 6,508 passed; all five assembly line/branch floors satisfied
- new harness subset: 50 passed on net8 and net9
- managed project closure passed
- changed C# formatting passed
- PowerShell coverage policy tests passed
- independent code review completed; actionable findings addressed

## Notes

The ordinary Windows test lane remains authoritative for generated sqltest fixtures and migration stress. Those classes are marked `CoverageExcluded` only for the duplicate instrumented lane because Coverlet changes lock timing and makes the 10,000-row fixtures prohibitively slow. The vendored sqltest corpus and pinned `turso-src` submodule are unchanged.