### PR TITLE
Close remaining stale table separator gaps

### DIFF
--- a/src/Ahtola.Core/EmbeddedFileStore.cs
+++ b/src/Ahtola.Core/EmbeddedFileStore.cs
@@ -934,7 +934,7 @@ internal sealed class EmbeddedFileStore : IDisposable
                     if (leaf.Cells.Count == 0)
                     {
                         if (isRoot)
-                            return new SchemaTreeReadResult(null, 0);
+                            return new SchemaTreeReadResult(null, null, 0);
                         throw new EmbeddedSqlException("Managed file database sqlite_schema has an empty leaf child page.");
                     }
 
@@ -959,7 +959,10 @@ internal sealed class EmbeddedFileStore : IDisposable
                         previousRowId = cell.Cell.RowId;
                     }
 
-                    return new SchemaTreeReadResult(previousRowId, 0);
+                    return new SchemaTreeReadResult(
+                        leaf.Cells[0].Cell.RowId,
+                        leaf.Cells[^1].Cell.RowId,
+                        0);
                 }
             case SqliteBtreePageType.TableInterior:
                 {
@@ -971,6 +974,7 @@ internal sealed class EmbeddedFileStore : IDisposable
                         throw new EmbeddedSqlException("Managed file database sqlite_schema has an empty interior page.");
 
                     int? childHeight = null;
+                    long? minimumRowId = null;
                     long? maximumRowId = null;
                     for (var childIndex = 0; childIndex <= interior.Cells.Count; childIndex++)
                     {
@@ -995,7 +999,8 @@ internal sealed class EmbeddedFileStore : IDisposable
                             occupiedPages,
                             ref previousRowId,
                             entries);
-                        if (child.MaximumRowId is not { } childMaximumRowId)
+                        if (child.MinimumRowId is not { } childMinimumRowId
+                            || child.MaximumRowId is not { } childMaximumRowId)
                         {
                             throw new EmbeddedSqlException(
                                 $"Managed file database sqlite_schema has an empty child page {childPage}.");
@@ -1004,6 +1009,12 @@ internal sealed class EmbeddedFileStore : IDisposable
                         {
                             throw new EmbeddedSqlException(
                                 $"Managed file database sqlite_schema interior page {pageNumber} has children with inconsistent heights.");
+                        }
+                        if (childIndex > 0
+                            && childMinimumRowId <= interior.Cells[childIndex - 1].Cell.RowId)
+                        {
+                            throw new EmbeddedSqlException(
+                                $"Managed file database sqlite_schema interior page {pageNumber} separator {childIndex - 1} is not below minimum rowid on child page {childPage}.");
                         }
                         // SQLite preserves table-interior separators as upper bounds
                         // when deleting the current maximum rowid from a left child.
@@ -1015,10 +1026,13 @@ internal sealed class EmbeddedFileStore : IDisposable
                         }
 
                         childHeight = child.Height;
+                        minimumRowId ??= childMinimumRowId;
                         maximumRowId = childMaximumRowId;
                     }
 
                     return new SchemaTreeReadResult(
+                        minimumRowId ?? throw new EmbeddedSqlException(
+                            $"Managed file database sqlite_schema has an empty interior page {pageNumber}."),
                         maximumRowId ?? throw new EmbeddedSqlException(
                             $"Managed file database sqlite_schema has an empty interior page {pageNumber}."),
                         checked((childHeight ?? throw new EmbeddedSqlException(
@@ -1121,7 +1135,10 @@ internal sealed class EmbeddedFileStore : IDisposable
                     }
 
                     previousRowId = leafMaximumRowId;
-                    return new TableTreeReadResult(leafMaximumRowId.Value, 0);
+                    return new TableTreeReadResult(
+                        leaf.Cells[0].Cell.RowId,
+                        leafMaximumRowId.Value,
+                        0);
                 }
             case SqliteBtreePageType.TableInterior:
                 break;
@@ -1158,6 +1175,7 @@ internal sealed class EmbeddedFileStore : IDisposable
         }
 
         int? childHeight = null;
+        long? minimumRowId = null;
         long? maximumRowId = null;
         SqliteBtreePageType? childType = null;
         for (var childIndex = 0; childIndex <= interior.Cells.Count; childIndex++)
@@ -1205,6 +1223,12 @@ internal sealed class EmbeddedFileStore : IDisposable
             }
 
             childHeight = childResult.Height;
+            if (childIndex > 0
+                && childResult.MinimumRowId <= interior.Cells[childIndex - 1].Cell.RowId)
+            {
+                throw new EmbeddedSqlException(
+                    $"Managed file database table rootpage {rootPage} interior page {pageNumber} separator {childIndex - 1} is not below minimum rowid on child page {childPage}.");
+            }
             // SQLite table-interior separators are search upper bounds for the left
             // child, not a maintained copy of that child's live maximum rowid.
             // After deletes, the separator can stay strictly greater than every
@@ -1217,10 +1241,13 @@ internal sealed class EmbeddedFileStore : IDisposable
                     $"Managed file database table rootpage {rootPage} interior page {pageNumber} separator {childIndex} is below maximum rowid on child page {childPage}.");
             }
 
+            minimumRowId ??= childResult.MinimumRowId;
             maximumRowId = childResult.MaximumRowId;
         }
 
         return new TableTreeReadResult(
+            minimumRowId ?? throw new EmbeddedSqlException(
+                $"Managed file database table rootpage {rootPage} has an empty interior page {pageNumber}."),
             maximumRowId ?? throw new EmbeddedSqlException(
                 $"Managed file database table rootpage {rootPage} has an empty interior page {pageNumber}."),
             checked((childHeight ?? throw new EmbeddedSqlException(
@@ -3036,7 +3063,6 @@ internal sealed class EmbeddedFileStore : IDisposable
             return false;
 
         var persistedCellIndex = 0;
-        long? previousMaximumRowId = null;
         SqliteTableLeafPageView? sourceRightLeaf = null;
         for (var childIndex = 0; childIndex < childPages.Length; childIndex++)
         {
@@ -3054,16 +3080,16 @@ internal sealed class EmbeddedFileStore : IDisposable
 
             var child = SqliteTableLeafPageView.Parse(childPageImage, _usableSpace);
             if (child.Cells.Count == 0
-                || child.Cells.Any(cell => cell.Cell.FirstOverflowPage is not null)
-                || (previousMaximumRowId is { } maximumRowId
-                    && child.Cells[0].Cell.RowId <= maximumRowId))
+                || child.Cells.Any(cell => cell.Cell.FirstOverflowPage is not null))
             {
                 return false;
             }
 
             var childMaximumRowId = child.Cells[^1].Cell.RowId;
-            if (childIndex < parent.Cells.Count
-                && parent.Cells[childIndex].Cell.RowId != childMaximumRowId)
+            if (!parent.IsChildRangeValid(
+                    childIndex,
+                    child.Cells[0].Cell.RowId,
+                    childMaximumRowId))
             {
                 return false;
             }
@@ -3080,7 +3106,6 @@ internal sealed class EmbeddedFileStore : IDisposable
                 persistedCellIndex++;
             }
 
-            previousMaximumRowId = childMaximumRowId;
             if (childIndex == childPages.Length - 1)
                 sourceRightLeaf = child;
         }
@@ -5428,6 +5453,7 @@ internal sealed class EmbeddedFileStore : IDisposable
             if (leafPages.Length != parent.Cells.Count + 1)
                 return false;
 
+            long? parentMinimumRowId = null;
             long? parentMaximumRowId = null;
             for (var leafIndex = 0; leafIndex < leafPages.Length; leafIndex++)
             {
@@ -5447,13 +5473,11 @@ internal sealed class EmbeddedFileStore : IDisposable
                 if (leaf.Cells.Count == 0
                     || leaf.Cells.Any(cell => cell.Cell.FirstOverflowPage is not null)
                     || (previousMaximumRowId is { } maximumRowId
-                        && leaf.Cells[0].Cell.RowId <= maximumRowId))
-                {
-                    return false;
-                }
-
-                if (leafIndex < parent.Cells.Count
-                    && leaf.Cells[^1].Cell.RowId != parent.Cells[leafIndex].Cell.RowId)
+                        && leaf.Cells[0].Cell.RowId <= maximumRowId)
+                    || !parent.IsChildRangeValid(
+                        leafIndex,
+                        leaf.Cells[0].Cell.RowId,
+                        leaf.Cells[^1].Cell.RowId))
                 {
                     return false;
                 }
@@ -5486,13 +5510,17 @@ internal sealed class EmbeddedFileStore : IDisposable
                     targetLeafIndex = leafIndex;
                 }
 
+                parentMinimumRowId ??= leaf.Cells[0].Cell.RowId;
                 parentMaximumRowId = leaf.Cells[^1].Cell.RowId;
                 previousMaximumRowId = parentMaximumRowId;
             }
 
-            if (parentMaximumRowId is null
-                || (parentIndex < root.Cells.Count
-                    && root.Cells[parentIndex].Cell.RowId != parentMaximumRowId.Value))
+            if (parentMinimumRowId is null
+                || parentMaximumRowId is null
+                || !root.IsChildRangeValid(
+                    parentIndex,
+                    parentMinimumRowId.Value,
+                    parentMaximumRowId.Value))
             {
                 return false;
             }
@@ -5732,6 +5760,7 @@ internal sealed class EmbeddedFileStore : IDisposable
             if (parentPages.Length != grandparent.Cells.Count + 1)
                 return false;
 
+            long? grandparentMinimumRowId = null;
             long? grandparentMaximumRowId = null;
             for (var parentIndex = 0; parentIndex < parentPages.Length; parentIndex++)
             {
@@ -5761,6 +5790,7 @@ internal sealed class EmbeddedFileStore : IDisposable
                 if (leafPages.Length != parent.Cells.Count + 1)
                     return false;
 
+                long? parentMinimumRowId = null;
                 long? parentMaximumRowId = null;
                 for (var leafIndex = 0; leafIndex < leafPages.Length; leafIndex++)
                 {
@@ -5783,13 +5813,11 @@ internal sealed class EmbeddedFileStore : IDisposable
                     if (leaf.Cells.Count == 0
                         || leaf.Cells.Any(cell => cell.Cell.FirstOverflowPage is not null)
                         || (previousMaximumRowId is { } maximumRowId
-                            && leaf.Cells[0].Cell.RowId <= maximumRowId))
-                    {
-                        return false;
-                    }
-
-                    if (leafIndex < parent.Cells.Count
-                        && leaf.Cells[^1].Cell.RowId != parent.Cells[leafIndex].Cell.RowId)
+                            && leaf.Cells[0].Cell.RowId <= maximumRowId)
+                        || !parent.IsChildRangeValid(
+                            leafIndex,
+                            leaf.Cells[0].Cell.RowId,
+                            leaf.Cells[^1].Cell.RowId))
                     {
                         return false;
                     }
@@ -5826,23 +5854,31 @@ internal sealed class EmbeddedFileStore : IDisposable
                         targetGrandparentIndex = grandparentIndex;
                     }
 
+                    parentMinimumRowId ??= leaf.Cells[0].Cell.RowId;
                     parentMaximumRowId = leaf.Cells[^1].Cell.RowId;
                     previousMaximumRowId = parentMaximumRowId;
                 }
 
-                if (parentMaximumRowId is null
-                    || (parentIndex < grandparent.Cells.Count
-                        && grandparent.Cells[parentIndex].Cell.RowId != parentMaximumRowId.Value))
+                if (parentMinimumRowId is null
+                    || parentMaximumRowId is null
+                    || !grandparent.IsChildRangeValid(
+                        parentIndex,
+                        parentMinimumRowId.Value,
+                        parentMaximumRowId.Value))
                 {
                     return false;
                 }
 
+                grandparentMinimumRowId ??= parentMinimumRowId.Value;
                 grandparentMaximumRowId = parentMaximumRowId;
             }
 
-            if (grandparentMaximumRowId is null
-                || (grandparentIndex < root.Cells.Count
-                    && root.Cells[grandparentIndex].Cell.RowId != grandparentMaximumRowId.Value))
+            if (grandparentMinimumRowId is null
+                || grandparentMaximumRowId is null
+                || !root.IsChildRangeValid(
+                    grandparentIndex,
+                    grandparentMinimumRowId.Value,
+                    grandparentMaximumRowId.Value))
             {
                 return false;
             }
@@ -6032,8 +6068,15 @@ internal sealed class EmbeddedFileStore : IDisposable
         var targetInsertionIndex = -1;
         var targetInteriorDepth = 0;
 
-        bool Visit(uint pageNumber, byte[] pageImage, int depth, out long maximumRowId)
+        bool Visit(
+            uint pageNumber,
+            byte[] pageImage,
+            int depth,
+            bool containsInsertionRoute,
+            out long minimumRowId,
+            out long maximumRowId)
         {
+            minimumRowId = 0;
             maximumRowId = 0;
             switch (SqliteBtreePageHeader.Parse(pageImage).PageType)
             {
@@ -6048,7 +6091,6 @@ internal sealed class EmbeddedFileStore : IDisposable
                         }
 
                         leafDepth ??= depth;
-                        var precedingRowId = previousRowId;
                         foreach (var cell in leaf.Cells)
                         {
                             if (persistedCellIndex >= persistedCells.Count
@@ -6065,7 +6107,7 @@ internal sealed class EmbeddedFileStore : IDisposable
                         }
 
                         var insertion = leaf.Search(insertedCell.RowId);
-                        if ((precedingRowId is null || insertedCell.RowId > precedingRowId)
+                        if (containsInsertionRoute
                             && !insertion.IsExact
                             && insertion.Index < leaf.Cells.Count
                             && insertedCell.RowId < leaf.Cells[^1].Cell.RowId)
@@ -6080,6 +6122,7 @@ internal sealed class EmbeddedFileStore : IDisposable
                             targetInteriorDepth = depth - 1;
                         }
 
+                        minimumRowId = leaf.Cells[0].Cell.RowId;
                         maximumRowId = leaf.Cells[^1].Cell.RowId;
                         return true;
                     }
@@ -6097,6 +6140,10 @@ internal sealed class EmbeddedFileStore : IDisposable
                         if (childPages.Length != interior.Cells.Count + 1)
                             return false;
 
+                        var insertionChildIndex = containsInsertionRoute
+                            ? interior.SearchChild(insertedCell.RowId).ChildIndex
+                            : -1;
+                        long? childMinimumRowId = null;
                         long? childMaximumRowId = null;
                         for (var childIndex = 0; childIndex < childPages.Length; childIndex++)
                         {
@@ -6108,20 +6155,32 @@ internal sealed class EmbeddedFileStore : IDisposable
                                 return false;
                             }
 
-                            if (!Visit(childPage, _pager.ReadCommittedPage(childPage), depth + 1, out var childMaximum))
+                            if (!Visit(
+                                    childPage,
+                                    _pager.ReadCommittedPage(childPage),
+                                    depth + 1,
+                                    containsInsertionRoute && childIndex == insertionChildIndex,
+                                    out var childMinimum,
+                                    out var childMaximum))
+                            {
                                 return false;
-                            if (childIndex < interior.Cells.Count
-                                && interior.Cells[childIndex].Cell.RowId != childMaximum)
+                            }
+                            if (!interior.IsChildRangeValid(
+                                    childIndex,
+                                    childMinimum,
+                                    childMaximum))
                             {
                                 return false;
                             }
 
+                            childMinimumRowId ??= childMinimum;
                             childMaximumRowId = childMaximum;
                         }
 
-                        if (childMaximumRowId is null)
+                        if (childMinimumRowId is null || childMaximumRowId is null)
                             return false;
 
+                        minimumRowId = childMinimumRowId.Value;
                         maximumRowId = childMaximumRowId.Value;
                         return true;
                     }
@@ -6131,7 +6190,13 @@ internal sealed class EmbeddedFileStore : IDisposable
             }
         }
 
-        if (!Visit(rootPage, existingRootPage.ToArray(), depth: 1, out _)
+        if (!Visit(
+                rootPage,
+                existingRootPage.ToArray(),
+                depth: 1,
+                containsInsertionRoute: true,
+                out _,
+                out _)
             || persistedCellIndex != persistedCells.Count
             || sourceLeaf is null
             || sourceLeafPage is null
@@ -6226,8 +6291,10 @@ internal sealed class EmbeddedFileStore : IDisposable
             byte[] pageImage,
             List<BoundedTableInteriorPathEntry> path,
             int depth,
+            out long minimumRowId,
             out long maximumRowId)
         {
+            minimumRowId = 0;
             maximumRowId = 0;
             switch (SqliteBtreePageHeader.Parse(pageImage).PageType)
             {
@@ -6268,6 +6335,7 @@ internal sealed class EmbeddedFileStore : IDisposable
                             targetPath = path.ToArray();
                         }
 
+                        minimumRowId = leaf.Cells[0].Cell.RowId;
                         maximumRowId = leaf.Cells[^1].Cell.RowId;
                         return true;
                     }
@@ -6285,6 +6353,7 @@ internal sealed class EmbeddedFileStore : IDisposable
                         if (childPages.Length != interior.Cells.Count + 1)
                             return false;
 
+                        long? childMinimumRowId = null;
                         long? childMaximumRowId = null;
                         for (var childIndex = 0; childIndex < childPages.Length; childIndex++)
                         {
@@ -6303,25 +6372,35 @@ internal sealed class EmbeddedFileStore : IDisposable
                                 interior,
                                 childIndex,
                                 childPage));
-                            if (!Visit(childPage, childImage, path, depth + 1, out var childMaximum))
+                            if (!Visit(
+                                    childPage,
+                                    childImage,
+                                    path,
+                                    depth + 1,
+                                    out var childMinimum,
+                                    out var childMaximum))
                             {
                                 path.RemoveAt(path.Count - 1);
                                 return false;
                             }
 
                             path.RemoveAt(path.Count - 1);
-                            if (childIndex < interior.Cells.Count
-                                && interior.Cells[childIndex].Cell.RowId != childMaximum)
+                            if (!interior.IsChildRangeValid(
+                                    childIndex,
+                                    childMinimum,
+                                    childMaximum))
                             {
                                 return false;
                             }
 
+                            childMinimumRowId ??= childMinimum;
                             childMaximumRowId = childMaximum;
                         }
 
-                        if (childMaximumRowId is null)
+                        if (childMinimumRowId is null || childMaximumRowId is null)
                             return false;
 
+                        minimumRowId = childMinimumRowId.Value;
                         maximumRowId = childMaximumRowId.Value;
                         return true;
                     }
@@ -6331,7 +6410,7 @@ internal sealed class EmbeddedFileStore : IDisposable
             }
         }
 
-        if (!Visit(rootPage, existingRootPage.ToArray(), [], depth: 1, out _)
+        if (!Visit(rootPage, existingRootPage.ToArray(), [], depth: 1, out _, out _)
             || persistedCellIndex != persistedCells.Count
             || sourceLeaf is null
             || sourceLeafPage is null
@@ -6548,6 +6627,7 @@ internal sealed class EmbeddedFileStore : IDisposable
         var ownedPages = new HashSet<uint> { rootPage };
         var persistedCellIndex = 0;
         long? previousMaximumRowId = null;
+        var insertedChildIndex = parent.SearchChild(insertedCell.RowId).ChildIndex;
         SqliteTableLeafPageView? sourceLeaf = null;
         byte[]? sourceLeafPage = null;
         uint targetLeafPage = 0;
@@ -6570,17 +6650,16 @@ internal sealed class EmbeddedFileStore : IDisposable
             if (childLeaf.Cells.Count == 0
                 || childLeaf.Cells.Any(cell => cell.Cell.FirstOverflowPage is not null)
                 || (previousMaximumRowId is { } previousMaximum
-                    && childLeaf.Cells[0].Cell.RowId <= previousMaximum))
+                    && childLeaf.Cells[0].Cell.RowId <= previousMaximum)
+                || !parent.IsChildRangeValid(
+                    childIndex,
+                    childLeaf.Cells[0].Cell.RowId,
+                    childLeaf.Cells[^1].Cell.RowId))
             {
                 return false;
             }
 
             var childMaximumRowId = childLeaf.Cells[^1].Cell.RowId;
-            if (childIndex < parent.Cells.Count
-                && parent.Cells[childIndex].Cell.RowId != childMaximumRowId)
-            {
-                return false;
-            }
 
             foreach (var cell in childLeaf.Cells)
             {
@@ -6595,8 +6674,7 @@ internal sealed class EmbeddedFileStore : IDisposable
                 persistedCellIndex++;
             }
 
-            if ((previousMaximumRowId is null || insertedCell.RowId > previousMaximumRowId)
-                && (childIndex == childPages.Length - 1 || insertedCell.RowId <= childMaximumRowId))
+            if (childIndex == insertedChildIndex)
             {
                 if (sourceLeaf is not null)
                     return false;
@@ -6692,13 +6770,11 @@ internal sealed class EmbeddedFileStore : IDisposable
             if (childLeaf.Cells.Count == 0
                 || childLeaf.Cells.Any(cell => cell.Cell.FirstOverflowPage is not null)
                 || (previousMaximumRowId is { } maximumRowId
-                    && childLeaf.Cells[0].Cell.RowId <= maximumRowId))
-            {
-                return false;
-            }
-
-            if (childIndex < parent.Cells.Count
-                && childLeaf.Cells[^1].Cell.RowId != parent.Cells[childIndex].Cell.RowId)
+                    && childLeaf.Cells[0].Cell.RowId <= maximumRowId)
+                || !parent.IsChildRangeValid(
+                    childIndex,
+                    childLeaf.Cells[0].Cell.RowId,
+                    childLeaf.Cells[^1].Cell.RowId))
             {
                 return false;
             }
@@ -11320,9 +11396,15 @@ internal sealed class EmbeddedFileStore : IDisposable
 
     private sealed record TableTreeChild(uint PageNumber, long MaximumRowId);
 
-    private readonly record struct SchemaTreeReadResult(long? MaximumRowId, int Height);
+    private readonly record struct SchemaTreeReadResult(
+        long? MinimumRowId,
+        long? MaximumRowId,
+        int Height);
 
-    private readonly record struct TableTreeReadResult(long MaximumRowId, int Height);
+    private readonly record struct TableTreeReadResult(
+        long MinimumRowId,
+        long MaximumRowId,
+        int Height);
 
     private sealed record PreparedIndexTree(
         byte[] RootPage,

--- a/src/Ahtola.Core/Storage/SqliteBtreeSplitWriter.cs
+++ b/src/Ahtola.Core/Storage/SqliteBtreeSplitWriter.cs
@@ -239,6 +239,7 @@ public sealed class SqliteBtreeSplitWriter
             parentImage,
             header.UsableSpace,
             isFirstPage: parentPageNumber.Value == 1);
+        ValidateTableChildRange(parent, leafPageNumber, leaf.Cells[0].Cell.RowId, leaf.Cells[^1].Cell.RowId);
 
         var rightPageNumber = reservations.NextPageNumber;
         var propagatedParent = BuildTableParentPage(
@@ -335,7 +336,6 @@ public sealed class SqliteBtreeSplitWriter
         }
 
         var replacementChildren = new List<TableTreeChild>(childPages.Length + 1);
-        long? previousMaximumRowId = null;
         byte[]? sourceRightLeafPage = null;
         SqliteTableLeafPageView? sourceRightLeaf = null;
         for (var childIndex = 0; childIndex < childPages.Length; childIndex++)
@@ -357,24 +357,27 @@ public sealed class SqliteBtreeSplitWriter
 
             var child = SqliteTableLeafPageView.Parse(childImage, header.UsableSpace);
             if (child.Cells.Count == 0
-                || child.Cells.Any(cell => cell.Cell.FirstOverflowPage is not null)
-                || (previousMaximumRowId is { } maximumRowId
-                    && child.Cells[0].Cell.RowId <= maximumRowId))
+                || child.Cells.Any(cell => cell.Cell.FirstOverflowPage is not null))
             {
                 throw new InvalidDataException(
                     "SQLite table-interior root has unsupported empty, overflow, or unordered leaf children.");
             }
 
             var childMaximumRowId = child.Cells[^1].Cell.RowId;
-            if (childIndex < root.Cells.Count
-                && root.Cells[childIndex].Cell.RowId != childMaximumRowId)
+            if (!root.IsChildRangeValid(
+                    childIndex,
+                    child.Cells[0].Cell.RowId,
+                    childMaximumRowId))
             {
                 throw new InvalidDataException(
-                    "SQLite table-interior root separator does not match its left child's maximum rowid.");
+                    "SQLite table-interior root has a leaf child outside its separator bounds.");
             }
 
-            replacementChildren.Add(new TableTreeChild(childPageNumber, childMaximumRowId));
-            previousMaximumRowId = childMaximumRowId;
+            var childUpperBoundRowId = childIndex < root.Cells.Count
+                ? root.Cells[childIndex].Cell.RowId
+                : long.MaxValue;
+
+            replacementChildren.Add(new TableTreeChild(childPageNumber, childUpperBoundRowId));
             if (childIndex == childPages.Length - 1)
             {
                 sourceRightLeafPage = childImage;
@@ -762,7 +765,7 @@ public sealed class SqliteBtreeSplitWriter
                     rightInteriorPage);
                 rootBuilder.Append(SqliteTableInteriorCell.Create(
                     leftInteriorPage,
-                    leftChildren[^1].MaximumRowId));
+                    leftChildren[^1].UpperBoundRowId));
                 replacementRootPage = sourceRootPage.ToArray();
                 rootBuilder.WriteTo(replacementRootPage);
                 return true;
@@ -801,7 +804,7 @@ public sealed class SqliteBtreeSplitWriter
                 var child = children[childIndex];
                 builder.Append(SqliteTableInteriorCell.Create(
                     child.PageNumber,
-                    child.MaximumRowId));
+                    child.UpperBoundRowId));
             }
 
             page = builder.Build();
@@ -1077,6 +1080,37 @@ public sealed class SqliteBtreeSplitWriter
         }
     }
 
+    private static void ValidateTableChildRange(
+        SqliteTableInteriorPageView parent,
+        uint childPageNumber,
+        long minimumRowId,
+        long maximumRowId)
+    {
+        var childIndex = FindTableLeftChildIndex(parent, childPageNumber);
+        if (childIndex < 0)
+        {
+            if (parent.Header.RightMostChildPage != childPageNumber)
+                throw new InvalidDataException("SQLite table-interior parent does not reference the split leaf.");
+            childIndex = parent.Cells.Count;
+        }
+
+        if (parent.IsChildRangeValid(childIndex, minimumRowId, maximumRowId))
+            return;
+
+        if (childIndex > 0 && minimumRowId <= parent.Cells[childIndex - 1].Cell.RowId)
+        {
+            throw new InvalidDataException(
+                "SQLite table-interior parent separator is not below its right child's minimum rowid.");
+        }
+        if (childIndex < parent.Cells.Count && maximumRowId > parent.Cells[childIndex].Cell.RowId)
+        {
+            throw new InvalidDataException(
+                "SQLite table-interior parent separator is below its left child's maximum rowid.");
+        }
+
+        throw new InvalidDataException("SQLite table-interior child has an invalid rowid range.");
+    }
+
     private static void EnsureIndexParentContainsChild(SqliteIndexInteriorPageView parent, uint childPageNumber)
     {
         if (FindIndexLeftChildIndex(parent, childPageNumber) < 0
@@ -1108,7 +1142,7 @@ public sealed class SqliteBtreeSplitWriter
         return -1;
     }
 
-    private sealed record TableTreeChild(uint PageNumber, long MaximumRowId);
+    private sealed record TableTreeChild(uint PageNumber, long UpperBoundRowId);
 
     private sealed record MaterializedIndexSeparator(
         SqliteIndexInteriorCell Cell,

--- a/src/Ahtola.Core/Storage/SqliteIncrementalTableBtree.cs
+++ b/src/Ahtola.Core/Storage/SqliteIncrementalTableBtree.cs
@@ -25,11 +25,10 @@ namespace Ahtola.Core.Storage;
 /// is not required.
 /// </para>
 /// <para>
-/// The managed loader requires an interior separator to equal the exact maximum
-/// rowid of its left child. That invariant is preserved without extra work on
-/// insertion, because a descent only routes a rowid into a non-right-most child
-/// when the rowid is at most that child's separator, and it is restored
-/// explicitly after a deletion removes a child's maximum rowid.
+/// Table-interior separators are inclusive upper bounds for their left
+/// subtrees. They may remain above the live maximum after a deletion, while
+/// insertion, split, and rebalance paths are allowed to tighten them to an
+/// exact maximum.
 /// </para>
 /// </remarks>
 public sealed class SqliteIncrementalTableBtree

--- a/src/Ahtola.Core/Storage/SqliteTableInteriorPage.cs
+++ b/src/Ahtola.Core/Storage/SqliteTableInteriorPage.cs
@@ -18,7 +18,10 @@ public sealed class SqliteTableInteriorCell
     /// <summary>The non-zero child page containing keys less than or equal to <see cref="RowId"/>.</summary>
     public uint LeftChildPage { get; }
 
-    /// <summary>The largest rowid in <see cref="LeftChildPage"/>.</summary>
+    /// <summary>
+    /// The inclusive routing upper bound for <see cref="LeftChildPage"/>.
+    /// SQLite may retain a value above that child's live maximum after deletion.
+    /// </summary>
     public long RowId { get; }
 
     /// <summary>The exact number of bytes occupied by this cell.</summary>
@@ -73,7 +76,7 @@ public sealed class SqliteTableInteriorCell
     }
 }
 
-/// <summary>Packs a compact SQLite table-interior page from sorted separator cells.</summary>
+/// <summary>Packs a compact SQLite table-interior page from sorted upper-bound separator cells.</summary>
 /// <remarks>
 /// This is a single-page codec. It has no page allocation, parent propagation,
 /// sibling handling, or durable multi-page mutation.
@@ -126,7 +129,7 @@ public sealed class SqliteTableInteriorPageBuilder
         => new ReadOnlyCollection<SqliteTableInteriorCell>(_cells);
 
     /// <summary>
-    /// Adds one left-child/maximum-rowid separator. Keys and child pages must be
+    /// Adds one left-child/inclusive-upper-bound separator. Keys and child pages must be
     /// unique so this one page cannot introduce an ambiguous path.
     /// </summary>
     public void Append(SqliteTableInteriorCell cell)
@@ -320,6 +323,19 @@ public sealed class SqliteTableInteriorPageView
             ranges,
             "table-interior");
         return new SqliteTableInteriorPageView(page.Length, usableSpace, header, pointers, cells);
+    }
+
+    /// <summary>
+    /// Returns whether a non-empty child's live rowid range fits between its
+    /// exclusive lower separator and inclusive upper separator.
+    /// </summary>
+    internal bool IsChildRangeValid(int childIndex, long minimumRowId, long maximumRowId)
+    {
+        if (childIndex < 0 || childIndex > Cells.Count || minimumRowId > maximumRowId)
+            return false;
+
+        return (childIndex == 0 || minimumRowId > Cells[childIndex - 1].Cell.RowId)
+            && (childIndex == Cells.Count || maximumRowId <= Cells[childIndex].Cell.RowId);
     }
 
     /// <summary>

--- a/src/Ahtola.Tests/ManagedIncrementalPagerTests.cs
+++ b/src/Ahtola.Tests/ManagedIncrementalPagerTests.cs
@@ -178,9 +178,8 @@ public sealed class ManagedIncrementalPagerTests
                 for (var id = 1; id <= 200; id++)
                     Execute(connection, InsertStatement(id));
 
-                // Deleting the largest rowid of an interior child lowers that
-                // child's maximum, which the managed loader only accepts when
-                // the separator above it is repaired to the new exact maximum.
+                // Deleting the largest rowid of an interior child exercises
+                // separator tightening in the incremental mutation path.
                 for (var id = 30; id <= 200; id += 30)
                     Execute(connection, $"DELETE FROM t WHERE id = {id};");
             }

--- a/src/Ahtola.Tests/ManagedSchemaInteriorFileStoreTests.cs
+++ b/src/Ahtola.Tests/ManagedSchemaInteriorFileStoreTests.cs
@@ -89,6 +89,68 @@ public sealed class ManagedSchemaInteriorFileStoreTests
         }
     }
 
+    [Test]
+    public void RejectsSchemaInteriorSeparatorThatOverlapsNextChild()
+    {
+        var path = CreateDatabasePath();
+        try
+        {
+            CreateExternalDatabase(path);
+            MsData.SqliteConnection.ClearAllPools();
+
+            using (var store = SqlitePageStore.Open(PhysicalFileSystem.Instance, path))
+            {
+                var page = store.ReadPage(1);
+                var interior = SqliteTableInteriorPageView.Parse(
+                    page,
+                    store.Header.UsableSpace,
+                    isFirstPage: true);
+                interior.Cells.Should().NotBeEmpty();
+
+                var nextChildPage = interior.Cells.Count == 1
+                    ? interior.Header.RightMostChildPage
+                    : interior.Cells[1].Cell.LeftChildPage;
+                var nextChild = SqliteTableLeafPageView.Parse(
+                    store.ReadPage(nextChildPage),
+                    store.Header.UsableSpace);
+                nextChild.Cells.Should().NotBeEmpty();
+
+                var separator = interior.Cells[0];
+                var nextMinimumRowId = nextChild.Cells[0].Cell.RowId;
+                SqliteVarint.GetLength(unchecked((ulong)nextMinimumRowId))
+                    .Should()
+                    .Be(separator.Cell.EncodedLength - sizeof(uint));
+                SqliteVarint.Write(
+                    unchecked((ulong)nextMinimumRowId),
+                    page.AsSpan(separator.Offset + sizeof(uint)));
+                store.WritePage(1, page);
+                store.Flush();
+            }
+
+            using (var sqlite = new MsData.SqliteConnection($"Data Source={path}"))
+            {
+                sqlite.Open();
+                using var quickCheck = sqlite.CreateCommand();
+                quickCheck.CommandText = "PRAGMA quick_check;";
+                Convert.ToString(quickCheck.ExecuteScalar()).Should().NotBe("ok");
+            }
+
+            MsData.SqliteConnection.ClearAllPools();
+            var exception = Assert.Throws<EmbeddedSqlException>(() =>
+            {
+                using var facade = new Ahtola.Data.Sqlite.SqliteConnection(
+                    $"Data Source={path};Mode=ReadOnly;Pooling=False");
+                facade.Open();
+            });
+            exception.Message.Should().Contain("is not below minimum rowid");
+        }
+        finally
+        {
+            MsData.SqliteConnection.ClearAllPools();
+            DeleteDatabase(path);
+        }
+    }
+
     private static void CreateExternalDatabase(string path)
     {
         using var sqlite = new MsData.SqliteConnection($"Data Source={path}");

--- a/src/Ahtola.Tests/ManagedTableInteriorFileStoreTests.cs
+++ b/src/Ahtola.Tests/ManagedTableInteriorFileStoreTests.cs
@@ -178,11 +178,69 @@ public class ManagedTableInteriorFileStoreTests
         }
 
         [Test]
-        public void OpensExternalSqliteTableInteriorWithStaleSeparatorsAfterDeletes()
+        public void ReopenRejectsInteriorWhoseSeparatorOverlapsFollowingLeaf()
         {
-            // Real SQLite leaves parent separators unchanged when the left child's
-            // maximum rowid is deleted. RDM Connections.db hits this shape; managed
-            // open must accept separator >= left-child max, not require equality.
+            var fileSystem = new InMemoryFileSystem();
+            const string path = "interior-overlapping-separator.db";
+            SqliteDatabaseHeader header;
+            uint rootPage;
+            using (var database = EmbeddedDatabase.OpenFile(path, fileSystem))
+            using (var connection = database.Connect())
+            {
+                Execute(connection, "CREATE TABLE t(id INTEGER PRIMARY KEY, value TEXT);");
+                Execute(connection, BuildInsert(1, 120));
+            }
+
+            using (var store = SqlitePageStore.Open(fileSystem, path))
+            {
+                header = store.Header;
+                var schema = SqliteTableLeafPageView.Parse(
+                    store.ReadPage(1),
+                    header.UsableSpace,
+                    isFirstPage: true);
+                rootPage = checked((uint)schema.Cells
+                    .Select(cell => SqliteRecordCodec.Decode(cell.Cell.LocalPayload.Span, header.TextEncoding))
+                    .Single(values => values[0].AsText() == "table" && values[1].AsText() == "t")[3]
+                    .AsInteger());
+
+                var rootImage = store.ReadPage(rootPage);
+                var root = SqliteTableInteriorPageView.Parse(rootImage, header.UsableSpace);
+                root.Cells.Should().NotBeEmpty();
+                var nextChildPage = root.Cells.Count == 1
+                    ? root.Header.RightMostChildPage
+                    : root.Cells[1].Cell.LeftChildPage;
+                var nextChild = SqliteTableLeafPageView.Parse(
+                    store.ReadPage(nextChildPage),
+                    header.UsableSpace);
+                nextChild.Cells.Should().NotBeEmpty();
+
+                var separator = root.Cells[0];
+                var nextMinimumRowId = nextChild.Cells[0].Cell.RowId;
+                SqliteVarint.GetLength(unchecked((ulong)nextMinimumRowId))
+                    .Should()
+                    .Be(separator.Cell.EncodedLength - sizeof(uint));
+                SqliteVarint.Write(
+                    unchecked((ulong)nextMinimumRowId),
+                    rootImage.AsSpan(separator.Offset + sizeof(uint)));
+                store.WritePage(rootPage, rootImage);
+                store.Flush();
+            }
+
+            fileSystem.DeleteFile(path + "-wal");
+            using (SqliteWalFile.Create(
+                       fileSystem,
+                       path + "-wal",
+                       SqliteWalHeader.Create(header.PageSize, salt1: 3, salt2: 5)))
+            {
+            }
+
+            var reopen = () => EmbeddedDatabase.OpenFile(path, fileSystem);
+            reopen.Should().Throw<EmbeddedSqlException>().WithMessage("*separator*is not below minimum rowid*");
+        }
+
+        [Test]
+        public void ReopenRejectsNestedSeparatorThatOverlapsFollowingSubtree()
+        {
             var path = CreateDatabasePath();
             try
             {
@@ -193,26 +251,85 @@ public class ManagedTableInteriorFileStoreTests
                     command.CommandText =
                         """
                         PRAGMA journal_mode=DELETE;
+                        PRAGMA page_size=512;
+                        VACUUM;
                         CREATE TABLE t(id INTEGER PRIMARY KEY, value TEXT NOT NULL);
                         """;
                     command.ExecuteNonQuery();
-
-                    command.CommandText = BuildInsert(1, 200);
-                    command.ExecuteNonQuery();
-
-                    // Do not VACUUM: rebuild would tighten separators. Stale parent keys
-                    // after deleting left-child maxima are what production RDM files keep.
-                    command.CommandText =
-                        """
-                        DELETE FROM t WHERE id % 5 = 0;
-                        DELETE FROM t WHERE id IN (1, 2, 3, 50, 51, 99, 100, 150, 199, 200);
-                        """;
+                    command.CommandText = BuildInsert(1, 2_000);
                     command.ExecuteNonQuery();
                 }
 
                 MsData.SqliteConnection.ClearAllPools();
+                using (var store = SqlitePageStore.Open(PhysicalFileSystem.Instance, path))
+                {
+                    var header = store.Header;
+                    var schema = SqliteTableLeafPageView.Parse(
+                        store.ReadPage(1),
+                        header.UsableSpace,
+                        isFirstPage: true);
+                    var rootPage = checked((uint)schema.Cells
+                        .Select(cell => SqliteRecordCodec.Decode(cell.Cell.LocalPayload.Span, header.TextEncoding))
+                        .Single(values => values[0].AsText() == "table" && values[1].AsText() == "t")[3]
+                        .AsInteger());
 
-                AssertStaleSeparatorPresent(path);
+                    var rootImage = store.ReadPage(rootPage);
+                    var root = SqliteTableInteriorPageView.Parse(rootImage, header.UsableSpace);
+                    root.Cells.Should().NotBeEmpty();
+                    var nextChildPage = root.Cells.Count == 1
+                        ? root.Header.RightMostChildPage
+                        : root.Cells[1].Cell.LeftChildPage;
+                    SqliteBtreePageHeader.Parse(store.ReadPage(nextChildPage)).PageType
+                        .Should()
+                        .Be(SqliteBtreePageType.TableInterior);
+
+                    var nextMinimumRowId = ReadSubtreeMinimumRowId(
+                        store,
+                        header,
+                        nextChildPage);
+                    var separator = root.Cells[0];
+                    SqliteVarint.GetLength(unchecked((ulong)nextMinimumRowId))
+                        .Should()
+                        .Be(separator.Cell.EncodedLength - sizeof(uint));
+                    SqliteVarint.Write(
+                        unchecked((ulong)nextMinimumRowId),
+                        rootImage.AsSpan(separator.Offset + sizeof(uint)));
+                    store.WritePage(rootPage, rootImage);
+                    store.Flush();
+                }
+
+                using (var sqlite = new MsData.SqliteConnection($"Data Source={path}"))
+                {
+                    sqlite.Open();
+                    using var quickCheck = sqlite.CreateCommand();
+                    quickCheck.CommandText = "PRAGMA quick_check;";
+                    Convert.ToString(quickCheck.ExecuteScalar()).Should().NotBe("ok");
+                }
+
+                MsData.SqliteConnection.ClearAllPools();
+                var reopen = () => EmbeddedDatabase.OpenFile(path);
+                reopen.Should().Throw<EmbeddedSqlException>().WithMessage("*separator*is not below minimum rowid*");
+            }
+            finally
+            {
+                MsData.SqliteConnection.ClearAllPools();
+                DeleteDatabase(path);
+            }
+        }
+
+        [Test]
+        public void OpensExternalSqliteTableInteriorWithStaleSeparatorsAfterDeletes()
+        {
+            // Real SQLite leaves parent separators unchanged when the left child's
+            // maximum rowid is deleted. RDM Connections.db hits this shape; managed
+            // open must accept separator >= left-child max, not require equality.
+            var path = CreateDatabasePath();
+            try
+            {
+                CreateExternalTableWithStaleSeparators(path);
+                MsData.SqliteConnection.ClearAllPools();
+
+                _ = FindStaleSeparatorRowId(path);
 
                 using (var database = EmbeddedDatabase.OpenFile(path))
                 using (var connection = database.Connect())
@@ -238,7 +355,76 @@ public class ManagedTableInteriorFileStoreTests
             }
         }
 
-        private static void AssertStaleSeparatorPresent(string path)
+        [Test]
+        public void InsertsAtExternalStaleSeparatorAndRemainsSqliteCompatible()
+        {
+            var path = CreateDatabasePath();
+            try
+            {
+                CreateExternalTableWithStaleSeparators(path);
+                MsData.SqliteConnection.ClearAllPools();
+                var staleSeparatorRowId = FindStaleSeparatorRowId(path);
+
+                using (var database = EmbeddedDatabase.OpenFile(path))
+                using (var connection = database.Connect())
+                {
+                    Execute(
+                        connection,
+                        $"INSERT INTO t VALUES ({staleSeparatorRowId}, 'restored-stale-separator');");
+                    Query(connection, $"SELECT value FROM t WHERE id = {staleSeparatorRowId};")
+                        .Should()
+                        .ContainSingle()
+                        .Which[0]
+                        .AsText()
+                        .Should()
+                        .Be("restored-stale-separator");
+                }
+
+                using var sqlite = new MsData.SqliteConnection($"Data Source={path}");
+                sqlite.Open();
+                using (var quickCheck = sqlite.CreateCommand())
+                {
+                    quickCheck.CommandText = "PRAGMA quick_check;";
+                    quickCheck.ExecuteScalar().Should().Be("ok");
+                }
+
+                using var select = sqlite.CreateCommand();
+                select.CommandText = $"SELECT value FROM t WHERE id = {staleSeparatorRowId};";
+                select.ExecuteScalar().Should().Be("restored-stale-separator");
+            }
+            finally
+            {
+                MsData.SqliteConnection.ClearAllPools();
+                DeleteDatabase(path);
+            }
+        }
+
+        private static void CreateExternalTableWithStaleSeparators(string path)
+        {
+            using var sqlite = new MsData.SqliteConnection($"Data Source={path}");
+            sqlite.Open();
+            using var command = sqlite.CreateCommand();
+            command.CommandText =
+                """
+                PRAGMA journal_mode=DELETE;
+                CREATE TABLE t(id INTEGER PRIMARY KEY, value TEXT NOT NULL);
+                """;
+            command.ExecuteNonQuery();
+
+            command.CommandText = BuildInsert(1, 200);
+            command.ExecuteNonQuery();
+
+            // Do not VACUUM: rebuild would tighten separators. Stale parent keys
+            // after deleting left-child maxima are what production RDM files keep.
+            command.CommandText =
+                """
+                DELETE FROM t WHERE id % 5 = 0;
+                DELETE FROM t WHERE id IN (1, 2, 3, 50, 51, 99, 100, 150, 199, 200);
+                """;
+            command.ExecuteNonQuery();
+        }
+
+        private static long FindStaleSeparatorRowId(string path)
         {
             using var store = SqlitePageStore.Open(PhysicalFileSystem.Instance, path, readOnly: true);
             var header = store.Header;
@@ -253,23 +439,26 @@ public class ManagedTableInteriorFileStoreTests
             var rootHeader = SqliteBtreePageHeader.Parse(store.ReadPage(rootPage));
             rootHeader.PageType.Should().Be(SqliteBtreePageType.TableInterior);
 
+            long? staleSeparatorRowId;
             SubtreeMaximumRowId(
                     store,
                     header,
                     rootPage,
-                    out var sawStaleSeparator)
+                    out staleSeparatorRowId)
                 .Should()
                 .NotBeNull();
-            sawStaleSeparator.Should().BeTrue("the fixture must keep at least one stale interior separator");
+            staleSeparatorRowId.Should().NotBeNull(
+                "the fixture must keep at least one stale interior separator");
+            return staleSeparatorRowId.GetValueOrDefault();
         }
 
         private static long? SubtreeMaximumRowId(
             SqlitePageStore store,
             SqliteDatabaseHeader header,
             uint pageNumber,
-            out bool sawStaleSeparator)
+            out long? staleSeparatorRowId)
         {
-            sawStaleSeparator = false;
+            staleSeparatorRowId = null;
             var page = store.ReadPage(pageNumber);
             var pageHeader = SqliteBtreePageHeader.Parse(page);
             if (pageHeader.PageType == SqliteBtreePageType.TableLeaf)
@@ -290,19 +479,45 @@ public class ManagedTableInteriorFileStoreTests
                     store,
                     header,
                     childPage,
-                    out var childStale);
-                sawStaleSeparator |= childStale;
+                    out var childStaleSeparatorRowId);
+                staleSeparatorRowId ??= childStaleSeparatorRowId;
                 if (childMax is { } value)
                     maximum = value;
                 if (index < interior.Cells.Count
                     && childMax is { } leftMax
                     && leftMax < interior.Cells[index].Cell.RowId)
                 {
-                    sawStaleSeparator = true;
+                    staleSeparatorRowId ??= interior.Cells[index].Cell.RowId;
                 }
             }
 
             return maximum;
+        }
+
+        private static long ReadSubtreeMinimumRowId(
+            SqlitePageStore store,
+            SqliteDatabaseHeader header,
+            uint pageNumber)
+        {
+            var page = store.ReadPage(pageNumber);
+            return SqliteBtreePageHeader.Parse(page).PageType switch
+            {
+                SqliteBtreePageType.TableLeaf => SqliteTableLeafPageView
+                    .Parse(page, header.UsableSpace)
+                    .Cells[0]
+                    .Cell
+                    .RowId,
+                SqliteBtreePageType.TableInterior => ReadSubtreeMinimumRowId(
+                    store,
+                    header,
+                    SqliteTableInteriorPageView
+                        .Parse(page, header.UsableSpace)
+                        .Cells[0]
+                        .Cell
+                        .LeftChildPage),
+                var pageType => throw new InvalidDataException(
+                    $"Expected a table b-tree page, found {pageType}."),
+            };
         }
 
         private static List<long> LoadSqliteRowIds(string path)

--- a/src/Ahtola.Tests/SqliteBtreeSplitStorageTests.cs
+++ b/src/Ahtola.Tests/SqliteBtreeSplitStorageTests.cs
@@ -139,6 +139,62 @@ public class SqliteBtreeSplitStorageTests
     }
 
     [Test]
+    public void FullTableInteriorRootPromotionAcceptsStaleValidSeparator()
+    {
+        var path = CreateDatabasePath("stale-interior-root-promotion");
+        try
+        {
+            int expectedRowCount;
+            using (var pager = CreatePagerAtPath(PhysicalFileSystem.Instance, path))
+            {
+                var seed = SeedFullTableInteriorRoot(pager);
+                MakeFirstTableSeparatorStale(pager, seed.RootPage);
+                expectedRowCount = seed.RowCount + 1;
+
+                PrepareTableInteriorRootPromotion(pager, seed).CommitTo(pager);
+                ReadTableHeight(pager, seed.RootPage).Should().Be(3);
+                ReadTableRowIds(pager, seed.RootPage)
+                    .Should()
+                    .Equal(Enumerable.Range(2, expectedRowCount - 1)
+                        .Select(value => (long)value)
+                        .Prepend(0));
+                pager.CheckpointToMainStore();
+            }
+
+            using (var reopened = SqlitePager.Open(
+                       PhysicalFileSystem.Instance,
+                       path,
+                       path + "-wal",
+                       readOnly: true))
+            {
+                ReadTableHeight(reopened, pageNumber: 2).Should().Be(3);
+                ReadTableRowIds(reopened, rootPage: 2)
+                    .Should()
+                    .Equal(Enumerable.Range(2, expectedRowCount - 1)
+                        .Select(value => (long)value)
+                        .Prepend(0));
+            }
+
+            using var sqlite = new MsData.SqliteConnection($"Data Source={path}");
+            sqlite.Open();
+            using (var integrity = sqlite.CreateCommand())
+            {
+                integrity.CommandText = "PRAGMA integrity_check;";
+                integrity.ExecuteScalar().Should().Be("ok");
+            }
+
+            using var count = sqlite.CreateCommand();
+            count.CommandText = "SELECT COUNT(*) FROM t;";
+            Convert.ToInt32(count.ExecuteScalar()).Should().Be(expectedRowCount);
+        }
+        finally
+        {
+            MsData.SqliteConnection.ClearAllPools();
+            DeleteDatabase(path);
+        }
+    }
+
+    [Test]
     public void EveryInterruptedFullTableInteriorRootPromotionRecoversThePriorTree()
     {
         for (var failedFrame = 1; failedFrame <= 6; failedFrame++)
@@ -484,6 +540,33 @@ public class SqliteBtreeSplitStorageTests
             RightMostLeafPage: rightMostLeafPage,
             AppendedCell: appendedCell,
             RowCount: (childCount - 1) + rightLeafCells.Count);
+    }
+
+    private static void MakeFirstTableSeparatorStale(SqlitePager pager, uint rootPage)
+    {
+        var header = SqliteDatabaseHeader.Parse(pager.ReadCommittedPage(1));
+        var root = SqliteTableInteriorPageView.Parse(
+            pager.ReadCommittedPage(rootPage),
+            header.UsableSpace);
+        root.Cells.Should().NotBeEmpty();
+
+        var firstChildPage = root.Cells[0].Cell.LeftChildPage;
+        var firstChild = SqliteTableLeafPageView.Parse(
+            pager.ReadCommittedPage(firstChildPage),
+            header.UsableSpace);
+        firstChild.Cells.Should().ContainSingle();
+        firstChild.Cells[0].Cell.FirstOverflowPage.Should().BeNull();
+        firstChild.Cells[0].Cell.RowId.Should().Be(root.Cells[0].Cell.RowId);
+
+        var builder = new SqliteTableLeafPageBuilder(pager.PageSize, header.UsableSpace);
+        builder.Append(SqliteTableLeafCell.Create(
+            firstChild.Cells[0].Cell.RowId - 1,
+            firstChild.Cells[0].Cell.LocalPayload.Span,
+            header.UsableSpace));
+        CommitPages(
+            pager,
+            pager.CommittedPageCount,
+            [new SqlitePageImage(firstChildPage, builder.Build())]);
     }
 
     private static BoundedTableRootSeed ReadFullTableInteriorRootSeed(SqlitePager pager)

--- a/src/Ahtola.Tests/SqliteInteriorStorageTests.cs
+++ b/src/Ahtola.Tests/SqliteInteriorStorageTests.cs
@@ -38,6 +38,34 @@ public class SqliteInteriorStorageTests
     }
 
     [Test]
+    public void TableInteriorChildRangesUseExclusiveLowerAndInclusiveUpperBounds()
+    {
+        const int usableSpace = SqlitePageSize.Minimum;
+        var builder = new SqliteTableInteriorPageBuilder(
+            SqlitePageSize.Minimum,
+            usableSpace,
+            rightMostChildPage: 3);
+        builder.Append(SqliteTableInteriorCell.Create(2, 10));
+        var view = SqliteTableInteriorPageView.Parse(builder.Build(), usableSpace);
+
+        view.IsChildRangeValid(childIndex: 0, minimumRowId: 1, maximumRowId: 8)
+            .Should()
+            .BeTrue("a stale separator may remain above its left child's live maximum");
+        view.IsChildRangeValid(childIndex: 0, minimumRowId: 1, maximumRowId: 10)
+            .Should()
+            .BeTrue();
+        view.IsChildRangeValid(childIndex: 0, minimumRowId: 1, maximumRowId: 11)
+            .Should()
+            .BeFalse();
+        view.IsChildRangeValid(childIndex: 1, minimumRowId: 11, maximumRowId: 20)
+            .Should()
+            .BeTrue();
+        view.IsChildRangeValid(childIndex: 1, minimumRowId: 10, maximumRowId: 20)
+            .Should()
+            .BeFalse("the lower separator belongs to the left child");
+    }
+
+    [Test]
     public void IndexInteriorCodecPreservesChildAndRecordOrder()
     {
         const int pageSize = SqlitePageSize.Minimum;


### PR DESCRIPTION
## Summary

Follow-up to #47. SQLite table-interior separator rowids are routing bounds, not maintained copies of each left subtree's live maximum.

- Validate every table child against an exclusive lower separator and inclusive upper separator, recursively through `sqlite_schema` and ordinary rowid tables.
- Accept valid stale separators across root promotion and bounded/arbitrary-depth mutation preflights while preserving their on-disk upper bounds.
- Route insertions by the parent separator ranges instead of adjacent live child maxima.
- Continue rejecting separators below a left subtree maximum or overlapping the following subtree.
- Keep index-interior handling unchanged because index separators are stored records, not stale table bounds.

## Coverage

Added regressions for:

- overlapping separators in `sqlite_schema`, one-level tables, and nested table trees;
- inserting the deleted rowid represented by a stale SQLite separator;
- promoting a full table-interior root containing a valid stale separator;
- the shared exclusive-lower/inclusive-upper child-range invariant;
- external SQLite `quick_check`/`integrity_check` interoperability.

## Validation

- `pwsh ./build.ps1 build`
- 66 related B-tree tests on `net10.0`
- new separator regressions on `net8.0`, `net9.0`, and `net10.0`
- full managed SQL conformance lane: 232 passed, 26 corpus-skipped; its only failure is the unrelated pre-existing expected-failure entry `join/default.sqltest::join-using-multiple-with-quoting`, which now passes and needs separate baseline cleanup

The repository-wide format gate also reports pre-existing whitespace debt in `SqliteIncrementalTableBtree.cs` and `ManagedTableInteriorFileStoreTests.cs`; the changed clean files pass focused `dotnet format --verify-no-changes`.