### PR TITLE
Close Turso planner, MVCC, and sync depth gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,13 +338,15 @@ Treat Ahtola as SQLite-*compatible*, not a full SQLite replacement:
   ephemeral tables, and opaque aggregate state do not yet spill. Prefer modest
   databases and explicit transactions for writes (managed writes are slower
   than native SQLite and the gap grows with table size).
-- **Planner** — `ANALYZE` / `sqlite_stat1` feed index scoring, System-R DP join
-  reordering for up to eight freely reorderable INNER members (greedy above
-  that), hash-build selection, and durable secondary-index equality seeks bound
-  by preceding outer rows. OUTER/NATURAL/USING barriers remain
-  correctness-preserving. Multi-index AND intersection, STAT4 histograms,
-  transient join auto-indexes, and direct pager-cursor join seeks are still
-  deferred. Prefer `ORDER BY` when order matters (`GROUP BY` is
+- **Planner** — `ANALYZE` / `sqlite_stat1` and validated `sqlite_stat4`
+  histograms feed index scoring, System-R DP join reordering for up to eight
+  freely reorderable INNER members (greedy above that), hash-build selection,
+  costed multi-index AND intersections, and transient automatic covering
+  indexes. Committed file-backed rowid-table joins seek durable SQLite index
+  b-trees directly; transaction-local, MVCC, WITHOUT ROWID, partial/expression,
+  custom-collation, and unsupported range shapes retain deterministic
+  materialized/scan fallbacks. OUTER/NATURAL/USING barriers remain
+  correctness-preserving. Prefer `ORDER BY` when order matters (`GROUP BY` is
   first-encounter order).
 - **File-backed platforms** — desktop physical files support Windows, 64-bit
   Linux, and macOS. Browser WebAssembly uses the separate OPFS package and its
@@ -371,11 +373,14 @@ Treat Ahtola as SQLite-*compatible*, not a full SQLite replacement:
   can read a DB still held by native SQLite/Turso (e.g. winget `index.db`) without
   taking main-file locks.
 - **MVCC** — process-local `PRAGMA journal_mode=mvcc` + `BEGIN CONCURRENT` with
-  typed rowid/composite-key and materialized-index overlays, a durable logical
-  log, and a synchronous page-WAL checkpoint sequence (`PRAGMA wal_checkpoint`
-  in MVCC mode). Not cross-process; concurrent DDL remains exclusive while
-  active MVCC snapshots exist, and lazy per-page cursor/checkpoint parity is
-  still deferred — see [docs/mvcc-port-contract.md](docs/mvcc-port-contract.md).
+  generation-scoped schema/table identities, typed rowid/composite-key lazy
+  base/version cursors, a sorted secondary-index overlay, a durable logical log,
+  and a crash-ordered page-WAL checkpoint state machine
+  (`PRAGMA wal_checkpoint` in MVCC mode). Checkpoint GC honors each reader's
+  pinned materialization generation, and recovery watermarks advance the
+  logical clock after interrupted log retirement. It is not cross-process;
+  schema publication fails busy while a peer concurrent snapshot is active.
+  See [docs/mvcc-port-contract.md](docs/mvcc-port-contract.md).
 - **Managed virtual-table subset** — statically registered `fts5`, `rtree`, and
   `rtree_i32` modules persist module-owned state in the managed catalog, but are
   not full SQLite FTS5/R-Tree implementations and do not create interoperable
@@ -397,9 +402,17 @@ Treat Ahtola as SQLite-*compatible*, not a full SQLite replacement:
   catch-up is durably marked complete; a crash in between is detected and the
   catch-up resumed on the next open. See
   [docs/replica-bootstrap-publication.md](docs/replica-bootstrap-publication.md).
+- **Managed replica sync** — physical-page and MVCC-logical protocols are
+  detected and persisted explicitly. `SyncAsync` pushes first, waits for remote
+  changes without closing sibling hosts, then applies one-shot staged changes
+  under the publication and cross-process leases. Local journal advancement is
+  rebased without another network pull; genuinely stale remote bases retry with
+  a bound. Page replacement retains crash-safe revert evidence. Pulls request
+  raw pages explicitly and reject zstd responses because no approved
+  pure-managed, trim-safe zstd implementation is shipped.
 - **Not implemented** — loadable extensions, raw `sqlite3*` handles (`Handle`
-  is null), the full sync engine / advanced replica protocols,
-  `CREATE SEQUENCE`, and typed-value extensions.
+  is null), zstd-compressed replica page sets, `CREATE SEQUENCE`, and
+  typed-value extensions.
 - **Native / Sync companions** — not shipped. Connection-string paths that need
   them fail closed. OS P/Invoke in the pager for locks/WAL is intentional engine
   code, not a Rust SDK binding.

--- a/docs/turso-gap-closure-roadmap.md
+++ b/docs/turso-gap-closure-roadmap.md
@@ -195,8 +195,8 @@ row count, built-in collation metadata, and sample record before using it.
 - [x] Preserve statement snapshots while peer commits advance the shared
   store.
 - [x] Port Turso checkpoint phases onto managed I/O: lock, collect,
-  materialize, page-WAL persist, backfill, logical-log retirement, WAL reset,
-  then version GC.
+  materialize, page-WAL persist, backfill, recovery-watermark publication,
+  logical-log retirement, WAL reset, then version GC.
 - [x] Keep recovery evidence valid at every injected crash boundary.
 - [x] Add deterministic schema-cookie, multi-connection, cursor, checkpoint,
   reopen, and oldest-snapshot GC tests.

--- a/docs/turso-gap-closure-roadmap.md
+++ b/docs/turso-gap-closure-roadmap.md
@@ -29,8 +29,8 @@ scope decision; it does not mean Ahtola implements every newer Turso feature.
 | 6 | `window-group-pipeline` | 9 sqltests closed | `core/translate/window.rs` | Done |
 | 7 | `join-coalescing-parity` | 4 sqltests closed | `core/translate/planner.rs`, `plan.rs`, `select.rs` | Done |
 | 8 | `planner-access-path-depth` | Documented runtime limit | `core/translate/optimizer/`, `planner.rs`, `main_loop/` | Planned |
-| 9 | `mvcc-page-native-depth` | Documented runtime limit | `core/mvcc/` | Planned |
-| 10 | `sync-engine-depth` | Wait/apply lifecycle split landed | `sync/engine/src/` | Partial (checkpoint policy blocked by rank 9) |
+| 9 | `mvcc-page-native-depth` | Documented runtime limit | `core/mvcc/` | Done |
+| 10 | `sync-engine-depth` | Wait/apply lifecycle split landed; passive checkpoint hook available | `sync/engine/src/` | Partial |
 
 The sqltest counts overlap by subsystem only in implementation, not in this
 classification: ranks 1-7 account for 133 distinct expected-failure entries.
@@ -179,18 +179,28 @@ classification: ranks 1-7 account for 133 distinct expected-failure entries.
 
 ### 9. Page-native MVCC depth
 
-- [ ] Version `sqlite_schema` identities and schema generations so concurrent
+- [x] Version `sqlite_schema` identities and schema generations so concurrent
   DDL can commit or conflict without exposing discarded catalog changes.
-- [ ] Replace materialized table/index overlays with lazy typed dual cursors
+- [x] Replace materialized table/index overlays with lazy typed dual cursors
   over base B-trees and version chains.
-- [ ] Preserve statement snapshots while peer commits advance the shared
+- [x] Preserve statement snapshots while peer commits advance the shared
   store.
-- [ ] Port Turso checkpoint phases onto managed I/O: lock, collect,
+- [x] Port Turso checkpoint phases onto managed I/O: lock, collect,
   materialize, page-WAL persist, backfill, logical-log retirement, WAL reset,
   then version GC.
-- [ ] Keep recovery evidence valid at every injected crash boundary.
-- [ ] Add deterministic schema-cookie, multi-connection, cursor, checkpoint,
+- [x] Keep recovery evidence valid at every injected crash boundary.
+- [x] Add deterministic schema-cookie, multi-connection, cursor, checkpoint,
   reopen, and oldest-snapshot GC tests.
+
+The managed port follows the pinned Turso `v0.8.0-pre.7` implementation:
+`core/mvcc/database/mod.rs` (`MVTableId`, schema-generation begin/commit
+checks, low-water mark GC), `core/mvcc/cursor.rs` (`MvccLazyCursor` and
+two-peek table/index merging), and
+`core/mvcc/database/checkpoint_state_machine.rs` (publish, backfill,
+logical-log retirement, WAL reset, then GC). Managed I/O completes each phase
+synchronously. A pager-first schema publish and pre-DDL retirement checkpoint
+keep discarded catalogs out of the logical log, while inclusive checkpoint
+watermark frames make every crash boundary replay-safe.
 
 ### 10. Managed sync-engine depth
 

--- a/docs/turso-gap-closure-roadmap.md
+++ b/docs/turso-gap-closure-roadmap.md
@@ -30,7 +30,7 @@ scope decision; it does not mean Ahtola implements every newer Turso feature.
 | 7 | `join-coalescing-parity` | 4 sqltests closed | `core/translate/planner.rs`, `plan.rs`, `select.rs` | Done |
 | 8 | `planner-access-path-depth` | Access-path depth completed | `core/translate/optimizer/`, `planner.rs`, `main_loop/` | Done |
 | 9 | `mvcc-page-native-depth` | Documented runtime limit | `core/mvcc/` | Done |
-| 10 | `sync-engine-depth` | Wait/apply lifecycle split landed; passive checkpoint hook available | `sync/engine/src/` | Partial |
+| 10 | `sync-engine-depth` | Split wait/apply lifecycle and crash-safe checkpoint policy | `sync/engine/src/` | Done |
 
 The sqltest counts overlap by subsystem only in implementation, not in this
 classification: ranks 1-7 account for 133 distinct expected-failure entries.
@@ -47,6 +47,15 @@ classification: ranks 1-7 account for 133 distinct expected-failure entries.
   exposed case was not in the 135-entry baseline).
 - Current expected-failure count: 2, both intentional STORED-generated-column
   differences. There are no actionable sqltest failures in the baseline.
+- 2026-08-29: closed `planner-access-path-depth` with costed AND intersections,
+  validated STAT4 selectivity, automatic covering indexes, and direct durable
+  index-btree seeks.
+- 2026-08-29: closed `mvcc-page-native-depth` with generation-scoped schema
+  identities, lazy typed cursors, crash-ordered checkpointing, recovery
+  watermarks, and reader-generation-aware GC.
+- 2026-08-29: closed `sync-engine-depth` with a split wait/apply lifecycle,
+  bounded stale-base retries, one-shot staged changes, and crash-safe
+  page-replacement checkpoint evidence.
 - 2026-08-29: `sync-engine-depth` -- landed the managed equivalent of Turso's
   `wait_changes_from_remote` -> opaque staged changes -> `apply_changes_from_remote`
   split (`ManagedReplicaBootstrapper.WaitForRemoteChangesAsync` /
@@ -213,23 +222,18 @@ watermark frames make every crash boundary replay-safe.
 
 ### 10. Managed sync-engine depth
 
-- [ ] Port the passive synced-prefix/history checkpoint policy without
-  weakening ambiguous-push recovery. Blocked on the parallel page-native MVCC
-  branch: Turso's `checkpoint_passive` (`sync/engine/src/database_sync_engine.rs`)
-  checkpoints only the already-synced WAL prefix
-  (`revert_since_wal_watermark`), which is a bounded, WAL-frame-based concept
-  that only exists once the MVCC logical protocol has a real logical log/WAL
-  to bound. The page protocol already has a *functionally* equivalent, tested
-  safety net for its own on-disk format: `ManagedReplicaRevertWal.CaptureAndCheckpoint`
-  captures a full pre-checkpoint page image before checkpointing WAL into the
-  main store, so a push that turns out to conflict can still restore the exact
-  pre-push database. Needed from the MVCC branch before this item can close:
-  an `Ahtola.Core/Mvcc` primitive that checkpoints up to a caller-supplied WAL
-  watermark while leaving frames above it (and their revert evidence) intact --
-  the managed equivalent of Turso's `revert_since_wal_watermark` /
-  `CheckpointMode::Passive { upper_bound_inclusive }`. No fail-closed seam was
-  added speculatively ahead of that primitive existing; see the sync-engine
-  session's report to the MVCC session for the exact requirement.
+- [x] Port the passive synced-prefix/history checkpoint policy without
+  weakening ambiguous-push recovery. Turso's page-stream apply protects its
+  revert database by passively backfilling the synced WAL prefix before replay.
+  Ahtola's page protocol uses the stronger format-appropriate
+  `ManagedReplicaRevertWal.CaptureAndCheckpoint`: it publishes a complete
+  pre-checkpoint page image before folding WAL into the main store, then keeps
+  that recovery bundle through ambiguous push outcomes. The Core-only
+  `SqliteWalWriterCheckpointCoordinator.CheckpointPassiveValidated` also
+  exposes an inclusive safe backfill watermark bound to WAL salts and the
+  WAL-index change counter for callers that need non-resetting passive evidence.
+  The MVCC-logical path does not use Turso's separate revert-WAL page replay and
+  therefore does not invent a page-frame watermark for logical transactions.
 - [x] Complete wait-for-changes cancellation, timeout, reconnect, and revision
   ordering. Ported Turso's `wait_changes_from_remote` -> opaque staged changes
   -> `apply_changes_from_remote` split
@@ -238,9 +242,11 @@ watermark frames make every crash boundary replay-safe.
   and validates a response without touching local state or holding any
   publication gate; applying consumes the staged result exactly once (fails
   closed on cross-replica, duplicate-apply, and disposed-result misuse) and
-  throws a dedicated `ManagedReplicaStaleChangesException` -- instead of
-  silently retrying a network fetch under a lease -- when local state advanced
-  past the snapshot the response was negotiated against. `AhtolaConnection.SyncAsync`
+  throws a dedicated `ManagedReplicaStaleChangesException` when the remote-facing
+  base advanced past the snapshot the response was negotiated against.
+  Local-only journal advancement is rebased onto the staged response without
+  another pull; genuinely stale bases retry with a finite backoff and bound.
+  `AhtolaConnection.SyncAsync`
   now runs push and the local apply as their own short publication windows,
   with the network long-poll for remote changes in between holding no gate at
   all, so sibling connections to the same replica keep serving local reads and

--- a/docs/turso-gap-closure-roadmap.md
+++ b/docs/turso-gap-closure-roadmap.md
@@ -30,7 +30,7 @@ scope decision; it does not mean Ahtola implements every newer Turso feature.
 | 7 | `join-coalescing-parity` | 4 sqltests closed | `core/translate/planner.rs`, `plan.rs`, `select.rs` | Done |
 | 8 | `planner-access-path-depth` | Documented runtime limit | `core/translate/optimizer/`, `planner.rs`, `main_loop/` | Planned |
 | 9 | `mvcc-page-native-depth` | Documented runtime limit | `core/mvcc/` | Planned |
-| 10 | `sync-engine-depth` | Documented runtime limit | `sync/engine/src/` | Blocked by rank 9 |
+| 10 | `sync-engine-depth` | Wait/apply lifecycle split landed | `sync/engine/src/` | Partial (checkpoint policy blocked by rank 9) |
 
 The sqltest counts overlap by subsystem only in implementation, not in this
 classification: ranks 1-7 account for 133 distinct expected-failure entries.
@@ -47,6 +47,14 @@ classification: ranks 1-7 account for 133 distinct expected-failure entries.
   exposed case was not in the 135-entry baseline).
 - Current expected-failure count: 2, both intentional STORED-generated-column
   differences. There are no actionable sqltest failures in the baseline.
+- 2026-08-29: `sync-engine-depth` -- landed the managed equivalent of Turso's
+  `wait_changes_from_remote` -> opaque staged changes -> `apply_changes_from_remote`
+  split (`ManagedReplicaBootstrapper.WaitForRemoteChangesAsync` /
+  `ApplyRemoteChangesAsync` / `ManagedReplicaStagedChanges`), and refactored
+  `AhtolaConnection.SyncAsync`'s host publication gate to close/reopen sibling
+  connections only around push and the local apply, never around the network
+  long-poll in between. See the detailed TODOs below for what remains blocked
+  on the parallel MVCC branch.
 
 ## Detailed TODOs
 
@@ -187,18 +195,64 @@ classification: ranks 1-7 account for 133 distinct expected-failure entries.
 ### 10. Managed sync-engine depth
 
 - [ ] Port the passive synced-prefix/history checkpoint policy without
-  weakening ambiguous-push recovery.
-- [ ] Complete wait-for-changes cancellation, timeout, reconnect, and revision
-  ordering.
-- [ ] Negotiate physical and logical protocols explicitly and qualify them
-  against the pinned reference server.
-- [ ] Evaluate compressed page sets only through a pure-managed,
+  weakening ambiguous-push recovery. Blocked on the parallel page-native MVCC
+  branch: Turso's `checkpoint_passive` (`sync/engine/src/database_sync_engine.rs`)
+  checkpoints only the already-synced WAL prefix
+  (`revert_since_wal_watermark`), which is a bounded, WAL-frame-based concept
+  that only exists once the MVCC logical protocol has a real logical log/WAL
+  to bound. The page protocol already has a *functionally* equivalent, tested
+  safety net for its own on-disk format: `ManagedReplicaRevertWal.CaptureAndCheckpoint`
+  captures a full pre-checkpoint page image before checkpointing WAL into the
+  main store, so a push that turns out to conflict can still restore the exact
+  pre-push database. Needed from the MVCC branch before this item can close:
+  an `Ahtola.Core/Mvcc` primitive that checkpoints up to a caller-supplied WAL
+  watermark while leaving frames above it (and their revert evidence) intact --
+  the managed equivalent of Turso's `revert_since_wal_watermark` /
+  `CheckpointMode::Passive { upper_bound_inclusive }`. No fail-closed seam was
+  added speculatively ahead of that primitive existing; see the sync-engine
+  session's report to the MVCC session for the exact requirement.
+- [x] Complete wait-for-changes cancellation, timeout, reconnect, and revision
+  ordering. Ported Turso's `wait_changes_from_remote` -> opaque staged changes
+  -> `apply_changes_from_remote` split
+  (`ManagedReplicaBootstrapper.WaitForRemoteChangesAsync` /
+  `ApplyRemoteChangesAsync` / `ManagedReplicaStagedChanges`): waiting stages
+  and validates a response without touching local state or holding any
+  publication gate; applying consumes the staged result exactly once (fails
+  closed on cross-replica, duplicate-apply, and disposed-result misuse) and
+  throws a dedicated `ManagedReplicaStaleChangesException` -- instead of
+  silently retrying a network fetch under a lease -- when local state advanced
+  past the snapshot the response was negotiated against. `AhtolaConnection.SyncAsync`
+  now runs push and the local apply as their own short publication windows,
+  with the network long-poll for remote changes in between holding no gate at
+  all, so sibling connections to the same replica keep serving local reads and
+  writes for however long the remote takes to answer. Cancellation, timeout,
+  and no-change (up-to-date) responses were already exercised end-to-end and
+  remain covered; reconnect/redirect handling in the HTTP transport itself was
+  untouched (no protocol-layer change was needed for this split).
+- [x] Negotiate physical and logical protocols explicitly and qualify them
+  against the pinned reference server. Already in place before this workstream
+  (raw `PageUpdatesEncodingReq=0`, persisted Pages/MvccLogical detection,
+  stream/apply mode parsing, LML3 logical replay) and unaffected by the
+  wait/apply split, which reuses the exact same request/response parsing code.
+- [x] Evaluate compressed page sets only through a pure-managed,
   NativeAOT/trim-safe dependency; otherwise keep explicit raw negotiation and
-  fail closed.
-- [ ] Preserve sparse-bootstrap publication, encryption exclusions, conflict
-  quarantine, and one push flight per physical identity.
-- [ ] Add canned-server protocol tests, every-boundary fault injection, and
-  cross-process publication tests.
+  fail closed. No pure-managed, trim-safe zstd implementation is available, so
+  the existing explicit raw-encoding request and fail-closed zstd rejection
+  stand as the deliberate, documented choice; the wait/apply split changes
+  nothing about encoding negotiation.
+- [x] Preserve sparse-bootstrap publication, encryption exclusions, conflict
+  quarantine, and one push flight per physical identity. Verified unchanged
+  by the full existing `ManagedReplicaPublicationRaceTests` /
+  `ManagedEmbeddedReplicaPushRecoveryTests` /
+  `ManagedReplicaBootstrapCatchUpDurabilityTests` suites, including the
+  cross-process conflict-during-network-wait races.
+- [x] Add canned-server protocol tests, every-boundary fault injection, and
+  cross-process publication tests. Added direct unit tests for the new staged
+  wait/apply primitives (cross-replica, duplicate-apply, disposed-result,
+  stale-revision retry, no-change response, cancellation mid-long-poll) plus
+  an integration test proving `SyncAsync` no longer blocks sibling reads/writes
+  during the long-poll (`ManagedReplicaWaitApplySplitTests.cs`); reran the full
+  existing canned-server and cross-process publication-race suites unchanged.
 
 ## Definition of done
 

--- a/docs/turso-gap-closure-roadmap.md
+++ b/docs/turso-gap-closure-roadmap.md
@@ -28,7 +28,7 @@ scope decision; it does not mean Ahtola implements every newer Turso feature.
 | 5 | `select-validation-parity` | 10 sqltests closed | `core/translate/planner.rs`, `expr/`, `select.rs` | Done |
 | 6 | `window-group-pipeline` | 9 sqltests closed | `core/translate/window.rs` | Done |
 | 7 | `join-coalescing-parity` | 4 sqltests closed | `core/translate/planner.rs`, `plan.rs`, `select.rs` | Done |
-| 8 | `planner-access-path-depth` | Documented runtime limit | `core/translate/optimizer/`, `planner.rs`, `main_loop/` | Planned |
+| 8 | `planner-access-path-depth` | Access-path depth completed | `core/translate/optimizer/`, `planner.rs`, `main_loop/` | Done |
 | 9 | `mvcc-page-native-depth` | Documented runtime limit | `core/mvcc/` | Done |
 | 10 | `sync-engine-depth` | Wait/apply lifecycle split landed; passive checkpoint hook available | `sync/engine/src/` | Partial |
 
@@ -165,17 +165,26 @@ classification: ranks 1-7 account for 133 distinct expected-failure entries.
 
 ### 8. Planner access-path depth
 
-- [ ] Add multi-index AND intersection with rowid-set cardinality costing and
+- [x] Add multi-index AND intersection with rowid-set cardinality costing and
   a full-scan fallback.
-- [ ] Read STAT4 samples and use histogram selectivity only when schema and
+- [x] Read STAT4 samples and use histogram selectivity only when schema and
   collation metadata match.
-- [ ] Build transient automatic indexes for profitable inner join inputs.
-- [ ] Replace materialized durable-index probes with lazy pager/index cursors
+- [x] Build transient automatic indexes for profitable inner join inputs.
+- [x] Replace materialized durable-index probes with lazy pager/index cursors
   where a covering or rowid lookup is proven.
-- [ ] Preserve deterministic plans without statistics and all existing outer
+- [x] Preserve deterministic plans without statistics and all existing outer
   join barriers.
-- [ ] Extend EXPLAIN QUERY PLAN, selectivity tests, and bounded benchmarks for
+- [x] Extend EXPLAIN QUERY PLAN, selectivity tests, and bounded benchmarks for
   every new path.
+
+The managed planner mirrors Turso's `multi_index.rs` row-set costing and
+automatic-index eligibility, while keeping LEFT/RIGHT/FULL, NATURAL, and USING
+subtrees opaque. Committed rowid-table joins now seek the SQLite index b-tree
+directly and defer the table fetch unless the index covers the row; transaction,
+MVCC, unsupported-shape, and unsupported-collation cases retain the materialized
+fallback. The pinned Turso release has no STAT4 reader, so Ahtola's histogram
+extension validates the standard `sqlite_stat4` schema, current `sqlite_stat1`
+row count, built-in collation metadata, and sample record before using it.
 
 ### 9. Page-native MVCC depth
 

--- a/docs/turso-gap-inventory.json
+++ b/docs/turso-gap-inventory.json
@@ -527,7 +527,7 @@
       "severity": "s3-perf",
       "effort": "L",
       "conformance_links": [],
-      "notes": "Closed 2026-08-23 by the cost-based N-way join-order stage (src/Ahtola.Core/EmbeddedDatabase.JoinOrderRewrites.cs + src/Ahtola.Core/Compilation/JoinOrdering/*), then extended with executable durable index-seek choices. Maximal plain-INNER segments are ordered by a System-R subset DP for up to 8 members and greedy build-up above that. Per-step choices now include nested-loop, either hash-build side, and outer-row-bound persisted-index seeks; estimate_index_cost (cost.rs:171-236) uses accumulated outer cardinality and sqlite_stat1 leading-prefix averages, plus the managed executor's one-time O(N log N) MVCC index-view reconstruction cost. Usable mandatory INDEXED BY candidates force the named seek; unusable hints retain evaluator semantics. LEFT/RIGHT/FULL/NATURAL/USING remain strict barriers. Evidence: JoinOrderOptimizerTests (including indexed DP-vs-brute-force permutation oracle), PlannerStat1JoinCostTests, IndexSeekJoinTests, EXPLAIN/EQP search text, JoinOrderDiagnostics and VdbeJoinIndexSeekMetrics. Residual: STAT4 histograms; multi-index AND intersection; direct pager/B-tree cursor seeks; bloom filters and auto-indexes; Turso required_lhs_by_table outer-join interleaving; general WHERE-term decomposition beyond single-member root-segment comparison pushdown.",
+      "notes": "Closed 2026-08-23 by the cost-based N-way join-order stage (src/Ahtola.Core/EmbeddedDatabase.JoinOrderRewrites.cs + src/Ahtola.Core/Compilation/JoinOrdering/*), then extended by planner-access-path-depth. Maximal plain-INNER segments are ordered by a System-R subset DP for up to 8 members and greedy build-up above that. Per-step choices include nested-loop, either hash-build side, build-once automatic indexes, and outer-row-bound persisted-index seeks. Committed file-backed rowid tables use lazy pager/index cursors with covering reconstruction or deferred rowid-table fetch; transaction/MVCC and unsupported shapes retain the materialized fallback. Usable mandatory INDEXED BY candidates force the named seek; unusable hints retain evaluator semantics. LEFT/RIGHT/FULL/NATURAL/USING remain strict barriers. Evidence: JoinOrderOptimizerTests, PlannerStat1JoinCostTests, IndexSeekJoinTests, PlannerAccessPathDepthTests, EXPLAIN/EQP search text, JoinOrderDiagnostics and VdbeJoinIndexSeekMetrics. Residual: bloom filters; Turso required_lhs_by_table outer-join interleaving; general WHERE-term decomposition beyond single-member root-segment comparison pushdown.",
       "status": "closed"
     },
     {
@@ -539,7 +539,7 @@
       "severity": "s3-perf",
       "effort": "L",
       "conformance_links": [],
-      "notes": "Closed 2026-08-06 for the managed single-table planner surface and extended for plain-INNER joins. TryPlanManagedIndexScan scores competing single-table indexes. JoinOrderEnumerator now costs ordinary persisted indexes whose contiguous leading equality prefix is bound by the current outer mask, using sqlite_stat1 prefix averages and the Turso estimate_index_cost formula, and threads the exact candidate into VdbeJoinIndexScanPlan. Evidence: CompiledSortedScanExecutionTests, JoinOrderOptimizerTests, IndexSeekJoinTests. Residual optimization: AND multi-index intersection, STAT4 histograms, and direct pager/B-tree cursor reuse.",
+      "notes": "Closed 2026-08-06 for the managed single-table planner surface and extended by planner-access-path-depth. TryPlanManagedIndexScan scores competing single-table indexes with current validated sqlite_stat4 samples where available. Top-level selective AND terms may intersect distinct rowid sets when their cost beats the full-scan and single-index baselines. JoinOrderEnumerator costs persisted and automatic indexes whose contiguous equality prefix is bound by the current outer mask; committed file-backed rowid tables seek the persisted SQLite b-tree directly. Evidence: CompiledSortedScanExecutionTests, JoinOrderOptimizerTests, IndexSeekJoinTests, PlannerAccessPathDepthTests.",
       "status": "closed"
     },
     {
@@ -551,7 +551,7 @@
       "severity": "s3-perf",
       "effort": "L",
       "conformance_links": [],
-      "notes": "Closed 2026-08-06 for the managed OR-union surface. Top-level equality OR branches SEARCH distinct indexes, union positions in the evaluator, compile Rewind over the union, and EQP/OpenRead report MULTI-INDEX OR. Evidence: CompiledSortedScanExecutionTests.OrClauseUsesMultiIndexUnion. Residual: VDBE bitmap-union opcodes and AND multi-index intersection remain optional perf extensions.",
+      "notes": "Closed 2026-08-06 for the managed OR-union surface. Top-level equality OR branches SEARCH distinct indexes, union positions in the evaluator, compile Rewind over the union, and EQP/OpenRead report MULTI-INDEX OR. The planner-access-path-depth workstream added the corresponding costed MULTI-INDEX AND rowid-set intersection. Evidence: CompiledSortedScanExecutionTests.OrClauseUsesMultiIndexUnion and PlannerAccessPathDepthTests. Residual: dedicated VDBE bitmap-union/intersection opcodes.",
       "status": "closed"
     },
     {
@@ -1188,15 +1188,15 @@
       "id": "compile-analyze-stat-tables",
       "layer": "compilation",
       "kind": "parity",
-      "turso_ref": "turso-src/core/translate/analyze.rs (ANALYZE, sqlite_stat1/stat4 planner statistics)",
-      "ahtola_ref": "none (Managed ANALYZE reports planner statistics not implemented)",
+      "turso_ref": "turso-src/core/translate/analyze.rs and core/stats.rs (ANALYZE and sqlite_stat1; pinned v0.8.0-pre.7 has no sqlite_stat4 reader)",
+      "ahtola_ref": "src/Ahtola.Core/EmbeddedDatabase.cs::ExecuteAnalyze; src/Ahtola.Core/EmbeddedDatabase.PlannerAccessPaths.cs (sqlite_stat4 generation, validation, and equality histogram estimates)",
       "severity": "s3-perf",
       "effort": "M",
       "conformance_links": [
         "snapshot_tests/analyze/stat1_rows.sqltest::analyze-indexed-table-does-not-insert-null-stat1-row",
         "join/memory.sqltest::correlated-subquery-hash-join-reuse"
       ],
-      "notes": "Closed 2026-08-06 for the sqlite_stat1 scope. ANALYZE deletes and rebuilds sqlite_stat1 rows, including table/index stats used by managed backup/adapters, and the previously linked stat cases pass. Cost-model consumption and any sqlite_stat4-equivalent planner statistics remain covered by compile-no-access-method-selection.",
+      "notes": "Closed 2026-08-06 for sqlite_stat1 and extended by planner-access-path-depth with standard sqlite_stat4 rows. ANALYZE deterministically samples supported ordinary indexes; the planner consumes equality histograms only when sqlite_stat4 has the standard six-column schema, sqlite_stat1 row counts are current, the index still matches, built-in collation semantics are not overridden, and every vector/sample record validates. Missing, stale, malformed, custom-collation, and unsupported-index cases fall back to deterministic stat1 or hardcoded selectivity. Managed snapshots preserve both statistics tables. Evidence: PlannerAccessPathDepthTests.",
       "status": "closed"
     },
     {

--- a/docs/wal-interoperability-contract.md
+++ b/docs/wal-interoperability-contract.md
@@ -578,6 +578,14 @@ pre-existing lock carrier, detached recovery cannot prove that an unlink raced a
 live client. Focused tests use SQLite-produced artifacts and separate
 reader/writer/lock-worker processes.
 
+`SqliteWalWriterCheckpointCoordinator.CheckpointPassiveValidated(...)` is the
+narrow Core-only handoff for sync/replication policy. It returns
+`SyncedFrameInclusive` only after main-store flush and binds that watermark to
+the validated `WalIndexChangeCounter`, `WalSalt1`, and `WalSalt2` captured under
+the checkpoint lock. Callers must reject or retry the watermark when the live
+WAL incarnation no longer matches; a busy result carries no validated
+incarnation. The API does not couple checkpoint policy to `Ahtola.Data`.
+
 This remains unreachable from `SqlitePager`, normal managed execution, cache
 invalidation, and managed recovery. It does not relax the Stage 0 ownership
 lock or establish any stock-SQLite concurrent interoperability claim.
@@ -666,6 +674,7 @@ the attached WAL boundary:
 | `ManagedPassiveCheckpointHonorsHeldReadMarksWithoutCoarseLockArea` | Stage 3 — PASSIVE uses marks/`mxSafeFrame`; reset still needs exclusive marks |
 | `ManagedCheckpointClaimsSqliteCheckpointLockByte` | Stage 3 — checkpoint takes `WAL_CKPT_LOCK` (byte 121) |
 | `ManagedCheckpointPublishesWalIndexBackfillProgress` | Stage 3 — `nBackfill`/`nBackfillAttempted` published after install |
+| `PassiveCheckpointEvidenceBindsInclusiveWatermarkToWalIncarnation` | Stage 3 — sync-facing inclusive watermark is bound to validated WAL salts/`iChange` |
 | `ManagedRolesStayInsideSqliteReservedSharedMemoryLockArea` | §1.2 — no locks outside bytes 120–127 |
 | `ManagedReadOnlyOpenRefusesToCreateAMissingSharedMemoryLockCarrier` | §1.2, §3 — read-only opens never create `-shm` |
 | `PooledReopenSurvivesSharedMemoryCarrierRemovedByNativeClose` (`ManagedConnectionPoolingTests.cs`) | §1.2 — a read-write pager recreates a missing carrier on demand like a native read-write connection, and the pooling catalog refresh tolerates its absence |

--- a/src/Ahtola.Core/ChangeDataCapture.cs
+++ b/src/Ahtola.Core/ChangeDataCapture.cs
@@ -288,7 +288,11 @@ internal sealed class ChangeDataCaptureSession(ChangeDataCaptureConfiguration co
         if (!cdcTable.HasRowid || !cdcTable.IsAutoIncrement)
             throw new EmbeddedSqlException($"CDC table '{_configuration.Table}' has an unsupported schema");
 
-        var changeId = AllocateChangeId(tables, cdcTable, concurrentStore);
+        var changeId = AllocateChangeId(
+            tables,
+            cdcTable,
+            concurrentStore,
+            concurrentTxId);
         var transactionId = _configuration.Version == ChangeDataCaptureVersion.V2
             ? GetOrSetTransactionId(changeId)
             : -1;
@@ -330,7 +334,9 @@ internal sealed class ChangeDataCaptureSession(ChangeDataCaptureConfiguration co
         {
             store.Insert(
                 txId,
-                new MvccRowId(store.GetOrCreateTableId(_configuration.Table), changeId),
+                new MvccRowId(
+                    store.GetOrCreateTableId(txId, _configuration.Table),
+                    changeId),
                 row);
         }
 
@@ -341,16 +347,17 @@ internal sealed class ChangeDataCaptureSession(ChangeDataCaptureConfiguration co
     private long AllocateChangeId(
         IReadOnlyDictionary<string, EmbeddedTable> tables,
         EmbeddedTable cdcTable,
-        MvStore? concurrentStore)
+        MvStore? concurrentStore,
+        MvccTxId? concurrentTxId)
     {
         var allocator = new EmbeddedDatabase.AutoIncrementStatementState();
         var tracker = allocator.GetTracker(_configuration.Table, cdcTable, tables);
         var largest = cdcTable.RowIds.Count == 0 ? 0 : cdcTable.RowIds.Max();
         long changeId;
-        if (concurrentStore is { } store)
+        if (concurrentStore is { } store && concurrentTxId is { } txId)
         {
             changeId = store.AllocateRowId(
-                store.GetOrCreateTableId(_configuration.Table),
+                store.GetOrCreateTableId(txId, _configuration.Table),
                 minimumExclusive: largest);
             tracker.Observe(changeId);
         }

--- a/src/Ahtola.Core/Compilation/JoinOrdering/JoinCostModel.cs
+++ b/src/Ahtola.Core/Compilation/JoinOrdering/JoinCostModel.cs
@@ -24,8 +24,8 @@ internal enum JoinStepShape
     HashBuildLeft,
 
     /// <summary>
-    /// The right member is positioned once per accumulated outer row through a durable index's
-    /// contiguous equality prefix.
+    /// The right member is positioned once per accumulated outer row through a durable or
+    /// automatic index's contiguous equality prefix.
     /// </summary>
     IndexSeekRight,
 }
@@ -147,14 +147,32 @@ internal static class JoinCostModel
     }
 
     /// <summary>
-    /// One-time incremental cost of reconstructing the managed, MVCC-visible index view used by
-    /// join seeks. Turso seeks an already-open B-tree; Ahtola currently projects and sorts the
-    /// visible base rows once per statement, so that O(N log N) work must not be hidden.
+    /// One-time incremental cost of reconstructing the managed, MVCC-visible fallback index view
+    /// used when a committed pager cursor is unavailable. The O(N log N) work must not be hidden.
     /// </summary>
     public static double EstimateManagedIndexViewBuildCost(double rowCount)
     {
         var rows = Sanitize(rowCount);
         return EstimateSortCost(rows) + rows * JoinCostParams.CpuCostPerRow;
+    }
+
+    /// <summary>
+    /// Build-once cost for an automatic equality index. This mirrors Turso's
+    /// <c>estimate_ephemeral_index_build_cost</c>: scan the input once, insert each
+    /// row into the transient lookup, then probe it once per accumulated outer row.
+    /// </summary>
+    public static double EstimateAutomaticIndexCost(
+        double baseRowCount,
+        double inputCardinality,
+        double rowsPerSeek)
+    {
+        var rows = Sanitize(baseRowCount);
+        var probes = Math.Max(1.0, Sanitize(inputCardinality));
+        var matches = Math.Max(0.0, Sanitize(rowsPerSeek));
+        return EstimateFullScanCost(rows, scanCount: 1.0)
+            + rows * (JoinCostParams.HashCpuCost + JoinCostParams.HashInsertCost)
+            + probes * (JoinCostParams.HashCpuCost + JoinCostParams.HashLookupCost)
+            + probes * matches * JoinCostParams.CpuCostPerRow;
     }
 
     /// <summary>

--- a/src/Ahtola.Core/Compilation/JoinOrdering/JoinOrderEnumerator.cs
+++ b/src/Ahtola.Core/Compilation/JoinOrdering/JoinOrderEnumerator.cs
@@ -489,6 +489,8 @@ internal static class JoinOrderEnumerator
             output,
             indexAccess);
         var candidate = segment.Members[member].IndexCandidates![indexAccess.CandidateIndex];
+        if (candidate.Automatic && best.Shape != JoinStepShape.HashBuildRight)
+            return best;
         return candidate.Forced || seek.StepCost < best.StepCost - CostEpsilon ? seek : best;
     }
 
@@ -502,8 +504,13 @@ internal static class JoinOrderEnumerator
         var uniquePointLookup = candidate.Unique
             && access.EqualityTermIndices.Length == candidate.Columns.Count;
         var rowsPerSeek = uniquePointLookup ? 1.0 : access.RowsPerSeek;
-        var cost = JoinCostModel.EstimateManagedIndexViewBuildCost(member.RowCount)
-            + JoinCostModel.EstimateIndexSeekCost(
+        var cost = candidate.Automatic
+            ? JoinCostModel.EstimateAutomaticIndexCost(
+                member.RowCount,
+                leftCardinality,
+                rowsPerSeek)
+            : (candidate.LazyCursor ? 0.0 : JoinCostModel.EstimateManagedIndexViewBuildCost(member.RowCount))
+                + JoinCostModel.EstimateIndexSeekCost(
                 member.RowCount,
                 candidate.Columns.Count,
                 candidate.TableColumnCount,
@@ -562,16 +569,22 @@ internal static class JoinOrderEnumerator
             var rowsPerSeek = candidate.Unique && termIndices.Count == candidate.Columns.Count
                 ? 1.0
                 : Math.Max(1.0, candidate.RowsPerPrefix[termIndices.Count - 1]);
-            var cost = JoinCostModel.EstimateManagedIndexViewBuildCost(
-                    segment.Members[member].RowCount)
-                + JoinCostModel.EstimateIndexSeekCost(
+            var cost = candidate.Automatic
+                ? JoinCostModel.EstimateAutomaticIndexCost(
                     segment.Members[member].RowCount,
-                    candidate.Columns.Count,
-                    candidate.TableColumnCount,
-                    candidate.HasRowIdAlias,
-                    candidate.Covering,
                     leftCardinality,
-                    rowsPerSeek);
+                    rowsPerSeek)
+                : (candidate.LazyCursor
+                        ? 0.0
+                        : JoinCostModel.EstimateManagedIndexViewBuildCost(segment.Members[member].RowCount))
+                    + JoinCostModel.EstimateIndexSeekCost(
+                        segment.Members[member].RowCount,
+                        candidate.Columns.Count,
+                        candidate.TableColumnCount,
+                        candidate.HasRowIdAlias,
+                        candidate.Covering,
+                        leftCardinality,
+                        rowsPerSeek);
             if (cost < bestCost - CostEpsilon
                 || Math.Abs(cost - bestCost) <= CostEpsilon
                     && best is not null

--- a/src/Ahtola.Core/Compilation/JoinOrdering/JoinOrderModel.cs
+++ b/src/Ahtola.Core/Compilation/JoinOrdering/JoinOrderModel.cs
@@ -10,7 +10,7 @@ namespace Ahtola.Core.Compilation.JoinOrdering;
 /// </param>
 /// <param name="RowCount">Estimated base cardinality, read from <c>sqlite_stat1</c>.</param>
 /// <param name="ColumnWidth">Number of value slots this member contributes to a joined row.</param>
-/// <param name="IndexCandidates">Persisted indexes whose leading-prefix statistics are available.</param>
+/// <param name="IndexCandidates">Persisted or automatic indexes available to this join step.</param>
 internal sealed record JoinSegmentMember(
     int OriginalIndex,
     double RowCount,
@@ -18,8 +18,8 @@ internal sealed record JoinSegmentMember(
     IReadOnlyList<JoinIndexCandidate>? IndexCandidates = null);
 
 /// <summary>
-/// One ordinary persisted B-tree index usable as an outer-bound join access. <c>Forced</c> is
-/// true when SQL named this index through mandatory <c>INDEXED BY</c>.
+/// One persisted or automatic index usable as an outer-bound join access. <c>Forced</c> is true
+/// when SQL named a persisted index through mandatory <c>INDEXED BY</c>.
 /// </summary>
 internal sealed record JoinIndexCandidate(
     string Name,
@@ -29,7 +29,9 @@ internal sealed record JoinIndexCandidate(
     bool Covering,
     int TableColumnCount,
     bool HasRowIdAlias,
-    bool Forced = false);
+    bool Forced = false,
+    bool Automatic = false,
+    bool LazyCursor = false);
 
 /// <summary>One key column in persisted index order.</summary>
 internal readonly record struct JoinIndexColumn(
@@ -82,7 +84,7 @@ internal sealed record JoinPredicateTerm(
     string? EqualityCollation = null);
 
 /// <summary>
-/// Exact persisted index and equality terms selected for one <c>IndexSeekRight</c> step.
+/// Exact index and equality terms selected for one <c>IndexSeekRight</c> step.
 /// </summary>
 internal sealed record JoinIndexAccessChoice(
     int CandidateIndex,

--- a/src/Ahtola.Core/Compilation/ScanCompilation.cs
+++ b/src/Ahtola.Core/Compilation/ScanCompilation.cs
@@ -2,6 +2,13 @@ using Ahtola.Core.Execution;
 
 namespace Ahtola.Core.Compilation;
 
+internal enum ScanAccessKind
+{
+    Default,
+    MultiIndexOr,
+    MultiIndexAnd,
+}
+
 /// <summary>
 /// Describes a single base table that a <see cref="SelectStatement"/> can scan
 /// directly. The caller supplies the live row list plus a column resolver so the
@@ -23,6 +30,7 @@ namespace Ahtola.Core.Compilation;
 /// Optional equality prefix for SEARCH plans: emit SeekGE/IdxGE on these table-column
 /// ordinals instead of Rewind, then residual WHERE Filter.
 /// </param>
+/// <param name="AccessKind">The explicit multi-index shape used by EXPLAIN formatting.</param>
 internal sealed record ScanTarget(
     string TableName,
     string Qualifier,
@@ -33,7 +41,8 @@ internal sealed record ScanTarget(
     string? IndexName = null,
     IReadOnlyList<EmbeddedColumn?>? ColumnDefinitions = null,
     IReadOnlyDictionary<string, EmbeddedColumn>? QualifiedColumnDefinitions = null,
-    IndexSeekPrefix? IndexSeek = null)
+    IndexSeekPrefix? IndexSeek = null,
+    ScanAccessKind AccessKind = ScanAccessKind.Default)
 {
     public bool HasRowId => RowIds is not null;
 

--- a/src/Ahtola.Core/Compilation/SelectStatementCompiler.cs
+++ b/src/Ahtola.Core/Compilation/SelectStatementCompiler.cs
@@ -42,9 +42,11 @@ internal sealed class SelectStatementCompiler
             return $"{target.TableName} USING COVERING INDEX {name}";
         }
 
-        // Multi-index OR unions use joined names (idx_a+idx_b).
-        if (target.IndexName.Contains('+', StringComparison.Ordinal))
+        if (target.AccessKind == ScanAccessKind.MultiIndexOr)
             return $"{target.TableName} USING MULTI-INDEX OR {target.IndexName}";
+
+        if (target.AccessKind == ScanAccessKind.MultiIndexAnd)
+            return $"{target.TableName} USING MULTI-INDEX AND {target.IndexName}";
 
         return $"{target.TableName} USING INDEX {target.IndexName}";
     }

--- a/src/Ahtola.Core/EmbeddedDatabase.JoinOrderRewrites.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.JoinOrderRewrites.cs
@@ -22,8 +22,9 @@ namespace Ahtola.Core;
 /// <c>FULL</c>, <c>NATURAL</c>, or carries <c>USING</c>. Semi/anti joins decline the rewrite
 /// outright. This is deliberately stricter than Turso's <c>required_lhs_by_table</c> /
 /// <c>left_join_illegal_map</c> legality bitmask (join.rs:1258-1324): the fine-grained scheme
-/// only pays off together with per-table access-method search, which needs index-seek join
-/// leaves this engine does not have. Freezing barrier subtrees is a provably safe subset.
+/// only pays off with finer null-extension provenance than the managed row shape currently
+/// carries. Freezing barrier subtrees remains the provably safe subset even though eligible
+/// inner leaves now support persisted and automatic index seeks.
 /// </para>
 /// <para>
 /// <b>Projection order.</b> Reordering permutes the physical value slots of a joined row. The
@@ -72,6 +73,7 @@ public sealed partial class EmbeddedDatabase
         Interlocked.Exchange(ref _joinOrderDeclines, 0);
         Interlocked.Exchange(ref _joinOrderPushedWhereTerms, 0);
         _joinIndexSeekMetrics.Reset();
+        _plannerAccessPathMetrics.Reset();
     }
 
     /// <summary>
@@ -273,11 +275,21 @@ public sealed partial class EmbeddedDatabase
         var members = new JoinSegmentMember[infos.Length];
         for (var index = 0; index < infos.Length; index++)
         {
+            var indexCandidates = infos[index].IndexCandidates;
+            if (DescribeAutomaticJoinIndexCandidate(
+                    sources[index],
+                    infos[index],
+                    terms,
+                    index) is { } automatic)
+            {
+                indexCandidates = [.. indexCandidates, automatic];
+            }
+
             members[index] = new JoinSegmentMember(
                 index,
                 infos[index].RowCount,
                 infos[index].Width,
-                infos[index].IndexCandidates);
+                indexCandidates);
         }
 
         Interlocked.Increment(ref _joinOrderSegmentsConsidered);
@@ -297,7 +309,7 @@ public sealed partial class EmbeddedDatabase
                 return false;
         }
 
-        var synthesized = SynthesizeJoinOrder(rewrittenMembers, infos, placements, plan, state);
+        var synthesized = SynthesizeJoinOrder(rewrittenMembers, infos, members, placements, plan, state);
         var slotMap = BuildJoinOrderSlotMap(rewrittenMembers, infos, plan.MemberOrder);
 
         Interlocked.Increment(ref _joinOrderSegmentsReordered);
@@ -366,6 +378,7 @@ public sealed partial class EmbeddedDatabase
     private static TableSource SynthesizeJoinOrder(
         JoinOrderRewrittenSource[] members,
         JoinOrderMemberInfo[] infos,
+        JoinSegmentMember[] planMembers,
         List<JoinOrderTermPlacement> placements,
         JoinOrderPlan plan,
         JoinOrderRewriteState state)
@@ -395,7 +408,7 @@ public sealed partial class EmbeddedDatabase
             if (plan.IndexAccesses[step] is { } indexAccess)
             {
                 state.IndexSeeks[joined] = new CompiledJoinIndexSelection(
-                    infos[member].IndexCandidates[indexAccess.CandidateIndex],
+                    planMembers[member].IndexCandidates![indexAccess.CandidateIndex],
                     indexAccess.EqualityTermIndices.Select(index => placements[index].Expression).ToArray());
             }
 
@@ -569,10 +582,102 @@ public sealed partial class EmbeddedDatabase
                 Enumerable.Range(0, table.Columns.Length).All(indexedColumns.Contains),
                 table.Columns.Length,
                 table.RowidAliasColumnIndex >= 0,
-                named.IndexDirective is IndexedByDirective));
+                named.IndexDirective is IndexedByDirective,
+                Automatic: false,
+                LazyCursor: context.ConcurrentMvStore is null
+                    && context.ConcurrentMvccTxId is null
+                    && !context.InTransaction
+                    && _fileStore?.CanOpenIndexAccessor(table, index) == true));
         }
 
         return candidates;
+    }
+
+    private static JoinIndexCandidate? DescribeAutomaticJoinIndexCandidate(
+        TableSource source,
+        JoinOrderMemberInfo info,
+        IReadOnlyList<JoinPredicateTerm> terms,
+        int member)
+    {
+        if (source is not NamedTableSource { IndexDirective: null }
+            || info.Table is not { } table)
+        {
+            return null;
+        }
+
+        var memberBit = 1UL << member;
+        var columns = new List<JoinIndexColumn>();
+        var rowsPerPrefix = new List<double>();
+        foreach (var term in terms)
+        {
+            int ordinal;
+            double matchRows;
+            if (term.EqualityRightMask == memberBit
+                && term.EqualityRightColumnOrdinal >= 0
+                && !term.EqualityLeftConvertsTextToNumeric
+                && !term.EqualityLeftConvertsNumericToText
+                && !term.EqualityRightConvertsTextToNumeric
+                && !term.EqualityRightConvertsNumericToText)
+            {
+                ordinal = term.EqualityRightColumnOrdinal;
+                matchRows = term.EqualityRightMatchRows;
+            }
+            else if (term.EqualityLeftMask == memberBit
+                     && term.EqualityLeftColumnOrdinal >= 0
+                     && !term.EqualityLeftConvertsTextToNumeric
+                     && !term.EqualityLeftConvertsNumericToText)
+            {
+                if (term.EqualityRightConvertsTextToNumeric
+                    || term.EqualityRightConvertsNumericToText)
+                {
+                    continue;
+                }
+
+                ordinal = term.EqualityLeftColumnOrdinal;
+                matchRows = term.EqualityLeftMatchRows;
+            }
+            else
+            {
+                continue;
+            }
+
+            if (term.EqualityCollation is not { } collation
+                || !IsHashableJoinKeyCollation(collation)
+                || !string.Equals(
+                    NormalizeDeclaredCollation(table.ColumnDefinitions[ordinal].Collation) ?? "BINARY",
+                    collation,
+                    StringComparison.OrdinalIgnoreCase)
+                || table.Indexes.Any(index => index.Columns.Any(column => column.ColumnIndex == ordinal))
+                || columns.Any(column => column.ColumnOrdinal == ordinal))
+            {
+                continue;
+            }
+
+            columns.Add(new JoinIndexColumn(ordinal, collation.ToUpperInvariant(), Descending: false));
+            var previous = rowsPerPrefix.Count == 0
+                ? Math.Max(1.0, info.RowCount)
+                : rowsPerPrefix[^1];
+            rowsPerPrefix.Add(Math.Max(
+                1.0,
+                Math.Min(
+                    Math.Max(1.0, matchRows),
+                    previous * JoinCostParams.SelectivityEqualityUnindexed)));
+        }
+
+        if (columns.Count == 0)
+            return null;
+
+        return new JoinIndexCandidate(
+            $"automatic_{table.Name}",
+            columns,
+            rowsPerPrefix,
+            Unique: false,
+            Covering: true,
+            table.Columns.Length,
+            table.RowidAliasColumnIndex >= 0,
+            Forced: false,
+            Automatic: true,
+            LazyCursor: false);
     }
 
     /// <summary>

--- a/src/Ahtola.Core/EmbeddedDatabase.PlannerAccessPaths.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.PlannerAccessPaths.cs
@@ -102,7 +102,8 @@ public sealed partial class EmbeddedDatabase
     private void AddIndexStat4Samples(
         EmbeddedTable statistics,
         EmbeddedTable table,
-        EmbeddedIndex index)
+        EmbeddedIndex index,
+        Stat4RowIdAllocator rowIds)
     {
         if (table.Rows.Count == 0
             || !table.HasRowid
@@ -154,58 +155,86 @@ public sealed partial class EmbeddedDatabase
         });
 
         var samplePositions = SelectStat4SamplePositions(table, index, entries);
-        var textEncoding = GetTextEncoding();
-        foreach (var samplePosition in samplePositions)
+        var sampleCount = samplePositions.Count;
+        var columnCount = index.Columns.Count;
+        var equalCounts = new long[sampleCount, columnCount];
+        var lessCounts = new long[sampleCount, columnCount];
+        var distinctLessCounts = new long[sampleCount, columnCount];
+        var commonPrefixLengths = new int[entries.Count];
+        long vectorComparisons = 0;
+        // One adjacent-key pass removes both the sample and prefix-length multipliers:
+        // every later prefix run boundary is a constant-time common-length check.
+        for (var entryIndex = 1; entryIndex < entries.Count; entryIndex++)
         {
-            var sample = entries[samplePosition];
-            var equalCounts = new long[index.Columns.Count];
-            var lessCounts = new long[index.Columns.Count];
-            var distinctLessCounts = new long[index.Columns.Count];
-            for (var prefixLength = 1; prefixLength <= index.Columns.Count; prefixLength++)
+            var left = entries[entryIndex - 1].Key;
+            var right = entries[entryIndex].Key;
+            var commonLength = 0;
+            while (commonLength < columnCount)
             {
-                SqlValue[]? previous = null;
-                for (var entryIndex = 0; entryIndex < entries.Count; entryIndex++)
+                var column = index.Columns[commonLength];
+                vectorComparisons++;
+                if (Compare(
+                        left[commonLength],
+                        right[commonLength],
+                        IndexExpressionSemantics.GetCollationName(table, column)) != 0)
                 {
-                    var current = entries[entryIndex].Key;
-                    var comparison = CompareIndexStatisticKeyPrefix(
-                        table,
-                        index,
-                        current,
-                        sample.Key,
-                        prefixLength);
-                    if (comparison < 0)
-                    {
-                        lessCounts[prefixLength - 1]++;
-                        if (previous is null
-                            || !IndexPrefixesEqual(
-                                table,
-                                index,
-                                previous,
-                                current,
-                                prefixLength))
-                        {
-                            distinctLessCounts[prefixLength - 1]++;
-                        }
-                    }
-                    else if (comparison == 0)
-                    {
-                        equalCounts[prefixLength - 1]++;
-                    }
-
-                    previous = current;
+                    break;
                 }
+                commonLength++;
             }
 
-            var recordValues = new SqlValue[index.Columns.Count + 1];
+            commonPrefixLengths[entryIndex] = commonLength;
+        }
+
+        for (var prefixIndex = 0; prefixIndex < columnCount; prefixIndex++)
+        {
+            var prefixLength = prefixIndex + 1;
+            var sampleCursor = 0;
+            var runStart = 0;
+            long runOrdinal = 0;
+            for (var entryIndex = 1; entryIndex <= entries.Count; entryIndex++)
+            {
+                var boundary = entryIndex == entries.Count
+                    || commonPrefixLengths[entryIndex] < prefixLength;
+
+                if (!boundary)
+                    continue;
+
+                while (sampleCursor < sampleCount && samplePositions[sampleCursor] < entryIndex)
+                {
+                    if (samplePositions[sampleCursor] < runStart)
+                        throw new InvalidOperationException("STAT4 sample positions are not ordered.");
+                    equalCounts[sampleCursor, prefixIndex] = entryIndex - runStart;
+                    lessCounts[sampleCursor, prefixIndex] = runStart;
+                    distinctLessCounts[sampleCursor, prefixIndex] = runOrdinal;
+                    sampleCursor++;
+                }
+
+                runStart = entryIndex;
+                runOrdinal++;
+            }
+
+            if (sampleCursor != sampleCount)
+                throw new InvalidOperationException("STAT4 sample positions extend beyond the sorted index.");
+        }
+        _plannerAccessPathMetrics.Stat4VectorsCompared(vectorComparisons);
+
+        var textEncoding = GetTextEncoding();
+        for (var sampleIndex = 0; sampleIndex < sampleCount; sampleIndex++)
+        {
+            var samplePosition = samplePositions[sampleIndex];
+            var sample = entries[samplePosition];
+            var recordValues = new SqlValue[columnCount + 1];
             Array.Copy(sample.Key, recordValues, sample.Key.Length);
             recordValues[^1] = SqlValue.Integer(sample.RowId);
             AddStat4Row(
                 statistics,
+                rowIds,
                 table.Name,
                 index.Name,
-                JoinStatVector(equalCounts),
-                JoinStatVector(lessCounts),
-                JoinStatVector(distinctLessCounts),
+                JoinStatVector(equalCounts, sampleIndex, columnCount),
+                JoinStatVector(lessCounts, sampleIndex, columnCount),
+                JoinStatVector(distinctLessCounts, sampleIndex, columnCount),
                 SqliteRecordCodec.Encode(recordValues, textEncoding));
         }
     }
@@ -219,7 +248,7 @@ public sealed partial class EmbeddedDatabase
         if (entries.Count <= maximumSamples)
             return Enumerable.Range(0, entries.Count).ToArray();
 
-        var runs = new List<(int Start, int Count)>();
+        var prominentRuns = new List<(int Start, int Count)>(maximumSamples / 2);
         var start = 0;
         for (var indexPosition = 1; indexPosition <= entries.Count; indexPosition++)
         {
@@ -234,18 +263,13 @@ public sealed partial class EmbeddedDatabase
                 continue;
             }
 
-            runs.Add((start, indexPosition - start));
+            AddProminentRun((start, indexPosition - start));
             start = indexPosition;
         }
 
         var selected = new HashSet<int>();
-        foreach (var run in runs
-                     .OrderByDescending(static run => run.Count)
-                     .ThenBy(static run => run.Start)
-                     .Take(maximumSamples / 2))
-        {
+        foreach (var run in prominentRuns)
             selected.Add(run.Start + (run.Count / 2));
-        }
 
         for (var sample = 0; selected.Count < maximumSamples && sample < maximumSamples; sample++)
         {
@@ -256,34 +280,40 @@ public sealed partial class EmbeddedDatabase
             selected.Add(position);
 
         return selected.Order().Take(maximumSamples).ToArray();
-    }
 
-    private int CompareIndexStatisticKeyPrefix(
-        EmbeddedTable table,
-        EmbeddedIndex index,
-        SqlValue[] left,
-        SqlValue[] right,
-        int prefixLength)
-    {
-        for (var position = 0; position < prefixLength; position++)
+        void AddProminentRun((int Start, int Count) candidate)
         {
-            var column = index.Columns[position];
-            var comparison = Compare(
-                left[position],
-                right[position],
-                IndexExpressionSemantics.GetCollationName(table, column));
-            if (comparison != 0)
-                return column.Descending ? -comparison : comparison;
-        }
+            var insertion = 0;
+            while (insertion < prominentRuns.Count)
+            {
+                var current = prominentRuns[insertion];
+                if (candidate.Count > current.Count
+                    || candidate.Count == current.Count && candidate.Start < current.Start)
+                {
+                    break;
+                }
+                insertion++;
+            }
 
-        return 0;
+            if (insertion >= maximumSamples / 2)
+                return;
+            prominentRuns.Insert(insertion, candidate);
+            if (prominentRuns.Count > maximumSamples / 2)
+                prominentRuns.RemoveAt(prominentRuns.Count - 1);
+        }
     }
 
-    private static string JoinStatVector(IEnumerable<long> values)
-        => string.Join(" ", values.Select(value => value.ToString(CultureInfo.InvariantCulture)));
+    private static string JoinStatVector(long[,] values, int row, int columnCount)
+    {
+        var parts = new string[columnCount];
+        for (var column = 0; column < columnCount; column++)
+            parts[column] = values[row, column].ToString(CultureInfo.InvariantCulture);
+        return string.Join(" ", parts);
+    }
 
     private static void AddStat4Row(
         EmbeddedTable statistics,
+        Stat4RowIdAllocator rowIds,
         string tableName,
         string indexName,
         string equal,
@@ -291,9 +321,7 @@ public sealed partial class EmbeddedDatabase
         string distinctLess,
         byte[] sample)
     {
-        var rowId = statistics.RowIds.Count == 0
-            ? 1
-            : NextAutoRowId(statistics.RowIds.Max(), new HashSet<long>(statistics.RowIds));
+        var rowId = rowIds.Allocate(statistics);
         statistics.Rows.Add(
         [
             SqlValue.Text(tableName),
@@ -304,6 +332,57 @@ public sealed partial class EmbeddedDatabase
             SqlValue.Blob(sample),
         ]);
         statistics.RowIds.Add(rowId);
+    }
+
+    // One allocator spans the whole ANALYZE statement, so inserting samples never rescans
+    // sqlite_stat4's accumulated rowids.
+    private sealed class Stat4RowIdAllocator
+    {
+        private readonly PlannerAccessPathMetrics _metrics;
+        private long _largest;
+        private bool _hasRows;
+        private HashSet<long>? _occupiedAtLimit;
+
+        public Stat4RowIdAllocator(
+            EmbeddedTable statistics,
+            PlannerAccessPathMetrics metrics)
+        {
+            ArgumentNullException.ThrowIfNull(statistics);
+            ArgumentNullException.ThrowIfNull(metrics);
+            _metrics = metrics;
+            foreach (var rowId in statistics.RowIds)
+            {
+                if (!_hasRows || rowId > _largest)
+                    _largest = rowId;
+                _hasRows = true;
+            }
+
+            _metrics.Stat4RowIdSeeded(statistics.RowIds.Count);
+        }
+
+        public long Allocate(EmbeddedTable statistics)
+        {
+            long rowId;
+            if (!_hasRows)
+            {
+                rowId = 1;
+                _largest = rowId;
+                _hasRows = true;
+            }
+            else if (_largest < long.MaxValue)
+            {
+                rowId = ++_largest;
+            }
+            else
+            {
+                _occupiedAtLimit ??= new HashSet<long>(statistics.RowIds);
+                rowId = NextAutoRowId(long.MaxValue, _occupiedAtLimit);
+                _occupiedAtLimit.Add(rowId);
+            }
+
+            _metrics.Stat4RowWritten();
+            return rowId;
+        }
     }
 
     private ManagedAndIndexIntersectionPlan? TryPlanManagedAndIndexIntersection(
@@ -749,7 +828,8 @@ public sealed partial class EmbeddedDatabase
             }
 
             var sampleRowId = sample[^1].AsInteger();
-            var sampleRowPosition = table.RowIds.IndexOf(sampleRowId);
+            var sampleRowPosition = table.TryGetRowIdPosition(sampleRowId, out var cacheRebuilt);
+            _plannerAccessPathMetrics.Stat4SampleRowIdLookedUp(cacheRebuilt);
             if (sampleRowPosition < 0)
                 return false;
             var currentKey = IndexExpressionSemantics.ProjectKey(
@@ -834,6 +914,12 @@ internal sealed class PlannerAccessPathMetrics
     private long _intersectionIndexPagesRead;
     private long _intersectionKeyComparisons;
     private long _stat4EstimatesUsed;
+    private long _stat4SampleRowIdLookups;
+    private long _stat4RowIdCacheRebuilds;
+    private long _stat4VectorComparisons;
+    private long _stat4RowIdSeedPasses;
+    private long _stat4RowIdSeedRowsVisited;
+    private long _stat4RowsWritten;
     private double _lastStat4EstimatedRows;
 
     public long IntersectionsExecuted => Interlocked.Read(ref _intersectionsExecuted);
@@ -847,6 +933,18 @@ internal sealed class PlannerAccessPathMetrics
     public long IntersectionKeyComparisons => Interlocked.Read(ref _intersectionKeyComparisons);
 
     public long Stat4EstimatesUsed => Interlocked.Read(ref _stat4EstimatesUsed);
+
+    public long Stat4SampleRowIdLookups => Interlocked.Read(ref _stat4SampleRowIdLookups);
+
+    public long Stat4RowIdCacheRebuilds => Interlocked.Read(ref _stat4RowIdCacheRebuilds);
+
+    public long Stat4VectorComparisons => Interlocked.Read(ref _stat4VectorComparisons);
+
+    public long Stat4RowIdSeedPasses => Interlocked.Read(ref _stat4RowIdSeedPasses);
+
+    public long Stat4RowIdSeedRowsVisited => Interlocked.Read(ref _stat4RowIdSeedRowsVisited);
+
+    public long Stat4RowsWritten => Interlocked.Read(ref _stat4RowsWritten);
 
     public double LastStat4EstimatedRows => Volatile.Read(ref _lastStat4EstimatedRows);
 
@@ -868,6 +966,24 @@ internal sealed class PlannerAccessPathMetrics
         Interlocked.Increment(ref _stat4EstimatesUsed);
     }
 
+    internal void Stat4SampleRowIdLookedUp(bool cacheRebuilt)
+    {
+        Interlocked.Increment(ref _stat4SampleRowIdLookups);
+        if (cacheRebuilt)
+            Interlocked.Increment(ref _stat4RowIdCacheRebuilds);
+    }
+
+    internal void Stat4VectorsCompared(long comparisons)
+        => Interlocked.Add(ref _stat4VectorComparisons, comparisons);
+
+    internal void Stat4RowIdSeeded(int rowsVisited)
+    {
+        Interlocked.Increment(ref _stat4RowIdSeedPasses);
+        Interlocked.Add(ref _stat4RowIdSeedRowsVisited, rowsVisited);
+    }
+
+    internal void Stat4RowWritten() => Interlocked.Increment(ref _stat4RowsWritten);
+
     internal void Reset()
     {
         Interlocked.Exchange(ref _intersectionsExecuted, 0);
@@ -876,6 +992,12 @@ internal sealed class PlannerAccessPathMetrics
         Interlocked.Exchange(ref _intersectionIndexPagesRead, 0);
         Interlocked.Exchange(ref _intersectionKeyComparisons, 0);
         Interlocked.Exchange(ref _stat4EstimatesUsed, 0);
+        Interlocked.Exchange(ref _stat4SampleRowIdLookups, 0);
+        Interlocked.Exchange(ref _stat4RowIdCacheRebuilds, 0);
+        Interlocked.Exchange(ref _stat4VectorComparisons, 0);
+        Interlocked.Exchange(ref _stat4RowIdSeedPasses, 0);
+        Interlocked.Exchange(ref _stat4RowIdSeedRowsVisited, 0);
+        Interlocked.Exchange(ref _stat4RowsWritten, 0);
         Volatile.Write(ref _lastStat4EstimatedRows, 0);
     }
 }

--- a/src/Ahtola.Core/EmbeddedDatabase.PlannerAccessPaths.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.PlannerAccessPaths.cs
@@ -155,68 +155,57 @@ public sealed partial class EmbeddedDatabase
 
         var samplePositions = SelectStat4SamplePositions(table, index, entries);
         var textEncoding = GetTextEncoding();
-        var equalCountsBySample = samplePositions
-            .Select(_ => new long[index.Columns.Count])
-            .ToArray();
-        var lessCountsBySample = samplePositions
-            .Select(_ => new long[index.Columns.Count])
-            .ToArray();
-        var distinctLessCountsBySample = samplePositions
-            .Select(_ => new long[index.Columns.Count])
-            .ToArray();
-        for (var prefixLength = 1; prefixLength <= index.Columns.Count; prefixLength++)
+        foreach (var samplePosition in samplePositions)
         {
-            _plannerAccessPathMetrics.RecordStat4AnalysisRowsScanned(entries.Count);
-            var sampleIndex = 0;
-            var runStart = 0;
-            var distinctBefore = 0L;
-            while (runStart < entries.Count)
+            var sample = entries[samplePosition];
+            var equalCounts = new long[index.Columns.Count];
+            var lessCounts = new long[index.Columns.Count];
+            var distinctLessCounts = new long[index.Columns.Count];
+            for (var prefixLength = 1; prefixLength <= index.Columns.Count; prefixLength++)
             {
-                var runEnd = runStart + 1;
-                while (runEnd < entries.Count
-                       && IndexPrefixesEqual(
-                           table,
-                           index,
-                           entries[runStart].Key,
-                           entries[runEnd].Key,
-                           prefixLength))
+                SqlValue[]? previous = null;
+                for (var entryIndex = 0; entryIndex < entries.Count; entryIndex++)
                 {
-                    runEnd++;
-                }
+                    var current = entries[entryIndex].Key;
+                    var comparison = CompareIndexStatisticKeyPrefix(
+                        table,
+                        index,
+                        current,
+                        sample.Key,
+                        prefixLength);
+                    if (comparison < 0)
+                    {
+                        lessCounts[prefixLength - 1]++;
+                        if (previous is null
+                            || !IndexPrefixesEqual(
+                                table,
+                                index,
+                                previous,
+                                current,
+                                prefixLength))
+                        {
+                            distinctLessCounts[prefixLength - 1]++;
+                        }
+                    }
+                    else if (comparison == 0)
+                    {
+                        equalCounts[prefixLength - 1]++;
+                    }
 
-                while (sampleIndex < samplePositions.Count
-                       && samplePositions[sampleIndex] < runEnd)
-                {
-                    equalCountsBySample[sampleIndex][prefixLength - 1] = runEnd - runStart;
-                    lessCountsBySample[sampleIndex][prefixLength - 1] = runStart;
-                    distinctLessCountsBySample[sampleIndex][prefixLength - 1] = distinctBefore;
-                    sampleIndex++;
+                    previous = current;
                 }
-
-                distinctBefore++;
-                runStart = runEnd;
             }
-        }
 
-        var usedStatisticsRowIds = new HashSet<long>(statistics.RowIds);
-        var lastStatisticsRowId = statistics.RowIds.Count == 0 ? 0 : statistics.RowIds.Max();
-        for (var sampleIndex = 0; sampleIndex < samplePositions.Count; sampleIndex++)
-        {
-            var sample = entries[samplePositions[sampleIndex]];
             var recordValues = new SqlValue[index.Columns.Count + 1];
             Array.Copy(sample.Key, recordValues, sample.Key.Length);
             recordValues[^1] = SqlValue.Integer(sample.RowId);
-            var statisticsRowId = NextAutoRowId(lastStatisticsRowId, usedStatisticsRowIds);
-            usedStatisticsRowIds.Add(statisticsRowId);
-            lastStatisticsRowId = statisticsRowId;
             AddStat4Row(
                 statistics,
-                statisticsRowId,
                 table.Name,
                 index.Name,
-                JoinStatVector(equalCountsBySample[sampleIndex]),
-                JoinStatVector(lessCountsBySample[sampleIndex]),
-                JoinStatVector(distinctLessCountsBySample[sampleIndex]),
+                JoinStatVector(equalCounts),
+                JoinStatVector(lessCounts),
+                JoinStatVector(distinctLessCounts),
                 SqliteRecordCodec.Encode(recordValues, textEncoding));
         }
     }
@@ -295,7 +284,6 @@ public sealed partial class EmbeddedDatabase
 
     private static void AddStat4Row(
         EmbeddedTable statistics,
-        long rowId,
         string tableName,
         string indexName,
         string equal,
@@ -303,6 +291,9 @@ public sealed partial class EmbeddedDatabase
         string distinctLess,
         byte[] sample)
     {
+        var rowId = statistics.RowIds.Count == 0
+            ? 1
+            : NextAutoRowId(statistics.RowIds.Max(), new HashSet<long>(statistics.RowIds));
         statistics.Rows.Add(
         [
             SqlValue.Text(tableName),
@@ -758,15 +749,9 @@ public sealed partial class EmbeddedDatabase
             }
 
             var sampleRowId = sample[^1].AsInteger();
-            if (!table.TryGetRowPosition(
-                    sampleRowId,
-                    out var sampleRowPosition,
-                    out var indexedRows))
-            {
+            var sampleRowPosition = table.RowIds.IndexOf(sampleRowId);
+            if (sampleRowPosition < 0)
                 return false;
-            }
-            if (indexedRows != 0)
-                _plannerAccessPathMetrics.RecordStat4RowIdMapBuilt(indexedRows);
             var currentKey = IndexExpressionSemantics.ProjectKey(
                 index,
                 table,
@@ -849,9 +834,6 @@ internal sealed class PlannerAccessPathMetrics
     private long _intersectionIndexPagesRead;
     private long _intersectionKeyComparisons;
     private long _stat4EstimatesUsed;
-    private long _stat4AnalysisRowsScanned;
-    private long _stat4RowIdMapBuilds;
-    private long _stat4RowIdsIndexed;
     private double _lastStat4EstimatedRows;
 
     public long IntersectionsExecuted => Interlocked.Read(ref _intersectionsExecuted);
@@ -865,12 +847,6 @@ internal sealed class PlannerAccessPathMetrics
     public long IntersectionKeyComparisons => Interlocked.Read(ref _intersectionKeyComparisons);
 
     public long Stat4EstimatesUsed => Interlocked.Read(ref _stat4EstimatesUsed);
-
-    public long Stat4AnalysisRowsScanned => Interlocked.Read(ref _stat4AnalysisRowsScanned);
-
-    public long Stat4RowIdMapBuilds => Interlocked.Read(ref _stat4RowIdMapBuilds);
-
-    public long Stat4RowIdsIndexed => Interlocked.Read(ref _stat4RowIdsIndexed);
 
     public double LastStat4EstimatedRows => Volatile.Read(ref _lastStat4EstimatedRows);
 
@@ -892,15 +868,6 @@ internal sealed class PlannerAccessPathMetrics
         Interlocked.Increment(ref _stat4EstimatesUsed);
     }
 
-    internal void RecordStat4AnalysisRowsScanned(int rows)
-        => Interlocked.Add(ref _stat4AnalysisRowsScanned, rows);
-
-    internal void RecordStat4RowIdMapBuilt(int rows)
-    {
-        Interlocked.Increment(ref _stat4RowIdMapBuilds);
-        Interlocked.Add(ref _stat4RowIdsIndexed, rows);
-    }
-
     internal void Reset()
     {
         Interlocked.Exchange(ref _intersectionsExecuted, 0);
@@ -909,9 +876,6 @@ internal sealed class PlannerAccessPathMetrics
         Interlocked.Exchange(ref _intersectionIndexPagesRead, 0);
         Interlocked.Exchange(ref _intersectionKeyComparisons, 0);
         Interlocked.Exchange(ref _stat4EstimatesUsed, 0);
-        Interlocked.Exchange(ref _stat4AnalysisRowsScanned, 0);
-        Interlocked.Exchange(ref _stat4RowIdMapBuilds, 0);
-        Interlocked.Exchange(ref _stat4RowIdsIndexed, 0);
         Volatile.Write(ref _lastStat4EstimatedRows, 0);
     }
 }

--- a/src/Ahtola.Core/EmbeddedDatabase.PlannerAccessPaths.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.PlannerAccessPaths.cs
@@ -155,57 +155,68 @@ public sealed partial class EmbeddedDatabase
 
         var samplePositions = SelectStat4SamplePositions(table, index, entries);
         var textEncoding = GetTextEncoding();
-        foreach (var samplePosition in samplePositions)
+        var equalCountsBySample = samplePositions
+            .Select(_ => new long[index.Columns.Count])
+            .ToArray();
+        var lessCountsBySample = samplePositions
+            .Select(_ => new long[index.Columns.Count])
+            .ToArray();
+        var distinctLessCountsBySample = samplePositions
+            .Select(_ => new long[index.Columns.Count])
+            .ToArray();
+        for (var prefixLength = 1; prefixLength <= index.Columns.Count; prefixLength++)
         {
-            var sample = entries[samplePosition];
-            var equalCounts = new long[index.Columns.Count];
-            var lessCounts = new long[index.Columns.Count];
-            var distinctLessCounts = new long[index.Columns.Count];
-            for (var prefixLength = 1; prefixLength <= index.Columns.Count; prefixLength++)
+            _plannerAccessPathMetrics.RecordStat4AnalysisRowsScanned(entries.Count);
+            var sampleIndex = 0;
+            var runStart = 0;
+            var distinctBefore = 0L;
+            while (runStart < entries.Count)
             {
-                SqlValue[]? previous = null;
-                for (var entryIndex = 0; entryIndex < entries.Count; entryIndex++)
+                var runEnd = runStart + 1;
+                while (runEnd < entries.Count
+                       && IndexPrefixesEqual(
+                           table,
+                           index,
+                           entries[runStart].Key,
+                           entries[runEnd].Key,
+                           prefixLength))
                 {
-                    var current = entries[entryIndex].Key;
-                    var comparison = CompareIndexStatisticKeyPrefix(
-                        table,
-                        index,
-                        current,
-                        sample.Key,
-                        prefixLength);
-                    if (comparison < 0)
-                    {
-                        lessCounts[prefixLength - 1]++;
-                        if (previous is null
-                            || !IndexPrefixesEqual(
-                                table,
-                                index,
-                                previous,
-                                current,
-                                prefixLength))
-                        {
-                            distinctLessCounts[prefixLength - 1]++;
-                        }
-                    }
-                    else if (comparison == 0)
-                    {
-                        equalCounts[prefixLength - 1]++;
-                    }
-
-                    previous = current;
+                    runEnd++;
                 }
-            }
 
+                while (sampleIndex < samplePositions.Count
+                       && samplePositions[sampleIndex] < runEnd)
+                {
+                    equalCountsBySample[sampleIndex][prefixLength - 1] = runEnd - runStart;
+                    lessCountsBySample[sampleIndex][prefixLength - 1] = runStart;
+                    distinctLessCountsBySample[sampleIndex][prefixLength - 1] = distinctBefore;
+                    sampleIndex++;
+                }
+
+                distinctBefore++;
+                runStart = runEnd;
+            }
+        }
+
+        var usedStatisticsRowIds = new HashSet<long>(statistics.RowIds);
+        var lastStatisticsRowId = statistics.RowIds.Count == 0 ? 0 : statistics.RowIds.Max();
+        for (var sampleIndex = 0; sampleIndex < samplePositions.Count; sampleIndex++)
+        {
+            var sample = entries[samplePositions[sampleIndex]];
             var recordValues = new SqlValue[index.Columns.Count + 1];
             Array.Copy(sample.Key, recordValues, sample.Key.Length);
             recordValues[^1] = SqlValue.Integer(sample.RowId);
+            var statisticsRowId = NextAutoRowId(lastStatisticsRowId, usedStatisticsRowIds);
+            usedStatisticsRowIds.Add(statisticsRowId);
+            lastStatisticsRowId = statisticsRowId;
             AddStat4Row(
                 statistics,
+                statisticsRowId,
                 table.Name,
                 index.Name,
-                JoinStatVector(equalCounts),
-                JoinStatVector(lessCounts),
-                JoinStatVector(distinctLessCounts),
+                JoinStatVector(equalCountsBySample[sampleIndex]),
+                JoinStatVector(lessCountsBySample[sampleIndex]),
+                JoinStatVector(distinctLessCountsBySample[sampleIndex]),
                 SqliteRecordCodec.Encode(recordValues, textEncoding));
         }
     }
@@ -284,6 +295,7 @@ public sealed partial class EmbeddedDatabase
 
     private static void AddStat4Row(
         EmbeddedTable statistics,
+        long rowId,
         string tableName,
         string indexName,
         string equal,
@@ -291,9 +303,6 @@ public sealed partial class EmbeddedDatabase
         string distinctLess,
         byte[] sample)
     {
-        var rowId = statistics.RowIds.Count == 0
-            ? 1
-            : NextAutoRowId(statistics.RowIds.Max(), new HashSet<long>(statistics.RowIds));
         statistics.Rows.Add(
         [
             SqlValue.Text(tableName),
@@ -749,9 +758,15 @@ public sealed partial class EmbeddedDatabase
             }
 
             var sampleRowId = sample[^1].AsInteger();
-            var sampleRowPosition = table.RowIds.IndexOf(sampleRowId);
-            if (sampleRowPosition < 0)
+            if (!table.TryGetRowPosition(
+                    sampleRowId,
+                    out var sampleRowPosition,
+                    out var indexedRows))
+            {
                 return false;
+            }
+            if (indexedRows != 0)
+                _plannerAccessPathMetrics.RecordStat4RowIdMapBuilt(indexedRows);
             var currentKey = IndexExpressionSemantics.ProjectKey(
                 index,
                 table,
@@ -834,6 +849,9 @@ internal sealed class PlannerAccessPathMetrics
     private long _intersectionIndexPagesRead;
     private long _intersectionKeyComparisons;
     private long _stat4EstimatesUsed;
+    private long _stat4AnalysisRowsScanned;
+    private long _stat4RowIdMapBuilds;
+    private long _stat4RowIdsIndexed;
     private double _lastStat4EstimatedRows;
 
     public long IntersectionsExecuted => Interlocked.Read(ref _intersectionsExecuted);
@@ -847,6 +865,12 @@ internal sealed class PlannerAccessPathMetrics
     public long IntersectionKeyComparisons => Interlocked.Read(ref _intersectionKeyComparisons);
 
     public long Stat4EstimatesUsed => Interlocked.Read(ref _stat4EstimatesUsed);
+
+    public long Stat4AnalysisRowsScanned => Interlocked.Read(ref _stat4AnalysisRowsScanned);
+
+    public long Stat4RowIdMapBuilds => Interlocked.Read(ref _stat4RowIdMapBuilds);
+
+    public long Stat4RowIdsIndexed => Interlocked.Read(ref _stat4RowIdsIndexed);
 
     public double LastStat4EstimatedRows => Volatile.Read(ref _lastStat4EstimatedRows);
 
@@ -868,6 +892,15 @@ internal sealed class PlannerAccessPathMetrics
         Interlocked.Increment(ref _stat4EstimatesUsed);
     }
 
+    internal void RecordStat4AnalysisRowsScanned(int rows)
+        => Interlocked.Add(ref _stat4AnalysisRowsScanned, rows);
+
+    internal void RecordStat4RowIdMapBuilt(int rows)
+    {
+        Interlocked.Increment(ref _stat4RowIdMapBuilds);
+        Interlocked.Add(ref _stat4RowIdsIndexed, rows);
+    }
+
     internal void Reset()
     {
         Interlocked.Exchange(ref _intersectionsExecuted, 0);
@@ -876,6 +909,9 @@ internal sealed class PlannerAccessPathMetrics
         Interlocked.Exchange(ref _intersectionIndexPagesRead, 0);
         Interlocked.Exchange(ref _intersectionKeyComparisons, 0);
         Interlocked.Exchange(ref _stat4EstimatesUsed, 0);
+        Interlocked.Exchange(ref _stat4AnalysisRowsScanned, 0);
+        Interlocked.Exchange(ref _stat4RowIdMapBuilds, 0);
+        Interlocked.Exchange(ref _stat4RowIdsIndexed, 0);
         Volatile.Write(ref _lastStat4EstimatedRows, 0);
     }
 }

--- a/src/Ahtola.Core/EmbeddedDatabase.PlannerAccessPaths.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.PlannerAccessPaths.cs
@@ -1,0 +1,881 @@
+using Ahtola.Core.Compilation;
+using Ahtola.Core.Compilation.JoinOrdering;
+using Ahtola.Core.Mvcc;
+using Ahtola.Core.Storage;
+using System.Globalization;
+
+namespace Ahtola.Core;
+
+public sealed partial class EmbeddedDatabase
+{
+    private readonly PlannerAccessPathMetrics _plannerAccessPathMetrics = new();
+
+    internal PlannerAccessPathMetrics PlannerAccessPathMetrics => _plannerAccessPathMetrics;
+
+    private sealed record ManagedAndIndexBranch(EmbeddedIndex Index, Expression Predicate);
+
+    private sealed record ManagedAndIndexIntersectionPlan(
+        NamedTableSource Source,
+        EmbeddedTable Table,
+        IReadOnlyList<ManagedAndIndexBranch> Branches,
+        double EstimatedRows);
+
+    private EmbeddedTable GetOrCreateSqliteStat4Table(SchemaCatalog catalog)
+    {
+        if (catalog.Tables.TryGetValue(SqliteStat4TableName, out var existing))
+        {
+            ValidateSqliteStat4Table(existing);
+            return existing;
+        }
+
+        if (catalog.Views.ContainsKey(SqliteStat4TableName)
+            || catalog.Triggers.ContainsKey(SqliteStat4TableName)
+            || TryFindIndex(catalog.Tables, SqliteStat4TableName, out _, out _))
+        {
+            throw new EmbeddedSqlException($"object name reserved for internal use: {SqliteStat4TableName}");
+        }
+
+        EnforceMaxPageCountForCatalogChange(1);
+        var statistics = new EmbeddedTable(
+            SqliteStat4TableName,
+            [
+                new EmbeddedColumn("tbl", null, false, false, false, null),
+                new EmbeddedColumn("idx", null, false, false, false, null),
+                new EmbeddedColumn("neq", null, false, false, false, null),
+                new EmbeddedColumn("nlt", null, false, false, false, null),
+                new EmbeddedColumn("ndlt", null, false, false, false, null),
+                new EmbeddedColumn("sample", null, false, false, false, null),
+            ])
+        {
+            Sql = "CREATE TABLE sqlite_stat4(tbl,idx,neq,nlt,ndlt,sample)"
+        };
+        catalog.Tables.Add(statistics.Name, statistics);
+        return statistics;
+    }
+
+    private static void ValidateSqliteStat4Table(EmbeddedTable table)
+    {
+        string[] expected = ["tbl", "idx", "neq", "nlt", "ndlt", "sample"];
+        if (!table.HasRowid
+            || table.ColumnDefinitions.Length != expected.Length
+            || table.PrimaryKeyColumns.Count != 0
+            || table.Indexes.Count != 0)
+        {
+            throw new EmbeddedSqlException("database disk image is malformed");
+        }
+
+        for (var index = 0; index < expected.Length; index++)
+        {
+            if (!string.Equals(
+                    table.ColumnDefinitions[index].Name,
+                    expected[index],
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                throw new EmbeddedSqlException("database disk image is malformed");
+            }
+        }
+    }
+
+    private static void DeletePlannerStatistics(
+        EmbeddedTable statistics,
+        string tableName,
+        string? indexName)
+    {
+        for (var rowIndex = statistics.Rows.Count - 1; rowIndex >= 0; rowIndex--)
+        {
+            var row = statistics.Rows[rowIndex];
+            if (row.Length < 2
+                || row[0].Kind != SqlValueKind.Text
+                || !string.Equals(row[0].AsText(), tableName, StringComparison.OrdinalIgnoreCase)
+                || indexName is not null
+                    && (row[1].Kind != SqlValueKind.Text
+                        || !string.Equals(row[1].AsText(), indexName, StringComparison.OrdinalIgnoreCase)))
+            {
+                continue;
+            }
+
+            statistics.Rows.RemoveAt(rowIndex);
+            statistics.RowIds.RemoveAt(rowIndex);
+        }
+    }
+
+    private void AddIndexStat4Samples(
+        EmbeddedTable statistics,
+        EmbeddedTable table,
+        EmbeddedIndex index)
+    {
+        if (table.Rows.Count == 0
+            || !table.HasRowid
+            || index.Columns.Count == 0
+            || index.IsPartial
+            || index.IsMethodIndex
+            || index.Columns.Any(static column => column.IsExpression)
+            || IndexUsesRegisteredFunctions(index)
+            || index.Columns.Any(column =>
+                !IsBuiltInCollation(IndexExpressionSemantics.GetCollationName(table, column))
+                || IsOverriddenBuiltInCollation(
+                    IndexExpressionSemantics.GetCollationName(table, column))))
+        {
+            return;
+        }
+
+        var entries = new List<(SqlValue[] Key, long RowId)>(table.Rows.Count);
+        for (var rowIndex = 0; rowIndex < table.Rows.Count; rowIndex++)
+        {
+            var row = table.Rows[rowIndex];
+            var rowId = table.RowIds[rowIndex];
+            if (!IndexExpressionSemantics.Qualifies(
+                    index,
+                    table,
+                    row,
+                    rowId,
+                    EvaluateIndexExpression))
+            {
+                continue;
+            }
+
+            entries.Add((
+                IndexExpressionSemantics.ProjectKey(
+                    index,
+                    table,
+                    row,
+                    rowId,
+                    EvaluateIndexExpression),
+                rowId));
+        }
+
+        if (entries.Count == 0)
+            return;
+
+        entries.Sort((left, right) =>
+        {
+            var comparison = CompareIndexStatisticKeys(table, index, left.Key, right.Key);
+            return comparison != 0 ? comparison : left.RowId.CompareTo(right.RowId);
+        });
+
+        var samplePositions = SelectStat4SamplePositions(table, index, entries);
+        var textEncoding = GetTextEncoding();
+        foreach (var samplePosition in samplePositions)
+        {
+            var sample = entries[samplePosition];
+            var equalCounts = new long[index.Columns.Count];
+            var lessCounts = new long[index.Columns.Count];
+            var distinctLessCounts = new long[index.Columns.Count];
+            for (var prefixLength = 1; prefixLength <= index.Columns.Count; prefixLength++)
+            {
+                SqlValue[]? previous = null;
+                for (var entryIndex = 0; entryIndex < entries.Count; entryIndex++)
+                {
+                    var current = entries[entryIndex].Key;
+                    var comparison = CompareIndexStatisticKeyPrefix(
+                        table,
+                        index,
+                        current,
+                        sample.Key,
+                        prefixLength);
+                    if (comparison < 0)
+                    {
+                        lessCounts[prefixLength - 1]++;
+                        if (previous is null
+                            || !IndexPrefixesEqual(
+                                table,
+                                index,
+                                previous,
+                                current,
+                                prefixLength))
+                        {
+                            distinctLessCounts[prefixLength - 1]++;
+                        }
+                    }
+                    else if (comparison == 0)
+                    {
+                        equalCounts[prefixLength - 1]++;
+                    }
+
+                    previous = current;
+                }
+            }
+
+            var recordValues = new SqlValue[index.Columns.Count + 1];
+            Array.Copy(sample.Key, recordValues, sample.Key.Length);
+            recordValues[^1] = SqlValue.Integer(sample.RowId);
+            AddStat4Row(
+                statistics,
+                table.Name,
+                index.Name,
+                JoinStatVector(equalCounts),
+                JoinStatVector(lessCounts),
+                JoinStatVector(distinctLessCounts),
+                SqliteRecordCodec.Encode(recordValues, textEncoding));
+        }
+    }
+
+    private IReadOnlyList<int> SelectStat4SamplePositions(
+        EmbeddedTable table,
+        EmbeddedIndex index,
+        IReadOnlyList<(SqlValue[] Key, long RowId)> entries)
+    {
+        const int maximumSamples = 24;
+        if (entries.Count <= maximumSamples)
+            return Enumerable.Range(0, entries.Count).ToArray();
+
+        var runs = new List<(int Start, int Count)>();
+        var start = 0;
+        for (var indexPosition = 1; indexPosition <= entries.Count; indexPosition++)
+        {
+            if (indexPosition < entries.Count
+                && IndexPrefixesEqual(
+                    table,
+                    index,
+                    entries[indexPosition - 1].Key,
+                    entries[indexPosition].Key,
+                    prefixLength: 1))
+            {
+                continue;
+            }
+
+            runs.Add((start, indexPosition - start));
+            start = indexPosition;
+        }
+
+        var selected = new HashSet<int>();
+        foreach (var run in runs
+                     .OrderByDescending(static run => run.Count)
+                     .ThenBy(static run => run.Start)
+                     .Take(maximumSamples / 2))
+        {
+            selected.Add(run.Start + (run.Count / 2));
+        }
+
+        for (var sample = 0; selected.Count < maximumSamples && sample < maximumSamples; sample++)
+        {
+            var position = (int)(((long)(sample * 2 + 1) * entries.Count) / (maximumSamples * 2L));
+            selected.Add(Math.Min(entries.Count - 1, position));
+        }
+        for (var position = 0; selected.Count < maximumSamples && position < entries.Count; position++)
+            selected.Add(position);
+
+        return selected.Order().Take(maximumSamples).ToArray();
+    }
+
+    private int CompareIndexStatisticKeyPrefix(
+        EmbeddedTable table,
+        EmbeddedIndex index,
+        SqlValue[] left,
+        SqlValue[] right,
+        int prefixLength)
+    {
+        for (var position = 0; position < prefixLength; position++)
+        {
+            var column = index.Columns[position];
+            var comparison = Compare(
+                left[position],
+                right[position],
+                IndexExpressionSemantics.GetCollationName(table, column));
+            if (comparison != 0)
+                return column.Descending ? -comparison : comparison;
+        }
+
+        return 0;
+    }
+
+    private static string JoinStatVector(IEnumerable<long> values)
+        => string.Join(" ", values.Select(value => value.ToString(CultureInfo.InvariantCulture)));
+
+    private static void AddStat4Row(
+        EmbeddedTable statistics,
+        string tableName,
+        string indexName,
+        string equal,
+        string less,
+        string distinctLess,
+        byte[] sample)
+    {
+        var rowId = statistics.RowIds.Count == 0
+            ? 1
+            : NextAutoRowId(statistics.RowIds.Max(), new HashSet<long>(statistics.RowIds));
+        statistics.Rows.Add(
+        [
+            SqlValue.Text(tableName),
+            SqlValue.Text(indexName),
+            SqlValue.Text(equal),
+            SqlValue.Text(less),
+            SqlValue.Text(distinctLess),
+            SqlValue.Blob(sample),
+        ]);
+        statistics.RowIds.Add(rowId);
+    }
+
+    private ManagedAndIndexIntersectionPlan? TryPlanManagedAndIndexIntersection(
+        SelectStatement statement,
+        QueryContext context)
+    {
+        if (statement.Source is not NamedTableSource { IndexDirective: null } source
+            || statement.Where is null
+            || statement.OrderBy.Count != 0
+            || statement.GroupBy.Count != 0
+            || statement.Having is not null
+            || statement.Distinct
+            || statement.Limit is not null
+            || statement.Offset is not null
+            || IsAggregateSelect(statement)
+            || context.ConcurrentMvStore is not null
+            || context.ConcurrentMvccTxId is not null
+            || IsSchemaTable(source.Name)
+            || context.CommonTableExpressions.ContainsKey(source.Name)
+            || context.Views?.ContainsKey(source.Name) == true
+            || !context.Tables.TryGetValue(source.Name, out var table))
+        {
+            return null;
+        }
+
+        var conjuncts = new List<Expression>();
+        CollectTopLevelAndLeaves(statement.Where, conjuncts);
+        if (conjuncts.Count < 2)
+            return null;
+
+        // A contiguous composite equality prefix is always preferable to building rowid sets.
+        if (table.Indexes.Any(index =>
+                !index.IsMethodIndex
+                && CountLeadingEqualityIndexTerms(statement.Where, table, index) >= 2))
+        {
+            return null;
+        }
+
+        var branches = new List<ManagedAndIndexBranch>();
+        foreach (var conjunct in conjuncts)
+        {
+            if (conjunct is not BinaryExpression { Operator: BinaryOperator.Equal }
+                || !TryFindEqualityIndexForBranch(table, source, conjunct, out var index)
+                || !TryCreateTransientEqualityLookup(
+                    source,
+                    table,
+                    conjunct,
+                    context,
+                    outerRow: null,
+                    out var lookup)
+                || index.Columns[0].ColumnIndex != lookup.ColumnOrdinal
+                || branches.Any(branch =>
+                    string.Equals(branch.Index.Name, index.Name, StringComparison.OrdinalIgnoreCase)))
+            {
+                continue;
+            }
+
+            branches.Add(new ManagedAndIndexBranch(index, conjunct));
+        }
+
+        if (branches.Count < 2)
+            return null;
+
+        var baseRows = Math.Max(1.0, table.Rows.Count);
+        var statsAreCurrent = TryGetSqliteStat1TableRowCount(context, table.Name, out var statRows)
+            && statRows == table.Rows.Count;
+        var estimates = new double[branches.Count];
+        var intersectionRows = baseRows;
+        var multiIndexCost = 0.0;
+        for (var index = 0; index < branches.Count; index++)
+        {
+            var branch = branches[index];
+            double estimate;
+            if (statsAreCurrent
+                && TryEstimateStat4EqualityRows(
+                    context,
+                    table,
+                    branch.Index,
+                    branch.Predicate,
+                    out var stat4Rows))
+            {
+                estimate = stat4Rows;
+            }
+            else if (statsAreCurrent
+                     && TryGetSqliteStat1LeadingAverage(
+                         context,
+                         table.Name,
+                         branch.Index.Name,
+                         out var leadingAverage))
+            {
+                estimate = leadingAverage;
+            }
+            else
+            {
+                estimate = baseRows * JoinCostParams.SelectivityEqualityUnindexed;
+            }
+
+            estimate = Math.Clamp(estimate, 1.0, baseRows);
+            estimates[index] = estimate;
+            intersectionRows *= estimate / baseRows;
+            multiIndexCost += Math.Log2(Math.Max(baseRows, 2.0))
+                + estimate
+                + estimate * 0.05;
+        }
+
+        intersectionRows = Math.Clamp(intersectionRows, 1.0, estimates.Min());
+        multiIndexCost += intersectionRows * 4.0;
+        var fullScanCost = baseRows;
+        var bestSingleIndexCost = estimates.Min(estimate =>
+            Math.Log2(Math.Max(baseRows, 2.0)) + estimate + estimate * 4.0);
+        if (multiIndexCost >= Math.Min(fullScanCost, bestSingleIndexCost))
+            return null;
+
+        return new ManagedAndIndexIntersectionPlan(source, table, branches, intersectionRows);
+    }
+
+    private static void CollectTopLevelAndLeaves(Expression expression, List<Expression> leaves)
+    {
+        if (expression is BinaryExpression { Operator: BinaryOperator.And } and)
+        {
+            CollectTopLevelAndLeaves(and.Left, leaves);
+            CollectTopLevelAndLeaves(and.Right, leaves);
+            return;
+        }
+
+        leaves.Add(expression);
+    }
+
+    private bool TryCompileManagedAndIndexIntersectionSelect(
+        SelectStatement select,
+        ManagedAndIndexIntersectionPlan plan,
+        SqlValue[] parameters,
+        QueryContext context,
+        SourceRow? outerRow,
+        bool materializeRows,
+        out CompiledSelect compiled)
+    {
+        compiled = null!;
+        if (select.Projections.Count == 0
+            || select.Distinct
+            || select.OrderBy.Count != 0
+            || select.GroupBy.Count != 0
+            || select.Having is not null
+            || select.Limit is not null
+            || select.Offset is not null
+            || IsAggregateSelect(select)
+            || CollectSelectWindowFunctions(select).Count != 0)
+        {
+            return false;
+        }
+
+        IReadOnlyList<SqlValue[]> rows;
+        IReadOnlyList<long>? rowIds;
+        if (materializeRows)
+        {
+            var intersected = GetManagedAndIndexIntersectionRows(
+                plan,
+                parameters,
+                context,
+                outerRow);
+            rows = intersected.Rows.Select(row => row.Values).ToArray();
+            rowIds = plan.Table.HasRowid
+                ? intersected.Rows.Select(row =>
+                    row.RowId ?? throw new InvalidOperationException(
+                        "An intersected row is missing its rowid.")).ToArray()
+                : null;
+        }
+        else
+        {
+            rows = plan.Table.Rows;
+            rowIds = plan.Table.HasRowid ? plan.Table.RowIds : null;
+        }
+
+        var qualifier = plan.Source.Alias ?? plan.Source.Name;
+        var qualifiedColumns = BuildQualifiedColumns(qualifier, plan.Table.Columns);
+        var target = new ScanTarget(
+            plan.Source.Name,
+            qualifier,
+            plan.Table.Columns,
+            rows,
+            name => ResolveScanColumnIndex(name, plan.Table.Columns, qualifiedColumns),
+            rowIds,
+            string.Join("&", plan.Branches.Select(branch => branch.Index.Name)),
+            plan.Table.ColumnDefinitions,
+            BuildQualifiedColumnDefinitions(qualifier, plan.Table.ColumnDefinitions),
+            AccessKind: ScanAccessKind.MultiIndexAnd);
+        var compiler = new SelectStatementCompiler(
+            IsConstantScalarExpression,
+            expression => Evaluate(expression, parameters, null, context),
+            _ => target,
+            (where, scan) => CompileRowPredicate(where, scan, parameters, context, outerRow),
+            (where, scan) => CanEmitNativeScanPredicate(where, scan, context),
+            (where, scan) => CompileSimpleRowIdPredicate(where, scan, parameters, context, outerRow),
+            (statement, scan) => CompileDistinctScanEquality(statement, scan, context),
+            function => TryGetRoutableBuiltinScalarCall(function, out var routable)
+                ? BuildBuiltinScalarFunction(routable, parameters, context)
+                : null,
+            ArithmeticNumericAffinity,
+            ModuloNumericAffinity,
+            BitwiseIntegerAffinity);
+        return compiler.TryCompile(select, out compiled);
+    }
+
+    private SourceData GetManagedAndIndexIntersectionRows(
+        ManagedAndIndexIntersectionPlan plan,
+        SqlValue[] parameters,
+        QueryContext context,
+        SourceRow? outerRow)
+    {
+        List<SourceRow>? firstRows = null;
+        HashSet<MvccKey>? intersection = null;
+        EmbeddedFileReadSnapshot? readSnapshot = null;
+        if (!context.InTransaction
+            && context.ConcurrentMvStore is null
+            && context.ConcurrentMvccTxId is null)
+        {
+            _ = _fileStore?.TryOpenReadSnapshot(plan.Table, out readSnapshot);
+        }
+
+        using (readSnapshot)
+        {
+            foreach (var branch in plan.Branches)
+            {
+                var candidates = GetManagedAndIndexBranchRows(
+                    plan,
+                    branch,
+                    parameters,
+                    context,
+                    outerRow,
+                    readSnapshot);
+                _plannerAccessPathMetrics.IntersectionProbe(candidates.Count);
+                var identities = candidates
+                    .Select(row => GetManagedIntersectionIdentity(plan.Table, row, context))
+                    .ToHashSet();
+                if (intersection is null)
+                {
+                    intersection = identities;
+                    firstRows = candidates.ToList();
+                }
+                else
+                {
+                    intersection.IntersectWith(identities);
+                }
+
+                if (intersection.Count == 0)
+                    break;
+            }
+        }
+
+        _plannerAccessPathMetrics.IntersectionExecuted();
+        if (intersection is null || firstRows is null || intersection.Count == 0)
+            return new SourceData(plan.Table.Columns, []);
+
+        return new SourceData(
+            plan.Table.Columns,
+            firstRows
+                .Where(row => intersection.Contains(GetManagedIntersectionIdentity(plan.Table, row, context)))
+                .ToArray());
+    }
+
+    private IReadOnlyList<SourceRow> GetManagedAndIndexBranchRows(
+        ManagedAndIndexIntersectionPlan plan,
+        ManagedAndIndexBranch branch,
+        SqlValue[] parameters,
+        QueryContext context,
+        SourceRow? outerRow,
+        EmbeddedFileReadSnapshot? readSnapshot)
+    {
+        if (TryCreateTransientEqualityLookup(
+                plan.Source,
+                plan.Table,
+                branch.Predicate,
+                context,
+                outerRow,
+                out var lookup))
+        {
+            var value = Evaluate(lookup.ValueExpression, parameters, outerRow, context);
+            if (value.Kind == SqlValueKind.Null)
+                return [];
+            if (lookup.ValueConvertsTextToNumeric)
+                value = ApplyComparisonNumericAffinity(value);
+            else if (lookup.ValueConvertsNumericToText
+                     && value.Kind is SqlValueKind.Integer or SqlValueKind.Real)
+                value = SqlValue.Text(ToSqlText(value));
+
+            if (readSnapshot is not null
+                && branch.Index.Columns.Count > 0
+                && branch.Index.Columns[0].ColumnIndex == lookup.ColumnOrdinal
+                && _fileStore?.TryOpenIndexAccessor(
+                    plan.Table,
+                    branch.Index,
+                    prefixLength: 1,
+                    covering: false,
+                    readSnapshot,
+                    out var accessor) == true)
+            {
+                var qualifier = plan.Source.Alias ?? plan.Source.Name;
+                var qualifiedColumns = BuildQualifiedColumns(qualifier, plan.Table.Columns);
+                var qualifiedDefinitions = BuildQualifiedColumnDefinitions(
+                    qualifier,
+                    plan.Table.ColumnDefinitions);
+                using (accessor)
+                {
+                    return accessor.Seek(
+                            [value],
+                            _plannerAccessPathMetrics.IntersectionIndexPageRead,
+                            _plannerAccessPathMetrics.IntersectionKeyCompared)
+                        .Select(row => new SourceRow(
+                            plan.Table.Columns,
+                            row.Values,
+                            qualifiedColumns,
+                            outerRow,
+                            RowId: row.RowId,
+                            RowIdQualifier: qualifier,
+                            ColumnDefinitions: plan.Table.ColumnDefinitions,
+                            QualifiedColumnDefinitions: qualifiedDefinitions))
+                        .ToArray();
+                }
+            }
+        }
+
+        return TryGetTransientLookupRows(
+                plan.Source,
+                branch.Predicate,
+                parameters,
+                context,
+                outerRow)?.Rows
+            ?? GetNamedTableRows(
+                plan.Source,
+                context,
+                maximumRows: null,
+                outerRow).Rows;
+    }
+
+    private static MvccKey GetManagedIntersectionIdentity(
+        EmbeddedTable table,
+        SourceRow row,
+        QueryContext context)
+        => table.HasRowid
+            ? MvccKey.FromInteger(
+                row.RowId ?? throw new InvalidOperationException(
+                    "A rowid-table intersection candidate is missing its rowid."))
+            : MvccKey.FromPrimaryKey(
+                table.PrimaryKeySchema
+                    ?? throw new InvalidOperationException(
+                        "A WITHOUT ROWID table is missing primary-key metadata."),
+                row.Values,
+                context.MvccTextEncoding);
+
+    private static string FormatManagedAndIndexIntersectionExplainDetail(
+        ManagedAndIndexIntersectionPlan plan)
+        => $"MULTI-INDEX AND {plan.Source.Alias ?? plan.Source.Name} "
+            + $"({string.Join(", ", plan.Branches.Select(branch => branch.Index.Name))})";
+
+    private bool TryEstimateStat4EqualityRows(
+        QueryContext context,
+        EmbeddedTable table,
+        EmbeddedIndex index,
+        Expression predicate,
+        out double rows)
+    {
+        rows = 0;
+        if (index.Columns.Count == 0
+            || index.IsPartial
+            || index.IsMethodIndex
+            || index.Columns.Any(static column => column.IsExpression)
+            || !IsBuiltInCollation(IndexExpressionSemantics.GetCollationName(table, index.Columns[0]))
+            || IsOverriddenBuiltInCollation(
+                IndexExpressionSemantics.GetCollationName(table, index.Columns[0]))
+            || !TryFindIndexEqualityBound(
+                predicate,
+                table,
+                index.Columns[0],
+                out var bound)
+            || bound is not LiteralExpression literal
+            || literal.Value.Kind == SqlValueKind.Null
+            || !context.Tables.TryGetValue(SqliteStat4TableName, out var statistics)
+            || !TryGetSqliteStat1TableRowCount(context, table.Name, out var statRows)
+            || statRows != table.Rows.Count)
+        {
+            return false;
+        }
+
+        try
+        {
+            ValidateSqliteStat4Table(statistics);
+        }
+        catch (EmbeddedSqlException)
+        {
+            return false;
+        }
+
+        var value = table.CoerceColumnAffinity(
+            table.ColumnDefinitions[index.Columns[0].ColumnIndex],
+            literal.Value);
+        var collation = IndexExpressionSemantics.GetCollationName(table, index.Columns[0]);
+        var exactEstimates = new List<long>();
+        var neighboringEstimates = new List<(int Comparison, long Rows)>();
+        var matchingRows = 0;
+        foreach (var row in statistics.Rows)
+        {
+            if (row.Length != 6
+                || row[0].Kind != SqlValueKind.Text
+                || row[1].Kind != SqlValueKind.Text
+                || !string.Equals(row[0].AsText(), table.Name, StringComparison.OrdinalIgnoreCase)
+                || !string.Equals(row[1].AsText(), index.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            matchingRows++;
+            if (row[2].Kind != SqlValueKind.Text
+                || row[3].Kind != SqlValueKind.Text
+                || row[4].Kind != SqlValueKind.Text
+                || row[5].Kind != SqlValueKind.Blob
+                || !TryParseStat4Vector(row[2].AsText(), index.Columns.Count, out var equal)
+                || !TryParseStat4Vector(row[3].AsText(), index.Columns.Count, out var less)
+                || !TryParseStat4Vector(row[4].AsText(), index.Columns.Count, out var distinctLess))
+            {
+                return false;
+            }
+
+            SqlValue[] sample;
+            try
+            {
+                sample = SqliteRecordCodec.Decode(row[5].AsBlob().Span, GetTextEncoding());
+            }
+            catch (InvalidDataException)
+            {
+                return false;
+            }
+
+            if (sample.Length < index.Columns.Count + 1
+                || sample[^1].Kind != SqlValueKind.Integer
+                || equal[0] <= 0
+                || equal[0] > table.Rows.Count
+                || less[0] < 0
+                || less[0] > table.Rows.Count
+                || distinctLess[0] < 0
+                || distinctLess[0] > less[0])
+            {
+                return false;
+            }
+
+            var sampleRowId = sample[^1].AsInteger();
+            var sampleRowPosition = table.RowIds.IndexOf(sampleRowId);
+            if (sampleRowPosition < 0)
+                return false;
+            var currentKey = IndexExpressionSemantics.ProjectKey(
+                index,
+                table,
+                table.Rows[sampleRowPosition],
+                sampleRowId,
+                EvaluateIndexExpression);
+            for (var position = 0; position < index.Columns.Count; position++)
+            {
+                if (Compare(
+                        sample[position],
+                        currentKey[position],
+                        IndexExpressionSemantics.GetCollationName(table, index.Columns[position])) != 0)
+                {
+                    return false;
+                }
+            }
+
+            var comparison = Compare(sample[0], value, collation);
+            if (comparison == 0)
+                exactEstimates.Add(equal[0]);
+            else
+                neighboringEstimates.Add((comparison, equal[0]));
+        }
+
+        if (matchingRows == 0)
+            return false;
+        if (exactEstimates.Count > 0)
+        {
+            exactEstimates.Sort();
+            rows = exactEstimates[exactEstimates.Count / 2];
+        }
+        else
+        {
+            var lower = neighboringEstimates.LastOrDefault(entry => entry.Comparison < 0);
+            var upper = neighboringEstimates.FirstOrDefault(entry => entry.Comparison > 0);
+            if (lower.Rows == 0 && upper.Rows == 0)
+                return false;
+            rows = lower.Rows == 0
+                ? upper.Rows
+                : upper.Rows == 0
+                    ? lower.Rows
+                    : Math.Max(1.0, (lower.Rows + upper.Rows) / 2.0);
+        }
+
+        _plannerAccessPathMetrics.Stat4EstimateUsed(rows);
+        return true;
+    }
+
+    private static bool TryParseStat4Vector(
+        string text,
+        int minimumCount,
+        out long[] values)
+    {
+        var parts = text.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        values = new long[parts.Length];
+        if (parts.Length < minimumCount)
+            return false;
+        for (var index = 0; index < parts.Length; index++)
+        {
+            if (!long.TryParse(
+                    parts[index],
+                    NumberStyles.None,
+                    CultureInfo.InvariantCulture,
+                    out values[index]))
+            {
+                values = [];
+                return false;
+            }
+        }
+
+        return true;
+    }
+}
+
+internal sealed class PlannerAccessPathMetrics
+{
+    private long _intersectionsExecuted;
+    private long _intersectionIndexProbes;
+    private long _intersectionCandidateRows;
+    private long _intersectionIndexPagesRead;
+    private long _intersectionKeyComparisons;
+    private long _stat4EstimatesUsed;
+    private double _lastStat4EstimatedRows;
+
+    public long IntersectionsExecuted => Interlocked.Read(ref _intersectionsExecuted);
+
+    public long IntersectionIndexProbes => Interlocked.Read(ref _intersectionIndexProbes);
+
+    public long IntersectionCandidateRows => Interlocked.Read(ref _intersectionCandidateRows);
+
+    public long IntersectionIndexPagesRead => Interlocked.Read(ref _intersectionIndexPagesRead);
+
+    public long IntersectionKeyComparisons => Interlocked.Read(ref _intersectionKeyComparisons);
+
+    public long Stat4EstimatesUsed => Interlocked.Read(ref _stat4EstimatesUsed);
+
+    public double LastStat4EstimatedRows => Volatile.Read(ref _lastStat4EstimatedRows);
+
+    internal void IntersectionExecuted() => Interlocked.Increment(ref _intersectionsExecuted);
+
+    internal void IntersectionProbe(int candidateRows)
+    {
+        Interlocked.Increment(ref _intersectionIndexProbes);
+        Interlocked.Add(ref _intersectionCandidateRows, candidateRows);
+    }
+
+    internal void IntersectionIndexPageRead() => Interlocked.Increment(ref _intersectionIndexPagesRead);
+
+    internal void IntersectionKeyCompared() => Interlocked.Increment(ref _intersectionKeyComparisons);
+
+    internal void Stat4EstimateUsed(double estimatedRows)
+    {
+        Volatile.Write(ref _lastStat4EstimatedRows, estimatedRows);
+        Interlocked.Increment(ref _stat4EstimatesUsed);
+    }
+
+    internal void Reset()
+    {
+        Interlocked.Exchange(ref _intersectionsExecuted, 0);
+        Interlocked.Exchange(ref _intersectionIndexProbes, 0);
+        Interlocked.Exchange(ref _intersectionCandidateRows, 0);
+        Interlocked.Exchange(ref _intersectionIndexPagesRead, 0);
+        Interlocked.Exchange(ref _intersectionKeyComparisons, 0);
+        Interlocked.Exchange(ref _stat4EstimatesUsed, 0);
+        Volatile.Write(ref _lastStat4EstimatedRows, 0);
+    }
+}

--- a/src/Ahtola.Core/EmbeddedDatabase.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.cs
@@ -777,7 +777,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
                     case SqliteChangeOperation.Delete:
                         store.DeleteOrTombstoneBase(
                             txId,
-                            new MvccRowId(store.GetOrCreateTableId(tableName), rowId));
+                            new MvccRowId(store.GetOrCreateTableId(txId, tableName), rowId));
                         break;
                     case SqliteChangeOperation.Update:
                         {
@@ -786,7 +786,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
                             {
                                 store.UpdateIncludingBase(
                                     txId,
-                                    new MvccRowId(store.GetOrCreateTableId(tableName), rowId),
+                                    new MvccRowId(store.GetOrCreateTableId(txId, tableName), rowId),
                                     table.Rows[index]);
                             }
 
@@ -798,7 +798,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
                             if (index < 0 || index >= table.Rows.Count)
                                 break;
 
-                            var tableId = store.GetOrCreateTableId(tableName);
+                            var tableId = store.GetOrCreateTableId(txId, tableName);
                             // Concurrent catalogs may both pick the same local rowid; promote
                             // to a store-global id so first-committer-wins does not collapse
                             // two inserts (Turso process-wide allocator).
@@ -862,7 +862,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
                     $"WITHOUT ROWID table '{tableName}' is missing primary-key metadata for concurrent MVCC.");
             }
 
-            var tableId = store.GetOrCreateTableId(tableName);
+            var tableId = store.GetOrCreateTableId(txId, tableName);
             var current = TryFindRow(table, rowId);
             var baseline = ConcurrentBaseTables is not null
                 && ConcurrentBaseTables.TryGetValue(tableName, out var baseTable)
@@ -2613,13 +2613,17 @@ public sealed partial class EmbeddedDatabase : IDisposable
     /// Applies committed version-store rows onto a clone of the live catalog after
     /// the concurrent tx's store commit succeeded (first-committer already won).
     /// </summary>
-    private SchemaCatalog MergeConcurrentCatalogFromStoreLocked(SchemaCatalog txCatalog)
+    private SchemaCatalog MergeConcurrentCatalogFromStoreLocked(
+        SchemaCatalog txCatalog,
+        MvccCheckpointSnapshot? checkpointSnapshot = null)
     {
         var store = _mvStore
             ?? throw new InvalidOperationException("MVCC store required for concurrent merge.");
         var merged = LiveCatalog.Clone();
-        var liveRows = store.SnapshotLiveCommittedRows();
-        var deleted = store.SnapshotCommittedDeletes();
+        var liveRows = checkpointSnapshot?.LiveRows
+            ?? store.SnapshotLiveCommittedRows();
+        var deleted = checkpointSnapshot?.DeletedRows
+            ?? store.SnapshotCommittedDeletes();
         var touchedTableIds = liveRows.Select(r => r.RowId.TableId)
             .Concat(deleted.Select(d => d.TableId))
             .ToHashSet();
@@ -2909,7 +2913,10 @@ public sealed partial class EmbeddedDatabase : IDisposable
         {
             if (_mvStore is not null || _fileSystem is null || string.IsNullOrEmpty(_databasePath))
                 return;
-            _mvStore = CreateOrGetSharedMvStore(_fileSystem, _databasePath);
+            _mvStore = CreateOrGetSharedMvStore(
+                _fileSystem,
+                _databasePath,
+                _fileCatalogVersion.SchemaCookie);
         }
     }
 
@@ -2941,13 +2948,17 @@ public sealed partial class EmbeddedDatabase : IDisposable
             if (_fileStore.JournalMode != SqliteJournalMode.Mvcc)
                 return;
 
-            _mvStore = CreateOrGetSharedMvStore(_fileSystem, _databasePath);
+            _mvStore = CreateOrGetSharedMvStore(
+                _fileSystem,
+                _databasePath,
+                _fileCatalogVersion.SchemaCookie);
         }
     }
 
     private static MvStore CreateOrGetSharedMvStore(
         IFileSystem fileSystem,
         string databasePath,
+        ulong schemaGeneration,
         SqliteSynchronousMode synchronousMode = SqliteSynchronousMode.Full)
     {
         MvccLogicalLog.ThrowIfMvccUnsupported(fileSystem);
@@ -2959,7 +2970,9 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 synchronousMode);
             try
             {
-                var store = new MvStore(logicalLog: logicalLog);
+                var store = new MvStore(
+                    logicalLog: logicalLog,
+                    schemaGeneration: schemaGeneration);
                 logicalLog.ReplayInto(store);
                 return store;
             }
@@ -3008,7 +3021,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
     internal MvccCheckpointResult RunMvccCheckpoint(
         string? mode,
         TimeSpan busyTimeout = default,
-        SqliteSynchronousMode synchronousMode = SqliteSynchronousMode.Full)
+        SqliteSynchronousMode synchronousMode = SqliteSynchronousMode.Full,
+        MvccTxId? permittedTransaction = null)
     {
         synchronousMode.Validate(nameof(synchronousMode));
         lock (_gate)
@@ -3037,17 +3051,22 @@ public sealed partial class EmbeddedDatabase : IDisposable
             stateMachine.Enter(MvccCheckpointPhase.AcquireLock);
             var wantTruncate = MvccCheckpoint.ShouldTruncateLog(mode);
 
-            if (!store.TryAcquireCheckpoint(out var checkpointLease))
+            if (!store.TryAcquireCheckpoint(out var checkpointLease, permittedTransaction))
                 return stateMachine.Result(busy: true, logBefore, checkpointedFrames: 0);
             using (checkpointLease)
             {
-                stateMachine.Enter(MvccCheckpointPhase.BuildSnapshot);
-                // The current catalog serializer remains the pager commit boundary.
+                MvccCheckpointFaultInjection.Hit(MvccCheckpointPhase.AcquireLock);
 
-                stateMachine.Enter(MvccCheckpointPhase.MaterializeRows);
-                var merged = MergeConcurrentCatalogFromStoreLocked(LiveCatalog);
+                var snapshot = store.CollectCheckpointSnapshot();
+                stateMachine.Enter(MvccCheckpointPhase.Collect);
+                MvccCheckpointFaultInjection.Hit(MvccCheckpointPhase.Collect);
 
-                stateMachine.Enter(MvccCheckpointPhase.CommitPager);
+                var merged = MergeConcurrentCatalogFromStoreLocked(
+                    LiveCatalog,
+                    snapshot);
+                stateMachine.Enter(MvccCheckpointPhase.Materialize);
+                MvccCheckpointFaultInjection.Hit(MvccCheckpointPhase.Materialize);
+
                 if (_fileStore is null)
                 {
                     PublishCatalog(merged);
@@ -3060,7 +3079,13 @@ public sealed partial class EmbeddedDatabase : IDisposable
                         forceFullRewrite: false,
                         busyTimeout,
                         checkpointAfterCommit: false);
+                }
 
+                stateMachine.Enter(MvccCheckpointPhase.PersistPageWal);
+                MvccCheckpointFaultInjection.Hit(MvccCheckpointPhase.PersistPageWal);
+
+                if (_fileStore is not null)
+                {
                     try
                     {
                         _ = _fileStore.BackfillMvccCheckpoint(busyTimeout);
@@ -3069,21 +3094,27 @@ public sealed partial class EmbeddedDatabase : IDisposable
                     {
                         return stateMachine.Result(busy: true, logBefore, checkpointedFrames: 0);
                     }
-
-                    stateMachine.Enter(MvccCheckpointPhase.BackfillMainStore);
-                    stateMachine.Enter(MvccCheckpointPhase.SyncMainStore);
                 }
 
-                var checkpointed = logBefore;
-                if ((wantTruncate || requiresLogUpgrade) && log is not null)
+                stateMachine.Enter(MvccCheckpointPhase.Backfill);
+                MvccCheckpointFaultInjection.Hit(MvccCheckpointPhase.Backfill);
+
+                var checkpointed = 0L;
+                if (log is not null)
                 {
+                    if (logBefore != 0)
+                    {
+                        log.AppendCheckpointWatermark(
+                            snapshot.DurableTimestamp,
+                            synchronousMode);
+                    }
                     log.TruncateAfterCheckpoint(synchronousMode);
                     if (requiresLogUpgrade)
                         log.UpgradeToVersion4AfterCheckpoint(synchronousMode);
-                    if (wantTruncate)
-                        checkpointed = logBefore;
-                    stateMachine.Enter(MvccCheckpointPhase.RetireLogicalLog);
+                    checkpointed = logBefore;
                 }
+                stateMachine.Enter(MvccCheckpointPhase.RetireLogicalLog);
+                MvccCheckpointFaultInjection.Hit(MvccCheckpointPhase.RetireLogicalLog);
 
                 if (wantTruncate && _fileStore is not null)
                 {
@@ -3097,17 +3128,20 @@ public sealed partial class EmbeddedDatabase : IDisposable
                         // validated WAL for a later restart rather than losing reader data.
                         return stateMachine.Result(busy: true, logBefore, checkpointed);
                     }
-                    stateMachine.Enter(MvccCheckpointPhase.ResetWal);
                 }
+                stateMachine.Enter(MvccCheckpointPhase.ResetWal);
+                MvccCheckpointFaultInjection.Hit(MvccCheckpointPhase.ResetWal);
 
-                store.GarbageCollectAfterCheckpoint();
+                store.GarbageCollectAfterCheckpoint(snapshot);
                 stateMachine.Enter(MvccCheckpointPhase.GarbageCollect);
+                MvccCheckpointFaultInjection.Hit(MvccCheckpointPhase.GarbageCollect);
 
                 stateMachine.Enter(MvccCheckpointPhase.Complete);
+                MvccCheckpointFaultInjection.Hit(MvccCheckpointPhase.Complete);
                 return stateMachine.Result(
                     busy: false,
                     logBefore,
-                    checkpointedFrames: wantTruncate ? checkpointed : 0);
+                    checkpointedFrames: checkpointed);
             }
         }
     }
@@ -3154,6 +3188,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
             _mvStore = CreateOrGetSharedMvStore(
                 _fileSystem,
                 _databasePath,
+                _fileCatalogVersion.SchemaCookie,
                 synchronousMode);
         else
             _mvStore = new MvStore();
@@ -15767,7 +15802,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
         SelectStatement select,
         QueryContext context,
         SourceRow? outerRow)
-        => (!context.CancellationToken.CanBeCanceled || IsAggregateSelect(select))
+        => context.ConcurrentMvStore is null
+            && (!context.CancellationToken.CanBeCanceled || IsAggregateSelect(select))
             && !CanStreamProjectionRows(select, context, outerRow);
 
     // True when any node of the FROM tree is one of the internal semi/anti joins introduced by
@@ -24491,12 +24527,22 @@ out bool hasReturning)
     private SourceData GetManagedIndexRows(
         ManagedIndexScanPlan plan,
         QueryContext context,
-        SourceRow? outerRow)
+        SourceRow? outerRow,
+        long? maximumRows = null)
     {
         var table = plan.Table;
-        // The managed index executor is materialized today. Build it from the
-        // MVCC table dual cursor rather than the catalog backing list so an index
-        // scan never returns a stale base row or misses a version-store insert.
+        if (context.ConcurrentMvStore is { } store
+            && context.ConcurrentMvccTxId is { } txId)
+        {
+            return GetConcurrentMvccIndexRows(
+                plan,
+                context,
+                outerRow,
+                store,
+                txId,
+                maximumRows);
+        }
+
         var visibleRows = GetNamedTableRows(
             plan.Source,
             context,
@@ -24505,7 +24551,7 @@ out bool hasReturning)
         var entries = GetManagedIndexEntries(table, plan.Index, visibleRows, context);
         var qualifier = plan.Source.Alias ?? plan.Source.Name;
         var qualifiedColumns = BuildQualifiedColumns(qualifier, table.Columns);
-        var rows = entries.Select(entry => entry.Row with
+        var projected = entries.Select(entry => entry.Row with
         {
             QualifiedColumns = qualifiedColumns,
             Parent = outerRow,
@@ -24514,9 +24560,197 @@ out bool hasReturning)
             QualifiedColumnDefinitions = BuildQualifiedColumnDefinitions(
                 qualifier,
                 table.ColumnDefinitions),
-        }).ToArray();
+        });
+        if (maximumRows is { } maximum)
+            projected = projected.Take(checked((int)Math.Min(maximum, int.MaxValue)));
+        var rows = projected.ToArray();
 
         return new SourceData(table.Columns, rows);
+    }
+
+    private SourceData GetConcurrentMvccIndexRows(
+        ManagedIndexScanPlan plan,
+        QueryContext context,
+        SourceRow? outerRow,
+        MvStore store,
+        MvccTxId txId,
+        long? maximumRows)
+    {
+        var table = plan.Table;
+        IComparer<MvccKey> tableKeyComparer = MvccKeyComparer.Integer;
+        if (!table.HasRowid)
+        {
+            var primaryKey = table.PrimaryKeySchema
+                ?? throw new EmbeddedSqlException(
+                    $"WITHOUT ROWID table '{table.Name}' is missing primary-key metadata for concurrent MVCC.");
+            tableKeyComparer = MvccKeyComparer.ForRecord(
+                new SqliteIndexRecordComparer(
+                    context.MvccTextEncoding,
+                    primaryKey.Terms.Select(term =>
+                        new SqliteIndexComparisonTerm(term.SortOrder, term.Collation)).ToArray()));
+        }
+
+        var indexComparer = Comparer<MvccDualCursor.IndexRow>.Create(
+            (left, right) => CompareMvccIndexRows(
+                table,
+                plan.Index,
+                tableKeyComparer,
+                left,
+                right));
+        var tableId = store.GetOrCreateTableId(txId, plan.Source.Name);
+        var baseOrder = table.GetOrCreateIndexScanOrder(
+            plan.Index.Name,
+            () => BuildBaseIndexScanOrder(
+                table,
+                plan.Index,
+                context,
+                indexComparer));
+
+        IEnumerable<MvccDualCursor.IndexRow> EnumerateBaseRows()
+        {
+            foreach (var position in baseOrder)
+            {
+                context.CheckInterrupt();
+                var row = table.Rows[position];
+                var rowId = table.HasRowid
+                    ? table.RowIds[position]
+                    : position + 1L;
+                yield return new MvccDualCursor.IndexRow(
+                    GetMvccTableKey(table, row, rowId),
+                    IndexExpressionSemantics.ProjectKey(
+                        plan.Index,
+                        table,
+                        row,
+                        table.HasRowid ? rowId : null,
+                        EvaluateIndexExpression),
+                    row);
+            }
+        }
+
+        MvccDualCursor.IndexRow? ProjectOverlay(MvccVisibleRow visible)
+        {
+            var cells = visible.Cells
+                ?? throw new InvalidOperationException("A visible MVCC index row has no payload.");
+            var rowId = table.HasRowid ? visible.Key.Integer : (long?)null;
+            if (!IndexExpressionSemantics.Qualifies(
+                    plan.Index,
+                    table,
+                    cells,
+                    rowId,
+                    EvaluateIndexExpression))
+            {
+                return null;
+            }
+
+            return new MvccDualCursor.IndexRow(
+                visible.Key,
+                IndexExpressionSemantics.ProjectKey(
+                    plan.Index,
+                    table,
+                    cells,
+                    rowId,
+                    EvaluateIndexExpression),
+                cells);
+        }
+
+        var qualifier = plan.Source.Alias ?? plan.Source.Name;
+        var qualifiedColumns = BuildQualifiedColumns(qualifier, table.Columns);
+        var qualifiedColumnDefinitions = BuildQualifiedColumnDefinitions(
+            qualifier,
+            table.ColumnDefinitions);
+        var merged = MvccDualCursor.EnumerateVisibleIndexRows(
+            store,
+            txId,
+            tableId,
+            EnumerateBaseRows(),
+            ProjectOverlay,
+            indexComparer,
+            tableKeyComparer);
+
+        IEnumerable<SourceRow> EnumerateSourceRows()
+        {
+            long emitted = 0;
+            foreach (var row in merged)
+            {
+                if (maximumRows is { } maximum && emitted >= maximum)
+                    yield break;
+                context.CheckInterrupt();
+                emitted++;
+                yield return new SourceRow(
+                    table.Columns,
+                    row.Cells,
+                    qualifiedColumns,
+                    outerRow,
+                    RowId: table.HasRowid ? row.TableKey.Integer : null,
+                    RowIdQualifier: qualifier,
+                    ColumnDefinitions: table.ColumnDefinitions,
+                    QualifiedColumnDefinitions: qualifiedColumnDefinitions);
+            }
+        }
+
+        return new SourceData(
+            table.Columns,
+            new LazyReadOnlyList<SourceRow>(EnumerateSourceRows()));
+    }
+
+    private int[] BuildBaseIndexScanOrder(
+        EmbeddedTable table,
+        EmbeddedIndex index,
+        QueryContext context,
+        IComparer<MvccDualCursor.IndexRow> comparer)
+    {
+        var entries = new List<(int Position, MvccDualCursor.IndexRow Row)>();
+        for (var position = 0; position < table.Rows.Count; position++)
+        {
+            context.CheckInterrupt();
+            var cells = table.Rows[position];
+            var rowId = table.HasRowid ? table.RowIds[position] : (long?)null;
+            if (!IndexExpressionSemantics.Qualifies(
+                    index,
+                    table,
+                    cells,
+                    rowId,
+                    EvaluateIndexExpression))
+            {
+                continue;
+            }
+
+            entries.Add((
+                position,
+                new MvccDualCursor.IndexRow(
+                    GetMvccTableKey(table, cells, rowId ?? position + 1L),
+                    IndexExpressionSemantics.ProjectKey(
+                        index,
+                        table,
+                        cells,
+                        rowId,
+                        EvaluateIndexExpression),
+                    cells)));
+        }
+
+        entries.Sort((left, right) => comparer.Compare(left.Row, right.Row));
+        return entries.Select(static entry => entry.Position).ToArray();
+    }
+
+    private int CompareMvccIndexRows(
+        EmbeddedTable table,
+        EmbeddedIndex index,
+        IComparer<MvccKey> tableKeyComparer,
+        MvccDualCursor.IndexRow left,
+        MvccDualCursor.IndexRow right)
+    {
+        for (var position = 0; position < index.Columns.Count; position++)
+        {
+            var term = index.Columns[position];
+            var comparison = Compare(
+                left.IndexKey[position],
+                right.IndexKey[position],
+                IndexExpressionSemantics.GetCollationName(table, term));
+            if (comparison != 0)
+                return term.Descending ? -comparison : comparison;
+        }
+
+        return tableKeyComparer.Compare(left.TableKey, right.TableKey);
     }
 
     private List<(SourceRow Row, SqlValue[] Key)> GetManagedIndexEntries(
@@ -24684,54 +24918,47 @@ out bool hasReturning)
             context,
             maximumRows: null,
             outerRow).Rows;
-        var selected = new HashSet<MvccKey>();
-        var selectedRows = new List<SourceRow>();
-        foreach (var (index, branch) in plan.Branches)
+        var qualifier = plan.Source.Alias ?? plan.Source.Name;
+        var qualifiedColumns = BuildQualifiedColumns(qualifier, table.Columns);
+        var qualifiedColumnDefinitions = BuildQualifiedColumnDefinitions(
+            qualifier,
+            table.ColumnDefinitions);
+
+        IEnumerable<SourceRow> EnumerateRows()
         {
             foreach (var row in visibleRows)
             {
                 context.CheckInterrupt();
                 var rowId = table.HasRowid ? row.RowId : null;
-                if (!IndexExpressionSemantics.Qualifies(
-                        index,
-                        table,
-                        row.Values,
-                        rowId,
-                        EvaluateIndexExpression))
+                foreach (var (index, branch) in plan.Branches)
                 {
-                    continue;
+                    if (!IndexExpressionSemantics.Qualifies(
+                            index,
+                            table,
+                            row.Values,
+                            rowId,
+                            EvaluateIndexExpression)
+                        || !IsTrue(Evaluate(branch, parameters, row, context)))
+                    {
+                        continue;
+                    }
+
+                    yield return row with
+                    {
+                        QualifiedColumns = qualifiedColumns,
+                        Parent = outerRow,
+                        RowIdQualifier = qualifier,
+                        ColumnDefinitions = table.ColumnDefinitions,
+                        QualifiedColumnDefinitions = qualifiedColumnDefinitions,
+                    };
+                    break;
                 }
-
-                // Branch equality is re-checked so non-matching keys on this index are skipped.
-                if (!IsTrue(Evaluate(branch, parameters, row, context)))
-                    continue;
-
-                var identity = table.HasRowid
-                    ? MvccKey.FromInteger(rowId!.Value)
-                    : MvccKey.FromPrimaryKey(
-                        table.PrimaryKeySchema
-                            ?? throw new InvalidOperationException("WITHOUT ROWID table has no primary-key metadata."),
-                        row.Values,
-                        context.MvccTextEncoding);
-                if (selected.Add(identity))
-                    selectedRows.Add(row);
             }
         }
 
-        var qualifier = plan.Source.Alias ?? plan.Source.Name;
-        var qualifiedColumns = BuildQualifiedColumns(qualifier, table.Columns);
-        var rows = selectedRows.Select(row => row with
-        {
-            QualifiedColumns = qualifiedColumns,
-            Parent = outerRow,
-            RowIdQualifier = qualifier,
-            ColumnDefinitions = table.ColumnDefinitions,
-            QualifiedColumnDefinitions = BuildQualifiedColumnDefinitions(
-                qualifier,
-                table.ColumnDefinitions),
-        }).ToArray();
-
-        return new SourceData(table.Columns, rows);
+        return new SourceData(
+            table.Columns,
+            new LazyReadOnlyList<SourceRow>(EnumerateRows()));
     }
 
     private static string FormatManagedOrIndexUnionExplainDetail(ManagedOrIndexUnionPlan plan)
@@ -24874,12 +25101,15 @@ out bool hasReturning)
         var orUnionPlan = indexPlan is null
             ? TryPlanManagedOrIndexUnion(statement, context)
             : null;
-        var streamProjectionRows = CanStreamProjectionRows(statement, context, outerRow);
+        var streamProjectionRows = CanStreamProjectionRows(statement, context, outerRow)
+            && !(context.ConcurrentMvStore is not null
+                && indexPlan is not null
+                && limit is >= 0);
         // A managed index plan wins over the transient probe: the index path defines
         // row order (SQLite parity, INDEXED BY), while the probe only prunes a plain scan.
         // Top-level OR equality branches can each SEARCH a different index and union positions.
         var source = indexPlan is not null
-            ? GetManagedIndexRows(indexPlan, context, outerRow)
+            ? GetManagedIndexRows(indexPlan, context, outerRow, sourceLimit)
             : orUnionPlan is not null
                 ? GetManagedOrIndexUnionRows(orUnionPlan, parameters, context, outerRow)
             : TryGetTransientLookupRows(
@@ -24912,6 +25142,17 @@ out bool hasReturning)
                         // can prove a method may return just the rows its pushed-down LIMIT keeps.
                         AllowsMethodIndexRowTruncation(statement)));
         var selectedRows = new List<SourceRow>();
+        var selectedRowLimit = !streamProjectionRows
+            && !hasAggregate
+            && !hasWindow
+            && statement.GroupBy.Count == 0
+            && statement.OrderBy.Count == 0
+            && !statement.Distinct
+            && limit is >= 0
+                ? limit.Value > long.MaxValue - offset
+                    ? long.MaxValue
+                    : offset + limit.Value
+                : (long?)null;
         foreach (var row in source.Rows)
         {
             context.CheckInterrupt();
@@ -24923,7 +25164,14 @@ out bool hasReturning)
                     parameters,
                     row,
                     context))
+            {
                 selectedRows.Add(row);
+                if (selectedRowLimit is { } maximum
+                    && selectedRows.Count >= maximum)
+                {
+                    break;
+                }
+            }
         }
 
         var columnNames = GetColumnNames(statement.Projections, outputColumns, rawOutputColumns);
@@ -29978,7 +30226,7 @@ out bool hasReturning)
                 }
             }
 
-            var tableId = store.GetOrCreateTableId(source.Name);
+            var tableId = store.GetOrCreateTableId(txId, source.Name);
             var merged = MvccDualCursor.EnumerateVisibleRows(
                 store,
                 txId,
@@ -49012,29 +49260,32 @@ Func<string, ParsedStatement> rewrite)
             {
                 if (mode == TransactionMode.Deferred || concurrent)
                     database.TransactionLock.ThrowIfReadBlocked(this, BusyTimeout);
-                var snapshot = database.CreateTransactionSnapshot(busyTimeout: BusyTimeout);
-                states.Add(database, new TransactionDatabaseState(
-                    snapshot.Catalog,
-                    snapshot.Version,
-                    snapshot.PragmaHeader));
 
-                // BEGIN CONCURRENT opens an MvStore tx on main only until attach+MVCC
-                // inheritance is complete. Attached schemas stay classic-catalog snapshots.
+                // Register the MVCC reader before cloning the catalog. This closes
+                // the begin/schema-publish race: once the transaction is visible
+                // to MvStore, DDL cannot publish a new generation underneath the
+                // catalog snapshot being captured here.
                 if (concurrent
                     && ReferenceEquals(database, _database)
                     && database.MvStore is { } store)
                 {
-                    var tx = store.BeginTransaction();
+                    var expectedSchemaGeneration = store.SchemaGeneration;
+                    var tx = store.BeginTransaction(expectedSchemaGeneration);
                     mvccTxs.Add(database, tx.Id);
                 }
                 else if (!concurrent
                     && database.MvStore is { } exclusiveStore
                     && mode is TransactionMode.Immediate or TransactionMode.Exclusive)
                 {
-                    // Write-mode statements under MVCC take an exclusive MVCC tx (Turso).
                     var tx = exclusiveStore.BeginExclusiveTransaction();
                     mvccTxs.Add(database, tx.Id);
                 }
+
+                var snapshot = database.CreateTransactionSnapshot(busyTimeout: BusyTimeout);
+                states.Add(database, new TransactionDatabaseState(
+                    snapshot.Catalog,
+                    snapshot.Version,
+                    snapshot.PragmaHeader));
             }
         }
         catch
@@ -49290,7 +49541,28 @@ Func<string, ParsedStatement> rewrite)
                 "Concurrent schema changes require an active main-database MVCC transaction.");
         }
 
+        if (store.HasSchemaChange(txId))
+            return;
+
         store.BeginSchemaChange(txId);
+        try
+        {
+            // Retire every older logical frame before the private catalog can
+            // diverge. The owner transaction is admitted only as a frozen
+            // snapshot; its uncommitted versions are excluded from collection.
+            var checkpoint = _database.RunMvccCheckpoint(
+                "TRUNCATE",
+                BusyTimeout,
+                GetSynchronousMode(_database),
+                permittedTransaction: txId);
+            if (checkpoint.Busy)
+                throw new EmbeddedBusyException();
+        }
+        catch
+        {
+            store.CancelSchemaChange(txId);
+            throw;
+        }
     }
 
     private string BeginConcurrentStatementSavepoint(MvStore store, MvccTxId txId)
@@ -49347,13 +49619,10 @@ Func<string, ParsedStatement> rewrite)
             throw new EmbeddedCommitVetoException();
         }
 
-        // MVCC commit protocol first (clock + WW conflict), then classic catalog publish.
-        // A schema generation stays pending across that boundary so no new BEGIN
-        // can capture old bindings while the page-one cookie is landing.
-        var pendingSchemaPublications = new List<(
-            EmbeddedDatabase Database,
-            MvccTxId TxId,
-            bool Publish)>();
+        // Ordinary MVCC commits publish the logical frame first. Schema-changing
+        // transactions instead stop at Preparing: their complete private catalog
+        // must land through the pager before the new generation becomes visible.
+        var preparedSchemaCommits = new List<(EmbeddedDatabase Database, MvccTxId TxId)>();
         var mvccWriteWasPublished = false;
         try
         {
@@ -49365,7 +49634,14 @@ Func<string, ParsedStatement> rewrite)
                     {
                         var publish = _transactionDatabases.TryGetValue(database, out var state)
                             && state.HasSchemaChanges;
-                        pendingSchemaPublications.Add((database, txId, publish));
+                        if (publish)
+                        {
+                            store.PrepareSchemaCommit(txId);
+                            preparedSchemaCommits.Add((database, txId));
+                            continue;
+                        }
+
+                        store.CancelSchemaChange(txId);
                     }
                     var hasPendingWrites = store.HasPendingWrites(txId);
                     store.Commit(txId, GetSynchronousMode(database));
@@ -49390,62 +49666,63 @@ Func<string, ParsedStatement> rewrite)
             .Where(pair => ReferenceEquals(pair.Key, _tempDatabase))
             .Select(pair => pair.Value)
             .SingleOrDefault();
+        ExceptionDispatchInfo? deferredMaintenanceFailure = null;
+        var schemaCatalogWasPublished = false;
         try
         {
             if (persistentChanges.Length == 1)
             {
                 var (database, state) = persistentChanges[0];
-                database.CommitTransaction(
-                    state.Catalog,
-                    state.Version,
-                    database.IsFileBacked && !state.HasSnapshotPragmaHeader && !state.HasSchemaChanges
-                        ? null
-                        : state.PragmaHeader,
-                    state.ForceFullCatalogRewrite,
-                    busyTimeout: BusyTimeout,
-                    concurrent: _transactionIsConcurrent,
-                    containsSchemaChanges: state.HasSchemaChanges,
-                    synchronousMode: GetSynchronousMode(database));
+                try
+                {
+                    database.CommitTransaction(
+                        state.Catalog,
+                        state.Version,
+                        database.IsFileBacked && !state.HasSnapshotPragmaHeader && !state.HasSchemaChanges
+                            ? null
+                            : state.PragmaHeader,
+                        state.ForceFullCatalogRewrite,
+                        busyTimeout: BusyTimeout,
+                        concurrent: _transactionIsConcurrent,
+                        containsSchemaChanges: state.HasSchemaChanges,
+                        synchronousMode: GetSynchronousMode(database));
+                }
+                catch (EmbeddedPostCommitMaintenanceException failure)
+                {
+                    // The pager commit is durable even though post-commit cleanup
+                    // failed. Publish the in-memory schema generation before the
+                    // maintenance error is surfaced.
+                    deferredMaintenanceFailure = ExceptionDispatchInfo.Capture(failure);
+                }
+                schemaCatalogWasPublished = state.HasSchemaChanges;
             }
 
-            foreach (var (database, txId, publish) in pendingSchemaPublications)
+            foreach (var (database, txId) in preparedSchemaCommits)
             {
-                if (publish)
-                {
-                    database.MvStore?.CompleteSchemaCheckpoint(GetSynchronousMode(database));
-                    database.MvStore?.PublishSchemaChange(txId);
-                }
-                else
-                    database.MvStore?.CancelSchemaChange(txId);
+                database.MvStore?.CompleteSchemaCommit(txId);
+                _mvccTransactions.Remove(database);
             }
-        }
-        catch (EmbeddedPostCommitMaintenanceException)
-        {
-            foreach (var (database, txId, _) in pendingSchemaPublications)
-                database.MvStore?.CancelSchemaChange(txId);
-            CommitTemporaryTransaction(tempChange);
-            ResetTransactionState();
-            throw;
         }
         catch (MvccLogicalLogCommitIndeterminateException)
         {
-            foreach (var (database, txId, _) in pendingSchemaPublications)
-                database.MvStore?.CancelSchemaChange(txId);
             ResetTransactionState();
             throw;
         }
         catch (Exception failure)
         {
-            foreach (var (database, txId, _) in pendingSchemaPublications)
-                database.MvStore?.CancelSchemaChange(txId);
-            if (!mvccWriteWasPublished)
+            if (!mvccWriteWasPublished && !schemaCatalogWasPublished)
+            {
+                if (preparedSchemaCommits.Count != 0)
+                    ResetTransactionState();
                 throw;
+            }
             ResetTransactionState();
             throw new EmbeddedPostCommitMaintenanceException(failure);
         }
 
         CommitTemporaryTransaction(tempChange);
         ResetTransactionState();
+        deferredMaintenanceFailure?.Throw();
     }
 
     private void CommitTemporaryTransaction(TransactionDatabaseState? tempChange)
@@ -50976,6 +51253,8 @@ internal sealed class EmbeddedTable
     private InsertConflictAlgorithm? _effectivePrimaryKeyConflictAlgorithm;
     private int[]? _cachedRowidScanOrder;
     private long _cachedRowidScanOrderRevision = -1;
+    private readonly Dictionary<string, (long Revision, int[] Order)> _cachedIndexScanOrders =
+        new(StringComparer.OrdinalIgnoreCase);
 
     public EmbeddedTable(
         string name,
@@ -51734,6 +52013,23 @@ internal sealed class EmbeddedTable
 
         foreach (var index in _cachedRowidScanOrder)
             yield return index;
+    }
+
+    internal IReadOnlyList<int> GetOrCreateIndexScanOrder(
+        string indexName,
+        Func<int[]> build)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(indexName);
+        ArgumentNullException.ThrowIfNull(build);
+        if (_cachedIndexScanOrders.TryGetValue(indexName, out var cached)
+            && cached.Revision == Rows.Revision)
+        {
+            return cached.Order;
+        }
+
+        var order = build();
+        _cachedIndexScanOrders[indexName] = (Rows.Revision, order);
+        return order;
     }
 
     public bool Strict { get; }

--- a/src/Ahtola.Core/EmbeddedDatabase.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.cs
@@ -3101,14 +3101,18 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 MvccCheckpointFaultInjection.Hit(MvccCheckpointPhase.Backfill);
 
                 var checkpointed = 0L;
+                if (log is not null && logBefore != 0)
+                {
+                    log.AppendCheckpointWatermark(
+                        snapshot.DurableTimestamp,
+                        synchronousMode);
+                }
+                stateMachine.Enter(MvccCheckpointPhase.PublishRecoveryWatermark);
+                MvccCheckpointFaultInjection.Hit(
+                    MvccCheckpointPhase.PublishRecoveryWatermark);
+
                 if (log is not null)
                 {
-                    if (logBefore != 0)
-                    {
-                        log.AppendCheckpointWatermark(
-                            snapshot.DurableTimestamp,
-                            synchronousMode);
-                    }
                     log.TruncateAfterCheckpoint(synchronousMode);
                     if (requiresLogUpgrade)
                         log.UpgradeToVersion4AfterCheckpoint(synchronousMode);
@@ -44693,6 +44697,10 @@ public sealed partial class EmbeddedConnection : IDisposable
     private const int MaximumAttachedDatabases = 10;
     private const char UnqualifiedSchemaMarker = '\0';
     private const string PersistentTriggerColumnSchemaMarker = "\u0001persistent-trigger-columns";
+
+    [field: ThreadStatic]
+    internal static Action? AfterMvccBeginBeforeCatalogSnapshotForTesting { get; set; }
+
     private readonly EmbeddedDatabase _database;
     private EmbeddedDatabase _tempDatabase;
     private readonly Dictionary<string, AttachedDatabase> _attachedDatabases = new(StringComparer.OrdinalIgnoreCase);
@@ -49414,10 +49422,12 @@ Func<string, ParsedStatement> rewrite)
 
     private void BeginTransaction(bool openedBySavepoint, TransactionMode mode)
     {
+        // A peer connection may have enabled MVCC after this connection opened.
+        // Every transaction mode must attach before deciding whether it needs an
+        // MvStore reader or exclusive-writer registration.
+        _database.EnsureMvccAttachedIfDurable();
         if (mode == TransactionMode.Concurrent)
         {
-            // Peer connections may have enabled MVCC after this connection opened.
-            _database.EnsureMvccAttachedIfDurable();
             if (!_database.IsMvccEnabled)
             {
                 throw new EmbeddedSqlException(
@@ -49460,6 +49470,7 @@ Func<string, ParsedStatement> rewrite)
                     var expectedSchemaGeneration = store.SchemaGeneration;
                     var tx = store.BeginTransaction(expectedSchemaGeneration);
                     mvccTxs.Add(database, tx.Id);
+                    AfterMvccBeginBeforeCatalogSnapshotForTesting?.Invoke();
                 }
                 else if (!concurrent
                     && database.MvStore is { } exclusiveStore

--- a/src/Ahtola.Core/EmbeddedDatabase.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.cs
@@ -806,10 +806,12 @@ public sealed partial class EmbeddedDatabase : IDisposable
                             var allocated = store.AllocateRowId(tableId, minimumExclusive: rowId - 1);
                             if (allocated != rowId)
                             {
+                                var promoted = table.Rows[index].ToArray();
                                 table.RowIds[index] = allocated;
                                 var aliasIndex = table.RowidAliasColumnIndex;
-                                if (aliasIndex >= 0 && aliasIndex < table.Rows[index].Length)
-                                    table.Rows[index][aliasIndex] = SqlValue.Integer(allocated);
+                                if (aliasIndex >= 0 && aliasIndex < promoted.Length)
+                                    promoted[aliasIndex] = SqlValue.Integer(allocated);
+                                table.Rows[index] = promoted;
                                 rowId = allocated;
                             }
                             else
@@ -5741,6 +5743,9 @@ public sealed partial class EmbeddedDatabase : IDisposable
 
         var statistics = GetOrCreateSqliteStat1Table(catalog);
         var histogramStatistics = GetOrCreateSqliteStat4Table(catalog);
+        var stat4RowIds = new Stat4RowIdAllocator(
+            histogramStatistics,
+            _plannerAccessPathMetrics);
         foreach (var target in targets)
         {
             DeleteStatistics(statistics, target.Table.Name, target.Index?.Name);
@@ -5748,13 +5753,13 @@ public sealed partial class EmbeddedDatabase : IDisposable
             if (target.Index is not null)
             {
                 AddIndexStatistic(statistics, target.Table, target.Index);
-                AddIndexStat4Samples(histogramStatistics, target.Table, target.Index);
+                AddIndexStat4Samples(histogramStatistics, target.Table, target.Index, stat4RowIds);
             }
             else
             {
                 AddTableStatistics(statistics, target.Table);
                 foreach (var index in target.Table.Indexes)
-                    AddIndexStat4Samples(histogramStatistics, target.Table, index);
+                    AddIndexStat4Samples(histogramStatistics, target.Table, index, stat4RowIds);
             }
         }
 
@@ -51548,6 +51553,9 @@ internal sealed class EmbeddedTable
     private InsertConflictAlgorithm? _effectivePrimaryKeyConflictAlgorithm;
     private int[]? _cachedRowidScanOrder;
     private long _cachedRowidScanOrderRevision = -1;
+    private Dictionary<long, int>? _cachedRowIdPositions;
+    private long _cachedRowIdPositionsRevision = -1;
+    private int _cachedRowIdPositionsCount = -1;
     private readonly Dictionary<string, (long Revision, int[] Order)> _cachedIndexScanOrders =
         new(StringComparer.OrdinalIgnoreCase);
 
@@ -52308,6 +52316,70 @@ internal sealed class EmbeddedTable
 
         foreach (var index in _cachedRowidScanOrder)
             yield return index;
+    }
+
+    // STAT4 validates a small sample set repeatedly while planning. Cache the rowid map by
+    // RowStore revision, but verify the live slot so same-count rowid replacements fail closed.
+    internal int TryGetRowIdPosition(long rowId, out bool cacheRebuilt)
+    {
+        cacheRebuilt = false;
+        if (!HasRowid || RowIds.Count != Rows.Count)
+        {
+            InvalidateCache();
+            return -1;
+        }
+
+        var builtThisCall = false;
+        if (_cachedRowIdPositions is null
+            || _cachedRowIdPositionsRevision != Rows.Revision
+            || _cachedRowIdPositionsCount != RowIds.Count)
+        {
+            RebuildCache();
+            cacheRebuilt = true;
+            builtThisCall = true;
+        }
+
+        if (TryReadLivePosition(rowId, out var position))
+            return position;
+        if (builtThisCall)
+            return -1;
+
+        // A same-count rowid replacement can bypass RowStore.Revision. Rebuild once on a stale
+        // hit or miss, then let the caller's live index-key validation decide whether to trust it.
+        RebuildCache();
+        cacheRebuilt = true;
+        return TryReadLivePosition(rowId, out position) ? position : -1;
+
+        bool TryReadLivePosition(long id, out int found)
+        {
+            if (_cachedRowIdPositions!.TryGetValue(id, out found)
+                && found >= 0
+                && found < RowIds.Count
+                && RowIds[found] == id)
+            {
+                return true;
+            }
+
+            found = -1;
+            return false;
+        }
+
+        void RebuildCache()
+        {
+            var positions = new Dictionary<long, int>(RowIds.Count);
+            for (var index = 0; index < RowIds.Count; index++)
+                positions.TryAdd(RowIds[index], index);
+            _cachedRowIdPositions = positions;
+            _cachedRowIdPositionsRevision = Rows.Revision;
+            _cachedRowIdPositionsCount = RowIds.Count;
+        }
+
+        void InvalidateCache()
+        {
+            _cachedRowIdPositions = null;
+            _cachedRowIdPositionsRevision = -1;
+            _cachedRowIdPositionsCount = -1;
+        }
     }
 
     internal IReadOnlyList<int> GetOrCreateIndexScanOrder(

--- a/src/Ahtola.Core/EmbeddedDatabase.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.cs
@@ -51441,6 +51441,8 @@ internal sealed class EmbeddedTable
     private InsertConflictAlgorithm? _effectivePrimaryKeyConflictAlgorithm;
     private int[]? _cachedRowidScanOrder;
     private long _cachedRowidScanOrderRevision = -1;
+    private Dictionary<long, int>? _cachedRowidPositions;
+    private long _cachedRowidPositionsRevision = -1;
     private readonly Dictionary<string, (long Revision, int[] Order)> _cachedIndexScanOrders =
         new(StringComparer.OrdinalIgnoreCase);
 
@@ -52201,6 +52203,34 @@ internal sealed class EmbeddedTable
 
         foreach (var index in _cachedRowidScanOrder)
             yield return index;
+    }
+
+    internal bool TryGetRowPosition(long rowId, out int position, out int indexedRows)
+    {
+        indexedRows = 0;
+        if (_cachedRowidPositions is null
+            || _cachedRowidPositionsRevision != Rows.Revision
+            || _cachedRowidPositions.Count != RowIds.Count)
+        {
+            if (RowIds.Count != Rows.Count)
+                throw new InvalidOperationException($"Table '{Name}' has inconsistent row identity metadata.");
+
+            var positions = new Dictionary<long, int>(RowIds.Count);
+            for (var index = 0; index < RowIds.Count; index++)
+            {
+                if (!positions.TryAdd(RowIds[index], index))
+                {
+                    position = -1;
+                    return false;
+                }
+            }
+
+            _cachedRowidPositions = positions;
+            _cachedRowidPositionsRevision = Rows.Revision;
+            indexedRows = RowIds.Count;
+        }
+
+        return _cachedRowidPositions.TryGetValue(rowId, out position);
     }
 
     internal IReadOnlyList<int> GetOrCreateIndexScanOrder(

--- a/src/Ahtola.Core/EmbeddedDatabase.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.cs
@@ -2261,54 +2261,88 @@ public sealed partial class EmbeddedDatabase : IDisposable
     {
         lock (_gate)
         {
-            if (_fileStore is not null)
-            {
-                if (_fileCatalogWriteLock is null)
-                    throw new InvalidOperationException("The managed file catalog persistence state is not initialized.");
+            RefreshTransactionSnapshotCatalogLocked(busyTimeout);
+            return CloneTransactionSnapshotLocked();
+        }
+    }
 
-                using (_fileCatalogWriteLock.Enter(Timeout.InfiniteTimeSpan))
-                {
-                    if (_foreignReadOnly)
-                    {
-                        RefreshForeignCatalogIfChangedLocked();
-                    }
-                    else
-                    {
-                        // BEGIN has no working state yet, so a stale snapshot is
-                        // simply re-read: the same catalog a freshly opened SQLite
-                        // connection would observe.
-                        while (true)
-                        {
-                            try
-                            {
-                                EnsureFileCatalogVersionCurrent(busyTimeout);
-                                break;
-                            }
-                            catch (EmbeddedCatalogSnapshotStaleException)
-                            {
-                                if (TryReloadFileCatalogIfChanged())
-                                    break;
-                                // The reload lost a mid-flight commit race; loop
-                                // to re-wait for stability and try again.
-                            }
-                        }
-                    }
-                }
+    internal (MvccTxId TransactionId, TransactionSnapshot Snapshot)
+        BeginConcurrentTransactionSnapshot(
+            TimeSpan busyTimeout,
+            Action? afterBegin)
+    {
+        lock (_gate)
+        {
+            RefreshTransactionSnapshotCatalogLocked(busyTimeout);
+            var store = _mvStore
+                ?? throw new InvalidOperationException(
+                    "A concurrent transaction snapshot requires an attached MVCC store.");
+            var transaction = store.BeginTransaction(store.SchemaGeneration);
+            try
+            {
+                afterBegin?.Invoke();
+                return (transaction.Id, CloneTransactionSnapshotLocked());
+            }
+            catch
+            {
+                store.Rollback(transaction.Id);
+                throw;
+            }
+        }
+    }
+
+    internal bool IsTransactionSnapshotGateHeldForTesting => Monitor.IsEntered(_gate);
+
+    private void RefreshTransactionSnapshotCatalogLocked(TimeSpan busyTimeout)
+    {
+        if (_fileStore is null)
+            return;
+        if (_fileCatalogWriteLock is null)
+            throw new InvalidOperationException("The managed file catalog persistence state is not initialized.");
+
+        using (_fileCatalogWriteLock.Enter(Timeout.InfiniteTimeSpan))
+        {
+            if (_foreignReadOnly)
+            {
+                RefreshForeignCatalogIfChangedLocked();
+                return;
             }
 
-            var pragmaHeader = _fileStore is null
-                ? _inMemoryPragmaHeader
-                : new PragmaHeaderMetadata(
-                    unchecked((int)_fileCatalogVersion.SchemaCookie),
-                    _fileCatalogVersion.UserVersion,
-                    _fileCatalogVersion.ApplicationId);
-            var catalog = new SchemaCatalog(_tables, _views, _triggers, _virtualTables).Clone();
-            _activeTransactions = checked(_activeTransactions + 1);
-            return new TransactionSnapshot(
-                catalog,
-                _version,
-                pragmaHeader);
+            // BEGIN has no working state yet, so a stale snapshot is simply
+            // re-read: the same catalog a freshly opened SQLite connection
+            // would observe.
+            while (true)
+            {
+                try
+                {
+                    EnsureFileCatalogVersionCurrent(busyTimeout);
+                    return;
+                }
+                catch (EmbeddedCatalogSnapshotStaleException)
+                {
+                    if (TryReloadFileCatalogIfChanged())
+                        return;
+                    // The reload lost a mid-flight commit race; loop to
+                    // re-wait for stability and try again.
+                }
+            }
         }
+    }
+
+    private TransactionSnapshot CloneTransactionSnapshotLocked()
+    {
+        var pragmaHeader = _fileStore is null
+            ? _inMemoryPragmaHeader
+            : new PragmaHeaderMetadata(
+                unchecked((int)_fileCatalogVersion.SchemaCookie),
+                _fileCatalogVersion.UserVersion,
+                _fileCatalogVersion.ApplicationId);
+        var catalog = new SchemaCatalog(_tables, _views, _triggers, _virtualTables).Clone();
+        _activeTransactions = checked(_activeTransactions + 1);
+        return new TransactionSnapshot(
+            catalog,
+            _version,
+            pragmaHeader);
     }
 
     internal SqlValue EvaluateConstant(Expression expression, SqlValue[] parameters, long lastInsertRowId)
@@ -44710,7 +44744,9 @@ public sealed partial class EmbeddedConnection : IDisposable
     private EmbeddedDatabase? _transactionWriteDatabase;
     private EmbeddedDatabase? _transactionMutationDatabase;
     private EmbeddedDatabase? _autocommitWriteReservation;
+    private IDisposable? _autocommitMvccWriteAdmission;
     private readonly List<EmbeddedDatabase> _writeReservations = [];
+    private readonly Dictionary<EmbeddedDatabase, IDisposable> _classicMvccWriteAdmissions = [];
     private bool _transactionOpenedBySavepoint;
     /// <summary>When set, the open SQL transaction is a Turso <c>BEGIN CONCURRENT</c> MVCC tx.</summary>
     private bool _transactionIsConcurrent;
@@ -49465,12 +49501,27 @@ Func<string, ParsedStatement> rewrite)
                 // catalog snapshot being captured here.
                 if (concurrent
                     && ReferenceEquals(database, _database)
-                    && database.MvStore is { } store)
+                    && database.MvStore is not null)
                 {
-                    var expectedSchemaGeneration = store.SchemaGeneration;
-                    var tx = store.BeginTransaction(expectedSchemaGeneration);
-                    mvccTxs.Add(database, tx.Id);
-                    AfterMvccBeginBeforeCatalogSnapshotForTesting?.Invoke();
+                    var concurrentSnapshot = database.BeginConcurrentTransactionSnapshot(
+                        BusyTimeout,
+                        AfterMvccBeginBeforeCatalogSnapshotForTesting);
+                    mvccTxs.Add(database, concurrentSnapshot.TransactionId);
+                    try
+                    {
+                        states.Add(database, new TransactionDatabaseState(
+                            concurrentSnapshot.Snapshot.Catalog,
+                            concurrentSnapshot.Snapshot.Version,
+                            concurrentSnapshot.Snapshot.PragmaHeader));
+                    }
+                    catch
+                    {
+                        mvccTxs.Remove(database);
+                        database.MvStore?.Rollback(concurrentSnapshot.TransactionId);
+                        database.EndTransaction();
+                        throw;
+                    }
+                    continue;
                 }
                 else if (!concurrent
                     && database.MvStore is { } exclusiveStore
@@ -49556,6 +49607,9 @@ Func<string, ParsedStatement> rewrite)
         for (var index = _writeReservations.Count - 1; index >= 0; index--)
             _writeReservations[index].TransactionLock.Exit(this);
         _writeReservations.Clear();
+        foreach (var admission in _classicMvccWriteAdmissions.Values)
+            admission.Dispose();
+        _classicMvccWriteAdmissions.Clear();
     }
 
     private void EnsureTransactionMayMutate(EmbeddedDatabase database, ParsedStatement statement)
@@ -49597,38 +49651,71 @@ Func<string, ParsedStatement> rewrite)
         if (!StatementMayMutate(database, statement))
             return false;
 
-        if (_transactionDatabases is null)
+        IDisposable? newClassicAdmission = null;
+        var retainClassicAdmission = false;
+        if (!ReferenceEquals(database, _tempDatabase)
+            && !_mvccTransactions.ContainsKey(database))
         {
-            // An autocommit write takes the write reservation for the whole
-            // statement, exactly like SQLite's implicit write transaction:
-            // contenders then block through the current writer's statement
-            // burst and evaluate against the committed state it leaves behind,
-            // instead of slipping into the gap between a peer's commit and its
-            // next autocommit statement (ENGINE #17 EF migrations-lock convoy).
-            // The catalog was refreshed at statement entry, before this
-            // reservation was taken, so re-sync it now that the lock is held:
-            // the statement must decide against the committed state it
-            // serializes with, the way native reads the btree under the write
-            // lock.
-            database.TransactionLock.EnterAutocommit(this, BusyTimeout);
-            try
+            database.EnsureMvccAttachedIfDurable();
+            if (database.MvStore is { } store
+                && (_transactionDatabases is null
+                    || !_classicMvccWriteAdmissions.ContainsKey(database)))
             {
-                database.RefreshOwnedCatalogForStatementIfNeeded();
+                newClassicAdmission = store.EnterClassicWrite();
+                retainClassicAdmission = _transactionDatabases is not null;
             }
-            catch
+        }
+
+        try
+        {
+            if (_transactionDatabases is null)
             {
-                database.TransactionLock.Exit(this);
-                throw;
+                // An autocommit write takes the write reservation for the whole
+                // statement, exactly like SQLite's implicit write transaction:
+                // contenders then block through the current writer's statement
+                // burst and evaluate against the committed state it leaves behind,
+                // instead of slipping into the gap between a peer's commit and its
+                // next autocommit statement (ENGINE #17 EF migrations-lock convoy).
+                // The catalog was refreshed at statement entry, before this
+                // reservation was taken, so re-sync it now that the lock is held:
+                // the statement must decide against the committed state it
+                // serializes with, the way native reads the btree under the write
+                // lock.
+                database.TransactionLock.EnterAutocommit(this, BusyTimeout);
+                try
+                {
+                    database.RefreshOwnedCatalogForStatementIfNeeded();
+                }
+                catch
+                {
+                    database.TransactionLock.Exit(this);
+                    throw;
+                }
+
+                _autocommitMvccWriteAdmission = newClassicAdmission;
+                newClassicAdmission = null;
+                _autocommitWriteReservation = database;
+                _transactionMutationDatabase = database;
+                return true;
             }
 
-            _autocommitWriteReservation = database;
+            ReserveWriteAccess(database);
+            if (retainClassicAdmission)
+            {
+                _classicMvccWriteAdmissions.Add(
+                    database,
+                    newClassicAdmission
+                        ?? throw new InvalidOperationException(
+                            "The MVCC classic-writer admission was lost."));
+                newClassicAdmission = null;
+            }
             _transactionMutationDatabase = database;
             return true;
         }
-
-        ReserveWriteAccess(database);
-        _transactionMutationDatabase = database;
-        return true;
+        finally
+        {
+            newClassicAdmission?.Dispose();
+        }
     }
 
     /// <summary>
@@ -49689,7 +49776,16 @@ Func<string, ParsedStatement> rewrite)
         if (ReferenceEquals(_autocommitWriteReservation, database))
         {
             _autocommitWriteReservation = null;
-            database.TransactionLock.Exit(this);
+            try
+            {
+                database.TransactionLock.Exit(this);
+            }
+            finally
+            {
+                var admission = _autocommitMvccWriteAdmission;
+                _autocommitMvccWriteAdmission = null;
+                admission?.Dispose();
+            }
         }
     }
 

--- a/src/Ahtola.Core/EmbeddedDatabase.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.cs
@@ -252,6 +252,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
     private static readonly AsyncLocal<EmbeddedDatabase?> RecursiveTriggerCallbackDatabase = new();
     internal const string SqliteSequenceTableName = "sqlite_sequence";
     internal const string SqliteStat1TableName = "sqlite_stat1";
+    internal const string SqliteStat4TableName = "sqlite_stat4";
     private const string TursoSequenceBackingTablePrefix = "__turso_internal_seq_";
     private const string TursoAutoIncrementSequencePrefix = "__turso_internal_autoincrement_";
     private static readonly ConditionalWeakTable<IFileSystem, FileCatalogWriteLockScope> FileCatalogWriteLocks = new();
@@ -5701,13 +5702,22 @@ public sealed partial class EmbeddedDatabase : IDisposable
         }
 
         var statistics = GetOrCreateSqliteStat1Table(catalog);
+        var histogramStatistics = GetOrCreateSqliteStat4Table(catalog);
         foreach (var target in targets)
         {
             DeleteStatistics(statistics, target.Table.Name, target.Index?.Name);
+            DeletePlannerStatistics(histogramStatistics, target.Table.Name, target.Index?.Name);
             if (target.Index is not null)
+            {
                 AddIndexStatistic(statistics, target.Table, target.Index);
+                AddIndexStat4Samples(histogramStatistics, target.Table, target.Index);
+            }
             else
+            {
                 AddTableStatistics(statistics, target.Table);
+                foreach (var index in target.Table.Indexes)
+                    AddIndexStat4Samples(histogramStatistics, target.Table, index);
+            }
         }
 
         return new ExecutionResult([], [], 0, Changed: true);
@@ -15750,7 +15760,19 @@ public sealed partial class EmbeddedDatabase : IDisposable
         if (canUseCompiledRoute)
         {
             var compiledIndex = false;
-            if ((!context.CancellationToken.CanBeCanceled || IsAggregateSelect(select))
+            if (!context.CancellationToken.CanBeCanceled
+                && TryPlanManagedAndIndexIntersection(select, context) is { } intersectionPlan)
+            {
+                compiledIndex = TryCompileManagedAndIndexIntersectionSelect(
+                    select,
+                    intersectionPlan,
+                    parameters,
+                    context,
+                    outerRow,
+                    materializeRows: true,
+                    out compiled);
+            }
+            else if ((!context.CancellationToken.CanBeCanceled || IsAggregateSelect(select))
                 && TryPlanManagedIndexScan(select, context) is { } indexPlan)
             {
                 compiledIndex = TryCompileManagedIndexSelect(
@@ -16028,7 +16050,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
             rowIds,
             indexLabel,
             plan.Table.ColumnDefinitions,
-            BuildQualifiedColumnDefinitions(qualifier, plan.Table.ColumnDefinitions));
+            BuildQualifiedColumnDefinitions(qualifier, plan.Table.ColumnDefinitions),
+            AccessKind: ScanAccessKind.MultiIndexOr);
 
         // WHERE was consumed while building the union positions.
         var compileForScan = select with { Where = null };
@@ -19080,15 +19103,24 @@ public sealed partial class EmbeddedDatabase : IDisposable
         description = string.Empty;
         if (join.Right is not NamedTableSource named
             || !context.Tables.TryGetValue(named.Name, out var table)
-            || table.Indexes.FirstOrDefault(index =>
-                string.Equals(index.Name, selection.Candidate.Name, StringComparison.OrdinalIgnoreCase)) is not { } index
-            || index.IsPartial
-            || index.IsMethodIndex
-            || index.Columns.Any(static column => column.IsExpression)
             || selection.EqualityTerms.Count == 0
             || selection.EqualityTerms.Count > selection.Candidate.Columns.Count)
         {
             return false;
+        }
+
+        EmbeddedIndex? index = null;
+        if (!selection.Candidate.Automatic)
+        {
+            index = table.Indexes.FirstOrDefault(candidate =>
+                string.Equals(candidate.Name, selection.Candidate.Name, StringComparison.OrdinalIgnoreCase));
+            if (index is null
+                || index.IsPartial
+                || index.IsMethodIndex
+                || index.Columns.Any(static column => column.IsExpression))
+            {
+                return false;
+            }
         }
 
         var keys = new EquiJoinKey[selection.EqualityTerms.Count];
@@ -19114,14 +19146,40 @@ public sealed partial class EmbeddedDatabase : IDisposable
             keys[position] = key;
         }
 
-        (VdbeCursorSource Source, IReadOnlyList<SqlValue[]> Keys) Materialize()
+        (VdbeCursorSource Source, IReadOnlyList<SqlValue[]> Keys) MaterializeDurable()
         {
             var visibleRows = GetNamedTableRows(
                 named,
                 context,
                 maximumRows: null,
                 outerRow).Rows;
-            var entries = GetManagedIndexEntries(table, index, visibleRows, context);
+            var entries = GetManagedIndexEntries(table, index!, visibleRows, context);
+            var rows = entries.Select(static entry => entry.Row.Values).ToArray();
+            var rowIds = table.HasRowid
+                ? entries.Select(static entry => entry.Row.RowId ?? 0L).ToArray()
+                : null;
+            return (
+                new VdbeCursorSource(rows, rowIds),
+                entries.Select(static entry => entry.Key).ToArray());
+        }
+
+        (VdbeCursorSource Source, IReadOnlyList<SqlValue[]> Keys) MaterializeAutomatic()
+        {
+            var visibleRows = GetNamedTableRows(
+                named,
+                context,
+                maximumRows: null,
+                outerRow).Rows;
+            var entries = new List<(SourceRow Row, SqlValue[] Key)>(visibleRows.Count);
+            for (var position = 0; position < visibleRows.Count; position++)
+            {
+                var row = visibleRows[position];
+                var key = new SqlValue[keys.Length];
+                for (var keyPosition = 0; keyPosition < key.Length; keyPosition++)
+                    key[keyPosition] = row.Values[selection.Candidate.Columns[keyPosition].ColumnOrdinal];
+                entries.Add((row, key));
+            }
+
             var rows = entries.Select(static entry => entry.Row.Values).ToArray();
             var rowIds = table.HasRowid
                 ? entries.Select(static entry => entry.Row.RowId ?? 0L).ToArray()
@@ -19167,22 +19225,98 @@ public sealed partial class EmbeddedDatabase : IDisposable
             return 0;
         }
 
+        string? CanonicalizeAutomaticKey(SqlValue[] values)
+        {
+            string? key = null;
+            for (var position = 0; position < values.Length; position++)
+            {
+                var segment = EquiJoinHashIndex.CanonicalizeJoinKeyValue(
+                    values[position],
+                    convertTextToNumeric: false,
+                    convertNumericToText: false,
+                    selection.Candidate.Columns[position].Collation);
+                if (segment is null)
+                    return null;
+                key = key is null
+                    ? segment.Length + ":" + segment
+                    : key + segment.Length + ":" + segment;
+            }
+
+            return key;
+        }
+
         var prefix = string.Join(
             ", ",
             selection.Candidate.Columns
                 .Take(keys.Length)
                 .Select(column => $"{table.Columns[column.ColumnOrdinal]}=?"));
-        var searchDescription = $"SEARCH {table.Name} USING INDEX {index.Name} ({prefix})";
+        var usingClause = selection.Candidate.Automatic
+            ? "USING AUTOMATIC COVERING INDEX"
+            : selection.Candidate.Covering
+                ? $"USING COVERING INDEX {index!.Name}"
+                : $"USING INDEX {index!.Name}";
+        var searchDescription = $"SEARCH {table.Name} {usingClause} ({prefix})";
+        if (selection.Candidate.Automatic)
+        {
+            plan = new VdbeJoinAutomaticIndexPlan(
+                table.Name,
+                searchDescription,
+                table.Columns.Length,
+                MaterializeAutomatic,
+                BuildSeekKey,
+                CanonicalizeAutomaticKey,
+                _joinIndexSeekMetrics);
+            description = $"automatic-index-seek {table.Name} ({prefix})";
+            return true;
+        }
+
+        if (context.ConcurrentMvStore is null
+            && context.ConcurrentMvccTxId is null
+            && !context.InTransaction
+            && _fileStore?.TryOpenIndexAccessor(
+                table,
+                index!,
+                keys.Length,
+                selection.Candidate.Covering,
+                sharedSnapshot: null,
+                out var accessor) == true)
+        {
+            IEnumerable<VdbeJoinRow> SeekPager(SqlValue[] seekKey)
+            {
+                foreach (var row in accessor.Seek(
+                             seekKey,
+                             _joinIndexSeekMetrics.IndexPageRead,
+                             _joinIndexSeekMetrics.KeyCompared,
+                             _joinIndexSeekMetrics.TableRowFetched))
+                {
+                    yield return new VdbeJoinRow(row.Values, [row.RowId]);
+                }
+            }
+
+            plan = new VdbeJoinPagerIndexSeekPlan(
+                table.Name,
+                index!.Name,
+                searchDescription,
+                table.Columns.Length,
+                BuildSeekKey,
+                SeekPager,
+                accessor.Open,
+                accessor.Dispose,
+                _joinIndexSeekMetrics);
+            description = $"pager-index-seek {table.Name} {usingClause} ({prefix})";
+            return true;
+        }
+
         plan = new VdbeJoinIndexScanPlan(
             table.Name,
-            index.Name,
+            index!.Name,
             searchDescription,
             table.Columns.Length,
-            Materialize,
+            MaterializeDurable,
             BuildSeekKey,
             ComparePrefix,
             _joinIndexSeekMetrics);
-        description = $"index-seek {table.Name} USING INDEX {index.Name} ({prefix})";
+        description = $"materialized-index-seek {table.Name} {usingClause} ({prefix})";
         return true;
     }
 
@@ -22656,6 +22790,23 @@ out bool hasReturning)
     {
         var compilationContext = EnsureAutoIncrementStatementState(context);
         ValidateStatementIndexDirectives(statement.Inner, compilationContext);
+        if (statement.Inner is SelectStatement intersectionSelect
+            && HasExplainSafeBounds(intersectionSelect)
+            && TryPlanManagedAndIndexIntersection(
+                intersectionSelect,
+                compilationContext) is { } intersectionPlan
+            && TryCompileManagedAndIndexIntersectionSelect(
+                intersectionSelect,
+                intersectionPlan,
+                parameters,
+                compilationContext,
+                outerRow: null,
+                materializeRows: false,
+                out var compiledIntersection))
+        {
+            return DescribeProgram(compiledIntersection.Program);
+        }
+
         if (statement.Inner is SelectStatement plannedSelect
             && HasExplainSafeBounds(plannedSelect)
             && TryPlanManagedIndexScan(plannedSelect, compilationContext) is { } indexPlan)
@@ -22781,6 +22932,23 @@ out bool hasReturning)
                         SqlValue.Integer(0),
                         SqlValue.Integer(0),
                         SqlValue.Text(FormatMethodIndexExplainDetail(methodPlan)),
+                    ],
+                ],
+                0);
+        }
+        if (statement.Inner is SelectStatement intersectionSelect
+            && TryPlanManagedAndIndexIntersection(
+                intersectionSelect,
+                compilationContext) is { } intersectionPlan)
+        {
+            return new ExecutionResult(
+                ExplainQueryPlanColumns(),
+                [
+                    [
+                        SqlValue.Integer(1),
+                        SqlValue.Integer(0),
+                        SqlValue.Integer(0),
+                        SqlValue.Text(FormatManagedAndIndexIntersectionExplainDetail(intersectionPlan)),
                     ],
                 ],
                 0);
@@ -22917,7 +23085,7 @@ out bool hasReturning)
 
         void Collect(VdbeJoinPlanNode node)
         {
-            if (node is VdbeJoinIndexScanPlan index)
+            if (node is IVdbeJoinSeekPlan index)
             {
                 searches.Add(index.SearchDescription);
                 return;
@@ -23941,7 +24109,7 @@ out bool hasReturning)
     /// When ANALYZE has populated <c>sqlite_stat1</c>, equality SEARCH gains a selectivity
     /// bonus from the leading-prefix average-rows figure (lower avg ⇒ higher score).
     /// </summary>
-    private static int ScoreManagedIndexPlan(
+    private int ScoreManagedIndexPlan(
         ManagedIndexScanPlan plan,
         SelectStatement statement,
         bool ordered,
@@ -23966,6 +24134,17 @@ out bool hasReturning)
             {
                 // Cap bonus so stats refine ranking without drowning structural signals.
                 score += Math.Min(300, 300 / leadingAverage);
+            }
+
+            if (statement.Where is not null
+                && TryEstimateStat4EqualityRows(
+                    context,
+                    plan.Table,
+                    plan.Index,
+                    statement.Where,
+                    out var stat4Rows))
+            {
+                score += Math.Min(600, 600 / Math.Max(1, (int)Math.Ceiling(stat4Rows)));
             }
         }
 
@@ -25097,8 +25276,11 @@ out bool hasReturning)
             && limit is >= 0
             ? limit
             : null;
-        var indexPlan = TryPlanManagedIndexScan(statement, context);
-        var orUnionPlan = indexPlan is null
+        var intersectionPlan = TryPlanManagedAndIndexIntersection(statement, context);
+        var indexPlan = intersectionPlan is null
+            ? TryPlanManagedIndexScan(statement, context)
+            : null;
+        var orUnionPlan = intersectionPlan is null && indexPlan is null
             ? TryPlanManagedOrIndexUnion(statement, context)
             : null;
         var streamProjectionRows = CanStreamProjectionRows(statement, context, outerRow)
@@ -25108,7 +25290,13 @@ out bool hasReturning)
         // A managed index plan wins over the transient probe: the index path defines
         // row order (SQLite parity, INDEXED BY), while the probe only prunes a plain scan.
         // Top-level OR equality branches can each SEARCH a different index and union positions.
-        var source = indexPlan is not null
+        var source = intersectionPlan is not null
+            ? GetManagedAndIndexIntersectionRows(
+                intersectionPlan,
+                parameters,
+                context,
+                outerRow)
+            : indexPlan is not null
             ? GetManagedIndexRows(indexPlan, context, outerRow, sourceLimit)
             : orUnionPlan is not null
                 ? GetManagedOrIndexUnionRows(orUnionPlan, parameters, context, outerRow)

--- a/src/Ahtola.Core/EmbeddedDatabase.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.cs
@@ -51548,8 +51548,6 @@ internal sealed class EmbeddedTable
     private InsertConflictAlgorithm? _effectivePrimaryKeyConflictAlgorithm;
     private int[]? _cachedRowidScanOrder;
     private long _cachedRowidScanOrderRevision = -1;
-    private Dictionary<long, int>? _cachedRowidPositions;
-    private long _cachedRowidPositionsRevision = -1;
     private readonly Dictionary<string, (long Revision, int[] Order)> _cachedIndexScanOrders =
         new(StringComparer.OrdinalIgnoreCase);
 
@@ -52310,34 +52308,6 @@ internal sealed class EmbeddedTable
 
         foreach (var index in _cachedRowidScanOrder)
             yield return index;
-    }
-
-    internal bool TryGetRowPosition(long rowId, out int position, out int indexedRows)
-    {
-        indexedRows = 0;
-        if (_cachedRowidPositions is null
-            || _cachedRowidPositionsRevision != Rows.Revision
-            || _cachedRowidPositions.Count != RowIds.Count)
-        {
-            if (RowIds.Count != Rows.Count)
-                throw new InvalidOperationException($"Table '{Name}' has inconsistent row identity metadata.");
-
-            var positions = new Dictionary<long, int>(RowIds.Count);
-            for (var index = 0; index < RowIds.Count; index++)
-            {
-                if (!positions.TryAdd(RowIds[index], index))
-                {
-                    position = -1;
-                    return false;
-                }
-            }
-
-            _cachedRowidPositions = positions;
-            _cachedRowidPositionsRevision = Rows.Revision;
-            indexedRows = RowIds.Count;
-        }
-
-        return _cachedRowidPositions.TryGetValue(rowId, out position);
     }
 
     internal IReadOnlyList<int> GetOrCreateIndexScanOrder(

--- a/src/Ahtola.Core/EmbeddedDatabase.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.cs
@@ -2273,27 +2273,49 @@ public sealed partial class EmbeddedDatabase : IDisposable
             TimeSpan busyTimeout,
             Action? afterBegin)
     {
+        MvStore store;
         lock (_gate)
         {
-            RefreshTransactionSnapshotCatalogLocked(busyTimeout);
-            var store = _mvStore
+            store = _mvStore
                 ?? throw new InvalidOperationException(
                     "A concurrent transaction snapshot requires an attached MVCC store.");
-            var transaction = store.BeginTransaction(store.SchemaGeneration);
-            try
+        }
+
+        using var beginBarrier = store.EnterSnapshotBegin();
+        lock (_gate)
+        {
+            if (_fileStore is null)
+                return BeginConcurrentTransactionSnapshotLocked(store, afterBegin);
+            if (_fileCatalogWriteLock is null)
+                throw new InvalidOperationException("The managed file catalog persistence state is not initialized.");
+
+            using (_fileCatalogWriteLock.Enter(Timeout.InfiniteTimeSpan))
             {
-                afterBegin?.Invoke();
-                return (transaction.Id, CloneTransactionSnapshotLocked());
-            }
-            catch
-            {
-                store.Rollback(transaction.Id);
-                throw;
+                RefreshTransactionSnapshotCatalogUnderWriteLockLocked(busyTimeout);
+                return BeginConcurrentTransactionSnapshotLocked(store, afterBegin);
             }
         }
     }
 
     internal bool IsTransactionSnapshotGateHeldForTesting => Monitor.IsEntered(_gate);
+
+    private (MvccTxId TransactionId, TransactionSnapshot Snapshot)
+        BeginConcurrentTransactionSnapshotLocked(
+            MvStore store,
+            Action? afterBegin)
+    {
+        var transaction = store.BeginTransaction(store.SchemaGeneration);
+        try
+        {
+            afterBegin?.Invoke();
+            return (transaction.Id, CloneTransactionSnapshotLocked());
+        }
+        catch
+        {
+            store.Rollback(transaction.Id);
+            throw;
+        }
+    }
 
     private void RefreshTransactionSnapshotCatalogLocked(TimeSpan busyTimeout)
     {
@@ -2304,29 +2326,34 @@ public sealed partial class EmbeddedDatabase : IDisposable
 
         using (_fileCatalogWriteLock.Enter(Timeout.InfiniteTimeSpan))
         {
-            if (_foreignReadOnly)
+            RefreshTransactionSnapshotCatalogUnderWriteLockLocked(busyTimeout);
+        }
+    }
+
+    private void RefreshTransactionSnapshotCatalogUnderWriteLockLocked(TimeSpan busyTimeout)
+    {
+        if (_foreignReadOnly)
+        {
+            RefreshForeignCatalogIfChangedLocked();
+            return;
+        }
+
+        // BEGIN has no working state yet, so a stale snapshot is simply
+        // re-read: the same catalog a freshly opened SQLite connection
+        // would observe.
+        while (true)
+        {
+            try
             {
-                RefreshForeignCatalogIfChangedLocked();
+                EnsureFileCatalogVersionCurrent(busyTimeout);
                 return;
             }
-
-            // BEGIN has no working state yet, so a stale snapshot is simply
-            // re-read: the same catalog a freshly opened SQLite connection
-            // would observe.
-            while (true)
+            catch (EmbeddedCatalogSnapshotStaleException)
             {
-                try
-                {
-                    EnsureFileCatalogVersionCurrent(busyTimeout);
+                if (TryReloadFileCatalogIfChanged())
                     return;
-                }
-                catch (EmbeddedCatalogSnapshotStaleException)
-                {
-                    if (TryReloadFileCatalogIfChanged())
-                        return;
-                    // The reload lost a mid-flight commit race; loop to
-                    // re-wait for stability and try again.
-                }
+                // The reload lost a mid-flight commit race; loop to
+                // re-wait for stability and try again.
             }
         }
     }
@@ -49656,8 +49683,7 @@ Func<string, ParsedStatement> rewrite)
         if (!StatementMayMutate(database, statement))
             return false;
 
-        IDisposable? newClassicAdmission = null;
-        var retainClassicAdmission = false;
+        MvStore? classicStore = null;
         if (!ReferenceEquals(database, _tempDatabase)
             && !_mvccTransactions.ContainsKey(database))
         {
@@ -49666,61 +49692,72 @@ Func<string, ParsedStatement> rewrite)
                 && (_transactionDatabases is null
                     || !_classicMvccWriteAdmissions.ContainsKey(database)))
             {
-                newClassicAdmission = store.EnterClassicWrite();
-                retainClassicAdmission = _transactionDatabases is not null;
+                classicStore = store;
             }
         }
 
-        try
+        if (_transactionDatabases is null)
         {
-            if (_transactionDatabases is null)
+            // An autocommit write takes the write reservation for the whole
+            // statement, exactly like SQLite's implicit write transaction:
+            // contenders then block through the current writer's statement
+            // burst and evaluate against the committed state it leaves behind,
+            // instead of slipping into the gap between a peer's commit and its
+            // next autocommit statement (ENGINE #17 EF migrations-lock convoy).
+            // The catalog was refreshed at statement entry, before this
+            // reservation was taken, so re-sync it now that the lock is held:
+            // the statement must decide against the committed state it
+            // serializes with, the way native reads the btree under the write
+            // lock.
+            database.TransactionLock.EnterAutocommit(this, BusyTimeout);
+            try
             {
-                // An autocommit write takes the write reservation for the whole
-                // statement, exactly like SQLite's implicit write transaction:
-                // contenders then block through the current writer's statement
-                // burst and evaluate against the committed state it leaves behind,
-                // instead of slipping into the gap between a peer's commit and its
-                // next autocommit statement (ENGINE #17 EF migrations-lock convoy).
-                // The catalog was refreshed at statement entry, before this
-                // reservation was taken, so re-sync it now that the lock is held:
-                // the statement must decide against the committed state it
-                // serializes with, the way native reads the btree under the write
-                // lock.
-                database.TransactionLock.EnterAutocommit(this, BusyTimeout);
-                try
-                {
-                    database.RefreshOwnedCatalogForStatementIfNeeded();
-                }
-                catch
-                {
-                    database.TransactionLock.Exit(this);
-                    throw;
-                }
-
-                _autocommitMvccWriteAdmission = newClassicAdmission;
-                newClassicAdmission = null;
-                _autocommitWriteReservation = database;
-                _transactionMutationDatabase = database;
-                return true;
+                database.RefreshOwnedCatalogForStatementIfNeeded();
+                _autocommitMvccWriteAdmission =
+                    classicStore?.EnterClassicWrite(BusyTimeout);
+            }
+            catch
+            {
+                database.TransactionLock.Exit(this);
+                throw;
             }
 
-            ReserveWriteAccess(database);
-            if (retainClassicAdmission)
-            {
-                _classicMvccWriteAdmissions.Add(
-                    database,
-                    newClassicAdmission
-                        ?? throw new InvalidOperationException(
-                            "The MVCC classic-writer admission was lost."));
-                newClassicAdmission = null;
-            }
+            _autocommitWriteReservation = database;
             _transactionMutationDatabase = database;
             return true;
         }
-        finally
+
+        var alreadyHeldWriteReservation = database.TransactionLock.IsHeldBy(this);
+        ReserveWriteAccess(database);
+        try
         {
-            newClassicAdmission?.Dispose();
+            if (classicStore is not null)
+            {
+                var admission = classicStore.EnterClassicWrite(BusyTimeout);
+                try
+                {
+                    _classicMvccWriteAdmissions.Add(database, admission);
+                }
+                catch
+                {
+                    admission.Dispose();
+                    throw;
+                }
+            }
         }
+        catch
+        {
+            if (!alreadyHeldWriteReservation
+                && database.TransactionLock.IsHeldBy(this))
+            {
+                _writeReservations.Remove(database);
+                database.TransactionLock.Exit(this);
+            }
+            throw;
+        }
+
+        _transactionMutationDatabase = database;
+        return true;
     }
 
     /// <summary>
@@ -49844,7 +49881,7 @@ Func<string, ParsedStatement> rewrite)
         if (store.HasSchemaChange(txId))
             return;
 
-        store.BeginSchemaChange(txId);
+        store.BeginSchemaChange(txId, BusyTimeout);
         try
         {
             // Retire every older logical frame before the private catalog can

--- a/src/Ahtola.Core/EmbeddedFileStore.cs
+++ b/src/Ahtola.Core/EmbeddedFileStore.cs
@@ -13,6 +13,42 @@ internal sealed record EmbeddedFileCatalog(
     Dictionary<string, TriggerDefinition> Triggers,
     Dictionary<string, EmbeddedDatabase.VirtualTableDefinition> VirtualTables);
 
+internal sealed record EmbeddedFileIndexSeekRow(SqlValue[] Values, long RowId);
+
+internal sealed class EmbeddedFileIndexAccessor(
+    Func<
+        SqlValue[],
+        Action?,
+        Action?,
+        Action?,
+        IEnumerable<EmbeddedFileIndexSeekRow>> seek,
+    Action open,
+    Action close) : IDisposable
+{
+    public void Open() => open();
+
+    public IEnumerable<EmbeddedFileIndexSeekRow> Seek(
+        SqlValue[] prefix,
+        Action? pageRead = null,
+        Action? keyCompared = null,
+        Action? tableRowFetched = null)
+        => seek(prefix, pageRead, keyCompared, tableRowFetched);
+
+    public void Dispose() => close();
+}
+
+internal sealed class EmbeddedFileReadSnapshot(
+    EmbeddedFileStore owner,
+    SqlitePagerReadTransaction transaction,
+    ISqliteBtreePageIo pageIo) : IDisposable
+{
+    internal EmbeddedFileStore Owner { get; } = owner;
+
+    internal ISqliteBtreePageIo PageIo { get; } = pageIo;
+
+    public void Dispose() => transaction.Dispose();
+}
+
 internal static class ManagedVirtualTableSchemaSql
 {
     private const string PayloadMarker = "/*ahtola-managed-vtab:";
@@ -267,6 +303,196 @@ internal sealed class EmbeddedFileStore : IDisposable
     /// A cheap race-free signal that the committed view may have changed; never rescans the WAL.
     /// </summary>
     internal long CommittedViewGeneration => _pager.CommittedViewGeneration;
+
+    internal bool CanOpenIndexAccessor(EmbeddedTable table, EmbeddedIndex index)
+    {
+        ArgumentNullException.ThrowIfNull(table);
+        ArgumentNullException.ThrowIfNull(index);
+        return !_disposed
+            && table.HasRowid
+            && !index.IsMethodIndex
+            && index.Columns.Count > 0
+            && index.Columns.All(static column => !column.IsExpression)
+            && _committedTables is not null
+            && _committedTables.TryGetValue(table.Name, out var committed)
+            && ReferenceEquals(committed, table)
+            && _tableRootPages.ContainsKey(table.Name)
+            && _indexRootPages.ContainsKey(index.Name);
+    }
+
+    internal bool TryOpenReadSnapshot(
+        EmbeddedTable table,
+        out EmbeddedFileReadSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(table);
+        snapshot = null!;
+        if (_disposed
+            || _committedTables is null
+            || !_committedTables.TryGetValue(table.Name, out var committed)
+            || !ReferenceEquals(committed, table)
+            || !_tableRootPages.ContainsKey(table.Name))
+        {
+            return false;
+        }
+
+        var transaction = _pager.BeginReadTransaction();
+        try
+        {
+            var pageIo = new SqliteStagedBtreePageIo(
+                transaction.ReadPage,
+                transaction.PageCount,
+                _pageSize,
+                _usableSpace);
+            snapshot = new EmbeddedFileReadSnapshot(this, transaction, pageIo);
+            return true;
+        }
+        catch
+        {
+            transaction.Dispose();
+            throw;
+        }
+    }
+
+    internal bool TryOpenIndexAccessor(
+        EmbeddedTable table,
+        EmbeddedIndex index,
+        int prefixLength,
+        bool covering,
+        EmbeddedFileReadSnapshot? sharedSnapshot,
+        out EmbeddedFileIndexAccessor accessor)
+    {
+        ArgumentNullException.ThrowIfNull(table);
+        ArgumentNullException.ThrowIfNull(index);
+        accessor = null!;
+        if (!CanOpenIndexAccessor(table, index)
+            || prefixLength < 1
+            || prefixLength > index.Columns.Count
+            || !_tableRootPages.TryGetValue(table.Name, out var tableRootPage)
+            || !_indexRootPages.TryGetValue(index.Name, out var indexRootPage))
+        {
+            return false;
+        }
+
+        var persistedIndex = table.Indexes.FirstOrDefault(candidate =>
+            ReferenceEquals(candidate, index)
+            || string.Equals(candidate.Name, index.Name, StringComparison.OrdinalIgnoreCase));
+        if (persistedIndex is null)
+            return false;
+
+        var comparer = CreateIndexComparer(table, persistedIndex);
+        var snapshotGate = new object();
+        SqlitePagerReadTransaction? snapshot = null;
+        ISqliteBtreePageIo? pageIo = null;
+        if (sharedSnapshot is not null)
+        {
+            if (!ReferenceEquals(sharedSnapshot.Owner, this))
+                throw new ArgumentException("The shared read snapshot belongs to another file store.", nameof(sharedSnapshot));
+            pageIo = sharedSnapshot.PageIo;
+        }
+
+        ISqliteBtreePageIo GetPageIo()
+        {
+            lock (snapshotGate)
+            {
+                if (pageIo is not null)
+                    return pageIo;
+                snapshot = _pager.BeginReadTransaction();
+                pageIo = new SqliteStagedBtreePageIo(
+                    snapshot.ReadPage,
+                    snapshot.PageCount,
+                    _pageSize,
+                    _usableSpace);
+                return pageIo;
+            }
+        }
+
+        void CloseSnapshot()
+        {
+            if (sharedSnapshot is not null)
+                return;
+            lock (snapshotGate)
+            {
+                snapshot?.Dispose();
+                snapshot = null;
+                pageIo = null;
+            }
+        }
+
+        accessor = new EmbeddedFileIndexAccessor(
+            (prefix, pageRead, keyCompared, tableRowFetched) => SeekCommittedIndex(
+                table,
+                persistedIndex,
+                tableRootPage,
+                indexRootPage,
+                prefixLength,
+                covering,
+                GetPageIo(),
+                comparer,
+                prefix,
+                pageRead,
+                keyCompared,
+                tableRowFetched),
+            sharedSnapshot is null ? () => _ = GetPageIo() : static () => { },
+            CloseSnapshot);
+        return true;
+    }
+
+    private IEnumerable<EmbeddedFileIndexSeekRow> SeekCommittedIndex(
+        EmbeddedTable table,
+        EmbeddedIndex index,
+        uint tableRootPage,
+        uint indexRootPage,
+        int prefixLength,
+        bool covering,
+        ISqliteBtreePageIo pageIo,
+        SqliteIndexRecordComparer comparer,
+        SqlValue[] prefix,
+        Action? pageRead,
+        Action? keyCompared,
+        Action? tableRowFetched)
+    {
+        if (prefix.Length != prefixLength)
+            throw new ArgumentException("The index seek key does not match the planned prefix length.", nameof(prefix));
+
+        var indexCursor = new SqliteIndexBtreeCursor(pageIo, comparer, _textEncoding);
+        var tableCursor = covering ? null : new SqliteTableBtreeCursor(pageIo);
+        foreach (var record in indexCursor.SeekPrefix(indexRootPage, prefix, pageRead, keyCompared))
+        {
+            var indexValues = SqliteRecordCodec.Decode(record, _textEncoding);
+            if (indexValues.Length <= index.Columns.Count
+                || indexValues[^1].Kind != SqlValueKind.Integer)
+            {
+                throw new InvalidDataException(
+                    $"SQLite index '{index.Name}' record is missing its rowid suffix.");
+            }
+
+            var rowId = indexValues[^1].AsInteger();
+            SqlValue[] row;
+            if (covering)
+            {
+                row = new SqlValue[table.Columns.Length];
+                Array.Fill(row, SqlValue.Null);
+                for (var position = 0; position < index.Columns.Count; position++)
+                    row[index.Columns[position].ColumnIndex] = indexValues[position];
+            }
+            else
+            {
+                if (!tableCursor!.TrySeek(tableRootPage, rowId, out var tableRecord))
+                {
+                    throw new InvalidDataException(
+                        $"SQLite index '{index.Name}' references missing rowid {rowId} in table '{table.Name}'.");
+                }
+
+                tableRowFetched?.Invoke();
+                row = RestoreRowidTableRecord(table, SqliteRecordCodec.Decode(tableRecord, _textEncoding));
+            }
+
+            if (table.RowidAliasColumnIndex >= 0)
+                row[table.RowidAliasColumnIndex] = SqlValue.Integer(rowId);
+            EmbeddedDatabase.RecomputeVirtualGeneratedColumns(table, table.Name, row);
+            yield return new EmbeddedFileIndexSeekRow(row, rowId);
+        }
+    }
 
     private EmbeddedFileCatalog Load()
     {
@@ -1358,7 +1584,7 @@ internal sealed class EmbeddedFileStore : IDisposable
         return SqliteRecordCodec.Decode(payload, _textEncoding);
     }
 
-    private static SqlValue[] RestoreRowidTableRecord(
+    internal static SqlValue[] RestoreRowidTableRecord(
         EmbeddedTable table,
         IReadOnlyList<SqlValue> storedValues)
     {

--- a/src/Ahtola.Core/Execution/VdbeProgram.cs
+++ b/src/Ahtola.Core/Execution/VdbeProgram.cs
@@ -969,6 +969,10 @@ public sealed class VdbeJoinIndexSeekMetrics
     private long _seeksAttempted;
     private long _keyComparisons;
     private long _candidateRowsVisited;
+    private long _automaticIndexesBuilt;
+    private long _durableCursorPlans;
+    private long _indexPagesRead;
+    private long _tableRowsFetched;
 
     public long PlansCreated => Interlocked.Read(ref _plansCreated);
 
@@ -980,17 +984,33 @@ public sealed class VdbeJoinIndexSeekMetrics
 
     public long CandidateRowsVisited => Interlocked.Read(ref _candidateRowsVisited);
 
-    internal void PlanCreated(int rowCount)
+    public long AutomaticIndexesBuilt => Interlocked.Read(ref _automaticIndexesBuilt);
+
+    public long DurableCursorPlans => Interlocked.Read(ref _durableCursorPlans);
+
+    public long IndexPagesRead => Interlocked.Read(ref _indexPagesRead);
+
+    public long TableRowsFetched => Interlocked.Read(ref _tableRowsFetched);
+
+    internal void PlanCreated(int rowCount, bool automatic = false)
     {
         Interlocked.Increment(ref _plansCreated);
         Interlocked.Add(ref _indexRowsMaterialized, rowCount);
+        if (automatic)
+            Interlocked.Increment(ref _automaticIndexesBuilt);
     }
+
+    internal void DurableCursorPlanCreated() => Interlocked.Increment(ref _durableCursorPlans);
 
     internal void SeekAttempted() => Interlocked.Increment(ref _seeksAttempted);
 
     internal void KeyCompared() => Interlocked.Increment(ref _keyComparisons);
 
     internal void CandidateVisited() => Interlocked.Increment(ref _candidateRowsVisited);
+
+    internal void IndexPageRead() => Interlocked.Increment(ref _indexPagesRead);
+
+    internal void TableRowFetched() => Interlocked.Increment(ref _tableRowsFetched);
 
     internal void Reset()
     {
@@ -999,19 +1019,34 @@ public sealed class VdbeJoinIndexSeekMetrics
         Interlocked.Exchange(ref _seeksAttempted, 0);
         Interlocked.Exchange(ref _keyComparisons, 0);
         Interlocked.Exchange(ref _candidateRowsVisited, 0);
+        Interlocked.Exchange(ref _automaticIndexesBuilt, 0);
+        Interlocked.Exchange(ref _durableCursorPlans, 0);
+        Interlocked.Exchange(ref _indexPagesRead, 0);
+        Interlocked.Exchange(ref _tableRowsFetched, 0);
     }
 }
 
+internal interface IVdbeJoinSeekPlan : IDisposable
+{
+    string SearchDescription { get; }
+
+    void Open();
+
+    IEnumerable<VdbeJoinRow> Seek(VdbeJoinRow outer);
+}
+
 /// <summary>
-/// Statement-scoped persisted-index view. Keys and base rows are aligned in durable index order;
-/// every outer row performs a lower-bound search followed by an equality-bounded walk.
+/// Statement-scoped materialized index view. Keys and base rows are aligned in index order;
+/// every outer row performs a lower-bound search followed by an equality-bounded walk. It is the
+/// fallback for non-durable snapshots and the build-once representation of automatic indexes.
 /// </summary>
-public sealed class VdbeJoinIndexScanPlan : VdbeJoinPlanNode
+public sealed class VdbeJoinIndexScanPlan : VdbeJoinPlanNode, IVdbeJoinSeekPlan
 {
     private readonly Lazy<(VdbeCursorSource Source, IReadOnlyList<SqlValue[]> Keys)> _rows;
     private readonly Func<VdbeJoinRow, SqlValue[]?> _buildSeekKey;
     private readonly Func<SqlValue[], SqlValue[], int> _comparePrefix;
     private readonly VdbeJoinIndexSeekMetrics _metrics;
+    private readonly bool _automatic;
 
     public VdbeJoinIndexScanPlan(
         string tableName,
@@ -1031,7 +1066,8 @@ public sealed class VdbeJoinIndexScanPlan : VdbeJoinPlanNode
             () => (source, keys),
             buildSeekKey,
             comparePrefix,
-            metrics)
+            metrics,
+            automatic: false)
     {
     }
 
@@ -1043,7 +1079,8 @@ public sealed class VdbeJoinIndexScanPlan : VdbeJoinPlanNode
         Func<(VdbeCursorSource Source, IReadOnlyList<SqlValue[]> Keys)> materialize,
         Func<VdbeJoinRow, SqlValue[]?> buildSeekKey,
         Func<SqlValue[], SqlValue[], int> comparePrefix,
-        VdbeJoinIndexSeekMetrics metrics)
+        VdbeJoinIndexSeekMetrics metrics,
+        bool automatic = false)
         : base(columnCount, sourceCount: 1)
     {
         ArgumentException.ThrowIfNullOrEmpty(tableName);
@@ -1060,6 +1097,7 @@ public sealed class VdbeJoinIndexScanPlan : VdbeJoinPlanNode
         _buildSeekKey = buildSeekKey;
         _comparePrefix = comparePrefix;
         _metrics = metrics;
+        _automatic = automatic;
         _rows = new Lazy<(VdbeCursorSource Source, IReadOnlyList<SqlValue[]> Keys)>(
             () =>
             {
@@ -1072,7 +1110,7 @@ public sealed class VdbeJoinIndexScanPlan : VdbeJoinPlanNode
                         "Index keys must align with base rows.");
                 }
 
-                _metrics.PlanCreated(rows.Source.Rows.Count);
+                _metrics.PlanCreated(rows.Source.Rows.Count, _automatic);
                 return rows;
             },
             LazyThreadSafetyMode.ExecutionAndPublication);
@@ -1103,7 +1141,7 @@ public sealed class VdbeJoinIndexScanPlan : VdbeJoinPlanNode
         }
     }
 
-    internal IEnumerable<VdbeJoinRow> Seek(VdbeJoinRow outer)
+    public IEnumerable<VdbeJoinRow> Seek(VdbeJoinRow outer)
     {
         _metrics.SeekAttempted();
         var seekKey = _buildSeekKey(outer);
@@ -1135,6 +1173,193 @@ public sealed class VdbeJoinIndexScanPlan : VdbeJoinPlanNode
                 [rows.Source.RowIds is null ? null : rows.Source.RowIds[index]]);
         }
     }
+
+    public void Dispose()
+    {
+    }
+
+    public void Open()
+    {
+    }
+}
+
+internal sealed class VdbeJoinAutomaticIndexPlan : VdbeJoinPlanNode, IVdbeJoinSeekPlan
+{
+    private readonly Lazy<(
+        VdbeCursorSource Source,
+        IReadOnlyDictionary<string, List<int>> Buckets)> _index;
+    private readonly Func<VdbeJoinRow, SqlValue[]?> _buildSeekKey;
+    private readonly Func<SqlValue[], string?> _canonicalizeKey;
+    private readonly VdbeJoinIndexSeekMetrics _metrics;
+
+    public VdbeJoinAutomaticIndexPlan(
+        string tableName,
+        string searchDescription,
+        int columnCount,
+        Func<(VdbeCursorSource Source, IReadOnlyList<SqlValue[]> Keys)> materialize,
+        Func<VdbeJoinRow, SqlValue[]?> buildSeekKey,
+        Func<SqlValue[], string?> canonicalizeKey,
+        VdbeJoinIndexSeekMetrics metrics)
+        : base(columnCount, sourceCount: 1)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(tableName);
+        ArgumentException.ThrowIfNullOrEmpty(searchDescription);
+        ArgumentNullException.ThrowIfNull(materialize);
+        ArgumentNullException.ThrowIfNull(buildSeekKey);
+        ArgumentNullException.ThrowIfNull(canonicalizeKey);
+        ArgumentNullException.ThrowIfNull(metrics);
+        TableName = tableName;
+        SearchDescription = searchDescription;
+        _buildSeekKey = buildSeekKey;
+        _canonicalizeKey = canonicalizeKey;
+        _metrics = metrics;
+        _index = new Lazy<(
+            VdbeCursorSource Source,
+            IReadOnlyDictionary<string, List<int>> Buckets)>(
+            () =>
+            {
+                var rows = materialize();
+                if (rows.Source.Rows.Count != rows.Keys.Count)
+                    throw new InvalidOperationException("Automatic-index keys must align with source rows.");
+                var buckets = new Dictionary<string, List<int>>(StringComparer.Ordinal);
+                for (var position = 0; position < rows.Keys.Count; position++)
+                {
+                    var key = _canonicalizeKey(rows.Keys[position]);
+                    if (key is null)
+                        continue;
+                    if (!buckets.TryGetValue(key, out var bucket))
+                    {
+                        bucket = [];
+                        buckets.Add(key, bucket);
+                    }
+                    bucket.Add(position);
+                }
+
+                _metrics.PlanCreated(rows.Source.Rows.Count, automatic: true);
+                return (rows.Source, buckets);
+            },
+            LazyThreadSafetyMode.ExecutionAndPublication);
+    }
+
+    public string TableName { get; }
+
+    public string SearchDescription { get; }
+
+    internal override IReadOnlyList<VdbeJoinRow> Materialize(int? maximumRows)
+        => Enumerate(maximumRows).ToArray();
+
+    internal override IEnumerable<VdbeJoinRow> Enumerate(int? maximumRows)
+    {
+        var source = _index.Value.Source;
+        var count = maximumRows is { } maximum
+            ? Math.Min(source.Rows.Count, maximum)
+            : source.Rows.Count;
+        for (var position = 0; position < count; position++)
+        {
+            yield return new VdbeJoinRow(
+                [.. source.Rows[position]],
+                [source.RowIds is null ? null : source.RowIds[position]]);
+        }
+    }
+
+    public IEnumerable<VdbeJoinRow> Seek(VdbeJoinRow outer)
+    {
+        _metrics.SeekAttempted();
+        var values = _buildSeekKey(outer);
+        if (values is null || _canonicalizeKey(values) is not { } key)
+            yield break;
+
+        var index = _index.Value;
+        if (!index.Buckets.TryGetValue(key, out var positions))
+            yield break;
+        foreach (var position in positions)
+        {
+            _metrics.CandidateVisited();
+            yield return new VdbeJoinRow(
+                [.. index.Source.Rows[position]],
+                [index.Source.RowIds is null ? null : index.Source.RowIds[position]]);
+        }
+    }
+
+    public void Dispose()
+    {
+    }
+
+    public void Open()
+    {
+    }
+}
+
+internal sealed class VdbeJoinPagerIndexSeekPlan : VdbeJoinPlanNode, IVdbeJoinSeekPlan
+{
+    private readonly Func<VdbeJoinRow, SqlValue[]?> _buildSeekKey;
+    private readonly Func<SqlValue[], IEnumerable<VdbeJoinRow>> _seek;
+    private readonly Action _open;
+    private readonly Action _close;
+    private readonly VdbeJoinIndexSeekMetrics _metrics;
+    private int _started;
+
+    public VdbeJoinPagerIndexSeekPlan(
+        string tableName,
+        string indexName,
+        string searchDescription,
+        int columnCount,
+        Func<VdbeJoinRow, SqlValue[]?> buildSeekKey,
+        Func<SqlValue[], IEnumerable<VdbeJoinRow>> seek,
+        Action open,
+        Action close,
+        VdbeJoinIndexSeekMetrics metrics)
+        : base(columnCount, sourceCount: 1)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(tableName);
+        ArgumentException.ThrowIfNullOrEmpty(indexName);
+        ArgumentException.ThrowIfNullOrEmpty(searchDescription);
+        ArgumentNullException.ThrowIfNull(buildSeekKey);
+        ArgumentNullException.ThrowIfNull(seek);
+        ArgumentNullException.ThrowIfNull(open);
+        ArgumentNullException.ThrowIfNull(close);
+        ArgumentNullException.ThrowIfNull(metrics);
+        TableName = tableName;
+        IndexName = indexName;
+        SearchDescription = searchDescription;
+        _buildSeekKey = buildSeekKey;
+        _seek = seek;
+        _open = open;
+        _close = close;
+        _metrics = metrics;
+    }
+
+    public string TableName { get; }
+
+    public string IndexName { get; }
+
+    public string SearchDescription { get; }
+
+    internal override IReadOnlyList<VdbeJoinRow> Materialize(int? maximumRows)
+        => Enumerate(maximumRows).ToArray();
+
+    internal override IEnumerable<VdbeJoinRow> Enumerate(int? maximumRows)
+        => throw new InvalidOperationException("A pager index seek requires an outer-row key.");
+
+    public IEnumerable<VdbeJoinRow> Seek(VdbeJoinRow outer)
+    {
+        _metrics.SeekAttempted();
+        var seekKey = _buildSeekKey(outer);
+        if (seekKey is null)
+            yield break;
+
+        if (Interlocked.Exchange(ref _started, 1) == 0)
+            _metrics.DurableCursorPlanCreated();
+        foreach (var row in _seek(seekKey))
+        {
+            _metrics.CandidateVisited();
+            yield return row;
+        }
+    }
+
+    public void Dispose() => _close();
+
+    public void Open() => _open();
 }
 
 /// <summary>
@@ -1213,7 +1438,7 @@ public sealed class VdbeJoinOperatorPlan : VdbeJoinPlanNode
         int? maximumRows,
         VdbeJoinExecutionContext context)
     {
-        if (Right is VdbeJoinIndexScanPlan indexSeek)
+        if (Right is IVdbeJoinSeekPlan indexSeek)
             return EnumerateIndexSeekRight(indexSeek, maximumRows, context);
 
         if (EquiProbe is not null)
@@ -1227,37 +1452,45 @@ public sealed class VdbeJoinOperatorPlan : VdbeJoinPlanNode
     }
 
     private IEnumerable<VdbeJoinRow> EnumerateIndexSeekRight(
-        VdbeJoinIndexScanPlan indexSeek,
+        IVdbeJoinSeekPlan indexSeek,
         int? maximumRows,
         VdbeJoinExecutionContext context)
     {
         if (Kind is not (VdbeJoinKind.Inner or VdbeJoinKind.Left))
             throw new InvalidOperationException("An index-seek right input requires an INNER or LEFT join.");
 
-        var emitted = 0;
-        foreach (var left in Left.Enumerate(maximumRows: null, context))
+        try
         {
-            var matched = false;
-            foreach (var right in indexSeek.Seek(left))
+            indexSeek.Open();
+            var emitted = 0;
+            foreach (var left in Left.Enumerate(maximumRows: null, context))
             {
-                var combined = Combine(left, right);
-                if (Condition is not null && !Condition(left, right, combined))
-                    continue;
+                var matched = false;
+                foreach (var right in indexSeek.Seek(left))
+                {
+                    var combined = Combine(left, right);
+                    if (Condition is not null && !Condition(left, right, combined))
+                        continue;
 
-                matched = true;
-                yield return combined;
-                emitted++;
-                if (maximumRows is { } maximum && emitted >= maximum)
-                    yield break;
-            }
+                    matched = true;
+                    yield return combined;
+                    emitted++;
+                    if (maximumRows is { } maximum && emitted >= maximum)
+                        yield break;
+                }
 
-            if (Kind == VdbeJoinKind.Left && !matched)
-            {
-                yield return Combine(left, NullRow(Right));
-                emitted++;
-                if (maximumRows is { } maximum && emitted >= maximum)
-                    yield break;
+                if (Kind == VdbeJoinKind.Left && !matched)
+                {
+                    yield return Combine(left, NullRow(Right));
+                    emitted++;
+                    if (maximumRows is { } maximum && emitted >= maximum)
+                        yield break;
+                }
             }
+        }
+        finally
+        {
+            indexSeek.Dispose();
         }
     }
 

--- a/src/Ahtola.Core/ManagedLocalAdapters.cs
+++ b/src/Ahtola.Core/ManagedLocalAdapters.cs
@@ -1010,6 +1010,7 @@ internal static class ManagedSnapshot
             var schema = ReadSchema(source);
             var sourceHasSqliteSequence = HasSqliteSequence(source);
             var sourceHasSqliteStat1 = HasSqliteStat1(source);
+            var sourceHasSqliteStat4 = HasSqliteStat4(source);
             var pragmaHeader = ReadPragmaHeader(source);
             if (ForeignKeysEnabled(destination))
             {
@@ -1048,6 +1049,10 @@ internal static class ManagedSnapshot
                     // Recreate it through ANALYZE, then preserve the source's exact persisted rows.
                     Execute(destination, "ANALYZE;");
                     CopySqliteStat1(source, destination);
+                    if (sourceHasSqliteStat4)
+                        CopySqliteStat4(source, destination);
+                    else if (HasSqliteStat4(destination))
+                        Execute(destination, "DROP TABLE sqlite_stat4;");
                 }
 
                 foreach (var entry in schema.Where(entry => entry.Type is "index" or "view" or "trigger"))
@@ -1086,6 +1091,8 @@ internal static class ManagedSnapshot
 
     private static void ClearSchema(IManagedConnectionAdapter destination)
     {
+        if (HasSqliteStat4(destination))
+            Execute(destination, "DROP TABLE sqlite_stat4;");
         if (HasSqliteStat1(destination))
             Execute(destination, "DROP TABLE sqlite_stat1;");
 
@@ -1144,6 +1151,15 @@ internal static class ManagedSnapshot
         return statement.GetValue(0).AsInteger() != 0;
     }
 
+    private static bool HasSqliteStat4(IManagedConnectionAdapter connection)
+    {
+        using var statement = connection.Prepare(
+            "SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'sqlite_stat4';");
+        if (statement.Step() != StatementStepResult.Row)
+            throw new InvalidOperationException("sqlite_master did not return a sqlite_stat4 count.");
+        return statement.GetValue(0).AsInteger() != 0;
+    }
+
     private static void EnsureSqliteSequence(IManagedConnectionAdapter destination)
     {
         if (HasSqliteSequence(destination))
@@ -1191,6 +1207,24 @@ internal static class ManagedSnapshot
             using var insert = destination.Prepare(
                 "INSERT INTO sqlite_stat1(rowid, tbl, idx, stat) VALUES ($p0, $p1, $p2, $p3);");
             for (var index = 0; index < 4; index++)
+                insert.Bind(index + 1, select.GetValue(index));
+            Execute(insert);
+        }
+    }
+
+    private static void CopySqliteStat4(
+        IManagedConnectionAdapter source,
+        IManagedConnectionAdapter destination)
+    {
+        Execute(destination, "DELETE FROM sqlite_stat4;");
+        using var select = source.Prepare(
+            "SELECT rowid, tbl, idx, neq, nlt, ndlt, sample FROM sqlite_stat4 ORDER BY rowid;");
+        while (select.Step() == StatementStepResult.Row)
+        {
+            using var insert = destination.Prepare(
+                "INSERT INTO sqlite_stat4(rowid, tbl, idx, neq, nlt, ndlt, sample) "
+                + "VALUES ($p0, $p1, $p2, $p3, $p4, $p5, $p6);");
+            for (var index = 0; index < 7; index++)
                 insert.Bind(index + 1, select.GetValue(index));
             Execute(insert);
         }

--- a/src/Ahtola.Core/Mvcc/MvStore.cs
+++ b/src/Ahtola.Core/Mvcc/MvStore.cs
@@ -315,6 +315,7 @@ internal sealed class MvStore
     private ulong _lastCommittedTimestamp;
     private ulong _checkpointGeneration;
     private ulong? _schemaChangeTransaction;
+    private int _activeClassicWriters;
     private bool _checkpointInProgress;
     private bool _hasUnresolvedLegacyRows;
     private bool _hasIndeterminateCommit;
@@ -613,6 +614,17 @@ internal sealed class MvStore
         }
     }
 
+    internal IDisposable EnterClassicWrite()
+    {
+        lock (_gate)
+        {
+            if (_schemaChangeTransaction is not null)
+                throw new EmbeddedBusyException();
+            _activeClassicWriters = checked(_activeClassicWriters + 1);
+            return new ClassicWriteLease(this);
+        }
+    }
+
     internal MvccTransaction BeginExclusiveTransaction(MvccTxId? existing = null)
     {
         lock (_gate)
@@ -682,6 +694,8 @@ internal sealed class MvStore
             if (tx.BeginCommitGeneration != _commitGeneration)
                 throw new EmbeddedBusyException();
             if (_schemaChangeTransaction is { } owner && owner != id.Value)
+                throw new EmbeddedBusyException();
+            if (_activeClassicWriters != 0)
                 throw new EmbeddedBusyException();
 
             EnsureSchemaOwnerIsOnlyTransactionLocked(id, busyOnConflict: true);
@@ -1715,6 +1729,27 @@ internal sealed class MvStore
         {
             var store = Interlocked.Exchange(ref _store, null);
             store?.ReleaseCheckpoint();
+        }
+    }
+
+    private void ReleaseClassicWrite()
+    {
+        lock (_gate)
+        {
+            if (_activeClassicWriters == 0)
+                throw new InvalidOperationException("MVCC classic-writer admission count underflow.");
+            _activeClassicWriters--;
+        }
+    }
+
+    private sealed class ClassicWriteLease(MvStore store) : IDisposable
+    {
+        private MvStore? _store = store;
+
+        public void Dispose()
+        {
+            var owner = Interlocked.Exchange(ref _store, null);
+            owner?.ReleaseClassicWrite();
         }
     }
 

--- a/src/Ahtola.Core/Mvcc/MvStore.cs
+++ b/src/Ahtola.Core/Mvcc/MvStore.cs
@@ -55,6 +55,14 @@ internal enum MvccTransactionState : byte
 }
 
 /// <summary>
+/// Versioned logical identity for a table binding. Turso reserves -1 for
+/// <c>sqlite_schema</c> and allocates negative ids for unmaterialized objects.
+/// </summary>
+internal readonly record struct MvccSchemaObjectIdentity(
+    ulong SchemaGeneration,
+    string Name);
+
+/// <summary>
 /// One in-flight MVCC transaction: begin timestamp, write set, and lifecycle.
 /// </summary>
 internal sealed class MvccTransaction
@@ -66,12 +74,18 @@ internal sealed class MvccTransaction
     private MvccTransactionState _state = MvccTransactionState.Active;
     private ulong? _commitTimestamp;
     private bool _schemaChange;
+    private ulong? _pendingSchemaGeneration;
 
-    internal MvccTransaction(MvccTxId id, ulong beginTimestamp, ulong beginCommitGeneration)
+    internal MvccTransaction(
+        MvccTxId id,
+        ulong beginTimestamp,
+        ulong beginCommitGeneration,
+        ulong beginSchemaGeneration)
     {
         Id = id;
         BeginTimestamp = beginTimestamp;
         BeginCommitGeneration = beginCommitGeneration;
+        BeginSchemaGeneration = beginSchemaGeneration;
     }
 
     internal MvccTxId Id { get; }
@@ -79,6 +93,13 @@ internal sealed class MvccTransaction
     internal ulong BeginTimestamp { get; }
 
     internal ulong BeginCommitGeneration { get; }
+
+    internal ulong BeginSchemaGeneration { get; }
+
+    internal ulong EffectiveSchemaGeneration
+    {
+        get { lock (_gate) return _pendingSchemaGeneration ?? BeginSchemaGeneration; }
+    }
 
     internal MvccTransactionState State
     {
@@ -95,12 +116,23 @@ internal sealed class MvccTransaction
         get { lock (_gate) return _schemaChange; }
     }
 
-    internal void MarkSchemaChange()
+    internal void MarkSchemaChange(ulong pendingSchemaGeneration)
     {
         lock (_gate)
         {
             ThrowIfNotActive();
             _schemaChange = true;
+            _pendingSchemaGeneration = pendingSchemaGeneration;
+        }
+    }
+
+    internal void CancelSchemaChange()
+    {
+        lock (_gate)
+        {
+            ThrowIfNotActive();
+            _schemaChange = false;
+            _pendingSchemaGeneration = null;
         }
     }
 
@@ -256,6 +288,8 @@ internal sealed class MvccTransaction
 /// </summary>
 internal sealed class MvStore
 {
+    internal const long SqliteSchemaTableId = -1;
+
     private readonly ILogicalClock _clock;
     private readonly object _gate = new();
     private readonly Dictionary<ulong, MvccTransaction> _transactions = [];
@@ -263,8 +297,10 @@ internal sealed class MvStore
     private readonly Dictionary<ulong, ulong> _finalizedCommitTimestamps = [];
     private readonly Dictionary<MvccRowId, List<MvccRowVersion>> _rows = [];
     private readonly Dictionary<long, OrderedTableKeys> _orderedTableKeys = [];
-    private readonly Dictionary<string, long> _tableIds = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<MvccSchemaObjectIdentity, long> _tableIds =
+        new(MvccSchemaObjectIdentityComparer.Instance);
     private readonly Dictionary<long, string> _tableNames = [];
+    private readonly Dictionary<long, ulong> _tableSchemaGenerations = [];
     private readonly Dictionary<long, long> _nextRowIds = [];
     private long _nextTableId = -2;
     private ulong _nextTxId = 1;
@@ -272,16 +308,22 @@ internal sealed class MvStore
     private ulong? _exclusiveTxId;
     private ulong _schemaGeneration;
     private ulong _commitGeneration;
+    private ulong _lastCommittedTimestamp;
+    private ulong _checkpointGeneration;
     private ulong? _schemaChangeTransaction;
     private bool _checkpointInProgress;
     private bool _hasUnresolvedLegacyRows;
     private bool _hasIndeterminateCommit;
     private MvccLogicalLog? _logicalLog;
 
-    internal MvStore(ILogicalClock? clock = null, MvccLogicalLog? logicalLog = null)
+    internal MvStore(
+        ILogicalClock? clock = null,
+        MvccLogicalLog? logicalLog = null,
+        ulong schemaGeneration = 0)
     {
         _clock = clock ?? new MvccClock();
         _logicalLog = logicalLog;
+        _schemaGeneration = schemaGeneration;
     }
 
     internal ILogicalClock Clock => _clock;
@@ -311,6 +353,11 @@ internal sealed class MvStore
     internal ulong CommitGeneration
     {
         get { lock (_gate) return _commitGeneration; }
+    }
+
+    internal ulong LastCommittedTimestamp
+    {
+        get { lock (_gate) return _lastCommittedTimestamp; }
     }
 
     /// <summary>Attach durable log after construction (file-backed enable path).</summary>
@@ -379,21 +426,32 @@ internal sealed class MvStore
 
             // Advance clock past recovered commits so new txs get higher timestamps.
             _clock.Reset(commitTs + 1);
+            _lastCommittedTimestamp = Math.Max(_lastCommittedTimestamp, commitTs);
         }
     }
 
-    /// <summary>Stable negative table id for <paramref name="tableName"/>.</summary>
+    /// <summary>
+    /// Stable negative table id for <paramref name="tableName"/> in the currently
+    /// published schema generation.
+    /// </summary>
     internal long GetOrCreateTableId(string tableName)
     {
         ArgumentException.ThrowIfNullOrEmpty(tableName);
         lock (_gate)
+            return GetOrCreateTableIdLocked(tableName, _schemaGeneration);
+    }
+
+    /// <summary>
+    /// Resolves a table identity against the transaction's pinned (or provisional
+    /// DDL) schema generation.
+    /// </summary>
+    internal long GetOrCreateTableId(MvccTxId txId, string tableName)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(tableName);
+        lock (_gate)
         {
-            if (_tableIds.TryGetValue(tableName, out var id))
-                return id;
-            id = _nextTableId--;
-            _tableIds[tableName] = id;
-            _tableNames[id] = tableName;
-            return id;
+            var tx = RequireActive(txId);
+            return GetOrCreateTableIdLocked(tableName, tx.EffectiveSchemaGeneration);
         }
     }
 
@@ -411,15 +469,33 @@ internal sealed class MvStore
             throw new InvalidDataException(
                 $"MVCC logical log maps table id {tableId} to both '{existingName}' and '{tableName}'.");
         }
-        if (_tableIds.TryGetValue(tableName, out var existingId) && existingId != tableId)
+        var identity = new MvccSchemaObjectIdentity(_schemaGeneration, tableName);
+        if (_tableIds.TryGetValue(identity, out var existingId) && existingId != tableId)
         {
             throw new InvalidDataException(
                 $"MVCC logical log maps table '{tableName}' to both {existingId} and {tableId}.");
         }
 
-        _tableIds[tableName] = tableId;
+        _tableIds[identity] = tableId;
         _tableNames[tableId] = tableName;
+        _tableSchemaGenerations[tableId] = _schemaGeneration;
         _nextTableId = Math.Min(_nextTableId, checked(tableId - 1));
+    }
+
+    private long GetOrCreateTableIdLocked(string tableName, ulong schemaGeneration)
+    {
+        var identity = new MvccSchemaObjectIdentity(schemaGeneration, tableName);
+        if (_tableIds.TryGetValue(identity, out var id))
+            return id;
+
+        id = string.Equals(tableName, "sqlite_schema", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(tableName, "sqlite_master", StringComparison.OrdinalIgnoreCase)
+                ? SqliteSchemaTableId
+                : _nextTableId--;
+        _tableIds[identity] = id;
+        _tableNames[id] = tableName;
+        _tableSchemaGenerations[id] = schemaGeneration;
+        return id;
     }
 
     private MvccLogOp CreateLogUpsert(MvccRowId rowId, SqlValue[] cells)
@@ -478,7 +554,7 @@ internal sealed class MvStore
         }
     }
 
-    internal MvccTransaction BeginTransaction()
+    internal MvccTransaction BeginTransaction(ulong? expectedSchemaGeneration = null)
     {
         lock (_gate)
         {
@@ -491,10 +567,19 @@ internal sealed class MvStore
                 || _exclusiveTxId is not null
                 || _schemaChangeTransaction is not null)
                 throw new EmbeddedBusyException();
+            if (expectedSchemaGeneration is { } expected
+                && expected != _schemaGeneration)
+            {
+                throw new EmbeddedCatalogSnapshotStaleException();
+            }
 
             var beginTs = NextBeginTimestamp();
             var id = new MvccTxId(_nextTxId++);
-            var tx = new MvccTransaction(id, beginTs, _commitGeneration);
+            var tx = new MvccTransaction(
+                id,
+                beginTs,
+                _commitGeneration,
+                _schemaGeneration);
             _transactions.Add(id.Value, tx);
             return tx;
         }
@@ -525,7 +610,11 @@ internal sealed class MvStore
 
             var beginTs = NextBeginTimestamp();
             var id = new MvccTxId(_nextTxId++);
-            var tx = new MvccTransaction(id, beginTs, _commitGeneration);
+            var tx = new MvccTransaction(
+                id,
+                beginTs,
+                _commitGeneration,
+                _schemaGeneration);
             _transactions.Add(id.Value, tx);
             _exclusiveTxId = id.Value;
             return tx;
@@ -555,6 +644,8 @@ internal sealed class MvStore
         lock (_gate)
         {
             var tx = RequireActive(id);
+            if (tx.HasSchemaChange && _schemaChangeTransaction == id.Value)
+                return;
             if (_checkpointInProgress)
                 throw new EmbeddedBusyException();
             if (tx.BeginCommitGeneration != _commitGeneration)
@@ -571,7 +662,9 @@ internal sealed class MvStore
                 }
             }
 
-            tx.MarkSchemaChange();
+            if (_schemaGeneration == ulong.MaxValue)
+                throw new InvalidOperationException("The MVCC schema generation is exhausted.");
+            tx.MarkSchemaChange(_schemaGeneration + 1);
             _schemaChangeTransaction = id.Value;
         }
     }
@@ -586,57 +679,95 @@ internal sealed class MvStore
         }
     }
 
-    /// <summary>
-    /// Publishes a schema generation only after the catalog and page-one cookie
-    /// have committed through the normal pager/WAL path.
-    /// </summary>
-    internal void PublishSchemaChange(MvccTxId id)
-    {
-        lock (_gate)
-        {
-            if (_schemaChangeTransaction != id.Value)
-                throw new InvalidOperationException("The MVCC transaction does not own a pending schema publication.");
-            _schemaGeneration = checked(_schemaGeneration + 1);
-            _schemaChangeTransaction = null;
-        }
-    }
-
     internal void CancelSchemaChange(MvccTxId id)
     {
         lock (_gate)
         {
             if (_schemaChangeTransaction == id.Value)
+            {
                 _schemaChangeTransaction = null;
+                if (_transactions.TryGetValue(id.Value, out var tx)
+                    && tx.State == MvccTransactionState.Active)
+                {
+                    tx.CancelSchemaChange();
+                    RemoveUnpublishedSchemaIdentitiesLocked(tx.BeginSchemaGeneration);
+                }
+            }
         }
     }
 
     /// <summary>
-    /// A schema catalog was durably rewritten after all concurrent snapshots were
-    /// excluded. Its catalog already contains every committed logical row, so
-    /// retire the old object identities and their log prefix before a table name
-    /// can be reused by CREATE/RENAME.
+    /// Validates and timestamps a schema-changing transaction without appending
+    /// its row operations to the logical log. Its complete private catalog is
+    /// persisted through the pager before <see cref="CompleteSchemaCommit"/>.
     /// </summary>
-    internal void CompleteSchemaCheckpoint(
-        SqliteSynchronousMode synchronousMode = SqliteSynchronousMode.Full)
+    internal void PrepareSchemaCommit(MvccTxId id)
     {
-        synchronousMode.Validate(nameof(synchronousMode));
+        MvccTransaction tx;
+        HashSet<MvccRowId> writes;
         lock (_gate)
         {
-            if (HasActiveTransactionsLocked())
+            if (_checkpointInProgress)
+                throw new EmbeddedBusyException();
+            tx = RequireActive(id);
+            if (!tx.HasSchemaChange || _schemaChangeTransaction != id.Value)
             {
                 throw new InvalidOperationException(
-                    "Cannot retire MVCC object identities while a transaction is active.");
+                    "The MVCC transaction does not own a pending schema publication.");
             }
 
-            _rows.Clear();
-            _orderedTableKeys.Clear();
-            _tableIds.Clear();
-            _tableNames.Clear();
-            _nextRowIds.Clear();
-            _nextTableId = -2;
-            _logicalLog?.TruncateAfterCheckpoint(synchronousMode);
-            if (_logicalLog is { RequiresVersion4Upgrade: true })
-                _logicalLog.UpgradeToVersion4AfterCheckpoint(synchronousMode);
+            writes = tx.SnapshotWriteSet().ToHashSet();
+            ValidateCommitLocked(tx, writes);
+            if (writes.Count != 0 && _commitGeneration == ulong.MaxValue)
+                throw new InvalidOperationException("The MVCC commit generation is exhausted.");
+        }
+
+        _clock.GetTimestamp(ts => tx.MarkPreparing(ts));
+
+        lock (_gate)
+        {
+            ValidatePreparingCommitLocked(tx, writes);
+        }
+    }
+
+    /// <summary>
+    /// Publishes a prepared schema generation after the catalog and page-one
+    /// schema cookie are durable. No I/O occurs here, so the post-pager publish
+    /// window cannot expose a discarded catalog.
+    /// </summary>
+    internal void CompleteSchemaCommit(MvccTxId id)
+    {
+        lock (_gate)
+        {
+            if (!_transactions.TryGetValue(id.Value, out var tx)
+                || tx.State != MvccTransactionState.Preparing
+                || !tx.HasSchemaChange
+                || _schemaChangeTransaction != id.Value)
+            {
+                throw new InvalidOperationException(
+                    "The MVCC schema transaction is not prepared for publication.");
+            }
+
+            var commitTs = tx.CommitTimestamp
+                ?? throw new InvalidOperationException(
+                    "Preparing schema transaction is missing its commit timestamp.");
+            var writes = tx.SnapshotWriteSet();
+            tx.MarkCommitted();
+            _finalizedStates[id.Value] = MvccTransactionState.Committed;
+            _finalizedCommitTimestamps[id.Value] = commitTs;
+            _lastCommittedTimestamp = Math.Max(_lastCommittedTimestamp, commitTs);
+            ClearExclusive(id);
+            _transactions.Remove(id.Value);
+            if (writes.Count != 0)
+                _commitGeneration++;
+
+            _schemaGeneration = tx.EffectiveSchemaGeneration;
+            _schemaChangeTransaction = null;
+
+            // The just-published catalog is a complete page-native image of this
+            // transaction, including its DML. The pre-DDL checkpoint retired every
+            // older logical frame, so no version or negative object identity remains.
+            ClearMaterializedStateLocked();
         }
     }
     /// <summary>Insert a new live version created by <paramref name="txId"/>.</summary>
@@ -646,6 +777,7 @@ internal sealed class MvStore
         lock (_gate)
         {
             var tx = RequireActive(txId);
+            ThrowIfCheckpointBlocksWriteLocked();
             var version = new MvccRowVersion(
                 _nextVersionId++,
                 begin: MvccStamp.FromTxId(txId),
@@ -676,6 +808,7 @@ internal sealed class MvStore
         lock (_gate)
         {
             var tx = RequireActive(txId);
+            ThrowIfCheckpointBlocksWriteLocked();
             if (!_rows.TryGetValue(rowId, out var chain))
                 return false;
 
@@ -706,6 +839,7 @@ internal sealed class MvStore
         lock (_gate)
         {
             var tx = RequireActive(txId);
+            ThrowIfCheckpointBlocksWriteLocked();
             if (_rows.TryGetValue(rowId, out var chain))
             {
                 for (var i = chain.Count - 1; i >= 0; i--)
@@ -789,6 +923,31 @@ internal sealed class MvStore
                 return true;
             }
 
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Resolves whether the version store has a visible upsert or delete that
+    /// shadows the physical/base row at <paramref name="rowId"/>.
+    /// </summary>
+    internal bool TryReadVisibleEffect(
+        MvccTxId txId,
+        MvccRowId rowId,
+        out SqlValue[]? cells,
+        out bool isDelete)
+    {
+        lock (_gate)
+        {
+            var tx = RequireActive(txId);
+            if (_rows.TryGetValue(rowId, out var chain)
+                && TryResolveVisibleEffectLocked(tx, chain, out cells, out isDelete))
+            {
+                return true;
+            }
+
+            cells = null;
+            isDelete = false;
             return false;
         }
     }
@@ -892,24 +1051,7 @@ internal sealed class MvStore
     internal IReadOnlyList<(MvccRowId RowId, SqlValue[] Cells)> SnapshotLiveCommittedRows()
     {
         lock (_gate)
-        {
-            var results = new List<(MvccRowId, SqlValue[])>();
-            foreach (var (rowId, chain) in _rows)
-            {
-                for (var i = chain.Count - 1; i >= 0; i--)
-                {
-                    var version = chain[i];
-                    if (version.End is not null || version.IsTombstone)
-                        continue;
-                    if (version.Begin is not { IsTimestamp: true })
-                        continue;
-                    results.Add((rowId, (SqlValue[])version.Cells.Clone()));
-                    break;
-                }
-            }
-
-            return results;
-        }
+            return SnapshotLiveCommittedRowsLocked();
     }
 
     /// <summary>
@@ -920,35 +1062,58 @@ internal sealed class MvStore
     internal IReadOnlyCollection<MvccRowId> SnapshotCommittedDeletes()
     {
         lock (_gate)
-        {
-            var deleted = new HashSet<MvccRowId>();
-            foreach (var (rowId, chain) in _rows)
-            {
-                var live = false;
-                var sawDelete = false;
-                for (var i = chain.Count - 1; i >= 0; i--)
-                {
-                    var version = chain[i];
-                    if (version.Begin is not { IsTimestamp: true })
-                        continue;
-                    if (version.End is null && !version.IsTombstone)
-                    {
-                        live = true;
-                        break;
-                    }
+            return SnapshotCommittedDeletesLocked();
+    }
 
-                    if (version.End is null && version.IsTombstone)
-                        sawDelete = true;
-                    else if (version.End is { IsTimestamp: true })
-                        sawDelete = true;
+    private IReadOnlyList<(MvccRowId RowId, SqlValue[] Cells)> SnapshotLiveCommittedRowsLocked()
+    {
+        var results = new List<(MvccRowId, SqlValue[])>();
+        foreach (var (rowId, chain) in _rows)
+        {
+            for (var i = chain.Count - 1; i >= 0; i--)
+            {
+                var version = chain[i];
+                if (version.End is not null || version.IsTombstone)
+                    continue;
+                if (version.Begin is not { IsTimestamp: true })
+                    continue;
+                results.Add((rowId, (SqlValue[])version.Cells.Clone()));
+                break;
+            }
+        }
+
+        return results;
+    }
+
+    private IReadOnlyCollection<MvccRowId> SnapshotCommittedDeletesLocked()
+    {
+        var deleted = new HashSet<MvccRowId>();
+        foreach (var (rowId, chain) in _rows)
+        {
+            var live = false;
+            var sawDelete = false;
+            for (var i = chain.Count - 1; i >= 0; i--)
+            {
+                var version = chain[i];
+                if (version.Begin is not { IsTimestamp: true })
+                    continue;
+                if (version.End is null && !version.IsTombstone)
+                {
+                    live = true;
+                    break;
                 }
 
-                if (!live && sawDelete)
-                    deleted.Add(rowId);
+                if (version.End is null && version.IsTombstone)
+                    sawDelete = true;
+                else if (version.End is { IsTimestamp: true })
+                    sawDelete = true;
             }
 
-            return deleted;
+            if (!live && sawDelete)
+                deleted.Add(rowId);
         }
+
+        return deleted;
     }
 
     /// <summary>Record a write-set entry without mutating version chains (catalog-path DML).</summary>
@@ -957,6 +1122,7 @@ internal sealed class MvStore
         lock (_gate)
         {
             var tx = RequireActive(id);
+            ThrowIfCheckpointBlocksWriteLocked();
             tx.RecordWrite(rowId);
         }
     }
@@ -974,7 +1140,14 @@ internal sealed class MvStore
         HashSet<MvccRowId> writes;
         lock (_gate)
         {
+            if (_checkpointInProgress)
+                throw new EmbeddedBusyException();
             tx = RequireActive(id);
+            if (tx.HasSchemaChange)
+            {
+                throw new InvalidOperationException(
+                    "Schema-changing MVCC transactions must use the pager-first schema commit path.");
+            }
             writes = tx.SnapshotWriteSet().ToHashSet();
             var preflightOps = tx.SnapshotLogOps();
             if (_logicalLog is { RequiresVersion4Upgrade: true }
@@ -984,40 +1157,18 @@ internal sealed class MvStore
                     "MVCC typed-key writes require a checkpoint that upgrades the logical log before commit.");
             }
 
-            foreach (var rowId in writes)
-            {
-                if (!_rows.TryGetValue(rowId, out var chain))
-                    continue;
-                foreach (var version in chain)
-                {
-                    if (IsWriteWriteConflict(tx, version))
-                        throw new EmbeddedWriteWriteConflictException();
-                }
-                if (!rowId.Key.IsInteger)
-                    ThrowIfTypedKeyInsertConflict(tx, chain);
-            }
+            ValidateCommitLocked(tx, writes);
+            if (writes.Count != 0 && _commitGeneration == ulong.MaxValue)
+                throw new InvalidOperationException("The MVCC commit generation is exhausted.");
         }
 
         _clock.GetTimestamp(ts => tx.MarkPreparing(ts));
 
         lock (_gate)
         {
+            ValidatePreparingCommitLocked(tx, writes);
             var commitTs = tx.CommitTimestamp
                 ?? throw new InvalidOperationException("Preparing transaction missing commit timestamp.");
-
-            foreach (var rowId in writes)
-            {
-                if (!_rows.TryGetValue(rowId, out var chain))
-                    continue;
-                foreach (var version in chain)
-                {
-                    if (IsWriteWriteConflict(tx, version))
-                    {
-                        AbortLocked(id, tx);
-                        throw new EmbeddedWriteWriteConflictException();
-                    }
-                }
-            }
 
             var logOps = tx.SnapshotLogOps();
             MvccLogicalLogCommitIndeterminateException? indeterminateCommit = null;
@@ -1040,10 +1191,11 @@ internal sealed class MvStore
             tx.MarkCommitted();
             _finalizedStates[id.Value] = MvccTransactionState.Committed;
             _finalizedCommitTimestamps[id.Value] = commitTs;
+            _lastCommittedTimestamp = Math.Max(_lastCommittedTimestamp, commitTs);
             ClearExclusive(id);
             _transactions.Remove(id.Value);
             if (writes.Count != 0)
-                _commitGeneration = checked(_commitGeneration + 1);
+                _commitGeneration++;
             PruneHistoryLocked(tx.BeginTimestamp);
             if (indeterminateCommit is not null)
             {
@@ -1167,7 +1319,10 @@ internal sealed class MvStore
 
         tx.MarkAborted();
         if (_schemaChangeTransaction == id.Value)
+        {
             _schemaChangeTransaction = null;
+            RemoveUnpublishedSchemaIdentitiesLocked(tx.BeginSchemaGeneration);
+        }
         _finalizedStates[id.Value] = MvccTransactionState.Aborted;
         ClearExclusive(id);
         _transactions.Remove(id.Value);
@@ -1358,17 +1513,21 @@ internal sealed class MvStore
     }
 
     /// <summary>
-    /// Acquires the process-shared stop-the-world checkpoint boundary. The lease
-    /// closes the transaction-admission race between checking the reader floor
-    /// and beginning catalog materialization.
+    /// Acquires the process-shared checkpoint boundary. Read-only snapshots may
+    /// remain active; the lease freezes their mutation path while collection and
+    /// page publication run. A schema owner may be explicitly admitted for the
+    /// pre-DDL retirement checkpoint.
     /// </summary>
-    internal bool TryAcquireCheckpoint(out CheckpointLease? lease)
+    internal bool TryAcquireCheckpoint(
+        out CheckpointLease? lease,
+        MvccTxId? permittedTransaction = null)
     {
         lock (_gate)
         {
             if (_checkpointInProgress
-                || _schemaChangeTransaction is not null
-                || HasActiveTransactionsLocked())
+                || (_schemaChangeTransaction is { } schemaOwner
+                    && schemaOwner != permittedTransaction?.Value)
+                || HasCheckpointBlockingTransactionLocked(permittedTransaction))
             {
                 lease = null;
                 return false;
@@ -1380,46 +1539,70 @@ internal sealed class MvStore
         }
     }
 
+    /// <summary>Collects one stable committed checkpoint input under its lease.</summary>
+    internal MvccCheckpointSnapshot CollectCheckpointSnapshot()
+    {
+        lock (_gate)
+        {
+            if (!_checkpointInProgress)
+                throw new InvalidOperationException("The MVCC checkpoint lease is not held.");
+
+            return new MvccCheckpointSnapshot(
+                SnapshotLiveCommittedRowsLocked(),
+                SnapshotCommittedDeletesLocked(),
+                _lastCommittedTimestamp);
+        }
+    }
+
     /// <summary>Count of version chains currently held (test/diagnostic).</summary>
     internal int VersionChainCount
     {
         get { lock (_gate) return _rows.Count; }
     }
 
-    /// <summary>
-    /// Post-checkpoint GC after catalog materialization. When no concurrent
-    /// transactions are open, drop the entire version store (rows now live in
-    /// the classic catalog). Otherwise prune ended history past the reader LWM
-    /// (Turso <c>GcTableRows</c> spirit without per-page btree walks).
-    /// </summary>
-    internal void GarbageCollectAfterCheckpoint()
+    internal int VersionCount
     {
+        get { lock (_gate) return _rows.Values.Sum(static chain => chain.Count); }
+    }
+
+    internal ulong OldestActiveSnapshot
+    {
+        get { lock (_gate) return ComputeReaderLowWaterMarkLocked(); }
+    }
+
+    /// <summary>
+    /// Stamps the collected committed prefix as page-materialized, then reclaims
+    /// only versions older than the oldest active snapshot. A current version is
+    /// dropped only when every active reader can use its pinned base catalog.
+    /// </summary>
+    internal void GarbageCollectAfterCheckpoint(MvccCheckpointSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
         lock (_gate)
         {
-            if (!HasActiveTransactionsLocked())
-            {
-                _rows.Clear();
-                foreach (var ordered in _orderedTableKeys.Values)
-                    ordered.Keys.Clear();
-                return;
-            }
-
+            if (!_checkpointInProgress)
+                throw new InvalidOperationException("The MVCC checkpoint lease is not held.");
+            if (_checkpointGeneration == ulong.MaxValue)
+                throw new InvalidOperationException("The MVCC checkpoint generation is exhausted.");
+            var materializedAt = ++_checkpointGeneration;
             var lwm = ComputeReaderLowWaterMarkLocked();
-            PruneHistoryLocked(lwm);
 
-            // Committed pure tombstones with begin &lt; LWM are catalog-owned once
-            // materialize has applied deletes; drop them so dual-cursor defers to base.
             foreach (var (rowId, chain) in _rows.ToArray())
             {
+                foreach (var version in chain)
+                {
+                    if (VersionIsCommittedThrough(version, snapshot.DurableTimestamp))
+                        version.MaterializedAt = materializedAt;
+                }
+
                 chain.RemoveAll(version =>
-                    version.IsTombstone
-                    && version.End is null
-                    && version.Begin is { IsTimestamp: true, Value: var beginTs }
-                    && beginTs < lwm);
+                    CanCollectMaterializedVersion(version, lwm, materializedAt));
 
                 if (chain.Count == 0)
                     RemoveRowLocked(rowId);
             }
+
+            PruneFinalizedTransactionsLocked(lwm);
         }
     }
 
@@ -1429,6 +1612,23 @@ internal sealed class MvStore
         {
             if (tx.State is MvccTransactionState.Active or MvccTransactionState.Preparing)
                 return true;
+        }
+
+        return false;
+    }
+
+    private bool HasCheckpointBlockingTransactionLocked(MvccTxId? permittedTransaction)
+    {
+        foreach (var tx in _transactions.Values)
+        {
+            if (permittedTransaction is { } permitted && tx.Id == permitted)
+                continue;
+            if (tx.State == MvccTransactionState.Preparing
+                || tx.HasSchemaChange
+                || tx.SnapshotWriteSet().Count != 0)
+            {
+                return true;
+            }
         }
 
         return false;
@@ -1472,8 +1672,7 @@ internal sealed class MvStore
                 : Math.Min(lowest.Value, active.BeginTimestamp);
         }
 
-        // No readers: LWM is a fresh clock tick so all ended history may drop.
-        return lowest ?? _clock.GetTimestamp(static _ => { });
+        return lowest ?? ulong.MaxValue;
     }
 
     private void PruneHistoryLocked(ulong minBegin)
@@ -1495,6 +1694,11 @@ internal sealed class MvStore
                 RemoveRowLocked(rowId);
         }
 
+        PruneFinalizedTransactionsLocked(lowestActiveBegin);
+    }
+
+    private void PruneFinalizedTransactionsLocked(ulong lowestActiveBegin)
+    {
         if (_finalizedStates.Count > 4096)
         {
             var stale = _finalizedCommitTimestamps
@@ -1506,6 +1710,112 @@ internal sealed class MvStore
                 _finalizedStates.Remove(key);
                 _finalizedCommitTimestamps.Remove(key);
             }
+        }
+    }
+
+    private void ValidateCommitLocked(
+        MvccTransaction tx,
+        IReadOnlyCollection<MvccRowId> writes)
+    {
+        foreach (var rowId in writes)
+        {
+            if (!_rows.TryGetValue(rowId, out var chain))
+                continue;
+            foreach (var version in chain)
+            {
+                if (IsWriteWriteConflict(tx, version))
+                    throw new EmbeddedWriteWriteConflictException();
+            }
+            if (!rowId.Key.IsInteger)
+                ThrowIfTypedKeyInsertConflict(tx, chain);
+        }
+    }
+
+    private void ValidatePreparingCommitLocked(
+        MvccTransaction tx,
+        IReadOnlyCollection<MvccRowId> writes)
+    {
+        foreach (var rowId in writes)
+        {
+            if (!_rows.TryGetValue(rowId, out var chain))
+                continue;
+            foreach (var version in chain)
+            {
+                if (!IsWriteWriteConflict(tx, version))
+                    continue;
+                AbortLocked(tx.Id, tx);
+                throw new EmbeddedWriteWriteConflictException();
+            }
+        }
+    }
+
+    private void ThrowIfCheckpointBlocksWriteLocked()
+    {
+        if (_checkpointInProgress)
+            throw new EmbeddedBusyException();
+    }
+
+    private static bool VersionIsCommittedThrough(
+        MvccRowVersion version,
+        ulong durableTimestamp)
+    {
+        if (version.Begin is { IsTimestamp: false }
+            || version.End is { IsTimestamp: false })
+        {
+            return false;
+        }
+
+        var latestTimestamp = Math.Max(
+            version.Begin is { IsTimestamp: true, Value: var beginTs } ? beginTs : 0,
+            version.End is { IsTimestamp: true, Value: var endTs } ? endTs : 0);
+        return latestTimestamp <= durableTimestamp;
+    }
+
+    private static bool CanCollectMaterializedVersion(
+        MvccRowVersion version,
+        ulong readerLowWaterMark,
+        ulong materializedAt)
+    {
+        if (version.MaterializedAt == 0 || version.MaterializedAt > materializedAt)
+            return false;
+        if (version.Begin is not { IsTimestamp: true, Value: var beginTs })
+            return false;
+
+        if (version.End is { IsTimestamp: true, Value: var endTs })
+            return endTs <= readerLowWaterMark;
+
+        return version.End is null && beginTs < readerLowWaterMark;
+    }
+
+    private void ClearMaterializedStateLocked()
+    {
+        _rows.Clear();
+        _orderedTableKeys.Clear();
+        _tableIds.Clear();
+        _tableNames.Clear();
+        _tableSchemaGenerations.Clear();
+        _nextRowIds.Clear();
+    }
+
+    private void RemoveUnpublishedSchemaIdentitiesLocked(ulong publishedGeneration)
+    {
+        var staleIds = _tableSchemaGenerations
+            .Where(pair => pair.Value != publishedGeneration)
+            .Select(pair => pair.Key)
+            .ToArray();
+        foreach (var tableId in staleIds)
+        {
+            if (_rows.Keys.Any(rowId => rowId.TableId == tableId))
+                continue;
+            var generation = _tableSchemaGenerations[tableId];
+            if (!_tableNames.Remove(tableId, out var tableName))
+                continue;
+            _tableSchemaGenerations.Remove(tableId);
+            _tableIds.Remove(new MvccSchemaObjectIdentity(
+                generation,
+                tableName));
+            _orderedTableKeys.Remove(tableId);
+            _nextRowIds.Remove(tableId);
         }
     }
 
@@ -1679,6 +1989,23 @@ internal sealed class MvStore
 
         internal SortedSet<MvccKey> Keys { get; } =
             new(comparer);
+    }
+
+    private sealed class MvccSchemaObjectIdentityComparer :
+        IEqualityComparer<MvccSchemaObjectIdentity>
+    {
+        internal static MvccSchemaObjectIdentityComparer Instance { get; } = new();
+
+        public bool Equals(
+            MvccSchemaObjectIdentity left,
+            MvccSchemaObjectIdentity right)
+            => left.SchemaGeneration == right.SchemaGeneration
+                && string.Equals(left.Name, right.Name, StringComparison.OrdinalIgnoreCase);
+
+        public int GetHashCode(MvccSchemaObjectIdentity identity)
+            => HashCode.Combine(
+                identity.SchemaGeneration,
+                StringComparer.OrdinalIgnoreCase.GetHashCode(identity.Name));
     }
 }
 

--- a/src/Ahtola.Core/Mvcc/MvStore.cs
+++ b/src/Ahtola.Core/Mvcc/MvStore.cs
@@ -1,4 +1,5 @@
 using Ahtola.Core.Storage;
+using System.Diagnostics;
 
 namespace Ahtola.Core.Mvcc;
 
@@ -316,6 +317,7 @@ internal sealed class MvStore
     private ulong _checkpointGeneration;
     private ulong? _schemaChangeTransaction;
     private int _activeClassicWriters;
+    private int _snapshotBeginsInProgress;
     private bool _checkpointInProgress;
     private bool _hasUnresolvedLegacyRows;
     private bool _hasIndeterminateCommit;
@@ -614,14 +616,29 @@ internal sealed class MvStore
         }
     }
 
-    internal IDisposable EnterClassicWrite()
+    internal IDisposable EnterClassicWrite(TimeSpan timeout)
     {
         lock (_gate)
         {
-            if (_schemaChangeTransaction is not null)
-                throw new EmbeddedBusyException();
+            WaitWhileLocked(() => _schemaChangeTransaction is not null, timeout);
             _activeClassicWriters = checked(_activeClassicWriters + 1);
             return new ClassicWriteLease(this);
+        }
+    }
+
+    internal IDisposable EnterSnapshotBegin()
+    {
+        lock (_gate)
+        {
+            if (_checkpointInProgress
+                || _exclusiveTxId is not null
+                || _schemaChangeTransaction is not null)
+            {
+                throw new EmbeddedBusyException();
+            }
+
+            _snapshotBeginsInProgress = checked(_snapshotBeginsInProgress + 1);
+            return new SnapshotBeginLease(this);
         }
     }
 
@@ -635,6 +652,7 @@ internal sealed class MvStore
                     "The MVCC store has an indeterminate logical-log commit; dispose and reopen the database before starting another transaction.");
             }
             if (_checkpointInProgress
+                || _snapshotBeginsInProgress != 0
                 || (_schemaChangeTransaction is { } schemaOwner
                     && (existing is null || schemaOwner != existing.Value.Value))
                 || (_exclusiveTxId is { } held
@@ -682,7 +700,7 @@ internal sealed class MvStore
     /// pinned an MVCC snapshot; publishing a schema against that snapshot would
     /// otherwise leave compiled cursors with stale object bindings.
     /// </summary>
-    internal void BeginSchemaChange(MvccTxId id)
+    internal void BeginSchemaChange(MvccTxId id, TimeSpan timeout = default)
     {
         lock (_gate)
         {
@@ -695,8 +713,9 @@ internal sealed class MvStore
                 throw new EmbeddedBusyException();
             if (_schemaChangeTransaction is { } owner && owner != id.Value)
                 throw new EmbeddedBusyException();
-            if (_activeClassicWriters != 0)
-                throw new EmbeddedBusyException();
+            WaitWhileLocked(
+                () => _activeClassicWriters != 0 || _snapshotBeginsInProgress != 0,
+                timeout);
 
             EnsureSchemaOwnerIsOnlyTransactionLocked(id, busyOnConflict: true);
 
@@ -724,6 +743,7 @@ internal sealed class MvStore
             if (_schemaChangeTransaction == id.Value)
             {
                 _schemaChangeTransaction = null;
+                Monitor.PulseAll(_gate);
                 if (_transactions.TryGetValue(id.Value, out var tx)
                     && tx.State == MvccTransactionState.Active)
                 {
@@ -803,6 +823,7 @@ internal sealed class MvStore
 
             _schemaGeneration = tx.EffectiveSchemaGeneration;
             _schemaChangeTransaction = null;
+            Monitor.PulseAll(_gate);
 
             // The just-published catalog is a complete page-native image of this
             // transaction, including its DML. The pre-DDL checkpoint retired every
@@ -1361,6 +1382,7 @@ internal sealed class MvStore
         if (_schemaChangeTransaction == id.Value)
         {
             _schemaChangeTransaction = null;
+            Monitor.PulseAll(_gate);
             RemoveUnpublishedSchemaIdentitiesLocked(tx.BeginSchemaGeneration);
         }
         _finalizedStates[id.Value] = MvccTransactionState.Aborted;
@@ -1565,6 +1587,7 @@ internal sealed class MvStore
         lock (_gate)
         {
             if (_checkpointInProgress
+                || _snapshotBeginsInProgress != 0
                 || (_schemaChangeTransaction is { } schemaOwner
                     && schemaOwner != permittedTransaction?.Value)
                 || HasCheckpointBlockingTransactionLocked(permittedTransaction))
@@ -1713,6 +1736,7 @@ internal sealed class MvStore
             if (!_checkpointInProgress)
                 throw new InvalidOperationException("The MVCC checkpoint lease is not held.");
             _checkpointInProgress = false;
+            Monitor.PulseAll(_gate);
         }
     }
 
@@ -1739,6 +1763,7 @@ internal sealed class MvStore
             if (_activeClassicWriters == 0)
                 throw new InvalidOperationException("MVCC classic-writer admission count underflow.");
             _activeClassicWriters--;
+            Monitor.PulseAll(_gate);
         }
     }
 
@@ -1750,6 +1775,49 @@ internal sealed class MvStore
         {
             var owner = Interlocked.Exchange(ref _store, null);
             owner?.ReleaseClassicWrite();
+        }
+    }
+
+    private void ReleaseSnapshotBegin()
+    {
+        lock (_gate)
+        {
+            if (_snapshotBeginsInProgress == 0)
+                throw new InvalidOperationException("MVCC snapshot-begin admission count underflow.");
+            _snapshotBeginsInProgress--;
+            Monitor.PulseAll(_gate);
+        }
+    }
+
+    private sealed class SnapshotBeginLease(MvStore store) : IDisposable
+    {
+        private MvStore? _store = store;
+
+        public void Dispose()
+        {
+            var owner = Interlocked.Exchange(ref _store, null);
+            owner?.ReleaseSnapshotBegin();
+        }
+    }
+
+    private void WaitWhileLocked(Func<bool> blocked, TimeSpan timeout)
+    {
+        if (!blocked())
+            return;
+        if (timeout == TimeSpan.Zero)
+            throw new EmbeddedBusyException();
+
+        var stopwatch = timeout == Timeout.InfiniteTimeSpan ? null : Stopwatch.StartNew();
+        while (blocked())
+        {
+            var remaining = stopwatch is null
+                ? Timeout.InfiniteTimeSpan
+                : timeout - stopwatch.Elapsed;
+            if (remaining <= TimeSpan.Zero
+                || !Monitor.Wait(_gate, remaining) && blocked())
+            {
+                throw new EmbeddedBusyException();
+            }
         }
     }
 

--- a/src/Ahtola.Core/Mvcc/MvStore.cs
+++ b/src/Ahtola.Core/Mvcc/MvStore.cs
@@ -80,12 +80,14 @@ internal sealed class MvccTransaction
         MvccTxId id,
         ulong beginTimestamp,
         ulong beginCommitGeneration,
-        ulong beginSchemaGeneration)
+        ulong beginSchemaGeneration,
+        ulong beginCheckpointGeneration)
     {
         Id = id;
         BeginTimestamp = beginTimestamp;
         BeginCommitGeneration = beginCommitGeneration;
         BeginSchemaGeneration = beginSchemaGeneration;
+        BeginCheckpointGeneration = beginCheckpointGeneration;
     }
 
     internal MvccTxId Id { get; }
@@ -95,6 +97,8 @@ internal sealed class MvccTransaction
     internal ulong BeginCommitGeneration { get; }
 
     internal ulong BeginSchemaGeneration { get; }
+
+    internal ulong BeginCheckpointGeneration { get; }
 
     internal ulong EffectiveSchemaGeneration
     {
@@ -431,6 +435,29 @@ internal sealed class MvStore
     }
 
     /// <summary>
+    /// Advances recovery ordering across a checkpoint watermark even when every
+    /// preceding transaction frame is skipped because its rows are page-resident.
+    /// </summary>
+    internal void ApplyRecoveredWatermark(ulong durableTimestamp)
+    {
+        lock (_gate)
+        {
+            if (HasActiveTransactionsLocked())
+            {
+                throw new InvalidOperationException(
+                    "Cannot apply an MVCC recovery watermark while transactions are active.");
+            }
+            if (durableTimestamp == ulong.MaxValue)
+                throw new InvalidDataException("MVCC recovery watermark exhausted the logical clock.");
+
+            _lastCommittedTimestamp = Math.Max(
+                _lastCommittedTimestamp,
+                durableTimestamp);
+            _clock.Reset(_lastCommittedTimestamp + 1);
+        }
+    }
+
+    /// <summary>
     /// Stable negative table id for <paramref name="tableName"/> in the currently
     /// published schema generation.
     /// </summary>
@@ -579,7 +606,8 @@ internal sealed class MvStore
                 id,
                 beginTs,
                 _commitGeneration,
-                _schemaGeneration);
+                _schemaGeneration,
+                _checkpointGeneration);
             _transactions.Add(id.Value, tx);
             return tx;
         }
@@ -595,6 +623,8 @@ internal sealed class MvStore
                     "The MVCC store has an indeterminate logical-log commit; dispose and reopen the database before starting another transaction.");
             }
             if (_checkpointInProgress
+                || (_schemaChangeTransaction is { } schemaOwner
+                    && (existing is null || schemaOwner != existing.Value.Value))
                 || (_exclusiveTxId is { } held
                     && (existing is null || held != existing.Value.Value)))
             {
@@ -614,7 +644,8 @@ internal sealed class MvStore
                 id,
                 beginTs,
                 _commitGeneration,
-                _schemaGeneration);
+                _schemaGeneration,
+                _checkpointGeneration);
             _transactions.Add(id.Value, tx);
             _exclusiveTxId = id.Value;
             return tx;
@@ -653,14 +684,7 @@ internal sealed class MvStore
             if (_schemaChangeTransaction is { } owner && owner != id.Value)
                 throw new EmbeddedBusyException();
 
-            foreach (var candidate in _transactions.Values)
-            {
-                if (candidate.Id != id
-                    && candidate.State is MvccTransactionState.Active or MvccTransactionState.Preparing)
-                {
-                    throw new EmbeddedBusyException();
-                }
-            }
+            EnsureSchemaOwnerIsOnlyTransactionLocked(id, busyOnConflict: true);
 
             if (_schemaGeneration == ulong.MaxValue)
                 throw new InvalidOperationException("The MVCC schema generation is exhausted.");
@@ -715,6 +739,7 @@ internal sealed class MvStore
                 throw new InvalidOperationException(
                     "The MVCC transaction does not own a pending schema publication.");
             }
+            EnsureSchemaOwnerIsOnlyTransactionLocked(id, busyOnConflict: true);
 
             writes = tx.SnapshotWriteSet().ToHashSet();
             ValidateCommitLocked(tx, writes);
@@ -747,6 +772,7 @@ internal sealed class MvStore
                 throw new InvalidOperationException(
                     "The MVCC schema transaction is not prepared for publication.");
             }
+            EnsureSchemaOwnerIsOnlyTransactionLocked(id, busyOnConflict: false);
 
             var commitTs = tx.CommitTimestamp
                 ?? throw new InvalidOperationException(
@@ -1550,7 +1576,8 @@ internal sealed class MvStore
             return new MvccCheckpointSnapshot(
                 SnapshotLiveCommittedRowsLocked(),
                 SnapshotCommittedDeletesLocked(),
-                _lastCommittedTimestamp);
+                _lastCommittedTimestamp,
+                checked(_checkpointGeneration + 1));
         }
     }
 
@@ -1582,26 +1609,38 @@ internal sealed class MvStore
         {
             if (!_checkpointInProgress)
                 throw new InvalidOperationException("The MVCC checkpoint lease is not held.");
-            if (_checkpointGeneration == ulong.MaxValue)
-                throw new InvalidOperationException("The MVCC checkpoint generation is exhausted.");
-            var materializedAt = ++_checkpointGeneration;
+            if (snapshot.MaterializationGeneration != _checkpointGeneration + 1)
+            {
+                throw new InvalidOperationException(
+                    "The MVCC checkpoint snapshot does not follow the published materialization generation.");
+            }
+            var materializedAt = snapshot.MaterializationGeneration;
             var lwm = ComputeReaderLowWaterMarkLocked();
+            var oldestBaseGeneration = ComputeReaderBaseGenerationLowWaterMarkLocked();
 
             foreach (var (rowId, chain) in _rows.ToArray())
             {
                 foreach (var version in chain)
                 {
-                    if (VersionIsCommittedThrough(version, snapshot.DurableTimestamp))
+                    if (version.MaterializedAt == 0
+                        && VersionIsCommittedThrough(version, snapshot.DurableTimestamp))
+                    {
                         version.MaterializedAt = materializedAt;
+                    }
                 }
 
                 chain.RemoveAll(version =>
-                    CanCollectMaterializedVersion(version, lwm, materializedAt));
+                    CanCollectMaterializedVersion(
+                        version,
+                        lwm,
+                        oldestBaseGeneration,
+                        materializedAt));
 
                 if (chain.Count == 0)
                     RemoveRowLocked(rowId);
             }
 
+            _checkpointGeneration = materializedAt;
             PruneFinalizedTransactionsLocked(lwm);
         }
     }
@@ -1615,6 +1654,25 @@ internal sealed class MvStore
         }
 
         return false;
+    }
+
+    private void EnsureSchemaOwnerIsOnlyTransactionLocked(
+        MvccTxId owner,
+        bool busyOnConflict)
+    {
+        foreach (var candidate in _transactions.Values)
+        {
+            if (candidate.Id == owner
+                || candidate.State is not (MvccTransactionState.Active or MvccTransactionState.Preparing))
+            {
+                continue;
+            }
+
+            if (busyOnConflict)
+                throw new EmbeddedBusyException();
+            throw new InvalidOperationException(
+                "A peer MVCC transaction was admitted while a schema generation was publishing.");
+        }
     }
 
     private bool HasCheckpointBlockingTransactionLocked(MvccTxId? permittedTransaction)
@@ -1670,6 +1728,21 @@ internal sealed class MvStore
             lowest = lowest is null
                 ? active.BeginTimestamp
                 : Math.Min(lowest.Value, active.BeginTimestamp);
+        }
+
+        return lowest ?? ulong.MaxValue;
+    }
+
+    private ulong ComputeReaderBaseGenerationLowWaterMarkLocked()
+    {
+        ulong? lowest = null;
+        foreach (var active in _transactions.Values)
+        {
+            if (active.State is not (MvccTransactionState.Active or MvccTransactionState.Preparing))
+                continue;
+            lowest = lowest is null
+                ? active.BeginCheckpointGeneration
+                : Math.Min(lowest.Value, active.BeginCheckpointGeneration);
         }
 
         return lowest ?? ulong.MaxValue;
@@ -1774,6 +1847,7 @@ internal sealed class MvStore
     private static bool CanCollectMaterializedVersion(
         MvccRowVersion version,
         ulong readerLowWaterMark,
+        ulong readerBaseGenerationLowWaterMark,
         ulong materializedAt)
     {
         if (version.MaterializedAt == 0 || version.MaterializedAt > materializedAt)
@@ -1784,7 +1858,9 @@ internal sealed class MvStore
         if (version.End is { IsTimestamp: true, Value: var endTs })
             return endTs <= readerLowWaterMark;
 
-        return version.End is null && beginTs < readerLowWaterMark;
+        return version.End is null
+            && beginTs < readerLowWaterMark
+            && version.MaterializedAt <= readerBaseGenerationLowWaterMark;
     }
 
     private void ClearMaterializedStateLocked()

--- a/src/Ahtola.Core/Mvcc/MvStore.cs
+++ b/src/Ahtola.Core/Mvcc/MvStore.cs
@@ -714,9 +714,18 @@ internal sealed class MvStore
             if (_schemaChangeTransaction is { } owner && owner != id.Value)
                 throw new EmbeddedBusyException();
             WaitWhileLocked(
-                () => _activeClassicWriters != 0 || _snapshotBeginsInProgress != 0,
+                () => _activeClassicWriters != 0
+                    || _snapshotBeginsInProgress != 0
+                    || _checkpointInProgress,
                 timeout);
 
+            if (tx.BeginCommitGeneration != _commitGeneration
+                || _checkpointInProgress
+                || _schemaChangeTransaction is { } currentOwner
+                    && currentOwner != id.Value)
+            {
+                throw new EmbeddedBusyException();
+            }
             EnsureSchemaOwnerIsOnlyTransactionLocked(id, busyOnConflict: true);
 
             if (_schemaGeneration == ulong.MaxValue)

--- a/src/Ahtola.Core/Mvcc/MvccCheckpoint.cs
+++ b/src/Ahtola.Core/Mvcc/MvccCheckpoint.cs
@@ -9,15 +9,14 @@ internal enum MvccCheckpointPhase : byte
 {
     Prepare = 0,
     AcquireLock = 1,
-    BuildSnapshot = 2,
-    MaterializeRows = 3,
-    CommitPager = 4,
-    BackfillMainStore = 5,
-    SyncMainStore = 6,
-    RetireLogicalLog = 7,
-    ResetWal = 8,
-    GarbageCollect = 9,
-    Complete = 10,
+    Collect = 2,
+    Materialize = 3,
+    PersistPageWal = 4,
+    Backfill = 5,
+    RetireLogicalLog = 6,
+    ResetWal = 7,
+    GarbageCollect = 8,
+    Complete = 9,
 }
 
 /// <summary>Outcome of a managed MVCC checkpoint attempt.</summary>
@@ -26,6 +25,15 @@ internal readonly record struct MvccCheckpointResult(
     long LogFramesBefore,
     long CheckpointedFrames,
     MvccCheckpointPhase CompletedThrough);
+
+/// <summary>
+/// Stable committed input collected while the checkpoint admission lease is held.
+/// The timestamp is an inclusive logical-log retirement boundary.
+/// </summary>
+internal sealed record MvccCheckpointSnapshot(
+    IReadOnlyList<(MvccRowId RowId, SqlValue[] Cells)> LiveRows,
+    IReadOnlyCollection<MvccRowId> DeletedRows,
+    ulong DurableTimestamp);
 
 /// <summary>
 /// Synchronous managed port of Turso's checkpoint durability sequence:
@@ -46,6 +54,16 @@ internal static class MvccCheckpoint
     internal static bool IsPassive(string? mode)
         => mode is null
             || mode.Equals("PASSIVE", StringComparison.OrdinalIgnoreCase);
+}
+
+/// <summary>Deterministic phase boundary hook used by crash/reopen tests.</summary>
+internal static class MvccCheckpointFaultInjection
+{
+    [field: ThreadStatic]
+    internal static Action<MvccCheckpointPhase>? AfterPhaseForTesting { get; set; }
+
+    internal static void Hit(MvccCheckpointPhase phase)
+        => AfterPhaseForTesting?.Invoke(phase);
 }
 
 /// <summary>

--- a/src/Ahtola.Core/Mvcc/MvccCheckpoint.cs
+++ b/src/Ahtola.Core/Mvcc/MvccCheckpoint.cs
@@ -13,10 +13,11 @@ internal enum MvccCheckpointPhase : byte
     Materialize = 3,
     PersistPageWal = 4,
     Backfill = 5,
-    RetireLogicalLog = 6,
-    ResetWal = 7,
-    GarbageCollect = 8,
-    Complete = 9,
+    PublishRecoveryWatermark = 6,
+    RetireLogicalLog = 7,
+    ResetWal = 8,
+    GarbageCollect = 9,
+    Complete = 10,
 }
 
 /// <summary>Outcome of a managed MVCC checkpoint attempt.</summary>
@@ -33,7 +34,8 @@ internal readonly record struct MvccCheckpointResult(
 internal sealed record MvccCheckpointSnapshot(
     IReadOnlyList<(MvccRowId RowId, SqlValue[] Cells)> LiveRows,
     IReadOnlyCollection<MvccRowId> DeletedRows,
-    ulong DurableTimestamp);
+    ulong DurableTimestamp,
+    ulong MaterializationGeneration);
 
 /// <summary>
 /// Synchronous managed port of Turso's checkpoint durability sequence:

--- a/src/Ahtola.Core/Mvcc/MvccDualCursor.cs
+++ b/src/Ahtola.Core/Mvcc/MvccDualCursor.cs
@@ -2,13 +2,18 @@ namespace Ahtola.Core.Mvcc;
 
 /// <summary>
 /// Merges a classic base-table snapshot with MVCC version-store overlays for one
-/// transaction (Turso dual-cursor isolation spirit). Base rows that the store
-/// has invalidated (deleted/updated for this reader) are suppressed; store-only
-/// inserts appear as additional rows.
+/// transaction (Turso <c>core/mvcc/cursor.rs::MvccLazyCursor</c>). Base rows
+/// invalidated for this reader are suppressed; store-only inserts appear as
+/// additional rows.
 /// </summary>
 internal static class MvccDualCursor
 {
     internal readonly record struct Row(MvccKey Key, SqlValue[] Cells);
+
+    internal readonly record struct IndexRow(
+        MvccKey TableKey,
+        SqlValue[] IndexKey,
+        SqlValue[] Cells);
 
     /// <summary>
     /// Lazily overlays an ordered base image with the ordered MVCC range. This
@@ -115,5 +120,130 @@ internal static class MvccDualCursor
                 MvccKeyComparer.Integer)
             .Select(static row => (row.Key.Integer, row.Cells))
             .ToArray();
+    }
+
+    /// <summary>
+    /// Lazily merges a base index cursor with visible version-chain entries. Base
+    /// entries shadowed by a visible table-key effect are skipped before index-key
+    /// comparison, so updates that move between index keys are emitted only at
+    /// their new position.
+    /// </summary>
+    internal static IEnumerable<IndexRow> EnumerateVisibleIndexRows(
+        MvStore store,
+        MvccTxId txId,
+        long tableId,
+        IEnumerable<IndexRow> baseRows,
+        Func<MvccVisibleRow, IndexRow?> projectOverlay,
+        IComparer<IndexRow> indexComparer,
+        IComparer<MvccKey> tableKeyComparer)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(baseRows);
+        ArgumentNullException.ThrowIfNull(projectOverlay);
+        ArgumentNullException.ThrowIfNull(indexComparer);
+        ArgumentNullException.ThrowIfNull(tableKeyComparer);
+
+        using var baseCursor = EnumerateUnshadowedBaseIndexRows(
+            store,
+            txId,
+            tableId,
+            baseRows).GetEnumerator();
+        using var overlayCursor = EnumerateOverlayIndexRows(
+            store,
+            txId,
+            tableId,
+            projectOverlay,
+            indexComparer,
+            tableKeyComparer).GetEnumerator();
+        var hasBase = baseCursor.MoveNext();
+        var hasOverlay = overlayCursor.MoveNext();
+        while (hasBase || hasOverlay)
+        {
+            if (!hasOverlay)
+            {
+                yield return baseCursor.Current;
+                hasBase = baseCursor.MoveNext();
+                continue;
+            }
+
+            if (!hasBase)
+            {
+                yield return overlayCursor.Current;
+                hasOverlay = overlayCursor.MoveNext();
+                continue;
+            }
+
+            var comparison = indexComparer.Compare(baseCursor.Current, overlayCursor.Current);
+            if (comparison < 0)
+            {
+                yield return baseCursor.Current;
+                hasBase = baseCursor.MoveNext();
+                continue;
+            }
+
+            yield return overlayCursor.Current;
+            hasOverlay = overlayCursor.MoveNext();
+            if (comparison == 0)
+                hasBase = baseCursor.MoveNext();
+        }
+    }
+
+    private static IEnumerable<IndexRow> EnumerateUnshadowedBaseIndexRows(
+        MvStore store,
+        MvccTxId txId,
+        long tableId,
+        IEnumerable<IndexRow> baseRows)
+    {
+        foreach (var row in baseRows)
+        {
+            if (store.TryReadVisibleEffect(
+                    txId,
+                    new MvccRowId(tableId, row.TableKey),
+                    out _,
+                    out _))
+            {
+                continue;
+            }
+
+            yield return new IndexRow(
+                row.TableKey,
+                (SqlValue[])row.IndexKey.Clone(),
+                (SqlValue[])row.Cells.Clone());
+        }
+    }
+
+    private static IEnumerable<IndexRow> EnumerateOverlayIndexRows(
+        MvStore store,
+        MvccTxId txId,
+        long tableId,
+        Func<MvccVisibleRow, IndexRow?> projectOverlay,
+        IComparer<IndexRow> indexComparer,
+        IComparer<MvccKey> tableKeyComparer)
+    {
+        IndexRow? previous = null;
+        while (true)
+        {
+            IndexRow? next = null;
+            foreach (var visible in store.EnumerateVisible(
+                         txId,
+                         tableId,
+                         tableKeyComparer))
+            {
+                if (visible.IsDelete || projectOverlay(visible) is not { } candidate)
+                    continue;
+                if (previous is { } prior
+                    && indexComparer.Compare(candidate, prior) <= 0)
+                {
+                    continue;
+                }
+                if (next is null || indexComparer.Compare(candidate, next.Value) < 0)
+                    next = candidate;
+            }
+
+            if (next is not { } selected)
+                yield break;
+            yield return selected;
+            previous = selected;
+        }
     }
 }

--- a/src/Ahtola.Core/Mvcc/MvccDualCursor.cs
+++ b/src/Ahtola.Core/Mvcc/MvccDualCursor.cs
@@ -220,30 +220,18 @@ internal static class MvccDualCursor
         IComparer<IndexRow> indexComparer,
         IComparer<MvccKey> tableKeyComparer)
     {
-        IndexRow? previous = null;
-        while (true)
+        var projected = new List<IndexRow>();
+        foreach (var visible in store.EnumerateVisible(
+                     txId,
+                     tableId,
+                     tableKeyComparer))
         {
-            IndexRow? next = null;
-            foreach (var visible in store.EnumerateVisible(
-                         txId,
-                         tableId,
-                         tableKeyComparer))
-            {
-                if (visible.IsDelete || projectOverlay(visible) is not { } candidate)
-                    continue;
-                if (previous is { } prior
-                    && indexComparer.Compare(candidate, prior) <= 0)
-                {
-                    continue;
-                }
-                if (next is null || indexComparer.Compare(candidate, next.Value) < 0)
-                    next = candidate;
-            }
-
-            if (next is not { } selected)
-                yield break;
-            yield return selected;
-            previous = selected;
+            if (!visible.IsDelete && projectOverlay(visible) is { } candidate)
+                projected.Add(candidate);
         }
+
+        projected.Sort(indexComparer);
+        foreach (var row in projected)
+            yield return row;
     }
 }

--- a/src/Ahtola.Core/Mvcc/MvccLogicalLog.cs
+++ b/src/Ahtola.Core/Mvcc/MvccLogicalLog.cs
@@ -237,6 +237,17 @@ internal sealed class MvccLogicalLog : IDisposable
         }
     }
 
+    /// <summary>
+    /// Appends a durable inclusive checkpoint watermark. A zero-operation frame
+    /// is reserved for this purpose; recovery skips transaction frames at or
+    /// below the greatest validated watermark, mirroring Turso's
+    /// <c>persistent_tx_ts_max</c> replay floor.
+    /// </summary>
+    internal void AppendCheckpointWatermark(
+        ulong durableTimestamp,
+        SqliteSynchronousMode synchronousMode = SqliteSynchronousMode.Full)
+        => AppendCommit(durableTimestamp, [], synchronousMode);
+
     /// <summary>Replay all frames into <paramref name="store"/> (fresh store expected).</summary>
     internal void ReplayInto(MvStore store)
     {
@@ -248,75 +259,18 @@ internal sealed class MvccLogicalLog : IDisposable
             if (file.Length <= LogHeaderSize)
                 return;
 
+            // First validate the complete prefix and discover the greatest
+            // checkpoint watermark. Applying during this pass would replay
+            // already-materialized frames before a later marker is encountered.
             long position = LogHeaderSize;
-            Span<byte> header = stackalloc byte[TxHeaderSize];
+            ulong durableTimestamp = 0;
             while (position + TxHeaderSize + TxTrailerSize <= file.Length)
             {
-                ReadExact(file, position, header);
-                int payloadSize;
-                uint opCount;
-                ulong commitTs;
-                try
-                {
-                    (payloadSize, opCount, commitTs) = MvccLogicalLogFormat.ReadFrameHeader(header);
-                }
-                catch (InvalidDataException exception)
-                {
-                    throw new InvalidDataException(
-                        $"Invalid MVCC log frame at offset {position}: {exception.Message}",
-                        exception);
-                }
-
-                var storedPayloadSize = _encryption is null
-                    ? payloadSize
-                    : MvccLogicalLogFormat.GetEncryptedPayloadSize(payloadSize);
-                var frameLen = checked(TxHeaderSize + storedPayloadSize + TxTrailerSize);
-                if (position + frameLen > file.Length)
-                {
-                    if (_encryption is not null
-                        && IsCompletePlaintextFrame(file, position, payloadSize))
-                    {
-                        throw new InvalidDataException(
-                            "Encrypted MVCC storage contains a plaintext logical-log frame. "
-                            + "Automatic migration is not safe; checkpoint the log without encryption first.");
-                    }
-                    if (ContainsCompleteStoredFrame(file, position))
-                    {
-                        throw new InvalidDataException(
-                            "MVCC logical-log payload length does not match its complete frame boundary. "
-                            + "The authenticated frame metadata was tampered with.");
-                    }
-                    break; // torn tail — stop (fail-closed leave partial unrecovered)
-                }
-
-                var frame = new byte[frameLen];
-                ReadExact(file, position, frame);
-                var expectedCrc = BinaryPrimitives.ReadUInt32LittleEndian(
-                    frame.AsSpan(TxHeaderSize + storedPayloadSize, 4));
-                var end = BinaryPrimitives.ReadUInt32LittleEndian(
-                    frame.AsSpan(TxHeaderSize + storedPayloadSize + 4, 4));
-                if (end != MvccLogicalLogFormat.EndMagic)
-                    throw new InvalidDataException("MVCC log frame end magic mismatch.");
-                var actualCrc = Crc32C.Compute(frame.AsSpan(0, TxHeaderSize + storedPayloadSize));
-                if (actualCrc != expectedCrc)
-                    throw new InvalidDataException("MVCC log frame CRC mismatch.");
-
-                var payload = frame.AsSpan(TxHeaderSize, storedPayloadSize);
-                var plaintext = _encryption is null
-                    ? payload.ToArray()
-                    : _encryption.DecryptPayload(
-                        payload,
-                        payloadSize,
-                        _salt,
-                        opCount,
-                        commitTs,
-                        _version);
-                var ops = DecodeOps(
-                    plaintext,
-                    (int)opCount,
-                    _version);
-                store.ApplyRecoveredCommit(commitTs, ops);
-                position += frameLen;
+                if (!TryReadValidatedFrame(file, position, out var validated))
+                    break;
+                if (validated.OpCount == 0)
+                    durableTimestamp = Math.Max(durableTimestamp, validated.CommitTimestamp);
+                position += validated.Length;
             }
 
             // A short final frame is a torn append, not a valid durability
@@ -329,7 +283,24 @@ internal sealed class MvccLogicalLog : IDisposable
                 file.FlushToDisk();
             }
 
-            _offset = position;
+            var validatedEnd = position;
+            position = LogHeaderSize;
+            while (position < validatedEnd)
+            {
+                if (!TryReadValidatedFrame(file, position, out var validated))
+                {
+                    throw new InvalidDataException(
+                        "MVCC logical-log validated prefix changed during recovery.");
+                }
+                if (validated.OpCount != 0
+                    && validated.CommitTimestamp > durableTimestamp)
+                {
+                    store.ApplyRecoveredCommit(validated.CommitTimestamp, validated.Operations);
+                }
+                position += validated.Length;
+            }
+
+            _offset = validatedEnd;
         }
     }
 
@@ -542,6 +513,82 @@ internal sealed class MvccLogicalLog : IDisposable
         return BinaryPrimitives.ReadUInt64LittleEndian(bytes);
     }
 
+    private bool TryReadValidatedFrame(
+        IFile file,
+        long position,
+        out ValidatedLogicalFrame validated)
+    {
+        Span<byte> header = stackalloc byte[TxHeaderSize];
+        ReadExact(file, position, header);
+        int payloadSize;
+        uint opCount;
+        ulong commitTs;
+        try
+        {
+            (payloadSize, opCount, commitTs) = MvccLogicalLogFormat.ReadFrameHeader(header);
+        }
+        catch (InvalidDataException exception)
+        {
+            throw new InvalidDataException(
+                $"Invalid MVCC log frame at offset {position}: {exception.Message}",
+                exception);
+        }
+
+        var storedPayloadSize = _encryption is null
+            ? payloadSize
+            : MvccLogicalLogFormat.GetEncryptedPayloadSize(payloadSize);
+        var frameLength = checked(TxHeaderSize + storedPayloadSize + TxTrailerSize);
+        if (position + frameLength > file.Length)
+        {
+            if (_encryption is not null
+                && IsCompletePlaintextFrame(file, position, payloadSize))
+            {
+                throw new InvalidDataException(
+                    "Encrypted MVCC storage contains a plaintext logical-log frame. "
+                    + "Automatic migration is not safe; checkpoint the log without encryption first.");
+            }
+            if (ContainsCompleteStoredFrame(file, position))
+            {
+                throw new InvalidDataException(
+                    "MVCC logical-log payload length does not match its complete frame boundary. "
+                    + "The authenticated frame metadata was tampered with.");
+            }
+
+            validated = default;
+            return false;
+        }
+
+        var frame = new byte[frameLength];
+        ReadExact(file, position, frame);
+        var expectedCrc = BinaryPrimitives.ReadUInt32LittleEndian(
+            frame.AsSpan(TxHeaderSize + storedPayloadSize, 4));
+        var end = BinaryPrimitives.ReadUInt32LittleEndian(
+            frame.AsSpan(TxHeaderSize + storedPayloadSize + 4, 4));
+        if (end != MvccLogicalLogFormat.EndMagic)
+            throw new InvalidDataException("MVCC log frame end magic mismatch.");
+        var actualCrc = Crc32C.Compute(frame.AsSpan(0, TxHeaderSize + storedPayloadSize));
+        if (actualCrc != expectedCrc)
+            throw new InvalidDataException("MVCC log frame CRC mismatch.");
+
+        var payload = frame.AsSpan(TxHeaderSize, storedPayloadSize);
+        var plaintext = _encryption is null
+            ? payload.ToArray()
+            : _encryption.DecryptPayload(
+                payload,
+                payloadSize,
+                _salt,
+                opCount,
+                commitTs,
+                _version);
+        var operations = DecodeOps(plaintext, checked((int)opCount), _version);
+        validated = new ValidatedLogicalFrame(
+            frameLength,
+            opCount,
+            commitTs,
+            operations);
+        return true;
+    }
+
     private static bool IsCompletePlaintextFrame(IFile file, long position, int payloadSize)
     {
         var frameLength = checked(TxHeaderSize + payloadSize + TxTrailerSize);
@@ -575,6 +622,12 @@ internal sealed class MvccLogicalLog : IDisposable
 
     private static bool RequiresVersion4(IReadOnlyList<MvccLogOp> ops)
         => ops.Any(static op => !op.RowId.Key.IsInteger);
+
+    private readonly record struct ValidatedLogicalFrame(
+        int Length,
+        uint OpCount,
+        ulong CommitTimestamp,
+        IReadOnlyList<MvccLogOp> Operations);
 
     private static byte[] EncodeOps(IReadOnlyList<MvccLogOp> ops, byte version)
     {

--- a/src/Ahtola.Core/Mvcc/MvccLogicalLog.cs
+++ b/src/Ahtola.Core/Mvcc/MvccLogicalLog.cs
@@ -284,6 +284,8 @@ internal sealed class MvccLogicalLog : IDisposable
             }
 
             var validatedEnd = position;
+            if (durableTimestamp != 0)
+                store.ApplyRecoveredWatermark(durableTimestamp);
             position = LogHeaderSize;
             while (position < validatedEnd)
             {

--- a/src/Ahtola.Core/Mvcc/MvccRowVersion.cs
+++ b/src/Ahtola.Core/Mvcc/MvccRowVersion.cs
@@ -47,6 +47,15 @@ internal sealed class MvccRowVersion
     /// <summary>True when this version only marks a base-row delete (no payload).</summary>
     internal bool IsTombstone { get; }
 
+    /// <summary>
+    /// Managed checkpoint generation whose durable base image contains this
+    /// version's effect. Zero means the version is still logical-log-only.
+    /// </summary>
+    internal ulong MaterializedAt { get; set; }
+
     internal MvccRowVersion Clone()
-        => new(VersionId, Begin, End, (SqlValue[])Cells.Clone(), IsTombstone);
+        => new(VersionId, Begin, End, (SqlValue[])Cells.Clone(), IsTombstone)
+        {
+            MaterializedAt = MaterializedAt,
+        };
 }

--- a/src/Ahtola.Core/Storage/SqliteIndexBtreeCursor.cs
+++ b/src/Ahtola.Core/Storage/SqliteIndexBtreeCursor.cs
@@ -1,0 +1,168 @@
+namespace Ahtola.Core.Storage;
+
+/// <summary>
+/// A read cursor over a SQLite index b-tree that yields one contiguous equality prefix.
+/// </summary>
+/// <remarks>
+/// Index interior separator cells are real index entries. The cursor therefore walks the
+/// lower-bound child, emits matching separators, and continues through adjacent children
+/// only while their separator prefixes can still equal the requested key.
+/// </remarks>
+public sealed class SqliteIndexBtreeCursor
+{
+    private const int MaximumDepth = 64;
+
+    private readonly ISqliteBtreePageIo _io;
+    private readonly SqliteIndexRecordComparer _comparer;
+    private readonly SqliteOverflowChainReader _overflowReader;
+    private readonly SqliteTextEncoding _textEncoding;
+
+    /// <summary>Creates a cursor over one index's page and comparison semantics.</summary>
+    public SqliteIndexBtreeCursor(
+        ISqliteBtreePageIo pageIo,
+        SqliteIndexRecordComparer comparer,
+        SqliteTextEncoding textEncoding)
+    {
+        ArgumentNullException.ThrowIfNull(pageIo);
+        ArgumentNullException.ThrowIfNull(comparer);
+        _io = pageIo;
+        _comparer = comparer;
+        _textEncoding = textEncoding is SqliteTextEncoding.Unset
+            ? SqliteTextEncoding.Utf8
+            : textEncoding;
+        _overflowReader = new SqliteOverflowChainReader(pageIo);
+    }
+
+    /// <summary>
+    /// Enumerates complete index records whose first fields equal <paramref name="prefix"/>.
+    /// </summary>
+    public IEnumerable<byte[]> SeekPrefix(
+        uint rootPage,
+        IReadOnlyList<SqlValue> prefix,
+        Action? pageRead = null,
+        Action? keyCompared = null)
+    {
+        ArgumentNullException.ThrowIfNull(prefix);
+        if (prefix.Count == 0)
+            throw new ArgumentException("An index seek prefix must contain at least one field.", nameof(prefix));
+        if (rootPage == 0 || rootPage > _io.PageCount)
+            throw new ArgumentOutOfRangeException(nameof(rootPage));
+
+        var seek = prefix as SqlValue[] ?? prefix.ToArray();
+        return EnumerateNode(rootPage, seek, depth: 0, pageRead, keyCompared);
+    }
+
+    private IEnumerable<byte[]> EnumerateNode(
+        uint pageNumber,
+        SqlValue[] prefix,
+        int depth,
+        Action? pageRead,
+        Action? keyCompared)
+    {
+        if (depth >= MaximumDepth)
+        {
+            throw new InvalidDataException(
+                $"SQLite index b-tree rooted above page {pageNumber} is deeper than {MaximumDepth} levels.");
+        }
+
+        var image = _io.ReadPage(pageNumber);
+        pageRead?.Invoke();
+        switch (SqliteBtreePageHeader.Parse(image).PageType)
+        {
+            case SqliteBtreePageType.IndexLeaf:
+                {
+                    var leaf = SqliteIndexLeafPageView.Parse(
+                        image,
+                        _io.UsableSpace,
+                        _textEncoding,
+                        overflowReader: _overflowReader,
+                        recordComparer: _comparer);
+                    var low = 0;
+                    var high = leaf.Cells.Count;
+                    while (low < high)
+                    {
+                        var middle = low + ((high - low) / 2);
+                        if (ComparePrefix(leaf.GetRecord(middle), prefix, keyCompared) < 0)
+                            low = middle + 1;
+                        else
+                            high = middle;
+                    }
+
+                    for (var index = low; index < leaf.Cells.Count; index++)
+                    {
+                        var record = leaf.GetRecord(index);
+                        var comparison = ComparePrefix(record, prefix, keyCompared);
+                        if (comparison != 0)
+                            yield break;
+                        yield return record;
+                    }
+
+                    yield break;
+                }
+
+            case SqliteBtreePageType.IndexInterior:
+                {
+                    var interior = SqliteIndexInteriorPageView.Parse(
+                        image,
+                        _io.UsableSpace,
+                        _textEncoding,
+                        overflowReader: _overflowReader,
+                        recordComparer: _comparer);
+                    var low = 0;
+                    var high = interior.Cells.Count;
+                    while (low < high)
+                    {
+                        var middle = low + ((high - low) / 2);
+                        if (ComparePrefix(interior.GetRecord(middle), prefix, keyCompared) < 0)
+                            low = middle + 1;
+                        else
+                            high = middle;
+                    }
+
+                    for (var childIndex = low; childIndex <= interior.Cells.Count; childIndex++)
+                    {
+                        var childPage = childIndex == interior.Cells.Count
+                            ? interior.Header.RightMostChildPage
+                            : interior.Cells[childIndex].Cell.LeftChildPage;
+                        foreach (var record in EnumerateNode(
+                                     childPage,
+                                     prefix,
+                                     depth + 1,
+                                     pageRead,
+                                     keyCompared))
+                        {
+                            yield return record;
+                        }
+
+                        if (childIndex == interior.Cells.Count)
+                            yield break;
+
+                        var separator = interior.GetRecord(childIndex);
+                        var comparison = ComparePrefix(separator, prefix, keyCompared);
+                        if (comparison > 0)
+                            yield break;
+                        if (comparison == 0)
+                            yield return separator;
+                    }
+
+                    yield break;
+                }
+
+            default:
+                throw new InvalidDataException(
+                    $"SQLite page {pageNumber} is not part of an index b-tree.");
+        }
+    }
+
+    private int ComparePrefix(byte[] record, SqlValue[] prefix, Action? keyCompared)
+    {
+        keyCompared?.Invoke();
+        var values = SqliteRecordCodec.Decode(record, _textEncoding);
+        if (values.Length < prefix.Length)
+            throw new InvalidDataException("SQLite index record is shorter than the requested seek prefix.");
+
+        if (values.Length != prefix.Length)
+            Array.Resize(ref values, prefix.Length);
+        return _comparer.Compare(values, prefix);
+    }
+}

--- a/src/Ahtola.Core/Storage/SqliteWalWriterCheckpointCoordinator.cs
+++ b/src/Ahtola.Core/Storage/SqliteWalWriterCheckpointCoordinator.cs
@@ -27,7 +27,34 @@ public sealed record SqliteWalCheckpointResult(
     uint BackfilledFrameCount,
     uint BackfillAttemptedFrameCount,
     bool IsBusy,
-    bool ResetWal);
+    bool ResetWal)
+{
+    /// <summary>Validated WAL-index change counter for this result.</summary>
+    public uint WalIndexChangeCounter { get; init; }
+
+    /// <summary>First salt of the validated WAL incarnation.</summary>
+    public uint WalSalt1 { get; init; }
+
+    /// <summary>Second salt of the validated WAL incarnation.</summary>
+    public uint WalSalt2 { get; init; }
+
+    /// <summary>Whether the incarnation fields were captured under the checkpoint lock.</summary>
+    public bool HasValidatedWalIncarnation { get; init; }
+}
+
+/// <summary>
+/// Core-only passive checkpoint evidence for replication/sync callers. The
+/// synced frame is inclusive and meaningful only for the returned validated
+/// WAL salt/change-counter incarnation.
+/// </summary>
+public sealed record SqliteWalPassiveCheckpointResult(
+    uint MaximumFrame,
+    uint SyncedFrameInclusive,
+    uint WalIndexChangeCounter,
+    uint WalSalt1,
+    uint WalSalt2,
+    bool IsBusy,
+    bool HasValidatedWalIncarnation);
 
 /// <summary>
 /// Coordinates detached writer, recovery, and checkpoint operations over existing
@@ -342,6 +369,28 @@ public sealed class SqliteWalWriterCheckpointCoordinator : IDisposable
         }
     }
 
+    /// <summary>
+    /// Runs a passive checkpoint and returns an inclusive durable WAL watermark
+    /// bound to the validated WAL-index salt/change-counter incarnation.
+    /// </summary>
+    public SqliteWalPassiveCheckpointResult CheckpointPassiveValidated(
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+    {
+        var result = Checkpoint(
+            SqliteWalCheckpointMode.Passive,
+            timeout,
+            cancellationToken);
+        return new SqliteWalPassiveCheckpointResult(
+            result.MaximumFrame,
+            result.BackfilledFrameCount,
+            result.WalIndexChangeCounter,
+            result.WalSalt1,
+            result.WalSalt2,
+            result.IsBusy,
+            result.HasValidatedWalIncarnation);
+    }
+
     /// <inheritdoc />
     public void Dispose()
     {
@@ -526,45 +575,62 @@ public sealed class SqliteWalWriterCheckpointCoordinator : IDisposable
                 }
 
                 _wal.ResetAfterDurableCheckpoint(publishCheckpointedRecoveryMarker: true);
-                _index.ResetAfterDurableRestart(
-                    confirmation.Header.WithRestartedWal(
-                        _mainStore.PageCount,
-                        _wal.Header.Salt1,
-                        _wal.Header.Salt2));
+                var restartedHeader = confirmation.Header.WithRestartedWal(
+                    _mainStore.PageCount,
+                    _wal.Header.Salt1,
+                    _wal.Header.Salt2);
+                _index.ResetAfterDurableRestart(restartedHeader);
                 if (mode == SqliteWalCheckpointMode.Truncate)
                     _wal.TruncateAfterDurableCheckpoint();
-                return new SqliteWalCheckpointResult(
+                return WithValidatedWalIncarnation(
+                    new SqliteWalCheckpointResult(
+                        mode,
+                        maximumFrame,
+                        safeFrame,
+                        BackfilledFrameCount: 0,
+                        BackfillAttemptedFrameCount: 0,
+                        IsBusy: false,
+                        ResetWal: true),
+                    restartedHeader);
+            }
+
+            return WithValidatedWalIncarnation(
+                new SqliteWalCheckpointResult(
                     mode,
                     maximumFrame,
                     safeFrame,
-                    BackfilledFrameCount: 0,
-                    BackfillAttemptedFrameCount: 0,
-                    IsBusy: false,
-                    ResetWal: true);
-            }
-
-            return new SqliteWalCheckpointResult(
-                mode,
-                maximumFrame,
-                safeFrame,
-                backfilledFrameCount,
-                attemptedFrameCount,
-                IsBusy: !allReadMarksExclusive && safeFrame < maximumFrame,
-                ResetWal: false);
+                    backfilledFrameCount,
+                    attemptedFrameCount,
+                    IsBusy: !allReadMarksExclusive && safeFrame < maximumFrame,
+                    ResetWal: false),
+                region.Header);
         }
     }
 
     private static SqliteWalCheckpointResult SoftSkipCheckpoint(
         SqliteWalCheckpointMode mode,
         SqliteWalIndexHeaderRegion liveRegion)
-        => new(
-            mode,
-            liveRegion.Header.MaximumFrame,
-            SafeFrame: liveRegion.CheckpointInfo.BackfilledFrameCount,
-            liveRegion.CheckpointInfo.BackfilledFrameCount,
-            liveRegion.CheckpointInfo.BackfillAttemptedFrameCount,
-            IsBusy: false,
-            ResetWal: false);
+        => WithValidatedWalIncarnation(
+            new SqliteWalCheckpointResult(
+                mode,
+                liveRegion.Header.MaximumFrame,
+                SafeFrame: liveRegion.CheckpointInfo.BackfilledFrameCount,
+                liveRegion.CheckpointInfo.BackfilledFrameCount,
+                liveRegion.CheckpointInfo.BackfillAttemptedFrameCount,
+                IsBusy: false,
+                ResetWal: false),
+            liveRegion.Header);
+
+    private static SqliteWalCheckpointResult WithValidatedWalIncarnation(
+        SqliteWalCheckpointResult result,
+        SqliteWalIndexHeader header)
+        => result with
+        {
+            WalIndexChangeCounter = header.ChangeCounter,
+            WalSalt1 = header.Salt1,
+            WalSalt2 = header.Salt2,
+            HasValidatedWalIncarnation = true,
+        };
 
     private void InstallBackfill(uint safeFrame)
     {

--- a/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
+++ b/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
@@ -21,6 +21,31 @@ internal static class ManagedReplicaBootstrapper
     private const int MaxTableMapEntries = 100_000;
     private const int MaxStringBytes = 64 * 1024;
     private const int MaxLogicalBodyLength = 256 * 1024 * 1024;
+
+    /// <summary>
+    /// Maximum number of cheap, local-only re-checks <see cref="RebaseOntoCurrentLocalStateOrThrowAsync"/>
+    /// performs while a staged response's remote-facing identity (revision, database hash,
+    /// revert/push state, journal watermark) stays compatible but the pending/acknowledged local
+    /// change lists keep advancing (an ordinary sibling connection committing writes). Each
+    /// attempt is a handful of local file reads under the already-held apply lease -- no network,
+    /// no host close/reopen -- so this bound exists only to guarantee eventual termination if a
+    /// sibling never stops writing, not because any single attempt is expensive.
+    /// </summary>
+    private const int MaxLocalJournalRebaseAttempts = 20;
+
+    /// <summary>Delay between <see cref="RebaseOntoCurrentLocalStateOrThrowAsync"/> attempts.</summary>
+    private static readonly TimeSpan LocalJournalRebaseDelay = TimeSpan.FromMilliseconds(5);
+
+    /// <summary>
+    /// Maximum number of full network re-fetches <see cref="WaitAndApplyRemoteChangesAsync"/>
+    /// performs when a staged response's remote-facing identity genuinely changed underneath it
+    /// (a competing sync/bootstrap-catch-up won the apply race) rather than merely the local
+    /// journal advancing. Unlike a local rebase attempt, each of these repeats the full
+    /// long-poll network round trip and a publication gate close/reopen, so this bound is much
+    /// smaller and paired with a backoff between attempts.
+    /// </summary>
+    private const int MaxRemoteRefetchRetryAttempts = 8;
+
     private static readonly byte[] SqliteHeader = "SQLite format 3\0"u8.ToArray();
     private static readonly UTF8Encoding StrictUtf8 = new(false, true);
     private static readonly IReadOnlyDictionary<ulong, string> EmptyTableMap = new Dictionary<ulong, string>();
@@ -868,56 +893,82 @@ internal static class ManagedReplicaBootstrapper
     /// </param>
     /// <param name="cancellationToken">Cancels the pull.</param>
     /// <remarks>
-    /// Composed from the same <see cref="WaitForRemoteChangesAsync"/> / <see cref="ApplyRemoteChangesAsync"/>
-    /// primitives a caller that wants the network long-poll to run without holding any in-process
-    /// publication gate uses directly (see <c>ManagedReplicaConnectionHost.RunSyncCycleAsync</c>).
-    /// This fused overload simply loops the two back-to-back -- retrying the whole cycle, in
-    /// place, whenever <see cref="ApplyRemoteChangesAsync"/> reports the staged response is stale
-    /// -- for callers (explicit conflict-rebase, and every existing test) that want one call
-    /// covering both halves. Mirrors Turso's <c>wait_changes_from_remote</c> -&gt;
+    /// Thin wrapper over <see cref="WaitAndApplyRemoteChangesAsync"/>, applying directly (no extra
+    /// gate) for callers (explicit conflict-rebase, and every existing test) that want one call
+    /// covering the whole wait/apply cycle. Mirrors Turso's <c>wait_changes_from_remote</c> -&gt;
     /// <c>apply_changes_from_remote</c> split (turso-src/sync/engine/src/database_sync_engine.rs)
     /// collapsed back into one step.
     /// </remarks>
-    internal static async Task<ManagedReplicaPullOutcome> CheckForUpdatesAsync(
+    internal static Task<ManagedReplicaPullOutcome> CheckForUpdatesAsync(
         AhtolaReplicaOptions options, ManagedReplicaMetadata metadata, AhtolaSyncOptions syncOptions,
         IReadOnlyList<ReplicaLocalChange> pendingLocalChanges,
         IReadOnlyList<ReplicaLocalChange> acknowledgedLocalChanges,
         ManagedReplicaConflictState? expectedConflictState,
         CancellationToken cancellationToken)
+        => WaitAndApplyRemoteChangesAsync(
+            options, metadata, syncOptions, pendingLocalChanges, acknowledgedLocalChanges,
+            (staged, token) => ApplyRemoteChangesAsync(options, staged, syncOptions, expectedConflictState, token),
+            cancellationToken);
+
+    /// <summary>
+    /// Runs the wait/apply cycle to completion: waits for remote changes, then applies the staged
+    /// response via <paramref name="applyStagedChangesAsync"/> (a caller-supplied delegate so a
+    /// caller such as <c>ManagedReplicaConnectionHost</c> can wrap only the apply step in whatever
+    /// publication gate its local concurrency model needs, without gating the network wait too).
+    /// When applying throws <see cref="ManagedReplicaStaleChangesException"/> -- the remote-facing
+    /// identity a staged response depended on genuinely changed underneath it, e.g. a competing
+    /// sync/bootstrap-catch-up won the apply race -- this discards the response and performs a
+    /// full network re-fetch against the fresh snapshot the exception carries, up to
+    /// <see cref="MaxRemoteRefetchRetryAttempts"/> times, with a short backoff between attempts so
+    /// repeated contention does not hammer the remote or thrash host close/reopen cycles. Exceeding
+    /// the bound throws a clear <see cref="AhtolaException"/> rather than retrying forever: unlike
+    /// the cheap, local-only rebase <see cref="ApplyRemoteChangesAsync"/> performs internally for a
+    /// merely-advancing local journal, every attempt here repeats the full long-poll round trip, so
+    /// an unbounded loop here would mean an unbounded number of network requests and publication
+    /// gate acquisitions when a genuinely competing operation keeps winning.
+    /// </summary>
+    internal static async Task<ManagedReplicaPullOutcome> WaitAndApplyRemoteChangesAsync(
+        AhtolaReplicaOptions options,
+        ManagedReplicaMetadata metadata,
+        AhtolaSyncOptions syncOptions,
+        IReadOnlyList<ReplicaLocalChange> pendingLocalChanges,
+        IReadOnlyList<ReplicaLocalChange> acknowledgedLocalChanges,
+        Func<ManagedReplicaStagedChanges, CancellationToken, Task<ManagedReplicaPullOutcome>> applyStagedChangesAsync,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(pendingLocalChanges);
         ArgumentNullException.ThrowIfNull(acknowledgedLocalChanges);
-        // The whole pull-and-apply cycle below is retried, in place, whenever the apply lease
-        // reveals that local state already moved past the snapshot (metadata, pending local
-        // changes) this iteration's request/response were negotiated against -- see
-        // ManagedReplicaStaleChangesException / TryUseCurrentLocalStateAsPullBase. That can only
-        // happen when a concurrent CheckForUpdatesAsync/ApplyRemoteChangesAsync call (another
-        // sync/bootstrap-catch-up racing through the very same per-path apply lease, or -- today,
-        // before the cross-process OS lock lands -- a second process) commits its own apply while
-        // this call was waiting on the network or the lease, both of which are deliberately
-        // outside the lease's scope (see ManagedReplicaApplyLock). Retrying here, before any
-        // apply, means a stale response can never be applied on top of a base it was not actually
-        // built from: doing so could silently regress metadata (rewind Revision) or discard an
-        // intervening local change instead of reconciling it.
-        while (true)
+        ArgumentNullException.ThrowIfNull(applyStagedChangesAsync);
+
+        for (var attempt = 0; ; attempt++)
         {
             using var staged = await WaitForRemoteChangesAsync(
                     options, metadata, syncOptions, pendingLocalChanges, acknowledgedLocalChanges, cancellationToken)
                 .ConfigureAwait(false);
             try
             {
-                return await ApplyRemoteChangesAsync(
-                        options, staged, syncOptions, expectedConflictState, cancellationToken)
-                    .ConfigureAwait(false);
+                return await applyStagedChangesAsync(staged, cancellationToken).ConfigureAwait(false);
             }
             catch (ManagedReplicaStaleChangesException stale)
             {
+                if (attempt >= MaxRemoteRefetchRetryAttempts)
+                {
+                    throw new AhtolaException(
+                        $"Managed embedded replica synchronization could not converge after {attempt + 1} "
+                        + "remote re-fetch attempts; a competing operation keeps applying changes before "
+                        + "this one can. Retry synchronization once the competing activity settles.");
+                }
+
                 metadata = stale.FreshMetadata;
                 pendingLocalChanges = stale.FreshPendingLocalChanges;
                 acknowledgedLocalChanges = stale.FreshAcknowledgedLocalChanges;
+                await Task.Delay(ComputeRemoteRefetchBackoff(attempt), cancellationToken).ConfigureAwait(false);
             }
         }
     }
+
+    private static TimeSpan ComputeRemoteRefetchBackoff(int attempt)
+        => TimeSpan.FromMilliseconds(Math.Min(50 * (attempt + 1), 500));
 
     /// <summary>
     /// Waits for the remote's next pull-updates response and stages it without touching any local
@@ -1106,6 +1157,62 @@ internal static class ManagedReplicaBootstrapper
                 .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Re-validates the local baseline a staged response was negotiated against while the
+    /// exclusive apply lease is held, tolerating a benign, common race: an ordinary sibling
+    /// connection committing a write (via the WAL, not through this lease) while the wait or a
+    /// prior rebase attempt was in flight. When the remote-facing identity the staged response
+    /// actually depends on -- revision, database file hash, revert/push state, and journal
+    /// watermark -- is unchanged but the pending/acknowledged local-change lists differ (grew,
+    /// shrank, or were pruned), this rebases onto the fresh local baseline and re-checks, up to
+    /// <see cref="MaxLocalJournalRebaseAttempts"/> times: each attempt is local file reads only
+    /// (no network, no host close/reopen), so replaying the additional local changes onto the
+    /// response the network already delivered is both cheap and correct (the reconciliation paths
+    /// downstream already replay whatever pending/acknowledged lists they are given). A genuine
+    /// change to the remote-facing identity -- or the local journal never settling within the
+    /// bound -- throws <see cref="ManagedReplicaStaleChangesException"/> exactly as a single-shot
+    /// check would, so the caller discards the staged response and performs a full network
+    /// re-fetch (see <see cref="WaitAndApplyRemoteChangesAsync"/>) against the fresh snapshot.
+    /// </summary>
+    private static async Task<(ManagedReplicaMetadata Metadata, IReadOnlyList<ReplicaLocalChange> PendingLocalChanges, IReadOnlyList<ReplicaLocalChange> AcknowledgedLocalChanges)>
+        RebaseOntoCurrentLocalStateOrThrowAsync(
+            string databasePath,
+            ManagedReplicaMetadata metadata,
+            IReadOnlyList<ReplicaLocalChange> pendingLocalChanges,
+            IReadOnlyList<ReplicaLocalChange> acknowledgedLocalChanges,
+            CancellationToken cancellationToken)
+    {
+        for (var attempt = 0; ; attempt++)
+        {
+            if (TryUseCurrentLocalStateAsPullBase(
+                    databasePath, metadata, pendingLocalChanges, acknowledgedLocalChanges,
+                    out var freshMetadata,
+                    out var freshPendingLocalChanges,
+                    out var freshAcknowledgedLocalChanges))
+            {
+                return (metadata, pendingLocalChanges, acknowledgedLocalChanges);
+            }
+
+            var remoteFacingIdentityUnchanged =
+                string.Equals(freshMetadata.Revision, metadata.Revision, StringComparison.Ordinal)
+                && string.Equals(freshMetadata.DatabaseSha256, metadata.DatabaseSha256, StringComparison.Ordinal)
+                && freshMetadata.RevertState == metadata.RevertState
+                && freshMetadata.PushState == metadata.PushState
+                && freshMetadata.JournalBaseWatermark == metadata.JournalBaseWatermark;
+
+            if (!remoteFacingIdentityUnchanged || attempt >= MaxLocalJournalRebaseAttempts)
+            {
+                throw new ManagedReplicaStaleChangesException(
+                    freshMetadata, freshPendingLocalChanges, freshAcknowledgedLocalChanges);
+            }
+
+            metadata = freshMetadata;
+            pendingLocalChanges = freshPendingLocalChanges;
+            acknowledgedLocalChanges = freshAcknowledgedLocalChanges;
+            await Task.Delay(LocalJournalRebaseDelay, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
     private static async Task<ManagedReplicaPullOutcome> ApplyStagedLogicalChangesAsync(
         AhtolaReplicaOptions options,
         ManagedReplicaStagedChanges staged,
@@ -1137,21 +1244,15 @@ internal static class ManagedReplicaBootstrapper
         // The request that produced this staged response (and the response itself) were
         // negotiated against `metadata` and `pendingLocalChanges` as they stood BEFORE the network
         // round trip and the wait for this lease -- both entirely outside its scope by design.
-        // Re-validate that base is still current now that the lease is actually held: if another
-        // caller already advanced local state in the meantime, this response is stale relative to
-        // it and must never be applied. Unlike the historical fused retry loop, this never retries
-        // the network round trip itself -- it throws so the caller discards the staged response
-        // and waits for remote changes again, instead of silently regressing metadata or
-        // discarding an intervening local change.
-        if (!TryUseCurrentLocalStateAsPullBase(
-                options.Path, metadata, pendingLocalChanges, acknowledgedLocalChanges,
-                out var freshMetadata,
-                out var freshPendingLocalChanges,
-                out var freshAcknowledgedLocalChanges))
-        {
-            throw new ManagedReplicaStaleChangesException(
-                freshMetadata, freshPendingLocalChanges, freshAcknowledgedLocalChanges);
-        }
+        // Re-validate that base is still current now that the lease is actually held: if only the
+        // local journal advanced (an ordinary sibling write), rebase onto it and keep applying
+        // this same response; if the remote-facing identity itself changed, or the journal never
+        // settles, this throws so the caller discards the staged response and waits for remote
+        // changes again, instead of silently regressing metadata or discarding an intervening
+        // local change.
+        (metadata, pendingLocalChanges, acknowledgedLocalChanges) = await RebaseOntoCurrentLocalStateOrThrowAsync(
+                options.Path, metadata, pendingLocalChanges, acknowledgedLocalChanges, cancellationToken)
+            .ConfigureAwait(false);
         ManagedReplicaRevertWal.EnsureSynchronizationReady(options.Path, metadata);
 
         var (outcome, statistics, replayed) = await ApplyLogicalUpdatesAsync(
@@ -1187,15 +1288,9 @@ internal static class ManagedReplicaBootstrapper
         ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.ReplicaApplyLockAcquired);
         cancellationToken.ThrowIfCancellationRequested();
         ManagedReplicaConflictState.ValidatePullPublication(options.Path, expectedConflictState);
-        if (!TryUseCurrentLocalStateAsPullBase(
-                options.Path, metadata, pendingLocalChanges, acknowledgedLocalChanges,
-                out var freshMetadata,
-                out var freshPendingLocalChanges,
-                out var freshAcknowledgedLocalChanges))
-        {
-            throw new ManagedReplicaStaleChangesException(
-                freshMetadata, freshPendingLocalChanges, freshAcknowledgedLocalChanges);
-        }
+        (metadata, pendingLocalChanges, acknowledgedLocalChanges) = await RebaseOntoCurrentLocalStateOrThrowAsync(
+                options.Path, metadata, pendingLocalChanges, acknowledgedLocalChanges, cancellationToken)
+            .ConfigureAwait(false);
         ManagedReplicaRevertWal.EnsureSynchronizationReady(options.Path, metadata);
         syncOptions.Progress?.Report(new AhtolaSyncProgress(AhtolaSyncProgressStage.Completed));
         return new ManagedReplicaPullOutcome(
@@ -1230,15 +1325,9 @@ internal static class ManagedReplicaBootstrapper
         cancellationToken.ThrowIfCancellationRequested();
         ManagedReplicaConflictState.ValidatePullPublication(options.Path, expectedConflictState);
 
-        if (!TryUseCurrentLocalStateAsPullBase(
-                options.Path, metadata, pendingLocalChanges, acknowledgedLocalChanges,
-                out var freshMetadata,
-                out var freshPendingLocalChanges,
-                out var freshAcknowledgedLocalChanges))
-        {
-            throw new ManagedReplicaStaleChangesException(
-                freshMetadata, freshPendingLocalChanges, freshAcknowledgedLocalChanges);
-        }
+        (metadata, pendingLocalChanges, acknowledgedLocalChanges) = await RebaseOntoCurrentLocalStateOrThrowAsync(
+                options.Path, metadata, pendingLocalChanges, acknowledgedLocalChanges, cancellationToken)
+            .ConfigureAwait(false);
         ManagedReplicaRevertWal.EnsureSynchronizationReady(options.Path, metadata);
 
         // The response turned out to be a Pages stream (Incremental or ReplaceBase) even though

--- a/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
+++ b/src/Ahtola.Data/ManagedReplicaBootstrapper.cs
@@ -867,6 +867,17 @@ internal static class ManagedReplicaBootstrapper
     /// state.
     /// </param>
     /// <param name="cancellationToken">Cancels the pull.</param>
+    /// <remarks>
+    /// Composed from the same <see cref="WaitForRemoteChangesAsync"/> / <see cref="ApplyRemoteChangesAsync"/>
+    /// primitives a caller that wants the network long-poll to run without holding any in-process
+    /// publication gate uses directly (see <c>ManagedReplicaConnectionHost.RunSyncCycleAsync</c>).
+    /// This fused overload simply loops the two back-to-back -- retrying the whole cycle, in
+    /// place, whenever <see cref="ApplyRemoteChangesAsync"/> reports the staged response is stale
+    /// -- for callers (explicit conflict-rebase, and every existing test) that want one call
+    /// covering both halves. Mirrors Turso's <c>wait_changes_from_remote</c> -&gt;
+    /// <c>apply_changes_from_remote</c> split (turso-src/sync/engine/src/database_sync_engine.rs)
+    /// collapsed back into one step.
+    /// </remarks>
     internal static async Task<ManagedReplicaPullOutcome> CheckForUpdatesAsync(
         AhtolaReplicaOptions options, ManagedReplicaMetadata metadata, AhtolaSyncOptions syncOptions,
         IReadOnlyList<ReplicaLocalChange> pendingLocalChanges,
@@ -876,273 +887,543 @@ internal static class ManagedReplicaBootstrapper
     {
         ArgumentNullException.ThrowIfNull(pendingLocalChanges);
         ArgumentNullException.ThrowIfNull(acknowledgedLocalChanges);
-        IReadOnlySet<long>? quarantinedSequences = expectedConflictState is { } conflict
-            ? new HashSet<long>(conflict.UnresolvedSequences)
-            : null;
-        ManagedReplicaSupportMatrix.ValidateOptions(options);
-        ManagedReplicaRevertWal.ValidateSynchronizationReady(options.Path, metadata);
         // The whole pull-and-apply cycle below is retried, in place, whenever the apply lease
         // reveals that local state already moved past the snapshot (metadata, pending local
         // changes) this iteration's request/response were negotiated against -- see
-        // TryUseCurrentLocalStateAsPullBase. That can only happen when a concurrent
-        // CheckForUpdatesAsync call (another sync/bootstrap-catch-up racing through the very same
-        // per-path apply lease, or -- today, before the cross-process OS lock lands -- a second
-        // process) commits its own apply while this call was waiting on the network or the lease,
-        // both of which are deliberately outside the lease's scope (see ManagedReplicaApplyLock).
-        // Retrying here, before any apply, means a stale response can never be applied on top of a
-        // base it was not actually built from: doing so could silently regress metadata (rewind
-        // Revision) or discard an intervening local change instead of reconciling it.
+        // ManagedReplicaStaleChangesException / TryUseCurrentLocalStateAsPullBase. That can only
+        // happen when a concurrent CheckForUpdatesAsync/ApplyRemoteChangesAsync call (another
+        // sync/bootstrap-catch-up racing through the very same per-path apply lease, or -- today,
+        // before the cross-process OS lock lands -- a second process) commits its own apply while
+        // this call was waiting on the network or the lease, both of which are deliberately
+        // outside the lease's scope (see ManagedReplicaApplyLock). Retrying here, before any
+        // apply, means a stale response can never be applied on top of a base it was not actually
+        // built from: doing so could silently regress metadata (rewind Revision) or discard an
+        // intervening local change instead of reconciling it.
         while (true)
         {
-            var requestLogical = metadata.Protocol == RemotePullProtocol.MvccLogical;
-            if (requestLogical && options.RemoteEncryption is not null)
-            {
-                throw new NotSupportedException(
-                    "Managed embedded replica synchronization does not support the MVCC logical pull "
-                    + "protocol combined with remote encryption.");
-            }
-
-            if (!requestLogical)
-            {
-                // A non-logical (page) protocol client can only ever receive a Pages response for
-                // any given pull, so this is known upfront and the guard can (and should) run before
-                // spending a network round-trip on a request that would have to be rejected anyway.
-                // This is the ORIGINAL, unconditional file-level check only (no pendingLocalChanges
-                // rejection): a page-protocol replica has never reconciled local writes via the pull
-                // path, so it has always tolerated unrelated journal-tracked pending push entries as
-                // long as the file itself has not diverged, and that historical behavior is
-                // preserved exactly here. A logical-protocol client cannot be checked here: its
-                // response might turn out to be a Pages stream too (see the equivalent, STRICTER
-                // check further down, after the actual stream kind of THIS response is known), or it
-                // might be a logical stream that needs no such check at all.
-                EnsureNoLocalDivergence(options.Path, metadata);
-            }
-
-            syncOptions.Progress?.Report(new AhtolaSyncProgress(AhtolaSyncProgressStage.Pulling));
-            var payload = CreatePullRequest(metadata.Revision, options.LongPollTimeout, requestLogical);
-            using var timeout = CreateTimeout(options.HttpPolicy.RequestTimeout, cancellationToken);
-            using var scope = options.EnterApplicationHttpScope();
-            using var client = options.HttpPolicy.CreateHttpClient(options.RemoteEncryption is not null);
-            client.Timeout = Timeout.InfiniteTimeSpan;
-            var token = string.IsNullOrWhiteSpace(options.AuthToken) ? null : options.AuthToken;
-            var effectiveToken = timeout?.Token ?? cancellationToken;
-            using var response = await AhtolaRemoteTransportSecurity
-                .SendAsync(
-                    client,
-                    CreatePullUpdatesUri(options.RemoteUri),
-                    requestUri => CreatePullUpdatesHttpRequest(
-                        requestUri,
-                        payload,
-                        token,
-                        options.RemoteEncryption),
-                    token,
-                    remoteEncryptionConfigured: options.RemoteEncryption is not null,
-                    HttpCompletionOption.ResponseHeadersRead,
-                    effectiveToken)
+            using var staged = await WaitForRemoteChangesAsync(
+                    options, metadata, syncOptions, pendingLocalChanges, acknowledgedLocalChanges, cancellationToken)
                 .ConfigureAwait(false);
-            response.EnsureSuccessStatusCode();
-            await using var stream = await response.Content.ReadAsStreamAsync(effectiveToken).ConfigureAwait(false);
-            var reader = new DelimitedProtobufReader(stream);
-            var message = await reader.ReadAsync(MaxHeaderLength, effectiveToken).ConfigureAwait(false)
-                ?? throw new InvalidDataException("The pull-updates response did not contain a protobuf header.");
-            var header = ParseHeader(message);
-
-            if (header.StreamKind == PullStreamKind.MvccLogicalLog)
+            try
             {
-                if (header.ApplyMode == PullApplyMode.ReplaceBase)
-                {
-                    throw new InvalidDataException(
-                        "The pull-updates response returned replace_base apply mode with an MVCC logical-log stream.");
-                }
-                if (!requestLogical)
-                {
-                    throw new InvalidDataException(
-                        "The pull-updates response returned an MVCC logical-log stream, but a logical pull was not requested.");
-                }
-
-                var body = await ReadRemainingBytesAsync(stream, effectiveToken).ConfigureAwait(false);
-
-                // Pull publication always takes the physical push-flight lease before the apply
-                // lease. Both stay outside the network round trip above and span only the short local
-                // apply. Besides excluding an in-flight push intent, this order prevents a main-file
-                // replacement from changing the physical identity behind the push carrier while an
-                // older carrier is still held.
-                ManagedReplicaFaultInjection.Hit(
-                    ManagedReplicaDurableBoundary.ReplicaPullPublicationLockWaiting);
-                await using var logicalPushLease = await ManagedReplicaPushLock
-                    .AcquireExclusiveAsync(options.Path, effectiveToken)
+                return await ApplyRemoteChangesAsync(
+                        options, staged, syncOptions, expectedConflictState, cancellationToken)
                     .ConfigureAwait(false);
-                await using var logicalApplyLease = await ManagedReplicaApplyLock.AcquireExclusiveAsync(options.Path, effectiveToken)
-                    .ConfigureAwait(false);
-                ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.ReplicaApplyLockAcquired);
-                effectiveToken.ThrowIfCancellationRequested();
-                ManagedReplicaConflictState.ValidatePullPublication(options.Path, expectedConflictState);
-
-                // The request above (and this response) were negotiated against `metadata` and
-                // `pendingLocalChanges` as they stood BEFORE the network round trip and the wait
-                // for this lease -- both entirely outside its scope by design. Re-validate that
-                // base is still current now that the lease is actually held: if another caller
-                // already advanced local state in the meantime, this response is stale relative to
-                // it and must never be applied; retry the whole pull against the now-current base
-                // instead of silently regressing metadata or discarding an intervening local change.
-                if (!TryUseCurrentLocalStateAsPullBase(
-                        options.Path, metadata, pendingLocalChanges, acknowledgedLocalChanges,
-                        out var freshLogicalMetadata,
-                        out var freshLogicalPendingLocalChanges,
-                        out var freshLogicalAcknowledgedLocalChanges))
-                {
-                    metadata = freshLogicalMetadata;
-                    pendingLocalChanges = freshLogicalPendingLocalChanges;
-                    acknowledgedLocalChanges = freshLogicalAcknowledgedLocalChanges;
-                    continue;
-                }
-                ManagedReplicaRevertWal.EnsureSynchronizationReady(options.Path, metadata);
-
-                var (outcome, statistics, replayed) = await ApplyLogicalUpdatesAsync(
-                    options, metadata, header, body, syncOptions,
-                    SelectReplayableLocalChanges(pendingLocalChanges, quarantinedSequences),
-                    acknowledgedLocalChanges,
-                    payload.Length, reader.BytesRead + body.Length,
-                    quarantinedSequences is { Count: > 0 },
-                    effectiveToken)
-                    .ConfigureAwait(false);
-                return new ManagedReplicaPullOutcome(new AhtolaSyncResult(outcome, statistics), replayed);
             }
-
-            // Pages stream (Incremental or ReplaceBase for a page-protocol remote, or a protocol-2
-            // remote using Pages+ReplaceBase for a validated full atomic replacement).
-            if (quarantinedSequences is { Count: > 0 })
+            catch (ManagedReplicaStaleChangesException stale)
             {
-                // A raw page stream has no per-operation replay mechanism at all: it either
-                // rejects every pending local change (Incremental) or replays all of them onto a
-                // whole new snapshot (ReplaceBase). Neither can honor a quarantine, so a conflict
-                // rebase over the page protocol fails closed instead of guessing.
-                throw new NotSupportedException(
-                    "Managed embedded replica cannot rebase an unresolved push conflict over a page-based "
-                    + "pull response; the page protocol has no way to hold back the conflicting changes. "
-                    + "Resolve or discard the conflicting changes explicitly instead.");
+                metadata = stale.FreshMetadata;
+                pendingLocalChanges = stale.FreshPendingLocalChanges;
+                acknowledgedLocalChanges = stale.FreshAcknowledgedLocalChanges;
             }
-            var pages = new List<PullPage>();
-            while (await reader.ReadAsync(MaxPageMessageLength, effectiveToken).ConfigureAwait(false) is { } page)
-            {
-                pages.Add(ParsePage(page));
-            }
-            if (pages.Count == 0 && string.Equals(header.Revision, metadata.Revision, StringComparison.Ordinal))
-            {
-                ManagedReplicaFaultInjection.Hit(
-                    ManagedReplicaDurableBoundary.ReplicaPullPublicationLockWaiting);
-                await using var noOpPushLease = await ManagedReplicaPushLock
-                    .AcquireExclusiveAsync(options.Path, effectiveToken)
-                    .ConfigureAwait(false);
-                await using var noOpApplyLease = await ManagedReplicaApplyLock
-                    .AcquireExclusiveAsync(options.Path, effectiveToken)
-                    .ConfigureAwait(false);
-                ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.ReplicaApplyLockAcquired);
-                effectiveToken.ThrowIfCancellationRequested();
-                ManagedReplicaConflictState.ValidatePullPublication(options.Path, expectedConflictState);
-                if (!TryUseCurrentLocalStateAsPullBase(
-                        options.Path, metadata, pendingLocalChanges, acknowledgedLocalChanges,
-                        out var freshNoOpMetadata,
-                        out var freshNoOpPendingLocalChanges,
-                        out var freshNoOpAcknowledgedLocalChanges))
-                {
-                    metadata = freshNoOpMetadata;
-                    pendingLocalChanges = freshNoOpPendingLocalChanges;
-                    acknowledgedLocalChanges = freshNoOpAcknowledgedLocalChanges;
-                    continue;
-                }
-                ManagedReplicaRevertWal.EnsureSynchronizationReady(options.Path, metadata);
-                syncOptions.Progress?.Report(new AhtolaSyncProgress(AhtolaSyncProgressStage.Completed));
-                return new ManagedReplicaPullOutcome(
-                    new AhtolaSyncResult(AhtolaSyncOutcome.UpToDate,
-                        new AhtolaSyncStatistics(0, 0, 0, DateTimeOffset.UtcNow, null, payload.Length, reader.BytesRead, metadata.Revision)),
-                    ReplayedLocalChangeCount: 0);
-            }
+        }
+    }
 
-            if (pages.Count == 0)
-                throw new InvalidDataException("The pull-updates response changed revision without returning page data.");
-            if (string.Equals(header.Revision, metadata.Revision, StringComparison.Ordinal))
-                throw new InvalidDataException("The pull-updates response returned page data without changing revision.");
-            if (header.ApplyMode == PullApplyMode.ReplaceBase && (ulong)pages.Count != header.DatabasePages)
+    /// <summary>
+    /// Waits for the remote's next pull-updates response and stages it without touching any local
+    /// database state: no push/apply lease is acquired, no page or logical change is applied, and
+    /// no metadata is published. Mirrors Turso's <c>wait_changes_from_remote</c>
+    /// (turso-src/sync/engine/src/database_sync_engine.rs) -- the network long-poll (bounded by
+    /// <see cref="AhtolaReplicaOptions.LongPollTimeout"/>) runs here and only here, so a caller
+    /// that does not wrap this call in an in-process publication gate (see
+    /// <c>ManagedReplicaSyncRegistry.Entry</c>) never blocks sibling connections to the same
+    /// replica while the remote takes its time to answer. The result must be applied at most once
+    /// with <see cref="ApplyRemoteChangesAsync"/>, or discarded via
+    /// <see cref="ManagedReplicaStagedChanges.Dispose"/> -- either is safe, since nothing durable
+    /// or in-memory-shared was touched while staged.
+    /// </summary>
+    internal static async Task<ManagedReplicaStagedChanges> WaitForRemoteChangesAsync(
+        AhtolaReplicaOptions options,
+        ManagedReplicaMetadata metadata,
+        AhtolaSyncOptions syncOptions,
+        IReadOnlyList<ReplicaLocalChange> pendingLocalChanges,
+        IReadOnlyList<ReplicaLocalChange> acknowledgedLocalChanges,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(pendingLocalChanges);
+        ArgumentNullException.ThrowIfNull(acknowledgedLocalChanges);
+        ManagedReplicaSupportMatrix.ValidateOptions(options);
+        ManagedReplicaRevertWal.ValidateSynchronizationReady(options.Path, metadata);
+
+        var requestLogical = metadata.Protocol == RemotePullProtocol.MvccLogical;
+        if (requestLogical && options.RemoteEncryption is not null)
+        {
+            throw new NotSupportedException(
+                "Managed embedded replica synchronization does not support the MVCC logical pull "
+                + "protocol combined with remote encryption.");
+        }
+
+        if (!requestLogical)
+        {
+            // A non-logical (page) protocol client can only ever receive a Pages response for
+            // any given pull, so this is known upfront and the guard can (and should) run before
+            // spending a network round-trip on a request that would have to be rejected anyway.
+            // This is the ORIGINAL, unconditional file-level check only (no pendingLocalChanges
+            // rejection): a page-protocol replica has never reconciled local writes via the pull
+            // path, so it has always tolerated unrelated journal-tracked pending push entries as
+            // long as the file itself has not diverged, and that historical behavior is
+            // preserved exactly here. A logical-protocol client cannot be checked here: its
+            // response might turn out to be a Pages stream too (see the equivalent, STRICTER
+            // check further down, after the actual stream kind of THIS response is known), or it
+            // might be a logical stream that needs no such check at all.
+            EnsureNoLocalDivergence(options.Path, metadata);
+        }
+
+        syncOptions.Progress?.Report(new AhtolaSyncProgress(AhtolaSyncProgressStage.Pulling));
+        var payload = CreatePullRequest(metadata.Revision, options.LongPollTimeout, requestLogical);
+        using var timeout = CreateTimeout(options.HttpPolicy.RequestTimeout, cancellationToken);
+        using var scope = options.EnterApplicationHttpScope();
+        using var client = options.HttpPolicy.CreateHttpClient(options.RemoteEncryption is not null);
+        client.Timeout = Timeout.InfiniteTimeSpan;
+        var token = string.IsNullOrWhiteSpace(options.AuthToken) ? null : options.AuthToken;
+        var effectiveToken = timeout?.Token ?? cancellationToken;
+        using var response = await AhtolaRemoteTransportSecurity
+            .SendAsync(
+                client,
+                CreatePullUpdatesUri(options.RemoteUri),
+                requestUri => CreatePullUpdatesHttpRequest(
+                    requestUri,
+                    payload,
+                    token,
+                    options.RemoteEncryption),
+                token,
+                remoteEncryptionConfigured: options.RemoteEncryption is not null,
+                HttpCompletionOption.ResponseHeadersRead,
+                effectiveToken)
+            .ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+        await using var stream = await response.Content.ReadAsStreamAsync(effectiveToken).ConfigureAwait(false);
+        var reader = new DelimitedProtobufReader(stream);
+        var message = await reader.ReadAsync(MaxHeaderLength, effectiveToken).ConfigureAwait(false)
+            ?? throw new InvalidDataException("The pull-updates response did not contain a protobuf header.");
+        var header = ParseHeader(message);
+
+        if (header.StreamKind == PullStreamKind.MvccLogicalLog)
+        {
+            if (header.ApplyMode == PullApplyMode.ReplaceBase)
             {
                 throw new InvalidDataException(
-                    "The pull-updates response used replace_base apply mode without returning every database page exactly once.");
+                    "The pull-updates response returned replace_base apply mode with an MVCC logical-log stream.");
             }
-
-            // Keep the same push-to-apply order as the logical branch. The response is already fully
-            // staged in memory, so no remote I/O is covered by either lease.
-            ManagedReplicaFaultInjection.Hit(
-                ManagedReplicaDurableBoundary.ReplicaPullPublicationLockWaiting);
-            await using var pagesPushLease = await ManagedReplicaPushLock
-                .AcquireExclusiveAsync(options.Path, effectiveToken)
-                .ConfigureAwait(false);
-            await using var pagesApplyLease = await ManagedReplicaApplyLock.AcquireExclusiveAsync(options.Path, effectiveToken)
-                .ConfigureAwait(false);
-            ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.ReplicaApplyLockAcquired);
-            effectiveToken.ThrowIfCancellationRequested();
-            ManagedReplicaConflictState.ValidatePullPublication(options.Path, expectedConflictState);
-
-            if (!TryUseCurrentLocalStateAsPullBase(
-                    options.Path, metadata, pendingLocalChanges, acknowledgedLocalChanges,
-                    out var freshPagesMetadata,
-                    out var freshPagesPendingLocalChanges,
-                    out var freshPagesAcknowledgedLocalChanges))
+            if (!requestLogical)
             {
-                metadata = freshPagesMetadata;
-                pendingLocalChanges = freshPagesPendingLocalChanges;
-                acknowledgedLocalChanges = freshPagesAcknowledgedLocalChanges;
-                continue;
-            }
-            ManagedReplicaRevertWal.EnsureSynchronizationReady(options.Path, metadata);
-
-            // The response turned out to be a Pages stream (Incremental or ReplaceBase) even though
-            // the remembered protocol is MvccLogical (a protocol-2 remote can still answer any given
-            // pull this way, e.g. after its logical log was garbage-collected). Unlike the ordinary,
-            // historical page-protocol path above, a logical-protocol replica's local writes are
-            // expected to keep living in the WAL between syncs (tracked by the change journal,
-            // reconciled by precollect/reapply for LOGICAL responses) -- but a raw page-based apply
-            // has no such reconciliation mechanism at all, so this surprise combination needs its
-            // OWN, apply-mode-aware guard: Incremental still rejects pending changes because a
-            // partial page patch cannot rebase journaled SQL. ReplaceBase installs every page, so
-            // pending statements can be replayed onto the new snapshot before metadata publication.
-            //
-            // The ordinary, historical page-protocol path (requestLogical == false) re-validates here
-            // too: EnsureNoLocalDivergence already ran once before the network call above, but only
-            // this post-network, lock-held check is authoritative -- a local write landing during the
-            // round trip must still be caught before the apply below mutates anything. Always the
-            // strict fingerprint/sidecar check here (never the checkpoint-and-discard behavior
-            // EnsurePagesApplyIsSafe uses for ReplaceBase): a page-protocol replica has no push
-            // mechanism, so there is no way to know local WAL content is already reflected upstream.
-            if (requestLogical)
-            {
-                metadata = EnsurePagesApplyIsSafe(
-                    options.Path,
-                    metadata,
-                    pendingLocalChanges,
-                    header.ApplyMode,
-                    effectiveToken);
-            }
-            else
-            {
-                CheckFileDivergence(options.Path, metadata);
+                throw new InvalidDataException(
+                    "The pull-updates response returned an MVCC logical-log stream, but a logical pull was not requested.");
             }
 
-            await ApplyIncrementalPagesAsync(
-                    options,
-                    header,
-                    pages,
-                    metadata,
-                    pendingLocalChanges,
-                    acknowledgedLocalChanges,
-                    effectiveToken)
-                .ConfigureAwait(false);
-            syncOptions.Progress?.Report(new AhtolaSyncProgress(AhtolaSyncProgressStage.Applying));
-            syncOptions.Progress?.Report(new AhtolaSyncProgress(AhtolaSyncProgressStage.Completed));
-            return new ManagedReplicaPullOutcome(
-                new AhtolaSyncResult(AhtolaSyncOutcome.RemoteChangesApplied,
-                    new AhtolaSyncStatistics(0, 0, 0, DateTimeOffset.UtcNow, null, payload.Length, reader.BytesRead, header.Revision)),
-                ReplayedLocalChangeCount: 0);
+            var body = await ReadRemainingBytesAsync(stream, effectiveToken).ConfigureAwait(false);
+            return ManagedReplicaStagedChanges.ForLogical(
+                options.Path, metadata, pendingLocalChanges, acknowledgedLocalChanges, requestLogical,
+                payload.Length, reader.BytesRead + body.Length, header, body);
         }
+
+        // Pages stream (Incremental or ReplaceBase for a page-protocol remote, or a protocol-2
+        // remote using Pages+ReplaceBase for a validated full atomic replacement).
+        var pages = new List<PullPage>();
+        while (await reader.ReadAsync(MaxPageMessageLength, effectiveToken).ConfigureAwait(false) is { } page)
+        {
+            pages.Add(ParsePage(page));
+        }
+        if (pages.Count == 0 && string.Equals(header.Revision, metadata.Revision, StringComparison.Ordinal))
+        {
+            return ManagedReplicaStagedChanges.ForNoOp(
+                options.Path, metadata, pendingLocalChanges, acknowledgedLocalChanges, requestLogical,
+                payload.Length, reader.BytesRead);
+        }
+
+        if (pages.Count == 0)
+            throw new InvalidDataException("The pull-updates response changed revision without returning page data.");
+        if (string.Equals(header.Revision, metadata.Revision, StringComparison.Ordinal))
+            throw new InvalidDataException("The pull-updates response returned page data without changing revision.");
+        if (header.ApplyMode == PullApplyMode.ReplaceBase && (ulong)pages.Count != header.DatabasePages)
+        {
+            throw new InvalidDataException(
+                "The pull-updates response used replace_base apply mode without returning every database page exactly once.");
+        }
+
+        return ManagedReplicaStagedChanges.ForPages(
+            options.Path, metadata, pendingLocalChanges, acknowledgedLocalChanges, requestLogical,
+            payload.Length, reader.BytesRead, header, pages);
+    }
+
+    /// <summary>
+    /// Consumes a response staged by <see cref="WaitForRemoteChangesAsync"/> and applies it to the
+    /// local database. Mirrors Turso's <c>apply_changes_from_remote</c>
+    /// (turso-src/sync/engine/src/database_sync_engine.rs): every local mutation -- lease
+    /// acquisition, staleness re-validation, and the actual logical/page apply -- lives here, so a
+    /// caller can wrap only this call (never <see cref="WaitForRemoteChangesAsync"/>) in whatever
+    /// write-blocking guard its local concurrency model needs. <paramref name="staged"/> is
+    /// consumed exactly once: reused, cross-replica, or already-disposed staged changes fail
+    /// closed with <see cref="InvalidOperationException"/> before any lease is taken. When local
+    /// state (metadata, pending/acknowledged local changes) advanced past the snapshot
+    /// <paramref name="staged"/> was negotiated against, this throws
+    /// <see cref="ManagedReplicaStaleChangesException"/> instead of silently regressing metadata
+    /// or discarding an intervening local change -- the caller must discard the staged response
+    /// and call <see cref="WaitForRemoteChangesAsync"/> again against the exception's fresh
+    /// snapshot, never retry the network round trip from inside this method.
+    /// </summary>
+    internal static async Task<ManagedReplicaPullOutcome> ApplyRemoteChangesAsync(
+        AhtolaReplicaOptions options,
+        ManagedReplicaStagedChanges staged,
+        AhtolaSyncOptions syncOptions,
+        ManagedReplicaConflictState? expectedConflictState,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(staged);
+        staged.ValidateAndConsume(options.Path);
+
+        IReadOnlySet<long>? quarantinedSequences = expectedConflictState is { } conflict
+            ? new HashSet<long>(conflict.UnresolvedSequences)
+            : null;
+
+        if (staged.Kind == ManagedReplicaStagedChanges.StagedKind.Logical)
+        {
+            return await ApplyStagedLogicalChangesAsync(
+                    options, staged, syncOptions, quarantinedSequences, expectedConflictState, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        // Pages stream (Incremental or ReplaceBase for a page-protocol remote, or a protocol-2
+        // remote using Pages+ReplaceBase for a validated full atomic replacement) -- including its
+        // no-op resolution (0 pages, unchanged revision). Checked unconditionally, before looking
+        // at whether the response turned out to carry any changes: a raw page stream has no
+        // per-operation replay mechanism at all, so it either rejects every pending local change
+        // (Incremental) or replays all of them onto a whole new snapshot (ReplaceBase). Neither
+        // can honor a quarantine, so a conflict rebase over the page protocol fails closed instead
+        // of guessing, even when the response itself turns out to be a no-op.
+        if (quarantinedSequences is { Count: > 0 })
+        {
+            throw new NotSupportedException(
+                "Managed embedded replica cannot rebase an unresolved push conflict over a page-based "
+                + "pull response; the page protocol has no way to hold back the conflicting changes. "
+                + "Resolve or discard the conflicting changes explicitly instead.");
+        }
+
+        return staged.IsEmpty
+            ? await ApplyStagedNoOpAsync(options, staged, syncOptions, expectedConflictState, cancellationToken)
+                .ConfigureAwait(false)
+            : await ApplyStagedPagesAsync(options, staged, syncOptions, expectedConflictState, cancellationToken)
+                .ConfigureAwait(false);
+    }
+
+    private static async Task<ManagedReplicaPullOutcome> ApplyStagedLogicalChangesAsync(
+        AhtolaReplicaOptions options,
+        ManagedReplicaStagedChanges staged,
+        AhtolaSyncOptions syncOptions,
+        IReadOnlySet<long>? quarantinedSequences,
+        ManagedReplicaConflictState? expectedConflictState,
+        CancellationToken cancellationToken)
+    {
+        var metadata = staged.RequestBaseMetadata;
+        var pendingLocalChanges = staged.RequestBasePendingLocalChanges;
+        var acknowledgedLocalChanges = staged.RequestBaseAcknowledgedLocalChanges;
+
+        // Pull publication always takes the physical push-flight lease before the apply
+        // lease. Both stay outside the network round trip (now entirely inside
+        // WaitForRemoteChangesAsync) and span only the short local apply. Besides excluding an
+        // in-flight push intent, this order prevents a main-file replacement from changing the
+        // physical identity behind the push carrier while an older carrier is still held.
+        ManagedReplicaFaultInjection.Hit(
+            ManagedReplicaDurableBoundary.ReplicaPullPublicationLockWaiting);
+        await using var logicalPushLease = await ManagedReplicaPushLock
+            .AcquireExclusiveAsync(options.Path, cancellationToken)
+            .ConfigureAwait(false);
+        await using var logicalApplyLease = await ManagedReplicaApplyLock.AcquireExclusiveAsync(options.Path, cancellationToken)
+            .ConfigureAwait(false);
+        ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.ReplicaApplyLockAcquired);
+        cancellationToken.ThrowIfCancellationRequested();
+        ManagedReplicaConflictState.ValidatePullPublication(options.Path, expectedConflictState);
+
+        // The request that produced this staged response (and the response itself) were
+        // negotiated against `metadata` and `pendingLocalChanges` as they stood BEFORE the network
+        // round trip and the wait for this lease -- both entirely outside its scope by design.
+        // Re-validate that base is still current now that the lease is actually held: if another
+        // caller already advanced local state in the meantime, this response is stale relative to
+        // it and must never be applied. Unlike the historical fused retry loop, this never retries
+        // the network round trip itself -- it throws so the caller discards the staged response
+        // and waits for remote changes again, instead of silently regressing metadata or
+        // discarding an intervening local change.
+        if (!TryUseCurrentLocalStateAsPullBase(
+                options.Path, metadata, pendingLocalChanges, acknowledgedLocalChanges,
+                out var freshMetadata,
+                out var freshPendingLocalChanges,
+                out var freshAcknowledgedLocalChanges))
+        {
+            throw new ManagedReplicaStaleChangesException(
+                freshMetadata, freshPendingLocalChanges, freshAcknowledgedLocalChanges);
+        }
+        ManagedReplicaRevertWal.EnsureSynchronizationReady(options.Path, metadata);
+
+        var (outcome, statistics, replayed) = await ApplyLogicalUpdatesAsync(
+            options, metadata, staged.Header, staged.LogicalBody!, syncOptions,
+            SelectReplayableLocalChanges(pendingLocalChanges, quarantinedSequences),
+            acknowledgedLocalChanges,
+            staged.RequestPayloadLength, staged.ResponseBytesRead,
+            quarantinedSequences is { Count: > 0 },
+            cancellationToken)
+            .ConfigureAwait(false);
+        return new ManagedReplicaPullOutcome(new AhtolaSyncResult(outcome, statistics), replayed);
+    }
+
+    private static async Task<ManagedReplicaPullOutcome> ApplyStagedNoOpAsync(
+        AhtolaReplicaOptions options,
+        ManagedReplicaStagedChanges staged,
+        AhtolaSyncOptions syncOptions,
+        ManagedReplicaConflictState? expectedConflictState,
+        CancellationToken cancellationToken)
+    {
+        var metadata = staged.RequestBaseMetadata;
+        var pendingLocalChanges = staged.RequestBasePendingLocalChanges;
+        var acknowledgedLocalChanges = staged.RequestBaseAcknowledgedLocalChanges;
+
+        ManagedReplicaFaultInjection.Hit(
+            ManagedReplicaDurableBoundary.ReplicaPullPublicationLockWaiting);
+        await using var noOpPushLease = await ManagedReplicaPushLock
+            .AcquireExclusiveAsync(options.Path, cancellationToken)
+            .ConfigureAwait(false);
+        await using var noOpApplyLease = await ManagedReplicaApplyLock
+            .AcquireExclusiveAsync(options.Path, cancellationToken)
+            .ConfigureAwait(false);
+        ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.ReplicaApplyLockAcquired);
+        cancellationToken.ThrowIfCancellationRequested();
+        ManagedReplicaConflictState.ValidatePullPublication(options.Path, expectedConflictState);
+        if (!TryUseCurrentLocalStateAsPullBase(
+                options.Path, metadata, pendingLocalChanges, acknowledgedLocalChanges,
+                out var freshMetadata,
+                out var freshPendingLocalChanges,
+                out var freshAcknowledgedLocalChanges))
+        {
+            throw new ManagedReplicaStaleChangesException(
+                freshMetadata, freshPendingLocalChanges, freshAcknowledgedLocalChanges);
+        }
+        ManagedReplicaRevertWal.EnsureSynchronizationReady(options.Path, metadata);
+        syncOptions.Progress?.Report(new AhtolaSyncProgress(AhtolaSyncProgressStage.Completed));
+        return new ManagedReplicaPullOutcome(
+            new AhtolaSyncResult(AhtolaSyncOutcome.UpToDate,
+                new AhtolaSyncStatistics(0, 0, 0, DateTimeOffset.UtcNow, null, staged.RequestPayloadLength, staged.ResponseBytesRead, metadata.Revision)),
+            ReplayedLocalChangeCount: 0);
+    }
+
+    private static async Task<ManagedReplicaPullOutcome> ApplyStagedPagesAsync(
+        AhtolaReplicaOptions options,
+        ManagedReplicaStagedChanges staged,
+        AhtolaSyncOptions syncOptions,
+        ManagedReplicaConflictState? expectedConflictState,
+        CancellationToken cancellationToken)
+    {
+        var metadata = staged.RequestBaseMetadata;
+        var pendingLocalChanges = staged.RequestBasePendingLocalChanges;
+        var acknowledgedLocalChanges = staged.RequestBaseAcknowledgedLocalChanges;
+        var header = staged.Header;
+        var pages = staged.Pages!;
+
+        // Keep the same push-to-apply order as the logical branch. The response is already fully
+        // staged in memory, so no remote I/O is covered by either lease.
+        ManagedReplicaFaultInjection.Hit(
+            ManagedReplicaDurableBoundary.ReplicaPullPublicationLockWaiting);
+        await using var pagesPushLease = await ManagedReplicaPushLock
+            .AcquireExclusiveAsync(options.Path, cancellationToken)
+            .ConfigureAwait(false);
+        await using var pagesApplyLease = await ManagedReplicaApplyLock.AcquireExclusiveAsync(options.Path, cancellationToken)
+            .ConfigureAwait(false);
+        ManagedReplicaFaultInjection.Hit(ManagedReplicaDurableBoundary.ReplicaApplyLockAcquired);
+        cancellationToken.ThrowIfCancellationRequested();
+        ManagedReplicaConflictState.ValidatePullPublication(options.Path, expectedConflictState);
+
+        if (!TryUseCurrentLocalStateAsPullBase(
+                options.Path, metadata, pendingLocalChanges, acknowledgedLocalChanges,
+                out var freshMetadata,
+                out var freshPendingLocalChanges,
+                out var freshAcknowledgedLocalChanges))
+        {
+            throw new ManagedReplicaStaleChangesException(
+                freshMetadata, freshPendingLocalChanges, freshAcknowledgedLocalChanges);
+        }
+        ManagedReplicaRevertWal.EnsureSynchronizationReady(options.Path, metadata);
+
+        // The response turned out to be a Pages stream (Incremental or ReplaceBase) even though
+        // the remembered protocol is MvccLogical (a protocol-2 remote can still answer any given
+        // pull this way, e.g. after its logical log was garbage-collected). Unlike the ordinary,
+        // historical page-protocol path above, a logical-protocol replica's local writes are
+        // expected to keep living in the WAL between syncs (tracked by the change journal,
+        // reconciled by precollect/reapply for LOGICAL responses) -- but a raw page-based apply
+        // has no such reconciliation mechanism at all, so this surprise combination needs its
+        // OWN, apply-mode-aware guard: Incremental still rejects pending changes because a
+        // partial page patch cannot rebase journaled SQL. ReplaceBase installs every page, so
+        // pending statements can be replayed onto the new snapshot before metadata publication.
+        //
+        // The ordinary, historical page-protocol path (requestLogical == false) re-validates here
+        // too: EnsureNoLocalDivergence already ran once before the network call above, but only
+        // this post-network, lock-held check is authoritative -- a local write landing during the
+        // round trip must still be caught before the apply below mutates anything. Always the
+        // strict fingerprint/sidecar check here (never the checkpoint-and-discard behavior
+        // EnsurePagesApplyIsSafe uses for ReplaceBase): a page-protocol replica has no push
+        // mechanism, so there is no way to know local WAL content is already reflected upstream.
+        if (staged.RequestedLogical)
+        {
+            metadata = EnsurePagesApplyIsSafe(
+                options.Path,
+                metadata,
+                pendingLocalChanges,
+                header.ApplyMode,
+                cancellationToken);
+        }
+        else
+        {
+            CheckFileDivergence(options.Path, metadata);
+        }
+
+        await ApplyIncrementalPagesAsync(
+                options,
+                header,
+                pages,
+                metadata,
+                pendingLocalChanges,
+                acknowledgedLocalChanges,
+                cancellationToken)
+            .ConfigureAwait(false);
+        syncOptions.Progress?.Report(new AhtolaSyncProgress(AhtolaSyncProgressStage.Applying));
+        syncOptions.Progress?.Report(new AhtolaSyncProgress(AhtolaSyncProgressStage.Completed));
+        return new ManagedReplicaPullOutcome(
+            new AhtolaSyncResult(AhtolaSyncOutcome.RemoteChangesApplied,
+                new AhtolaSyncStatistics(0, 0, 0, DateTimeOffset.UtcNow, null, staged.RequestPayloadLength, staged.ResponseBytesRead, header.Revision)),
+            ReplayedLocalChangeCount: 0);
+    }
+
+    /// <summary>
+    /// A pull-updates response staged by <see cref="WaitForRemoteChangesAsync"/> but not yet
+    /// applied to the local database. Mirrors Turso's <c>DbChangesStatus</c>
+    /// (turso-src/sync/engine/src/types.rs) -- the opaque handle threaded from
+    /// <c>wait_changes_from_remote</c> to <c>apply_changes_from_remote</c>. Nothing durable or
+    /// shared is touched while an instance is staged, so discarding one (via <see cref="Dispose"/>
+    /// without ever applying it) is always safe. Applying is guarded against every documented
+    /// misuse: <see cref="ApplyRemoteChangesAsync"/> fails closed with
+    /// <see cref="InvalidOperationException"/> before taking any lease if the instance was staged
+    /// for a different replica path, was already applied, or was already discarded.
+    /// </summary>
+    internal sealed class ManagedReplicaStagedChanges : IDisposable
+    {
+        internal enum StagedKind
+        {
+            NoOp,
+            Logical,
+            Pages,
+        }
+
+        private readonly string _databasePath;
+        private int _consumed;
+
+        private ManagedReplicaStagedChanges(
+            string databasePath,
+            ManagedReplicaMetadata requestBaseMetadata,
+            IReadOnlyList<ReplicaLocalChange> requestBasePendingLocalChanges,
+            IReadOnlyList<ReplicaLocalChange> requestBaseAcknowledgedLocalChanges,
+            bool requestedLogical,
+            int requestPayloadLength,
+            long responseBytesRead,
+            StagedKind kind,
+            PullHeader header,
+            byte[]? logicalBody,
+            IReadOnlyList<PullPage>? pages)
+        {
+            _databasePath = databasePath;
+            RequestBaseMetadata = requestBaseMetadata;
+            RequestBasePendingLocalChanges = requestBasePendingLocalChanges;
+            RequestBaseAcknowledgedLocalChanges = requestBaseAcknowledgedLocalChanges;
+            RequestedLogical = requestedLogical;
+            RequestPayloadLength = requestPayloadLength;
+            ResponseBytesRead = responseBytesRead;
+            Kind = kind;
+            Header = header;
+            LogicalBody = logicalBody;
+            Pages = pages;
+        }
+
+        internal ManagedReplicaMetadata RequestBaseMetadata { get; }
+        internal IReadOnlyList<ReplicaLocalChange> RequestBasePendingLocalChanges { get; }
+        internal IReadOnlyList<ReplicaLocalChange> RequestBaseAcknowledgedLocalChanges { get; }
+        internal bool RequestedLogical { get; }
+        internal int RequestPayloadLength { get; }
+        internal long ResponseBytesRead { get; }
+        internal StagedKind Kind { get; }
+        internal PullHeader Header { get; }
+        internal byte[]? LogicalBody { get; }
+        internal IReadOnlyList<PullPage>? Pages { get; }
+
+        /// <summary>The response carried no changes and the revision did not move.</summary>
+        internal bool IsEmpty => Kind == StagedKind.NoOp;
+
+        internal static ManagedReplicaStagedChanges ForNoOp(
+            string databasePath,
+            ManagedReplicaMetadata requestBaseMetadata,
+            IReadOnlyList<ReplicaLocalChange> requestBasePendingLocalChanges,
+            IReadOnlyList<ReplicaLocalChange> requestBaseAcknowledgedLocalChanges,
+            bool requestedLogical,
+            int requestPayloadLength,
+            long responseBytesRead)
+            => new(databasePath, requestBaseMetadata, requestBasePendingLocalChanges,
+                requestBaseAcknowledgedLocalChanges, requestedLogical, requestPayloadLength, responseBytesRead,
+                StagedKind.NoOp, default, null, null);
+
+        internal static ManagedReplicaStagedChanges ForLogical(
+            string databasePath,
+            ManagedReplicaMetadata requestBaseMetadata,
+            IReadOnlyList<ReplicaLocalChange> requestBasePendingLocalChanges,
+            IReadOnlyList<ReplicaLocalChange> requestBaseAcknowledgedLocalChanges,
+            bool requestedLogical,
+            int requestPayloadLength,
+            long responseBytesRead,
+            PullHeader header,
+            byte[] body)
+            => new(databasePath, requestBaseMetadata, requestBasePendingLocalChanges,
+                requestBaseAcknowledgedLocalChanges, requestedLogical, requestPayloadLength, responseBytesRead,
+                StagedKind.Logical, header, body, null);
+
+        internal static ManagedReplicaStagedChanges ForPages(
+            string databasePath,
+            ManagedReplicaMetadata requestBaseMetadata,
+            IReadOnlyList<ReplicaLocalChange> requestBasePendingLocalChanges,
+            IReadOnlyList<ReplicaLocalChange> requestBaseAcknowledgedLocalChanges,
+            bool requestedLogical,
+            int requestPayloadLength,
+            long responseBytesRead,
+            PullHeader header,
+            IReadOnlyList<PullPage> pages)
+            => new(databasePath, requestBaseMetadata, requestBasePendingLocalChanges,
+                requestBaseAcknowledgedLocalChanges, requestedLogical, requestPayloadLength, responseBytesRead,
+                StagedKind.Pages, header, null, pages);
+
+        /// <summary>
+        /// Atomically marks this staged response consumed, failing closed if it was staged for a
+        /// different replica path (cross-replica misuse), or if it was already applied or already
+        /// discarded via <see cref="Dispose"/> (duplicate-apply / disposed-result misuse). Must be
+        /// the first thing <see cref="ApplyRemoteChangesAsync"/> does, before any lease is taken.
+        /// </summary>
+        internal void ValidateAndConsume(string databasePath)
+        {
+            if (!string.Equals(Path.GetFullPath(databasePath), Path.GetFullPath(_databasePath), PathComparison))
+            {
+                throw new InvalidOperationException(
+                    "Managed embedded replica staged remote changes were staged for a different replica path "
+                    + "and cannot be applied here.");
+            }
+            if (Interlocked.CompareExchange(ref _consumed, 1, 0) != 0)
+            {
+                throw new InvalidOperationException(
+                    "Managed embedded replica staged remote changes were already applied or discarded and "
+                    + "cannot be applied again.");
+            }
+        }
+
+        private static StringComparison PathComparison =>
+            OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+        /// <summary>
+        /// Discards the staged response without applying it. Safe to call whether or not it was
+        /// ever applied: nothing durable or shared was touched while staged, so this only ever
+        /// marks the instance consumed (idempotent) to enforce the one-shot contract.
+        /// </summary>
+        public void Dispose() => Volatile.Write(ref _consumed, 1);
     }
 
     /// <summary>
@@ -4155,19 +4436,19 @@ internal static class ManagedReplicaBootstrapper
         long FirstSequence,
         long Watermark);
 
-    private enum PullStreamKind
+    internal enum PullStreamKind
     {
         Pages = 0,
         MvccLogicalLog = 1,
     }
 
-    private enum PullApplyMode
+    internal enum PullApplyMode
     {
         Incremental = 0,
         ReplaceBase = 1,
     }
 
-    private readonly record struct ManagedReplicaLogicalLogMetadata(
+    internal readonly record struct ManagedReplicaLogicalLogMetadata(
         string Format,
         bool CheckpointTransition,
         IReadOnlyList<ManagedReplicaLogicalLogRange> Ranges);
@@ -4179,14 +4460,14 @@ internal static class ManagedReplicaBootstrapper
         IReadOnlyList<ulong> MaterializedPageIds,
         bool IsPartial);
 
-    private readonly record struct PullHeader(
+    internal readonly record struct PullHeader(
         string Revision,
         ulong DatabasePages,
         PullStreamKind StreamKind,
         PullApplyMode ApplyMode,
         RemotePullProtocol Protocol,
         ManagedReplicaLogicalLogMetadata? LogicalMetadata);
-    private readonly record struct PullPage(ulong PageId, byte[] Data);
+    internal readonly record struct PullPage(ulong PageId, byte[] Data);
     private readonly record struct RoaringContainer(
         ushort Key,
         int Cardinality,
@@ -4332,6 +4613,35 @@ internal static class ManagedReplicaBootstrapper
             _offset += length;
         }
     }
+}
+
+/// <summary>
+/// Signals that local state (metadata, pending/acknowledged local changes) advanced past the
+/// snapshot a <see cref="ManagedReplicaBootstrapper.ManagedReplicaStagedChanges"/> response was
+/// negotiated against, between <see cref="ManagedReplicaBootstrapper.WaitForRemoteChangesAsync"/>
+/// capturing it and <see cref="ManagedReplicaBootstrapper.ApplyRemoteChangesAsync"/> re-validating
+/// it under the exclusive apply lease (see <c>TryUseCurrentLocalStateAsPullBase</c>). The staged
+/// response is never applied on top of a base it was not actually built from -- doing so could
+/// silently regress metadata (rewind <c>Revision</c>) or discard an intervening local change
+/// instead of reconciling it. Callers must discard the staged response and call
+/// <see cref="ManagedReplicaBootstrapper.WaitForRemoteChangesAsync"/> again against
+/// <see cref="FreshMetadata"/>, <see cref="FreshPendingLocalChanges"/>, and
+/// <see cref="FreshAcknowledgedLocalChanges"/>, rather than retrying the stale response or
+/// refetching from inside an apply-time lease.
+/// </summary>
+internal sealed class ManagedReplicaStaleChangesException(
+    ManagedReplicaBootstrapper.ManagedReplicaMetadata freshMetadata,
+    IReadOnlyList<ReplicaLocalChange> freshPendingLocalChanges,
+    IReadOnlyList<ReplicaLocalChange> freshAcknowledgedLocalChanges)
+    : Exception(
+        "Managed embedded replica local state advanced past the snapshot the staged remote changes "
+        + "were negotiated against; discard them and wait for remote changes again.")
+{
+    internal ManagedReplicaBootstrapper.ManagedReplicaMetadata FreshMetadata { get; } = freshMetadata;
+
+    internal IReadOnlyList<ReplicaLocalChange> FreshPendingLocalChanges { get; } = freshPendingLocalChanges;
+
+    internal IReadOnlyList<ReplicaLocalChange> FreshAcknowledgedLocalChanges { get; } = freshAcknowledgedLocalChanges;
 }
 
 /// <summary>The local on-disk state of a managed embedded replica, as determined purely from

--- a/src/Ahtola.Data/ManagedReplicaConnectionHost.cs
+++ b/src/Ahtola.Data/ManagedReplicaConnectionHost.cs
@@ -707,18 +707,21 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
         metadata = ManagedReplicaBootstrapper.EnsureLegacyRemoteBaseSnapshot(
             replicaOptions.Path,
             metadata);
-        var hasTrackedLocalChanges = _changeJournal.ReadBatch(int.MaxValue).Changes.Count != 0
-            || _changeJournal.ReadAcknowledged(metadata.JournalBaseWatermark).Count != 0;
-        var retainedMaterializer = _materializationLease?.FileSystem;
 
         // Push local changes, then (when a partial bootstrap is still catching up) complete the
         // partial image. Both can mutate the local database file directly, so both run gated --
         // every host on this path closed for their duration -- exactly as before the wait/apply
         // split below. Unlike before, that gate is now its own short publication window instead of
-        // spanning the network wait for remote changes too.
+        // spanning the network wait for remote changes too. hasTrackedLocalChanges and the
+        // retained materializer are read INSIDE PreparePushAndPartialReplicaAsync, once the gate
+        // is actually held, not here: acquiring the gate is no longer instantaneous now that the
+        // network wait for remote changes runs ungated, so an intervening publication (another
+        // host's own sync, bootstrap catch-up, or partial-image completion) can advance the
+        // journal or dispose/replace _materializationLease while this call is still waiting its
+        // turn. Reading them here, before the gate, would risk handing PreparePushAndPartialReplicaAsync
+        // a stale bool or an already-disposed file system.
         var (metadataAfterPush, pushedChangeCount) = await _syncEntry.PublishExclusiveAsync(
-                token => PreparePushAndPartialReplicaAsync(
-                    replicaOptions, metadata, syncOptions, hasTrackedLocalChanges, retainedMaterializer, token),
+                token => PreparePushAndPartialReplicaAsync(replicaOptions, metadata, syncOptions, token),
                 cancellationToken)
             .ConfigureAwait(false);
         metadata = metadataAfterPush;
@@ -727,43 +730,21 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
         var pendingLocalChanges = _changeJournal.ReadBatch(int.MaxValue).Changes;
         var acknowledgedLocalChanges = _changeJournal.ReadAcknowledged(metadata.JournalBaseWatermark);
 
-        AhtolaSyncResult result;
-        while (true)
-        {
-            // Wait for remote changes: a pure network long-poll, entirely outside any publication
-            // gate, so sibling connections to this replica keep serving local reads and writes for
-            // however long the remote takes to answer. Mirrors Turso's wait_changes_from_remote
-            // (turso-src/sync/engine/src/database_sync_engine.rs); see
-            // ManagedReplicaBootstrapper.WaitForRemoteChangesAsync.
-            using var staged = await ManagedReplicaBootstrapper.WaitForRemoteChangesAsync(
-                    replicaOptions, metadata, syncOptions, pendingLocalChanges, acknowledgedLocalChanges,
-                    cancellationToken)
-                .ConfigureAwait(false);
-
-            try
-            {
-                // Apply the staged response: gated, since it mutates the local database file.
-                // Mirrors Turso's apply_changes_from_remote; see
-                // ManagedReplicaBootstrapper.ApplyRemoteChangesAsync.
-                var outcome = await _syncEntry.PublishExclusiveAsync(
-                        token => ManagedReplicaBootstrapper.ApplyRemoteChangesAsync(
-                            replicaOptions, staged, syncOptions, expectedConflictState: null, token),
-                        cancellationToken)
-                    .ConfigureAwait(false);
-                result = outcome.Result;
-                break;
-            }
-            catch (ManagedReplicaStaleChangesException stale)
-            {
-                // Local state (metadata/journal) advanced past the snapshot the staged response
-                // was negotiated against -- discard it and wait for remote changes again against
-                // the fresh snapshot, exactly as the original fused retry loop did, but without
-                // ever refetching over the network while a publication gate is held.
-                metadata = stale.FreshMetadata;
-                pendingLocalChanges = stale.FreshPendingLocalChanges;
-                acknowledgedLocalChanges = stale.FreshAcknowledgedLocalChanges;
-            }
-        }
+        // Wait for remote changes and apply them, retrying (bounded, with backoff) when the staged
+        // response turns out to be stale relative to local state. The wait itself runs entirely
+        // outside any publication gate -- see ManagedReplicaBootstrapper.WaitAndApplyRemoteChangesAsync
+        // -- while the apply runs gated, since it mutates the local database file. Mirrors Turso's
+        // wait_changes_from_remote -> apply_changes_from_remote split
+        // (turso-src/sync/engine/src/database_sync_engine.rs).
+        var outcome = await ManagedReplicaBootstrapper.WaitAndApplyRemoteChangesAsync(
+                replicaOptions, metadata, syncOptions, pendingLocalChanges, acknowledgedLocalChanges,
+                (staged, token) => _syncEntry.PublishExclusiveAsync(
+                    applyToken => ManagedReplicaBootstrapper.ApplyRemoteChangesAsync(
+                        replicaOptions, staged, syncOptions, expectedConflictState: null, applyToken),
+                    token),
+                cancellationToken)
+            .ConfigureAwait(false);
+        var result = outcome.Result;
 
         _metadata = ManagedReplicaBootstrapper.LoadMetadata(replicaOptions.Path);
         if (result.Outcome == AhtolaSyncOutcome.RemoteChangesApplied && _metadata is { } published)
@@ -786,15 +767,27 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
     /// publication unit, distinct from the apply publication unit that follows the ungated wait
     /// for remote changes.
     /// </summary>
+    /// <remarks>
+    /// Reads <c>_materializationLease</c> and the change journal itself, rather than receiving them
+    /// as parameters computed before the publication gate was requested: this method only ever runs
+    /// once the gate is actually held, so these reads reflect whatever the most recent prior
+    /// publication (another host's own sync, bootstrap catch-up, or partial-image completion) left
+    /// in place. Reading them earlier, in <see cref="SynchronizeAsync"/> before the gate is even
+    /// requested, could observe a retained materializer that an intervening publication then
+    /// disposes before this operation gets its turn -- a use-after-dispose -- or a
+    /// tracked-local-changes snapshot that is stale by the time it is actually acted upon.
+    /// </remarks>
     private async Task<(ManagedReplicaBootstrapper.ManagedReplicaMetadata Metadata, long PushedChangeCount)>
         PreparePushAndPartialReplicaAsync(
             AhtolaReplicaOptions replicaOptions,
             ManagedReplicaBootstrapper.ManagedReplicaMetadata metadata,
             AhtolaSyncOptions syncOptions,
-            bool hasTrackedLocalChanges,
-            ManagedReplicaPageMaterializingFileSystem? retainedMaterializer,
             CancellationToken cancellationToken)
     {
+        var hasTrackedLocalChanges = _changeJournal.ReadBatch(int.MaxValue).Changes.Count != 0
+            || _changeJournal.ReadAcknowledged(metadata.JournalBaseWatermark).Count != 0;
+        var retainedMaterializer = _materializationLease?.FileSystem;
+
         var push = await PushLocalChangesAsync(
                 replicaOptions,
                 metadata,

--- a/src/Ahtola.Data/ManagedReplicaConnectionHost.cs
+++ b/src/Ahtola.Data/ManagedReplicaConnectionHost.cs
@@ -27,6 +27,7 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
     private IDisposable? _sqlTransactionOperation;
     private bool _sqlTransactionBeginPending;
     private bool _sqlTransactionCompletionPending;
+    private long _retainedMaterializerReadsForTesting;
 
     private ManagedReplicaConnectionHost(
         IManagedDatabaseAdapter database,
@@ -58,6 +59,12 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
     }
 
     public bool SupportsSync => _metadata is not null;
+
+    internal long RetainedMaterializerReadsForTesting
+        => Interlocked.Read(ref _retainedMaterializerReadsForTesting);
+
+    internal ManagedReplicaPageMaterializingFileSystem? RetainedMaterializerForTesting
+        => _materializationLease?.FileSystem;
 
     public IDisposable EnterLocalOperation(CancellationToken cancellationToken)
         => _syncEntry.EnterLocalOperation(cancellationToken);
@@ -786,7 +793,7 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
     {
         var hasTrackedLocalChanges = _changeJournal.ReadBatch(int.MaxValue).Changes.Count != 0
             || _changeJournal.ReadAcknowledged(metadata.JournalBaseWatermark).Count != 0;
-        var retainedMaterializer = _materializationLease?.FileSystem;
+        var retainedMaterializer = ReadRetainedMaterializer();
 
         var push = await PushLocalChangesAsync(
                 replicaOptions,
@@ -807,6 +814,12 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
             .ConfigureAwait(false);
 
         return (metadata, push.ChangeCount);
+    }
+
+    private ManagedReplicaPageMaterializingFileSystem? ReadRetainedMaterializer()
+    {
+        Interlocked.Increment(ref _retainedMaterializerReadsForTesting);
+        return _materializationLease?.FileSystem;
     }
 
     public void Dispose()
@@ -956,6 +969,7 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
                     _options.Path,
                     retainedLease!.FileSystem,
                     readOnly: false);
+                _ = database.Connect();
                 materializationLease = retainedLease;
             }
             else

--- a/src/Ahtola.Data/ManagedReplicaConnectionHost.cs
+++ b/src/Ahtola.Data/ManagedReplicaConnectionHost.cs
@@ -710,36 +710,61 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
         var hasTrackedLocalChanges = _changeJournal.ReadBatch(int.MaxValue).Changes.Count != 0
             || _changeJournal.ReadAcknowledged(metadata.JournalBaseWatermark).Count != 0;
         var retainedMaterializer = _materializationLease?.FileSystem;
-        var push = await PushLocalChangesAsync(
-                replicaOptions,
-                metadata,
-                syncOptions,
-                retainedMaterializer,
-                cancellationToken)
-            .ConfigureAwait(false);
-        metadata = push.Metadata;
-        var pushedChangeCount = push.ChangeCount;
 
-        metadata = await ManagedReplicaBootstrapper
-            .CompletePartialReplicaAsync(
-                replicaOptions,
-                metadata,
-                allowTrackedLocalMutations: hasTrackedLocalChanges,
-                retainedMaterializer,
+        // Push local changes, then (when a partial bootstrap is still catching up) complete the
+        // partial image. Both can mutate the local database file directly, so both run gated --
+        // every host on this path closed for their duration -- exactly as before the wait/apply
+        // split below. Unlike before, that gate is now its own short publication window instead of
+        // spanning the network wait for remote changes too.
+        var (metadataAfterPush, pushedChangeCount) = await _syncEntry.PublishExclusiveAsync(
+                token => PreparePushAndPartialReplicaAsync(
+                    replicaOptions, metadata, syncOptions, hasTrackedLocalChanges, retainedMaterializer, token),
                 cancellationToken)
             .ConfigureAwait(false);
+        metadata = metadataAfterPush;
         _metadata = metadata;
 
         var pendingLocalChanges = _changeJournal.ReadBatch(int.MaxValue).Changes;
         var acknowledgedLocalChanges = _changeJournal.ReadAcknowledged(metadata.JournalBaseWatermark);
-        var result = await ManagedReplicaBootstrapper.CheckForUpdatesAsync(
-                replicaOptions,
-                metadata,
-                syncOptions,
-                pendingLocalChanges,
-                acknowledgedLocalChanges,
-                cancellationToken)
-            .ConfigureAwait(false);
+
+        AhtolaSyncResult result;
+        while (true)
+        {
+            // Wait for remote changes: a pure network long-poll, entirely outside any publication
+            // gate, so sibling connections to this replica keep serving local reads and writes for
+            // however long the remote takes to answer. Mirrors Turso's wait_changes_from_remote
+            // (turso-src/sync/engine/src/database_sync_engine.rs); see
+            // ManagedReplicaBootstrapper.WaitForRemoteChangesAsync.
+            using var staged = await ManagedReplicaBootstrapper.WaitForRemoteChangesAsync(
+                    replicaOptions, metadata, syncOptions, pendingLocalChanges, acknowledgedLocalChanges,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            try
+            {
+                // Apply the staged response: gated, since it mutates the local database file.
+                // Mirrors Turso's apply_changes_from_remote; see
+                // ManagedReplicaBootstrapper.ApplyRemoteChangesAsync.
+                var outcome = await _syncEntry.PublishExclusiveAsync(
+                        token => ManagedReplicaBootstrapper.ApplyRemoteChangesAsync(
+                            replicaOptions, staged, syncOptions, expectedConflictState: null, token),
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                result = outcome.Result;
+                break;
+            }
+            catch (ManagedReplicaStaleChangesException stale)
+            {
+                // Local state (metadata/journal) advanced past the snapshot the staged response
+                // was negotiated against -- discard it and wait for remote changes again against
+                // the fresh snapshot, exactly as the original fused retry loop did, but without
+                // ever refetching over the network while a publication gate is held.
+                metadata = stale.FreshMetadata;
+                pendingLocalChanges = stale.FreshPendingLocalChanges;
+                acknowledgedLocalChanges = stale.FreshAcknowledgedLocalChanges;
+            }
+        }
+
         _metadata = ManagedReplicaBootstrapper.LoadMetadata(replicaOptions.Path);
         if (result.Outcome == AhtolaSyncOutcome.RemoteChangesApplied && _metadata is { } published)
             _changeJournal.PruneAcknowledged(published.JournalBaseWatermark);
@@ -751,6 +776,44 @@ internal sealed class ManagedReplicaConnectionHost : IDisposable
                 LastPush = pushedChangeCount == 0 ? result.Statistics.LastPush : DateTimeOffset.UtcNow,
             },
         };
+    }
+
+    /// <summary>
+    /// Runs the gated first half of one sync cycle: push local changes to the remote, then (when a
+    /// partial bootstrap is still catching up) complete the partial image. Split out of
+    /// <see cref="SynchronizeAsync"/> so it can be handed to
+    /// <see cref="ManagedReplicaSyncRegistry.Entry.PublishExclusiveAsync{T}"/> as its own
+    /// publication unit, distinct from the apply publication unit that follows the ungated wait
+    /// for remote changes.
+    /// </summary>
+    private async Task<(ManagedReplicaBootstrapper.ManagedReplicaMetadata Metadata, long PushedChangeCount)>
+        PreparePushAndPartialReplicaAsync(
+            AhtolaReplicaOptions replicaOptions,
+            ManagedReplicaBootstrapper.ManagedReplicaMetadata metadata,
+            AhtolaSyncOptions syncOptions,
+            bool hasTrackedLocalChanges,
+            ManagedReplicaPageMaterializingFileSystem? retainedMaterializer,
+            CancellationToken cancellationToken)
+    {
+        var push = await PushLocalChangesAsync(
+                replicaOptions,
+                metadata,
+                syncOptions,
+                retainedMaterializer,
+                cancellationToken)
+            .ConfigureAwait(false);
+        metadata = push.Metadata;
+
+        metadata = await ManagedReplicaBootstrapper
+            .CompletePartialReplicaAsync(
+                replicaOptions,
+                metadata,
+                allowTrackedLocalMutations: hasTrackedLocalChanges,
+                retainedMaterializer,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        return (metadata, push.ChangeCount);
     }
 
     public void Dispose()

--- a/src/Ahtola.Data/ManagedReplicaSyncRegistry.cs
+++ b/src/Ahtola.Data/ManagedReplicaSyncRegistry.cs
@@ -173,6 +173,9 @@ internal static class ManagedReplicaSyncRegistry
             Func<CancellationToken, Task<AhtolaSyncResult>> stagedOperation,
             CancellationToken cancellationToken)
         {
+            AhtolaSyncResult? result = null;
+            Exception? failure = null;
+            var canceled = false;
             try
             {
                 // Unlike PublishAsync/PublishExclusiveAsync, this deliberately does NOT itself wrap
@@ -183,21 +186,43 @@ internal static class ManagedReplicaSyncRegistry
                 // own rare conflict-restore branch; the actual apply). Coalescing concurrent
                 // SyncAsync callers for this path into one shared in-flight task is this method's
                 // only job; deciding when to gate is entirely the staged operation's business.
-                completion.TrySetResult(await stagedOperation(cancellationToken).ConfigureAwait(false));
+                result = await stagedOperation(cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException exception) when (exception.CancellationToken == cancellationToken)
             {
-                completion.TrySetCanceled(cancellationToken);
+                canceled = true;
             }
             catch (Exception exception)
             {
-                completion.TrySetException(exception);
+                failure = exception;
             }
-            finally
+
+            // Clear the in-flight slot BEFORE completing the TaskCompletionSource below.
+            // TrySetResult/TrySetException/TrySetCanceled make completion.Task observably complete
+            // (IsCompleted becomes true synchronously, even though continuations queued with
+            // RunContinuationsAsynchronously run later) the instant they are called. If
+            // _inFlightSync stayed pointing at that task past this point, a SyncAsync call
+            // arriving in the resulting window would see a non-null _inFlightSync, join it via the
+            // read in SynchronizeAsync, and receive this ALREADY-COMPLETED result without
+            // performing any new work at all -- silently skipping a sync its caller explicitly
+            // requested. The identity check guards against a stale write if this slot were ever
+            // touched from elsewhere. Retirement is re-checked here too: with RetireIfUnusedNoLock
+            // now refusing to retire while _inFlightSync is set, clearing it may be the very last
+            // condition standing between an already-unreferenced entry and retirement.
+            lock (_gate)
             {
-                lock (_gate)
+                if (ReferenceEquals(_inFlightSync, completion.Task))
                     _inFlightSync = null;
+                SignalStateChangedNoLock();
+                RetireIfUnusedNoLock();
             }
+
+            if (canceled)
+                completion.TrySetCanceled(cancellationToken);
+            else if (failure is not null)
+                completion.TrySetException(failure);
+            else
+                completion.TrySetResult(result!);
         }
 
         public Task PublishAsync(
@@ -301,6 +326,24 @@ internal static class ManagedReplicaSyncRegistry
                 Task stateChanged;
                 lock (_gate)
                 {
+                    if (_retired)
+                    {
+                        // Defense in depth: RetireIfUnusedNoLock now refuses to retire while
+                        // _inFlightSync is set, so an entry with a sync (push/wait/apply cycle)
+                        // still in flight should never reach retirement in the first place, and no
+                        // publication should ever observe _retired here. If it ever does, some
+                        // other path let an in-flight operation survive past this entry's removal
+                        // from the registry -- failing loudly is far safer than silently closing
+                        // and reopening zero coordinated hosts and running the staged operation
+                        // (e.g. an apply that mutates the physical file) with no protection against
+                        // a brand-new, unrelated Entry that may now be governing the very same
+                        // physical replica path.
+                        throw new InvalidOperationException(
+                            "Managed embedded replica sync coordination entry was already retired and "
+                            + "cannot accept new publication work; an operation raced a retired registry "
+                            + "entry and must not proceed.");
+                    }
+
                     if (!request.OwnsPublication && !_publicationPending && !_publicationActive)
                     {
                         _publicationPending = true;
@@ -338,7 +381,8 @@ internal static class ManagedReplicaSyncRegistry
                 || _hosts.Count != 0
                 || _activeLocalOperations != 0
                 || _publicationPending
-                || _publicationActive)
+                || _publicationActive
+                || _inFlightSync is not null)
             {
                 return;
             }

--- a/src/Ahtola.Data/ManagedReplicaSyncRegistry.cs
+++ b/src/Ahtola.Data/ManagedReplicaSyncRegistry.cs
@@ -175,9 +175,15 @@ internal static class ManagedReplicaSyncRegistry
         {
             try
             {
-                completion.TrySetResult(
-                    await PublishAsync(stagedOperation, cancellationToken, clearInFlightSync: true)
-                        .ConfigureAwait(false));
+                // Unlike PublishAsync/PublishExclusiveAsync, this deliberately does NOT itself wrap
+                // stagedOperation in one publication window: SyncAsync's staged operation runs its
+                // network-bound phases (push, then the long-poll wait for remote changes) entirely
+                // without any publication gate held, and calls PublishExclusiveAsync itself --
+                // possibly more than once -- only around the short local-mutating phases (push's
+                // own rare conflict-restore branch; the actual apply). Coalescing concurrent
+                // SyncAsync callers for this path into one shared in-flight task is this method's
+                // only job; deciding when to gate is entirely the staged operation's business.
+                completion.TrySetResult(await stagedOperation(cancellationToken).ConfigureAwait(false));
             }
             catch (OperationCanceledException exception) when (exception.CancellationToken == cancellationToken)
             {
@@ -186,6 +192,11 @@ internal static class ManagedReplicaSyncRegistry
             catch (Exception exception)
             {
                 completion.TrySetException(exception);
+            }
+            finally
+            {
+                lock (_gate)
+                    _inFlightSync = null;
             }
         }
 
@@ -200,8 +211,7 @@ internal static class ManagedReplicaSyncRegistry
                     await stagedOperation(token).ConfigureAwait(false);
                     return true;
                 },
-                cancellationToken,
-                clearInFlightSync: false);
+                cancellationToken);
         }
 
         /// <summary>
@@ -215,13 +225,12 @@ internal static class ManagedReplicaSyncRegistry
             CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(stagedOperation);
-            return PublishAsync(stagedOperation, cancellationToken, clearInFlightSync: false);
+            return PublishAsync(stagedOperation, cancellationToken);
         }
 
         private async Task<T> PublishAsync<T>(
             Func<CancellationToken, Task<T>> stagedOperation,
-            CancellationToken cancellationToken,
-            bool clearInFlightSync)
+            CancellationToken cancellationToken)
         {
             var request = new PublicationRequest();
             try
@@ -276,8 +285,6 @@ internal static class ManagedReplicaSyncRegistry
                     {
                         _publicationActive = false;
                         _publicationPending = false;
-                        if (clearInFlightSync)
-                            _inFlightSync = null;
                         SignalStateChangedNoLock();
                         RetireIfUnusedNoLock();
                     }

--- a/src/Ahtola.Tests/ManagedReplicaConflictRebaseTests.cs
+++ b/src/Ahtola.Tests/ManagedReplicaConflictRebaseTests.cs
@@ -1307,7 +1307,12 @@ public sealed class ManagedReplicaConflictRebaseTests
         // Between the request and the apply, a concurrent participant acknowledges the first
         // journal entry. The staleness check must reload BOTH the pending and the acknowledged
         // history: refreshing only the pending set would leave the acknowledged entry in neither
-        // replay list, and the protected rebuild would silently drop its row.
+        // replay list, and the protected rebuild would silently drop its row. Since the
+        // acknowledge only advances local journal state -- metadata's revision, database hash,
+        // revert/push state, and journal watermark are all untouched -- this is exactly the
+        // benign case the apply lease rebases onto in place (see
+        // ManagedReplicaBootstrapper.RebaseOntoCurrentLocalStateOrThrowAsync) rather than
+        // discarding the response and re-fetching from the remote.
         var path = NewReplicaPath("conflict-stale-retry-acknowledged");
         var image = CreateLogicalSourceImage(path + ".source");
         var (logicalBody, rangeMessage) = BuildSimpleLogicalPullBody(
@@ -1320,7 +1325,6 @@ public sealed class ManagedReplicaConflictRebaseTests
         [
             CreatePagePullResponse("revision-42", image, protocol: 2),
             CreateLogicalPullResponse("revision-42", []),
-            CreateLogicalPullResponse("revision-43", logicalBody, [rangeMessage]),
             CreateLogicalPullResponse("revision-43", logicalBody, [rangeMessage]),
         ]);
         var options = CreateOptions(path, handler);
@@ -1359,8 +1363,12 @@ public sealed class ManagedReplicaConflictRebaseTests
                     CancellationToken.None);
                 result.Outcome.Should().Be(AhtolaSyncOutcome.RemoteChangesApplied);
             }
-            interleaved.Should().BeGreaterThan(1, "the stale response must have been discarded and re-pulled");
-            handler.PullCallCount.Should().Be(4);
+            interleaved.Should().Be(
+                1,
+                "the acknowledge only advances local journal state, so the apply lease rebases onto the "
+                + "refreshed journal in place instead of discarding the response and re-pulling from the "
+                + "remote");
+            handler.PullCallCount.Should().Be(3);
             using var reopened = AhtolaConnection.CreateReplica(options);
             reopened.Open();
             ReadJournalEventValues(reopened).Should().Equal(
@@ -1368,6 +1376,92 @@ public sealed class ManagedReplicaConflictRebaseTests
                 "the acknowledged write must be replayed from the refreshed acknowledged history");
             ReadScalar(reopened, "SELECT x FROM remote_items WHERE id = 2;").Should().Be("remote");
             ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.JournalBaseWatermark.Should().Be(2);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task SiblingConnectionWriteBeforeTheApplyIsRebasedWithoutAnExtraPullOrHostChurn()
+    {
+        // The same benign race as the previous test, but end-to-end through a second, genuinely
+        // independent AhtolaConnection instead of a raw journal acknowledge: a sibling connection
+        // commits an ordinary local write after the pull request/response this call replays were
+        // captured, but before CheckForUpdatesAsync's apply lease re-validates the local baseline
+        // against them -- exactly the ordering a real concurrent sibling write racing the network
+        // long-poll produces, sequenced deterministically here instead of via a timing-dependent
+        // concurrent write. Only the pending local-change journal advances -- the remote-facing
+        // identity the staged response depends on (revision, database hash, revert/push state,
+        // journal watermark) does not -- so the apply lease must rebase onto the fresh journal in
+        // place instead of discarding the response and re-pulling from the remote, bounding both
+        // network traffic and host close/reopen churn to exactly what this one pull needs.
+        var path = NewReplicaPath("conflict-stale-retry-sibling-write");
+        var image = CreateLogicalSourceImage(path + ".source");
+        var (logicalBody, rangeMessage) = BuildSimpleLogicalPullBody(
+            tableName: "remote_items",
+            rowId: 2,
+            columnValue: "remote",
+            schemaSql: "CREATE TABLE remote_items(id INTEGER PRIMARY KEY, x TEXT)",
+            salt: 7222UL);
+        var handler = ConflictHandler.NoPush(
+        [
+            CreatePagePullResponse("revision-42", image, protocol: 2),
+            CreateLogicalPullResponse("revision-42", []),
+            CreateLogicalPullResponse("revision-43", logicalBody, [rangeMessage]),
+        ]);
+        var options = CreateOptions(path, handler);
+        try
+        {
+            IReadOnlyList<ReplicaLocalChange> pendingChanges;
+            ManagedReplicaBootstrapper.ManagedReplicaMetadata metadata;
+            using (var connection = AhtolaConnection.CreateReplica(options))
+            {
+                connection.Open();
+                connection.ExecuteNonQuery("INSERT INTO journal_events VALUES (10);");
+                pendingChanges = ManagedReplicaChangeJournal.Open(path).ReadBatch(int.MaxValue).Changes;
+                metadata = ManagedReplicaBootstrapper.LoadMetadata(path)!.Value;
+            }
+            pendingChanges.Select(change => change.Sequence).Should().Equal(1L);
+
+            // A second, independent connection commits an ordinary write after pendingChanges/
+            // metadata above were captured as this pull's request base, but before
+            // CheckForUpdatesAsync (below) ever re-validates that base against fresh disk state.
+            using (var sibling = AhtolaConnection.CreateReplica(options))
+            {
+                sibling.Open();
+                sibling.ExecuteNonQuery("INSERT INTO journal_events VALUES (20);");
+            }
+
+            var applyLockAcquisitions = 0;
+            using (ManagedReplicaFaultInjection.Push(boundary =>
+            {
+                if (boundary == ManagedReplicaDurableBoundary.ReplicaApplyLockAcquired)
+                    Interlocked.Increment(ref applyLockAcquisitions);
+            }))
+            {
+                var result = await ManagedReplicaBootstrapper.CheckForUpdatesAsync(
+                    options, metadata, new AhtolaSyncOptions(), pendingChanges, [], CancellationToken.None);
+                result.Outcome.Should().Be(AhtolaSyncOutcome.RemoteChangesApplied);
+            }
+
+            applyLockAcquisitions.Should().Be(
+                1,
+                "the sibling connection's write only advances the local journal, so the apply lease "
+                + "rebases onto it in place instead of discarding the response and re-pulling from "
+                + "the remote");
+            handler.PullCallCount.Should().Be(
+                3,
+                "bootstrap plus catch-up plus exactly one explicit pull -- no extra re-fetch for the "
+                + "sibling connection's write");
+
+            using var reopened = AhtolaConnection.CreateReplica(options);
+            reopened.Open();
+            ReadJournalEventValues(reopened).Should().Equal(
+                [10, 20],
+                "the sibling connection's write must survive the rebase, not be lost or overwritten");
+            ReadScalar(reopened, "SELECT x FROM remote_items WHERE id = 2;").Should().Be("remote");
         }
         finally
         {

--- a/src/Ahtola.Tests/ManagedReplicaWaitApplySplitTests.cs
+++ b/src/Ahtola.Tests/ManagedReplicaWaitApplySplitTests.cs
@@ -479,6 +479,14 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
             using var hostA = ManagedReplicaConnectionHost.Open(options);
             using var hostB = ManagedReplicaConnectionHost.Open(options);
 
+            await hostB.QuiesceAndReopenAsync(
+                _ => Task.CompletedTask,
+                CancellationToken.None);
+            File.Exists(path + ManagedReplicaPageMaterializingFileSystem.StateSuffix)
+                .Should().BeTrue();
+            ReadHostScalar(hostA, "SELECT value FROM bootstrap_marker;").Should().Be(42);
+            ReadHostScalar(hostB, "SELECT value FROM bootstrap_marker;").Should().Be(42);
+
             var paused = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var pausedOnce = 0;
@@ -550,5 +558,12 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
         {
             DeleteReplicaFiles(path);
         }
+    }
+
+    private static long ReadHostScalar(ManagedReplicaConnectionHost host, string sql)
+    {
+        using var statement = host.Database.Connection.Prepare(sql);
+        statement.Step().Should().Be(Ahtola.Core.StatementStepResult.Row);
+        return statement.GetValue(0).AsInteger();
     }
 }

--- a/src/Ahtola.Tests/ManagedReplicaWaitApplySplitTests.cs
+++ b/src/Ahtola.Tests/ManagedReplicaWaitApplySplitTests.cs
@@ -1,0 +1,353 @@
+using System.Net;
+using System.Net.Http.Headers;
+using AwesomeAssertions;
+
+namespace Ahtola.Tests;
+
+/// <summary>
+/// Covers the managed replica sync engine's staged wait/apply lifecycle (mirrors Turso's
+/// <c>wait_changes_from_remote</c> -&gt; opaque staged changes -&gt;
+/// <c>apply_changes_from_remote</c> split; see
+/// turso-src/sync/engine/src/database_sync_engine.rs): that
+/// <see cref="AhtolaConnection.SyncAsync(AhtolaSyncOptions, CancellationToken)"/> no longer holds
+/// the per-path host publication gate during the network long-poll, and that
+/// <see cref="ManagedReplicaBootstrapper.ManagedReplicaStagedChanges"/> fails closed against
+/// cross-replica, duplicate-apply, disposed-result, and stale-revision misuse.
+/// </summary>
+public sealed partial class ManagedEmbeddedReplicaConnectionTests
+{
+    [Test]
+    public async Task SyncAsyncDoesNotBlockSiblingReadsDuringTheNetworkWait()
+    {
+        var path = NewReplicaPath("managed-replica-wait-split-read-unblocked");
+        var image = CreateDatabaseImage(path + ".source");
+        var handler = new BlockingPullUpdatesHandler(
+            CreatePullResponse("revision-42", image),
+            CreatePullResponse("revision-42", [], declaredPages: 1));
+        try
+        {
+            using var local = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            using var synchronizer = AhtolaConnection.CreateReplica(CreateOptions(path, handler));
+            local.Open();
+            synchronizer.Open();
+
+            var sync = synchronizer.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
+            await handler.SyncStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            // The sync's pull-updates request is now blocked inside the network long-poll. Before
+            // the wait/apply split, the per-path publication gate was held for this entire staged
+            // operation (push, then the fused wait+apply), so a sibling connection's database
+            // adapter would already be closed and this read would either block on
+            // EnterLocalOperationAsync or fail outright. It must instead complete immediately: the
+            // wait for remote changes no longer holds any publication gate (see
+            // ManagedReplicaBootstrapper.WaitForRemoteChangesAsync).
+            var readTask = Task.Run(() => local.ExecuteNonQuery("SELECT value FROM bootstrap_marker;"));
+            (await readTask.WaitAsync(TimeSpan.FromSeconds(5))).Should().Be(0);
+            sync.IsCompleted.Should().BeFalse();
+
+            // A brand-new read-only transaction started while the wait is in flight is not
+            // blocked either.
+            using (var transaction = local.BeginTransaction())
+            {
+                using var command = local.CreateCommand();
+                command.CommandText = "SELECT value FROM bootstrap_marker;";
+                command.Transaction = transaction;
+                _ = command.ExecuteScalar();
+                transaction.Commit();
+            }
+            sync.IsCompleted.Should().BeFalse();
+
+            handler.Release();
+            (await sync.WaitAsync(TimeSpan.FromSeconds(5))).Outcome.Should().Be(AhtolaSyncOutcome.UpToDate);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task WaitForRemoteChangesAsyncStagesAPagesResponseWithoutMutatingLocalState()
+    {
+        var path = NewReplicaPath("managed-replica-wait-split-stage-pages");
+        var image = CreateDatabaseImage(path + ".source");
+        var updatedImage = CreateDatabaseImageWithMarker(path + ".updated", 84);
+        var handler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", image),
+            CreatePullResponse("revision-43", updatedImage),
+        ]);
+        var options = CreateOptions(path, handler);
+        try
+        {
+            using (var setup = AhtolaConnection.CreateReplica(options))
+                setup.Open();
+
+            var metadata = ManagedReplicaBootstrapper.LoadMetadata(path)!.Value;
+            using var staged = await ManagedReplicaBootstrapper.WaitForRemoteChangesAsync(
+                    options, metadata, new AhtolaSyncOptions(), pendingLocalChanges: [], acknowledgedLocalChanges: [],
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+
+            // Staging never touches the durable database: the revision on disk is unchanged, and
+            // the response is not yet applied.
+            staged.IsEmpty.Should().BeFalse();
+            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.Revision.Should().Be("revision-42");
+
+            var applied = await ManagedReplicaBootstrapper.ApplyRemoteChangesAsync(
+                    options, staged, new AhtolaSyncOptions(), expectedConflictState: null, CancellationToken.None)
+                .ConfigureAwait(false);
+            applied.Result.Outcome.Should().Be(AhtolaSyncOutcome.RemoteChangesApplied);
+            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.Revision.Should().Be("revision-43");
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task WaitForRemoteChangesAsyncStagesANoOpResponseThatAppliesToUpToDate()
+    {
+        var path = NewReplicaPath("managed-replica-wait-split-stage-noop");
+        var image = CreateDatabaseImage(path + ".source");
+        var handler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", image),
+            CreatePullResponse("revision-42", [], declaredPages: 1),
+        ]);
+        var options = CreateOptions(path, handler);
+        try
+        {
+            using (var setup = AhtolaConnection.CreateReplica(options))
+                setup.Open();
+
+            var metadata = ManagedReplicaBootstrapper.LoadMetadata(path)!.Value;
+            using var staged = await ManagedReplicaBootstrapper.WaitForRemoteChangesAsync(
+                    options, metadata, new AhtolaSyncOptions(), pendingLocalChanges: [], acknowledgedLocalChanges: [],
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+
+            staged.IsEmpty.Should().BeTrue();
+
+            var applied = await ManagedReplicaBootstrapper.ApplyRemoteChangesAsync(
+                    options, staged, new AhtolaSyncOptions(), expectedConflictState: null, CancellationToken.None)
+                .ConfigureAwait(false);
+            applied.Result.Outcome.Should().Be(AhtolaSyncOutcome.UpToDate);
+            applied.ReplayedLocalChangeCount.Should().Be(0);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task ApplyRemoteChangesAsyncThrowsWhenLocalStateAdvancedPastTheStagedSnapshot()
+    {
+        var path = NewReplicaPath("managed-replica-wait-split-stale-revision");
+        var image = CreateDatabaseImage(path + ".source");
+        var handler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", image),
+            CreatePullResponse("revision-43", CreateDatabaseImageWithMarker(path + ".updated-a", 100)),
+            CreatePullResponse("revision-44", CreateDatabaseImageWithMarker(path + ".updated-b", 200)),
+        ]);
+        var options = CreateOptions(path, handler);
+        try
+        {
+            using (var setup = AhtolaConnection.CreateReplica(options))
+                setup.Open();
+
+            var metadata = ManagedReplicaBootstrapper.LoadMetadata(path)!.Value;
+
+            // Two independent waits negotiated against the SAME (revision-42) base -- exactly the
+            // situation a concurrent racer (another sync, another process) creates for the second
+            // one once the first has published.
+            using var stagedFirst = await ManagedReplicaBootstrapper.WaitForRemoteChangesAsync(
+                    options, metadata, new AhtolaSyncOptions(), pendingLocalChanges: [], acknowledgedLocalChanges: [],
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+            using var stagedSecond = await ManagedReplicaBootstrapper.WaitForRemoteChangesAsync(
+                    options, metadata, new AhtolaSyncOptions(), pendingLocalChanges: [], acknowledgedLocalChanges: [],
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+
+            var appliedFirst = await ManagedReplicaBootstrapper.ApplyRemoteChangesAsync(
+                    options, stagedFirst, new AhtolaSyncOptions(), expectedConflictState: null, CancellationToken.None)
+                .ConfigureAwait(false);
+            appliedFirst.Result.Outcome.Should().Be(AhtolaSyncOutcome.RemoteChangesApplied);
+            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.Revision.Should().Be("revision-43");
+
+            // The second staged response was negotiated against revision-42, which the durable
+            // metadata has since moved past -- applying it must never silently regress metadata or
+            // discard the first apply; it must fail closed with the fresh snapshot instead.
+            var stale = Assert.ThrowsAsync<ManagedReplicaStaleChangesException>(() =>
+                ManagedReplicaBootstrapper.ApplyRemoteChangesAsync(
+                    options, stagedSecond, new AhtolaSyncOptions(), expectedConflictState: null, CancellationToken.None));
+            stale!.FreshMetadata.Revision.Should().Be("revision-43");
+            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.Revision.Should().Be("revision-43");
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task ApplyRemoteChangesAsyncRejectsChangesStagedForADifferentReplicaPath()
+    {
+        var pathA = NewReplicaPath("managed-replica-wait-split-cross-replica-a");
+        var pathB = NewReplicaPath("managed-replica-wait-split-cross-replica-b");
+        var imageA = CreateDatabaseImage(pathA + ".source");
+        var imageB = CreateDatabaseImage(pathB + ".source");
+        var handlerA = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", imageA),
+            CreatePullResponse("revision-43", CreateDatabaseImageWithMarker(pathA + ".updated", 7)),
+        ]);
+        var handlerB = new PullUpdatesHandler([CreatePullResponse("revision-42", imageB)]);
+        var optionsA = CreateOptions(pathA, handlerA);
+        var optionsB = CreateOptions(pathB, handlerB);
+        try
+        {
+            using (var setupA = AhtolaConnection.CreateReplica(optionsA))
+                setupA.Open();
+            using (var setupB = AhtolaConnection.CreateReplica(optionsB))
+                setupB.Open();
+
+            var metadataA = ManagedReplicaBootstrapper.LoadMetadata(pathA)!.Value;
+            using var staged = await ManagedReplicaBootstrapper.WaitForRemoteChangesAsync(
+                    optionsA, metadataA, new AhtolaSyncOptions(), pendingLocalChanges: [], acknowledgedLocalChanges: [],
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+
+            var exception = Assert.ThrowsAsync<InvalidOperationException>(() =>
+                ManagedReplicaBootstrapper.ApplyRemoteChangesAsync(
+                    optionsB, staged, new AhtolaSyncOptions(), expectedConflictState: null, CancellationToken.None));
+            exception!.Message.Should().Contain("different replica path");
+
+            // Misuse against the wrong path must not have consumed the staged changes: applying
+            // them against the CORRECT path afterward still succeeds.
+            var applied = await ManagedReplicaBootstrapper.ApplyRemoteChangesAsync(
+                    optionsA, staged, new AhtolaSyncOptions(), expectedConflictState: null, CancellationToken.None)
+                .ConfigureAwait(false);
+            applied.Result.Outcome.Should().Be(AhtolaSyncOutcome.RemoteChangesApplied);
+        }
+        finally
+        {
+            DeleteReplicaFiles(pathA);
+            DeleteReplicaFiles(pathB);
+        }
+    }
+
+    [Test]
+    public async Task ApplyRemoteChangesAsyncRejectsReapplyingTheSameStagedChanges()
+    {
+        var path = NewReplicaPath("managed-replica-wait-split-duplicate-apply");
+        var image = CreateDatabaseImage(path + ".source");
+        var handler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", image),
+            CreatePullResponse("revision-43", CreateDatabaseImageWithMarker(path + ".updated", 7)),
+        ]);
+        var options = CreateOptions(path, handler);
+        try
+        {
+            using (var setup = AhtolaConnection.CreateReplica(options))
+                setup.Open();
+
+            var metadata = ManagedReplicaBootstrapper.LoadMetadata(path)!.Value;
+            using var staged = await ManagedReplicaBootstrapper.WaitForRemoteChangesAsync(
+                    options, metadata, new AhtolaSyncOptions(), pendingLocalChanges: [], acknowledgedLocalChanges: [],
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+
+            var applied = await ManagedReplicaBootstrapper.ApplyRemoteChangesAsync(
+                    options, staged, new AhtolaSyncOptions(), expectedConflictState: null, CancellationToken.None)
+                .ConfigureAwait(false);
+            applied.Result.Outcome.Should().Be(AhtolaSyncOutcome.RemoteChangesApplied);
+
+            var exception = Assert.ThrowsAsync<InvalidOperationException>(() =>
+                ManagedReplicaBootstrapper.ApplyRemoteChangesAsync(
+                    options, staged, new AhtolaSyncOptions(), expectedConflictState: null, CancellationToken.None));
+            exception!.Message.Should().Contain("already applied or discarded");
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task ApplyRemoteChangesAsyncRejectsChangesAlreadyDiscarded()
+    {
+        var path = NewReplicaPath("managed-replica-wait-split-disposed-result");
+        var image = CreateDatabaseImage(path + ".source");
+        var handler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", image),
+            CreatePullResponse("revision-43", CreateDatabaseImageWithMarker(path + ".updated", 7)),
+        ]);
+        var options = CreateOptions(path, handler);
+        try
+        {
+            using (var setup = AhtolaConnection.CreateReplica(options))
+                setup.Open();
+
+            var metadata = ManagedReplicaBootstrapper.LoadMetadata(path)!.Value;
+            var staged = await ManagedReplicaBootstrapper.WaitForRemoteChangesAsync(
+                    options, metadata, new AhtolaSyncOptions(), pendingLocalChanges: [], acknowledgedLocalChanges: [],
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+
+            // Discarding a staged response that was never applied must be a safe no-op: nothing
+            // durable or shared was ever touched while it was staged.
+            staged.Dispose();
+            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.Revision.Should().Be("revision-42");
+
+            var exception = Assert.ThrowsAsync<InvalidOperationException>(() =>
+                ManagedReplicaBootstrapper.ApplyRemoteChangesAsync(
+                    options, staged, new AhtolaSyncOptions(), expectedConflictState: null, CancellationToken.None));
+            exception!.Message.Should().Contain("already applied or discarded");
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task WaitForRemoteChangesAsyncObservesCancellationDuringTheLongPollWithoutMutatingLocalState()
+    {
+        var path = NewReplicaPath("managed-replica-wait-split-cancel");
+        var image = CreateDatabaseImage(path + ".source");
+        var bootstrapHandler = new PullUpdatesHandler([CreatePullResponse("revision-42", image)]);
+        var options = CreateOptions(path, bootstrapHandler);
+        try
+        {
+            using (var setup = AhtolaConnection.CreateReplica(options))
+                setup.Open();
+
+            var metadata = ManagedReplicaBootstrapper.LoadMetadata(path)!.Value;
+            var delayed = new DelayedPullHandler(CreatePullResponse("revision-43", image));
+            var delayedOptions = CreateOptions(path, delayed);
+            using var cancellation = new CancellationTokenSource();
+
+            var wait = ManagedReplicaBootstrapper.WaitForRemoteChangesAsync(
+                delayedOptions, metadata, new AhtolaSyncOptions(), pendingLocalChanges: [], acknowledgedLocalChanges: [],
+                cancellation.Token);
+            await delayed.RequestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            cancellation.Cancel();
+
+            Assert.CatchAsync<OperationCanceledException>(() => wait);
+            // A cancelled wait never reached any lock or local mutation: the durable revision is
+            // exactly as it was before the call.
+            ManagedReplicaBootstrapper.LoadMetadata(path)!.Value.Revision.Should().Be("revision-42");
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+}

--- a/src/Ahtola.Tests/ManagedReplicaWaitApplySplitTests.cs
+++ b/src/Ahtola.Tests/ManagedReplicaWaitApplySplitTests.cs
@@ -350,4 +350,188 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
             DeleteReplicaFiles(path);
         }
     }
+
+    [Test]
+    public async Task SyncAsyncCalledImmediatelyAfterAPriorSyncCompletesNeverJoinsItsAlreadyCompletedTask()
+    {
+        var path = NewReplicaPath("managed-replica-wait-split-reentrant-sync");
+        var image = CreateDatabaseImage(path + ".source");
+        var handler = new PullUpdatesHandler(
+        [
+            CreatePullResponse("revision-42", image),
+            CreatePullResponse("revision-42", [], declaredPages: 1),
+            CreatePullResponse("revision-43", CreateDatabaseImageWithMarker(path + ".updated", 7)),
+        ]);
+        var options = CreateOptions(path, handler);
+        try
+        {
+            using var connection = AhtolaConnection.CreateReplica(options);
+            connection.Open();
+
+            var first = connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
+
+            // Chained via ContinueWith rather than a sequential await: this schedules the second
+            // call to run as soon as `first` becomes observably complete -- exactly the
+            // reentrancy window ManagedReplicaSyncRegistry.Entry.CompleteSyncAsync's fix closes.
+            // Clearing _inFlightSync now happens-before completing first's TaskCompletionSource,
+            // so any continuation of `first` (including this one) is guaranteed to observe
+            // _inFlightSync already cleared and must start a brand-new sync rather than silently
+            // joining the first call's already-completed cached result.
+            var second = first
+                .ContinueWith(_ => connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None))
+                .Unwrap();
+
+            var firstResult = await first.WaitAsync(TimeSpan.FromSeconds(5));
+            var secondResult = await second.WaitAsync(TimeSpan.FromSeconds(5));
+
+            firstResult.Outcome.Should().Be(AhtolaSyncOutcome.UpToDate);
+            secondResult.Outcome.Should().Be(AhtolaSyncOutcome.RemoteChangesApplied);
+            // Bootstrap consumed the first queued response; each SyncAsync call above must have
+            // performed its own real network poll rather than the second one silently reusing the
+            // first's already-completed result, so exactly three /pull-updates calls were made.
+            handler.CallCount.Should().Be(3);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task DisposingTheLastHostWhileASyncIsWaitingForRemoteChangesDoesNotRetireTheEntry()
+    {
+        var path = NewReplicaPath("managed-replica-wait-split-dispose-during-wait");
+        var image = CreateDatabaseImage(path + ".source");
+        var handler = new BlockingPullUpdatesHandler(
+            CreatePullResponse("revision-42", image),
+            CreatePullResponse("revision-42", [], declaredPages: 1));
+        var options = CreateOptions(path, handler);
+        try
+        {
+            var connection = AhtolaConnection.CreateReplica(options);
+            connection.Open();
+
+            var entryBeforeDispose = ManagedReplicaSyncRegistry.Acquire(path);
+            entryBeforeDispose.ReleaseReference();
+
+            var sync = connection.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
+            await handler.SyncStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            // The sync's pull-updates request is now blocked inside the network long-poll, which
+            // -- per the wait/apply split -- runs without holding the per-path publication gate.
+            // Disposing the only host registered for this path while that wait is still in flight
+            // must not let RetireIfUnusedNoLock remove the coordinating Entry from the registry: a
+            // subsequently opened host for the same path would otherwise get a brand-new,
+            // unrelated Entry with no in-process coordination against this orphaned sync's still-
+            // pending apply.
+            connection.Dispose();
+
+            var entryAfterDispose = ManagedReplicaSyncRegistry.Acquire(path);
+            try
+            {
+                entryAfterDispose.Should().BeSameAs(entryBeforeDispose);
+            }
+            finally
+            {
+                entryAfterDispose.ReleaseReference();
+            }
+
+            handler.Release();
+            var result = await sync.WaitAsync(TimeSpan.FromSeconds(5));
+            result.Outcome.Should().Be(AhtolaSyncOutcome.UpToDate);
+
+            // The orphaned sync's apply (a no-op here, since the response carried no changes)
+            // still completed successfully with no host left registered to observe it. A fresh
+            // connection afterward must see correct, undamaged data, proving the pinned Entry was
+            // reused correctly and released cleanly once the sync actually finished.
+            using var reopened = AhtolaConnection.CreateReplica(options);
+            reopened.Open();
+            ReadBootstrapMarker(reopened).Should().Be(42);
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
+
+    [Test]
+    public async Task PreparePushReadsTheMaterializationLeaseFreshAfterAConcurrentHostsPublicationDisposesIt()
+    {
+        var path = NewReplicaPath("managed-replica-wait-split-materializer-turnover");
+        var databaseImage = CreateDatabaseImage(path + ".source");
+        var handler = new LazyPagePullHandler("revision-prefix", databaseImage);
+        var options = CreateOptions(
+            path,
+            handler,
+            partialBootstrap: AhtolaPartialBootstrapOptions.Prefix(4096));
+
+        try
+        {
+            using (var connection = AhtolaConnection.CreateReplica(options))
+            {
+                connection.Open();
+                ReadBootstrapMarker(connection).Should().Be(42);
+            }
+
+            // Both hosts open onto the still-partial replica: each attaches its own reference-
+            // counted Lease onto the SAME underlying ManagedReplicaPageMaterializingFileSystem
+            // (see ManagedReplicaPageMaterializationRegistry.Acquire).
+            using var connectionA = AhtolaConnection.CreateReplica(options);
+            using var connectionB = AhtolaConnection.CreateReplica(options);
+            connectionA.Open();
+            connectionB.Open();
+
+            var paused = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var pausedOnce = 0;
+            using (ManagedReplicaFaultInjection.Push(boundary =>
+                   {
+                       if (boundary != ManagedReplicaDurableBoundary.ReplicaPublicationOwnershipAcquired
+                           || Interlocked.Exchange(ref pausedOnce, 1) != 0)
+                       {
+                           return;
+                       }
+
+                       paused.TrySetResult();
+                       release.Task.GetAwaiter().GetResult();
+                   }))
+            {
+                // Host B's own sync acquires the publication gate first and pauses there --
+                // still holding it -- immediately before it would complete the partial image
+                // (deleting the sidecar) and reopen every registered host, including host A.
+                var syncB = Task.Run(
+                    () => connectionB.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+                await paused.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+                // Host A's own sync now queues behind host B's held gate. With the fix, host A's
+                // gated PreparePushAndPartialReplicaAsync has not run yet -- and will not until
+                // host B's publication (and its reopen pass across every host) has fully
+                // completed -- so it has not read _materializationLease at all yet.
+                var syncA = connectionA.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
+                await Task.Delay(TimeSpan.FromMilliseconds(250));
+                syncA.IsCompleted.Should().BeFalse();
+
+                release.TrySetResult();
+                var resultB = await syncB.WaitAsync(TimeSpan.FromSeconds(5));
+                resultB.Outcome.Should().Be(AhtolaSyncOutcome.UpToDate);
+
+                // Host B's publication has now completed the partial image and reopened every
+                // host, including host A, which disposed host A's OWN retained lease (the
+                // sidecar is gone). Host A's own gated PreparePushAndPartialReplicaAsync runs
+                // next and must read _materializationLease fresh -- now null -- rather than
+                // reuse whatever it captured before it ever requested the gate; the old,
+                // reverted ordering would hand a disposed ManagedReplicaPageMaterializingFileSystem
+                // to PushLocalChangesAsync/CompletePartialReplicaAsync here and throw
+                // ObjectDisposedException.
+                var resultA = await syncA.WaitAsync(TimeSpan.FromSeconds(5));
+                resultA.Outcome.Should().Be(AhtolaSyncOutcome.UpToDate);
+            }
+
+            File.Exists(path + ManagedReplicaPageMaterializingFileSystem.StateSuffix).Should().BeFalse();
+        }
+        finally
+        {
+            DeleteReplicaFiles(path);
+        }
+    }
 }

--- a/src/Ahtola.Tests/ManagedReplicaWaitApplySplitTests.cs
+++ b/src/Ahtola.Tests/ManagedReplicaWaitApplySplitTests.cs
@@ -508,7 +508,7 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
                                     options,
                                     metadata,
                                     allowTrackedLocalMutations: false,
-                                    retainedMaterializer: null,
+                                    retainedMaterializer: hostB.RetainedMaterializerForTesting,
                                     token)
                                 .ConfigureAwait(false);
                         },
@@ -522,6 +522,9 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
                 var syncA = hostA.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
                 await Task.Delay(TimeSpan.FromMilliseconds(250));
                 syncA.IsCompleted.Should().BeFalse();
+                hostA.RetainedMaterializerReadsForTesting.Should().Be(
+                    0,
+                    "the queued sync must not capture publication-owned state before it acquires the gate");
 
                 release.TrySetResult();
                 await publicationB.WaitAsync(TimeSpan.FromSeconds(5));
@@ -536,6 +539,9 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
                 // ObjectDisposedException.
                 var resultA = await syncA.WaitAsync(TimeSpan.FromSeconds(5));
                 resultA.Outcome.Should().Be(AhtolaSyncOutcome.UpToDate);
+                hostA.RetainedMaterializerReadsForTesting.Should().Be(
+                    1,
+                    "the retained materializer is read exactly once inside host A's gated preparation");
             }
 
             File.Exists(path + ManagedReplicaPageMaterializingFileSystem.StateSuffix).Should().BeFalse();

--- a/src/Ahtola.Tests/ManagedReplicaWaitApplySplitTests.cs
+++ b/src/Ahtola.Tests/ManagedReplicaWaitApplySplitTests.cs
@@ -476,10 +476,8 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
             // Both hosts open onto the still-partial replica: each attaches its own reference-
             // counted Lease onto the SAME underlying ManagedReplicaPageMaterializingFileSystem
             // (see ManagedReplicaPageMaterializationRegistry.Acquire).
-            using var connectionA = AhtolaConnection.CreateReplica(options);
-            using var connectionB = AhtolaConnection.CreateReplica(options);
-            connectionA.Open();
-            connectionB.Open();
+            using var hostA = ManagedReplicaConnectionHost.Open(options);
+            using var hostB = ManagedReplicaConnectionHost.Open(options);
 
             var paused = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -496,24 +494,37 @@ public sealed partial class ManagedEmbeddedReplicaConnectionTests
                        release.Task.GetAwaiter().GetResult();
                    }))
             {
-                // Host B's own sync acquires the publication gate first and pauses there --
-                // still holding it -- immediately before it would complete the partial image
-                // (deleting the sidecar) and reopen every registered host, including host A.
-                var syncB = Task.Run(
-                    () => connectionB.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None));
+                // Use a non-coalesced publication for host B. A second SyncAsync would join host A's
+                // single-flight task and never run its own publication body, which would not exercise
+                // the retained-materializer turnover this regression protects.
+                var publicationB = Task.Run(
+                    () => hostB.QuiesceAndReopenAsync(
+                        async token =>
+                        {
+                            var metadata = ManagedReplicaBootstrapper.LoadMetadata(path)
+                                ?? throw new InvalidDataException(
+                                    "Managed replica metadata disappeared during materializer turnover.");
+                            _ = await ManagedReplicaBootstrapper.CompletePartialReplicaAsync(
+                                    options,
+                                    metadata,
+                                    allowTrackedLocalMutations: false,
+                                    retainedMaterializer: null,
+                                    token)
+                                .ConfigureAwait(false);
+                        },
+                        CancellationToken.None));
                 await paused.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
                 // Host A's own sync now queues behind host B's held gate. With the fix, host A's
                 // gated PreparePushAndPartialReplicaAsync has not run yet -- and will not until
                 // host B's publication (and its reopen pass across every host) has fully
                 // completed -- so it has not read _materializationLease at all yet.
-                var syncA = connectionA.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
+                var syncA = hostA.SyncAsync(new AhtolaSyncOptions(), CancellationToken.None);
                 await Task.Delay(TimeSpan.FromMilliseconds(250));
                 syncA.IsCompleted.Should().BeFalse();
 
                 release.TrySetResult();
-                var resultB = await syncB.WaitAsync(TimeSpan.FromSeconds(5));
-                resultB.Outcome.Should().Be(AhtolaSyncOutcome.UpToDate);
+                await publicationB.WaitAsync(TimeSpan.FromSeconds(5));
 
                 // Host B's publication has now completed the partial image and reopened every
                 // host, including host A, which disposed host A's OWN retained lease (the

--- a/src/Ahtola.Tests/MvccCheckpointStateMachineTests.cs
+++ b/src/Ahtola.Tests/MvccCheckpointStateMachineTests.cs
@@ -8,7 +8,8 @@ namespace Ahtola.Tests;
 
 /// <summary>
 /// Managed MVCC checkpoint phases from Turso's <c>CheckpointStateMachine</c>:
-/// collect, materialize, page-WAL persist, backfill, retire/reset, and GC.
+/// collect, materialize, page-WAL persist, backfill, publish recovery evidence,
+/// retire/reset, and GC.
 /// </summary>
 public sealed class MvccCheckpointStateMachineTests
 {
@@ -341,6 +342,7 @@ public sealed class MvccCheckpointStateMachineTests
     [TestCase(nameof(MvccCheckpointPhase.Materialize))]
     [TestCase(nameof(MvccCheckpointPhase.PersistPageWal))]
     [TestCase(nameof(MvccCheckpointPhase.Backfill))]
+    [TestCase(nameof(MvccCheckpointPhase.PublishRecoveryWatermark))]
     [TestCase(nameof(MvccCheckpointPhase.RetireLogicalLog))]
     [TestCase(nameof(MvccCheckpointPhase.ResetWal))]
     [TestCase(nameof(MvccCheckpointPhase.GarbageCollect))]
@@ -379,6 +381,60 @@ public sealed class MvccCheckpointStateMachineTests
         using var reopenedConnection = reopened.Connect();
         ReadScalar(reopenedConnection, "SELECT v FROM t;").Should().Be(107L);
         reopened.RunMvccCheckpoint("TRUNCATE").Busy.Should().BeFalse();
+    }
+
+    [Test]
+    public void RecoveryWatermarkAdvancesClockBeforeTheNextLogicalCommit()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        const string path = "mvcc-watermark-clock.db";
+        ulong watermark;
+
+        using (var database = EmbeddedDatabase.OpenFile(path, fileSystem))
+        using (var connection = database.Connect())
+        {
+            Execute(connection, "CREATE TABLE t(v INTEGER);");
+            Execute(connection, "PRAGMA journal_mode=mvcc;");
+            Execute(connection, "BEGIN CONCURRENT;");
+            Execute(connection, "INSERT INTO t VALUES (1);");
+            Execute(connection, "COMMIT;");
+            watermark = database.MvStore!.LastCommittedTimestamp;
+
+            try
+            {
+                MvccCheckpointFaultInjection.AfterPhaseForTesting = phase =>
+                {
+                    if (phase == MvccCheckpointPhase.PublishRecoveryWatermark)
+                        throw new IOException("Injected crash after checkpoint watermark publication.");
+                };
+                Assert.Throws<IOException>(() => database.RunMvccCheckpoint("TRUNCATE"));
+            }
+            finally
+            {
+                MvccCheckpointFaultInjection.AfterPhaseForTesting = null;
+            }
+        }
+
+        using (var reopened = EmbeddedDatabase.OpenFile(path, fileSystem))
+        using (var connection = reopened.Connect())
+        {
+            reopened.MvStore!.LastCommittedTimestamp.Should().Be(watermark);
+            Execute(connection, "BEGIN CONCURRENT;");
+            Execute(connection, "INSERT INTO t VALUES (2);");
+            Execute(connection, "COMMIT;");
+            reopened.MvStore!.LastCommittedTimestamp.Should().BeGreaterThan(watermark);
+        }
+
+        using var final = EmbeddedDatabase.OpenFile(path, fileSystem);
+        var table = final.MvStore!.GetOrCreateTableId("t");
+        var reader = final.MvStore.BeginTransaction();
+        final.MvStore.TryRead(
+                reader.Id,
+                new MvccRowId(table, 2),
+                out var cells)
+            .Should().BeTrue();
+        cells![0].Should().Be(SqlValue.Integer(2));
+        final.MvStore.Rollback(reader.Id);
     }
 
     private static object? Scalar(SqliteConnection connection, string sql)

--- a/src/Ahtola.Tests/MvccCheckpointStateMachineTests.cs
+++ b/src/Ahtola.Tests/MvccCheckpointStateMachineTests.cs
@@ -7,8 +7,8 @@ using Ahtola.Data.Sqlite;
 namespace Ahtola.Tests;
 
 /// <summary>
-/// Managed MVCC checkpoint skeleton (Turso <c>CheckpointStateMachine</c> phases):
-/// materialize store → catalog, truncate logical log, GC, cold reopen.
+/// Managed MVCC checkpoint phases from Turso's <c>CheckpointStateMachine</c>:
+/// collect, materialize, page-WAL persist, backfill, retire/reset, and GC.
 /// </summary>
 public sealed class MvccCheckpointStateMachineTests
 {
@@ -111,7 +111,12 @@ public sealed class MvccCheckpointStateMachineTests
         store.Commit(tx.Id);
 
         store.VersionChainCount.Should().BeGreaterThan(0);
-        store.GarbageCollectAfterCheckpoint();
+        store.TryAcquireCheckpoint(out var lease).Should().BeTrue();
+        using (lease)
+        {
+            var snapshot = store.CollectCheckpointSnapshot();
+            store.GarbageCollectAfterCheckpoint(snapshot);
+        }
         store.VersionChainCount.Should().Be(0);
     }
 
@@ -138,7 +143,7 @@ public sealed class MvccCheckpointStateMachineTests
 
             Assert.Throws<IOException>(() => database.RunMvccCheckpoint("TRUNCATE"));
 
-            ReadFileLength(fileSystem, path + "-log").Should().Be(logLength);
+            ReadFileLength(fileSystem, path + "-log").Should().BeGreaterThan(logLength);
             AssertCommittedWal(fileSystem, path + "-wal");
 
             // A failed durability phase must release process-local admission.
@@ -222,7 +227,7 @@ public sealed class MvccCheckpointStateMachineTests
     }
 
     [Test]
-    public void ActiveConcurrentReaderPreventsLogicalLogRetirement()
+    public void ActiveConcurrentReaderKeepsItsSnapshotAcrossCheckpoint()
     {
         var fileSystem = new InMemoryFileSystem();
         const string path = "mvcc-reader-floor.db";
@@ -232,21 +237,23 @@ public sealed class MvccCheckpointStateMachineTests
         using var reader = database.Connect();
         Execute(writer, "CREATE TABLE t(v INTEGER);");
         Execute(writer, "PRAGMA journal_mode=mvcc;");
+        Execute(reader, "BEGIN CONCURRENT;");
         Execute(writer, "BEGIN CONCURRENT;");
         Execute(writer, "INSERT INTO t VALUES (91);");
         Execute(writer, "COMMIT;");
 
         var logLength = ReadFileLength(fileSystem, path + "-log");
-        Execute(reader, "BEGIN CONCURRENT;");
-
-        var blocked = database.RunMvccCheckpoint("TRUNCATE");
-        blocked.Busy.Should().BeTrue();
-        blocked.CompletedThrough.Should().Be(MvccCheckpointPhase.AcquireLock);
-        ReadFileLength(fileSystem, path + "-log").Should().Be(logLength);
+        var checkpoint = database.RunMvccCheckpoint("TRUNCATE");
+        checkpoint.Busy.Should().BeFalse();
+        checkpoint.CompletedThrough.Should().Be(MvccCheckpointPhase.Complete);
+        ReadFileLength(fileSystem, path + "-log").Should().BeLessThan(logLength);
+        ReadScalar(reader, "SELECT COUNT(*) FROM t WHERE v = 91;").Should().Be(0);
+        database.MvStore!.VersionCount.Should().BeGreaterThan(0);
 
         Execute(reader, "ROLLBACK;");
         database.RunMvccCheckpoint("TRUNCATE").Busy.Should().BeFalse();
         ReadFileLength(fileSystem, path + "-log").Should().Be(56);
+        database.MvStore!.VersionCount.Should().Be(0);
     }
 
     [Test]
@@ -327,6 +334,51 @@ public sealed class MvccCheckpointStateMachineTests
         reopened.MvStore!.LogicalLog!.RequiresVersion4Upgrade.Should().BeTrue();
         reopened.RunMvccCheckpoint("PASSIVE").Busy.Should().BeFalse();
         reopened.MvStore!.LogicalLog!.RequiresVersion4Upgrade.Should().BeFalse();
+    }
+
+    [TestCase(nameof(MvccCheckpointPhase.AcquireLock))]
+    [TestCase(nameof(MvccCheckpointPhase.Collect))]
+    [TestCase(nameof(MvccCheckpointPhase.Materialize))]
+    [TestCase(nameof(MvccCheckpointPhase.PersistPageWal))]
+    [TestCase(nameof(MvccCheckpointPhase.Backfill))]
+    [TestCase(nameof(MvccCheckpointPhase.RetireLogicalLog))]
+    [TestCase(nameof(MvccCheckpointPhase.ResetWal))]
+    [TestCase(nameof(MvccCheckpointPhase.GarbageCollect))]
+    [TestCase(nameof(MvccCheckpointPhase.Complete))]
+    public void EveryCheckpointPhaseBoundaryColdReopensWithoutLosingTheCommit(string phaseName)
+    {
+        var phase = Enum.Parse<MvccCheckpointPhase>(phaseName);
+        var fileSystem = new InMemoryFileSystem();
+        var path = $"mvcc-phase-{phaseName}.db";
+
+        using (var database = EmbeddedDatabase.OpenFile(path, fileSystem))
+        using (var connection = database.Connect())
+        {
+            Execute(connection, "CREATE TABLE t(v INTEGER);");
+            Execute(connection, "PRAGMA journal_mode=mvcc;");
+            Execute(connection, "BEGIN CONCURRENT;");
+            Execute(connection, "INSERT INTO t VALUES (107);");
+            Execute(connection, "COMMIT;");
+
+            try
+            {
+                MvccCheckpointFaultInjection.AfterPhaseForTesting = completed =>
+                {
+                    if (completed == phase)
+                        throw new IOException($"Injected crash after {completed}.");
+                };
+                Assert.Throws<IOException>(() => database.RunMvccCheckpoint("TRUNCATE"));
+            }
+            finally
+            {
+                MvccCheckpointFaultInjection.AfterPhaseForTesting = null;
+            }
+        }
+
+        using var reopened = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        ReadScalar(reopenedConnection, "SELECT v FROM t;").Should().Be(107L);
+        reopened.RunMvccCheckpoint("TRUNCATE").Busy.Should().BeFalse();
     }
 
     private static object? Scalar(SqliteConnection connection, string sql)

--- a/src/Ahtola.Tests/MvccHeaderAndDualCursorTests.cs
+++ b/src/Ahtola.Tests/MvccHeaderAndDualCursorTests.cs
@@ -188,6 +188,48 @@ public sealed class MvccHeaderAndDualCursorTests
             .Equal("alpha-3", "alpha-2", "alpha-1", "beta-1");
     }
 
+    [Test]
+    public void OpenDualCursorKeepsItsTransactionSnapshotAsAPeerCommits()
+    {
+        var store = new MvStore();
+        var reader = store.BeginTransaction();
+        var writer = store.BeginTransaction();
+        var table = store.GetOrCreateTableId(reader.Id, "t");
+        var rows = MvccDualCursor.EnumerateVisibleRows(
+            store,
+            reader.Id,
+            table,
+            [
+                new MvccDualCursor.Row(
+                    MvccKey.FromInteger(1),
+                    [SqlValue.Text("one")]),
+                new MvccDualCursor.Row(
+                    MvccKey.FromInteger(2),
+                    [SqlValue.Text("two")]),
+            ],
+            MvccKeyComparer.Integer);
+
+        using var cursor = rows.GetEnumerator();
+        cursor.MoveNext().Should().BeTrue();
+        cursor.Current.Key.Integer.Should().Be(1);
+
+        store.UpdateIncludingBase(
+            writer.Id,
+            new MvccRowId(table, 2),
+            [SqlValue.Text("updated")]);
+        store.Insert(
+            writer.Id,
+            new MvccRowId(table, 3),
+            [SqlValue.Text("three")]);
+        store.Commit(writer.Id);
+
+        cursor.MoveNext().Should().BeTrue();
+        cursor.Current.Key.Integer.Should().Be(2);
+        cursor.Current.Cells[0].Should().Be(SqlValue.Text("two"));
+        cursor.MoveNext().Should().BeFalse();
+        store.Rollback(reader.Id);
+    }
+
     private static SqlValue ReadValue(EmbeddedConnection connection, string sql)
     {
         using var statement = connection.Prepare(sql);

--- a/src/Ahtola.Tests/MvccHeaderAndDualCursorTests.cs
+++ b/src/Ahtola.Tests/MvccHeaderAndDualCursorTests.cs
@@ -230,6 +230,102 @@ public sealed class MvccHeaderAndDualCursorTests
         store.Rollback(reader.Id);
     }
 
+    [Test]
+    public void WriterCommitThenActiveReaderRetainsCurrentOverlayUntilItsBaseGenerationAdvances()
+    {
+        var store = new MvStore();
+        var table = store.GetOrCreateTableId("t");
+        var writer = store.BeginTransaction();
+        store.Insert(
+            writer.Id,
+            new MvccRowId(table, 1),
+            [SqlValue.Text("committed")]);
+        store.Commit(writer.Id);
+
+        var reader = store.BeginTransaction();
+        store.TryAcquireCheckpoint(out var lease).Should().BeTrue();
+        using (lease)
+        {
+            var snapshot = store.CollectCheckpointSnapshot();
+            store.GarbageCollectAfterCheckpoint(snapshot);
+        }
+
+        MvccDualCursor.EnumerateVisibleRows(
+                store,
+                reader.Id,
+                table,
+                baseRows: [],
+                comparer: MvccKeyComparer.Integer)
+            .Should()
+            .ContainSingle()
+            .Which.Cells[0]
+            .Should()
+            .Be(SqlValue.Text("committed"));
+
+        store.Rollback(reader.Id);
+        store.TryAcquireCheckpoint(out lease).Should().BeTrue();
+        using (lease)
+        {
+            var snapshot = store.CollectCheckpointSnapshot();
+            store.GarbageCollectAfterCheckpoint(snapshot);
+        }
+        store.VersionCount.Should().Be(0);
+    }
+
+    [Test]
+    public void IndexOverlayProjectsAndSortsEachVisibleVersionOnlyOnce()
+    {
+        const int rowCount = 1_024;
+        var store = new MvStore();
+        var transaction = store.BeginTransaction();
+        var table = store.GetOrCreateTableId(transaction.Id, "items");
+        for (var rowId = 1; rowId <= rowCount; rowId++)
+        {
+            store.Insert(
+                transaction.Id,
+                new MvccRowId(table, rowId),
+                [SqlValue.Integer(rowCount - rowId + 1)]);
+        }
+
+        var projections = 0;
+        var comparer = Comparer<MvccDualCursor.IndexRow>.Create((left, right) =>
+        {
+            var comparison = left.IndexKey[0].AsInteger()
+                .CompareTo(right.IndexKey[0].AsInteger());
+            return comparison != 0
+                ? comparison
+                : left.TableKey.Integer.CompareTo(right.TableKey.Integer);
+        });
+        MvccDualCursor.IndexRow? Project(MvccVisibleRow visible)
+        {
+            projections++;
+            return new MvccDualCursor.IndexRow(
+                visible.Key,
+                [visible.Cells![0]],
+                visible.Cells);
+        }
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        var rows = MvccDualCursor.EnumerateVisibleIndexRows(
+                store,
+                transaction.Id,
+                table,
+                baseRows: [],
+                projectOverlay: Project,
+                indexComparer: comparer,
+                tableKeyComparer: MvccKeyComparer.Integer)
+            .ToArray();
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        projections.Should().Be(rowCount);
+        rows.Select(row => row.IndexKey[0].AsInteger())
+            .Should().Equal(Enumerable.Range(1, rowCount).Select(static value => (long)value));
+        allocated.Should().BeLessThan(
+            8 * 1024 * 1024,
+            "the version overlay should be projected and sorted once rather than rescanned per row");
+        store.Rollback(transaction.Id);
+    }
+
     private static SqlValue ReadValue(EmbeddedConnection connection, string sql)
     {
         using var statement = connection.Prepare(sql);

--- a/src/Ahtola.Tests/MvccLogicalLogTests.cs
+++ b/src/Ahtola.Tests/MvccLogicalLogTests.cs
@@ -66,6 +66,42 @@ public sealed class MvccLogicalLogTests
     }
 
     [Test]
+    public void RecoverySkipsFramesAtOrBelowTheLastCheckpointWatermark()
+    {
+        var fs = new InMemoryFileSystem();
+        const string dbPath = "mvcc-checkpoint-watermark.db";
+
+        using (var log = MvccLogicalLog.CreateOrOpen(fs, dbPath))
+        {
+            var store = new MvStore(logicalLog: log);
+            var table = store.GetOrCreateTableId("t");
+            var materialized = store.BeginTransaction();
+            store.Insert(
+                materialized.Id,
+                new MvccRowId(table, 1),
+                [SqlValue.Text("materialized")]);
+            store.Commit(materialized.Id);
+            log.AppendCheckpointWatermark(store.LastCommittedTimestamp);
+
+            var afterCheckpoint = store.BeginTransaction();
+            store.Insert(
+                afterCheckpoint.Id,
+                new MvccRowId(table, 2),
+                [SqlValue.Text("logical-only")]);
+            store.Commit(afterCheckpoint.Id);
+        }
+
+        using var reopened = MvccLogicalLog.CreateOrOpen(fs, dbPath);
+        var recovered = new MvStore();
+        reopened.ReplayInto(recovered);
+        var reader = recovered.BeginTransaction();
+        var rows = recovered.ScanVisible(reader.Id);
+        rows.Should().ContainSingle();
+        rows[0].RowId.RowId.Should().Be(2);
+        rows[0].Cells[0].Should().Be(SqlValue.Text("logical-only"));
+    }
+
+    [Test]
     public void DeleteOpsReplayAsTombstones()
     {
         var fs = new InMemoryFileSystem();

--- a/src/Ahtola.Tests/MvccSelectDualCursorRoutingTests.cs
+++ b/src/Ahtola.Tests/MvccSelectDualCursorRoutingTests.cs
@@ -361,7 +361,60 @@ public sealed class MvccSelectDualCursorRoutingTests
     }
 
     [Test]
-    public void MvccBeginRegistersBeforeCatalogCloneCanRaceSchemaPublication()
+    public async Task ClassicWriterWaitsForSchemaPublicationWithinBusyTimeout()
+    {
+        using var db = new RoutingFileDatabase();
+        using var schemaWriter = db.Connect();
+        using var classicWriter = db.Connect();
+
+        schemaWriter.ExecuteNonQuery("PRAGMA journal_mode=mvcc;");
+        classicWriter.ExecuteNonQuery("PRAGMA busy_timeout=2000;");
+        schemaWriter.ExecuteNonQuery("BEGIN CONCURRENT;");
+        schemaWriter.ExecuteNonQuery("CREATE TABLE added(v INTEGER);");
+
+        var write = Task.Run(() => classicWriter.ExecuteNonQuery("INSERT INTO t VALUES (99);"));
+        await Task.Delay(100);
+        write.IsCompleted.Should().BeFalse();
+
+        schemaWriter.ExecuteNonQuery("COMMIT;");
+        await write.WaitAsync(TimeSpan.FromSeconds(5));
+        Convert.ToInt64(Scalar(classicWriter, "SELECT COUNT(*) FROM t WHERE v=99;"))
+            .Should().Be(1L);
+    }
+
+    [Test]
+    public async Task SchemaPublicationWaitsForDeferredClassicWriterWithinBusyTimeout()
+    {
+        using var db = new RoutingFileDatabase();
+        using var classicWriter = db.Connect();
+        using var schemaWriter = db.Connect();
+
+        classicWriter.ExecuteNonQuery("PRAGMA journal_mode=mvcc;");
+        schemaWriter.ExecuteNonQuery("PRAGMA busy_timeout=2000;");
+        classicWriter.ExecuteNonQuery("BEGIN;");
+        classicWriter.ExecuteNonQuery("INSERT INTO t VALUES (99);");
+        schemaWriter.ExecuteNonQuery("BEGIN CONCURRENT;");
+
+        var schemaChange = Task.Run(
+            () => Capture(
+                () => schemaWriter.ExecuteNonQuery("CREATE TABLE added(v INTEGER);")));
+        await Task.Delay(100);
+        schemaChange.IsCompleted.Should().BeFalse();
+
+        classicWriter.ExecuteNonQuery("COMMIT;");
+        var staleSchema = await schemaChange.WaitAsync(TimeSpan.FromSeconds(5));
+        staleSchema.Should().NotBeNull();
+        staleSchema!.Message.Should().ContainEquivalentOf("locked");
+        schemaWriter.ExecuteNonQuery("ROLLBACK;");
+        schemaWriter.ExecuteNonQuery("BEGIN CONCURRENT;");
+        schemaWriter.ExecuteNonQuery("CREATE TABLE added(v INTEGER);");
+        schemaWriter.ExecuteNonQuery("COMMIT;");
+        Convert.ToInt64(Scalar(schemaWriter, "SELECT COUNT(*) FROM t WHERE v=99;"))
+            .Should().Be(1L);
+    }
+
+    [Test]
+    public async Task MvccBeginRegistersBeforeCatalogCloneCanRaceSchemaPublication()
     {
         var fileSystem = new Ahtola.Core.Storage.InMemoryFileSystem();
         const string path = "mvcc-begin-schema-race.db";
@@ -372,6 +425,8 @@ public sealed class MvccSelectDualCursorRoutingTests
         Execute(reader, "PRAGMA journal_mode=mvcc;");
         Exception? rejected = null;
         var snapshotGateHeld = false;
+        Task? schemaAttempt = null;
+        using var peerStarted = new ManualResetEventSlim();
 
         try
         {
@@ -379,10 +434,16 @@ public sealed class MvccSelectDualCursorRoutingTests
             {
                 EmbeddedConnection.AfterMvccBeginBeforeCatalogSnapshotForTesting = null;
                 snapshotGateHeld = database.IsTransactionSnapshotGateHeldForTesting;
-                Execute(schemaWriter, "BEGIN CONCURRENT;");
-                rejected = Capture(
-                    () => Execute(schemaWriter, "CREATE TABLE raced(v INTEGER);"));
-                Execute(schemaWriter, "ROLLBACK;");
+                schemaAttempt = Task.Run(() =>
+                {
+                    peerStarted.Set();
+                    Execute(schemaWriter, "BEGIN CONCURRENT;");
+                    rejected = Capture(
+                        () => Execute(schemaWriter, "CREATE TABLE raced(v INTEGER);"));
+                    Execute(schemaWriter, "ROLLBACK;");
+                });
+                peerStarted.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+                Thread.Sleep(100);
             };
             Execute(reader, "BEGIN CONCURRENT;");
         }
@@ -391,6 +452,7 @@ public sealed class MvccSelectDualCursorRoutingTests
             EmbeddedConnection.AfterMvccBeginBeforeCatalogSnapshotForTesting = null;
         }
 
+        await schemaAttempt!.WaitAsync(TimeSpan.FromSeconds(5));
         snapshotGateHeld.Should().BeTrue();
         rejected.Should().NotBeNull();
         rejected!.Message.Should().ContainEquivalentOf("locked");
@@ -405,11 +467,12 @@ public sealed class MvccSelectDualCursorRoutingTests
     {
         var fileSystem = new Ahtola.Core.Storage.InMemoryFileSystem();
         const string path = "mvcc-begin-checkpoint-race.db";
-        using var database = EmbeddedDatabase.OpenFile(path, fileSystem);
-        using var reader = database.Connect();
-        using var peer = database.Connect();
+        using var readerDatabase = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var reader = readerDatabase.Connect();
         Execute(reader, "CREATE TABLE t(v INTEGER);");
         Execute(reader, "PRAGMA journal_mode=mvcc;");
+        using var peerDatabase = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var peer = peerDatabase.Connect();
         Task? peerCheckpoint = null;
         using var peerStarted = new ManualResetEventSlim();
 

--- a/src/Ahtola.Tests/MvccSelectDualCursorRoutingTests.cs
+++ b/src/Ahtola.Tests/MvccSelectDualCursorRoutingTests.cs
@@ -420,6 +420,45 @@ public sealed class MvccSelectDualCursorRoutingTests
     }
 
     [Test]
+    public async Task SchemaAdmissionRechecksCommitGenerationAfterClassicWriterWait()
+    {
+        var fileSystem = new Ahtola.Core.Storage.InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile(
+            "mvcc-schema-wait-generation.db",
+            fileSystem);
+        using var schemaWriter = database.Connect();
+        using var classicWriter = database.Connect();
+        using var concurrentWriter = database.Connect();
+        Execute(schemaWriter, "CREATE TABLE t(v INTEGER);");
+        Execute(schemaWriter, "PRAGMA journal_mode=mvcc;");
+        schemaWriter.BusyTimeout = TimeSpan.FromSeconds(2);
+        Execute(classicWriter, "BEGIN;");
+        Execute(classicWriter, "INSERT INTO t VALUES (99);");
+        Execute(schemaWriter, "BEGIN CONCURRENT;");
+
+        var schemaChange = Task.Run(
+            () => Capture(() => Execute(schemaWriter, "CREATE TABLE added(v INTEGER);")));
+        await Task.Delay(100);
+        schemaChange.IsCompleted.Should().BeFalse();
+
+        Execute(concurrentWriter, "BEGIN CONCURRENT;");
+        Execute(concurrentWriter, "INSERT INTO t VALUES (2);");
+        Execute(concurrentWriter, "COMMIT;");
+        Execute(classicWriter, "ROLLBACK;");
+
+        var staleSchema = await schemaChange.WaitAsync(TimeSpan.FromSeconds(5));
+        staleSchema.Should().NotBeNull();
+        staleSchema!.Message.Should().ContainEquivalentOf("locked");
+        Execute(schemaWriter, "ROLLBACK;");
+        Execute(schemaWriter, "BEGIN CONCURRENT;");
+        Execute(schemaWriter, "CREATE TABLE added(v INTEGER);");
+        Execute(schemaWriter, "COMMIT;");
+
+        ReadEmbeddedScalar(schemaWriter, "SELECT COUNT(*) FROM t WHERE v=2;")
+            .Should().Be(1L);
+    }
+
+    [Test]
     public async Task MvccBeginRegistersBeforeCatalogCloneCanRaceSchemaPublication()
     {
         var fileSystem = new Ahtola.Core.Storage.InMemoryFileSystem();

--- a/src/Ahtola.Tests/MvccSelectDualCursorRoutingTests.cs
+++ b/src/Ahtola.Tests/MvccSelectDualCursorRoutingTests.cs
@@ -444,6 +444,75 @@ public sealed class MvccSelectDualCursorRoutingTests
     }
 
     [Test]
+    public void FailedConcurrentDdlCommitDoesNotPublishItsSchemaGenerationOrRows()
+    {
+        var faults = new Ahtola.Core.Storage.DeterministicFaultInjector();
+        var fileSystem = new Ahtola.Core.Storage.InMemoryFileSystem(faults);
+        const string path = "mvcc-schema-publication-fault.db";
+        using var database = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var connection = database.Connect();
+
+        Execute(connection, "CREATE TABLE original(v INTEGER);");
+        Execute(connection, "PRAGMA journal_mode=mvcc;");
+        Execute(connection, "BEGIN CONCURRENT;");
+        Execute(connection, "INSERT INTO original VALUES (1);");
+        Execute(connection, "COMMIT;");
+
+        var cookie = ReadEmbeddedScalar(connection, "PRAGMA schema_version;");
+        var generation = database.MvStore!.SchemaGeneration;
+        Execute(connection, "BEGIN CONCURRENT;");
+        Execute(connection, "INSERT INTO original VALUES (2);");
+        Execute(connection, "CREATE TABLE discarded(v INTEGER);");
+        Execute(connection, "INSERT INTO discarded VALUES (99);");
+
+        faults.FailNext(Ahtola.Core.Storage.FileSystemOperation.Write);
+        Assert.Throws<IOException>(() => Execute(connection, "COMMIT;"));
+
+        ReadEmbeddedScalar(connection, "PRAGMA schema_version;").Should().Be(cookie);
+        database.MvStore!.SchemaGeneration.Should().Be(generation);
+        ReadEmbeddedScalar(connection, "SELECT COUNT(*) FROM original;").Should().Be(1L);
+        ReadEmbeddedScalar(
+            connection,
+            "SELECT COUNT(*) FROM sqlite_schema WHERE name = 'discarded';").Should().Be(0L);
+
+        Execute(connection, "BEGIN CONCURRENT;");
+        Execute(connection, "CREATE TABLE committed(v INTEGER);");
+        Execute(connection, "COMMIT;");
+        ReadEmbeddedScalar(connection, "PRAGMA schema_version;").Should().Be(cookie + 1);
+        database.MvStore!.SchemaGeneration.Should().Be(generation + 1);
+    }
+
+    [Test]
+    public void ConcurrentDmlAndDdlCommitAsOnePagerPublishedSchemaGeneration()
+    {
+        var fileSystem = new Ahtola.Core.Storage.InMemoryFileSystem();
+        const string path = "mvcc-schema-and-dml-commit.db";
+
+        using (var database = EmbeddedDatabase.OpenFile(path, fileSystem))
+        using (var connection = database.Connect())
+        {
+            Execute(connection, "CREATE TABLE original(v INTEGER);");
+            Execute(connection, "PRAGMA journal_mode=mvcc;");
+            var generation = database.MvStore!.SchemaGeneration;
+
+            Execute(connection, "BEGIN CONCURRENT;");
+            Execute(connection, "INSERT INTO original VALUES (1);");
+            Execute(connection, "CREATE TABLE added(v INTEGER);");
+            Execute(connection, "INSERT INTO added VALUES (2);");
+            Execute(connection, "COMMIT;");
+
+            database.MvStore!.SchemaGeneration.Should().Be(generation + 1);
+            ReadEmbeddedScalar(connection, "SELECT v FROM original;").Should().Be(1L);
+            ReadEmbeddedScalar(connection, "SELECT v FROM added;").Should().Be(2L);
+        }
+
+        using var reopened = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        ReadEmbeddedScalar(reopenedConnection, "SELECT v FROM original;").Should().Be(1L);
+        ReadEmbeddedScalar(reopenedConnection, "SELECT v FROM added;").Should().Be(2L);
+    }
+
+    [Test]
     public void ConcurrentLimitOneAllocationDoesNotScaleWithTheBaseCatalog()
     {
         const int largeRowCount = 10_000;
@@ -453,6 +522,18 @@ public sealed class MvccSelectDualCursorRoutingTests
         largeAllocation.Should().BeLessThan(
             smallAllocation + 256 * 1024,
             "a warmed LIMIT 1 scan should retain only the lazy cursor peeks and consumed row");
+    }
+
+    [Test]
+    public void ConcurrentIndexLimitOneAllocationDoesNotScaleWithTheBaseCatalog()
+    {
+        const int largeRowCount = 10_000;
+        var smallAllocation = MeasureConcurrentIndexLimitOneAllocation(rowCount: 10);
+        var largeAllocation = MeasureConcurrentIndexLimitOneAllocation(largeRowCount);
+
+        largeAllocation.Should().BeLessThan(
+            smallAllocation + 256 * 1024,
+            "a warmed index LIMIT 1 scan should not rebuild a materialized MVCC overlay");
     }
 
     private static object? Scalar(SqliteConnection connection, string sql)
@@ -476,6 +557,19 @@ public sealed class MvccSelectDualCursorRoutingTests
         {
             return exception;
         }
+    }
+
+    private static void Execute(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        _ = statement.Step();
+    }
+
+    private static long ReadEmbeddedScalar(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        statement.Step().Should().Be(StatementStepResult.Row);
+        return statement.GetValue(0).AsInteger();
     }
 
     private static long MeasureConcurrentLimitOneAllocation(int rowCount)
@@ -514,9 +608,48 @@ public sealed class MvccSelectDualCursorRoutingTests
         return allocated;
     }
 
+    private static long MeasureConcurrentIndexLimitOneAllocation(int rowCount)
+    {
+        var fileSystem = new Ahtola.Core.Storage.InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile($"mvcc-index-limit-{rowCount}.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE t(v INTEGER);");
+        Execute(connection, "CREATE INDEX ix_t_v ON t(v);");
+
+        var values = new System.Text.StringBuilder("INSERT INTO t VALUES ");
+        for (var value = rowCount; value >= 1; value--)
+        {
+            if (value != rowCount)
+                values.Append(',');
+            values.Append('(').Append(value).Append(')');
+        }
+        values.Append(';');
+        Execute(connection, values.ToString());
+        Execute(connection, "PRAGMA journal_mode=mvcc;");
+        Execute(connection, "BEGIN CONCURRENT;");
+
+        ExecuteIndexLimitOne(connection);
+        ExecuteIndexLimitOne(connection);
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        ExecuteIndexLimitOne(connection);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Execute(connection, "ROLLBACK;");
+        return allocated;
+    }
+
     private static void ExecuteLimitOne(EmbeddedConnection connection)
     {
         using var statement = connection.Prepare("SELECT v FROM t LIMIT 1;");
+        statement.Step().Should().Be(StatementStepResult.Row);
+        statement.GetValue(0).AsInteger().Should().Be(1L);
+    }
+
+    private static void ExecuteIndexLimitOne(EmbeddedConnection connection)
+    {
+        using var statement = connection.Prepare(
+            "SELECT v FROM t INDEXED BY ix_t_v WHERE v > 0 LIMIT 1;");
         statement.Step().Should().Be(StatementStepResult.Row);
         statement.GetValue(0).AsInteger().Should().Be(1L);
     }

--- a/src/Ahtola.Tests/MvccSelectDualCursorRoutingTests.cs
+++ b/src/Ahtola.Tests/MvccSelectDualCursorRoutingTests.cs
@@ -237,6 +237,119 @@ public sealed class MvccSelectDualCursorRoutingTests
     }
 
     [Test]
+    public void ReadOnlyPeerSurvivesRejectedDdlBeforeTheNextSchemaGenerationCommits()
+    {
+        using var db = new RoutingFileDatabase();
+        using var reader = db.Connect();
+        using var schemaWriter = db.Connect();
+
+        reader.ExecuteNonQuery("PRAGMA journal_mode=mvcc;");
+        reader.ExecuteNonQuery("BEGIN CONCURRENT;");
+        schemaWriter.ExecuteNonQuery("BEGIN CONCURRENT;");
+        var rejected = Capture(
+            () => schemaWriter.ExecuteNonQuery("CREATE INDEX ix_t_v ON t(v);"));
+        rejected.Should().NotBeNull();
+        rejected!.Message.Should().ContainEquivalentOf("locked");
+        Convert.ToInt64(Scalar(reader, "SELECT COUNT(*) FROM t;")).Should().Be(0L);
+
+        schemaWriter.ExecuteNonQuery("ROLLBACK;");
+        reader.ExecuteNonQuery("COMMIT;");
+        schemaWriter.ExecuteNonQuery("BEGIN CONCURRENT;");
+        schemaWriter.ExecuteNonQuery("CREATE INDEX ix_t_v ON t(v);");
+        schemaWriter.ExecuteNonQuery("COMMIT;");
+
+        Convert.ToInt64(Scalar(
+            reader,
+            "SELECT COUNT(*) FROM sqlite_schema WHERE name = 'ix_t_v';")).Should().Be(1L);
+    }
+
+    [Test]
+    public void WritePeerSurvivesRejectedDdlAndPublishesBeforeTheSchemaOwnerRetries()
+    {
+        using var db = new RoutingFileDatabase();
+        using var writer = db.Connect();
+        using var schemaWriter = db.Connect();
+
+        writer.ExecuteNonQuery("PRAGMA journal_mode=mvcc;");
+        writer.ExecuteNonQuery("BEGIN CONCURRENT;");
+        writer.ExecuteNonQuery("INSERT INTO t VALUES (41);");
+        schemaWriter.ExecuteNonQuery("BEGIN CONCURRENT;");
+        var rejected = Capture(
+            () => schemaWriter.ExecuteNonQuery("CREATE TABLE added(v INTEGER);"));
+        rejected.Should().NotBeNull();
+        rejected!.Message.Should().ContainEquivalentOf("locked");
+
+        schemaWriter.ExecuteNonQuery("ROLLBACK;");
+        writer.ExecuteNonQuery("COMMIT;");
+        schemaWriter.ExecuteNonQuery("BEGIN CONCURRENT;");
+        schemaWriter.ExecuteNonQuery("CREATE TABLE added(v INTEGER);");
+        schemaWriter.ExecuteNonQuery("COMMIT;");
+
+        Convert.ToInt64(Scalar(writer, "SELECT v FROM t;")).Should().Be(41L);
+        Convert.ToInt64(Scalar(
+            writer,
+            "SELECT COUNT(*) FROM sqlite_schema WHERE name = 'added';")).Should().Be(1L);
+    }
+
+    [TestCase("IMMEDIATE")]
+    [TestCase("EXCLUSIVE")]
+    public void SchemaOwnerBlocksClassicMvccWriterAdmission(string mode)
+    {
+        using var db = new RoutingFileDatabase();
+        using var schemaOwner = db.Connect();
+        using var peer = db.Connect();
+
+        schemaOwner.ExecuteNonQuery("PRAGMA journal_mode=mvcc;");
+        schemaOwner.ExecuteNonQuery("BEGIN CONCURRENT;");
+        schemaOwner.ExecuteNonQuery("CREATE TABLE pending(v INTEGER);");
+
+        var rejected = Capture(() => peer.ExecuteNonQuery($"BEGIN {mode};"));
+        rejected.Should().NotBeNull();
+        rejected!.Message.Should().ContainEquivalentOf("locked");
+
+        schemaOwner.ExecuteNonQuery("ROLLBACK;");
+        peer.ExecuteNonQuery($"BEGIN {mode};");
+        peer.ExecuteNonQuery("ROLLBACK;");
+    }
+
+    [Test]
+    public void MvccBeginRegistersBeforeCatalogCloneCanRaceSchemaPublication()
+    {
+        var fileSystem = new Ahtola.Core.Storage.InMemoryFileSystem();
+        const string path = "mvcc-begin-schema-race.db";
+        using var database = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var reader = database.Connect();
+        using var schemaWriter = database.Connect();
+        Execute(reader, "CREATE TABLE t(v INTEGER);");
+        Execute(reader, "PRAGMA journal_mode=mvcc;");
+        Exception? rejected = null;
+
+        try
+        {
+            EmbeddedConnection.AfterMvccBeginBeforeCatalogSnapshotForTesting = () =>
+            {
+                EmbeddedConnection.AfterMvccBeginBeforeCatalogSnapshotForTesting = null;
+                Execute(schemaWriter, "BEGIN CONCURRENT;");
+                rejected = Capture(
+                    () => Execute(schemaWriter, "CREATE TABLE raced(v INTEGER);"));
+                Execute(schemaWriter, "ROLLBACK;");
+            };
+            Execute(reader, "BEGIN CONCURRENT;");
+        }
+        finally
+        {
+            EmbeddedConnection.AfterMvccBeginBeforeCatalogSnapshotForTesting = null;
+        }
+
+        rejected.Should().NotBeNull();
+        rejected!.Message.Should().ContainEquivalentOf("locked");
+        ReadEmbeddedScalar(
+            reader,
+            "SELECT COUNT(*) FROM sqlite_schema WHERE name = 'raced';").Should().Be(0L);
+        Execute(reader, "ROLLBACK;");
+    }
+
+    [Test]
     public void FailedOrSavepointRolledBackConcurrentDdlReleasesTheSchemaGate()
     {
         using var db = new RoutingFileDatabase();

--- a/src/Ahtola.Tests/MvccSelectDualCursorRoutingTests.cs
+++ b/src/Ahtola.Tests/MvccSelectDualCursorRoutingTests.cs
@@ -388,6 +388,7 @@ public sealed class MvccSelectDualCursorRoutingTests
         using var db = new RoutingFileDatabase();
         using var classicWriter = db.Connect();
         using var schemaWriter = db.Connect();
+        using var concurrentWriter = db.Connect();
 
         classicWriter.ExecuteNonQuery("PRAGMA journal_mode=mvcc;");
         schemaWriter.ExecuteNonQuery("PRAGMA busy_timeout=2000;");
@@ -401,7 +402,10 @@ public sealed class MvccSelectDualCursorRoutingTests
         await Task.Delay(100);
         schemaChange.IsCompleted.Should().BeFalse();
 
-        classicWriter.ExecuteNonQuery("COMMIT;");
+        concurrentWriter.ExecuteNonQuery("BEGIN CONCURRENT;");
+        concurrentWriter.ExecuteNonQuery("INSERT INTO t VALUES (2);");
+        concurrentWriter.ExecuteNonQuery("COMMIT;");
+        classicWriter.ExecuteNonQuery("ROLLBACK;");
         var staleSchema = await schemaChange.WaitAsync(TimeSpan.FromSeconds(5));
         staleSchema.Should().NotBeNull();
         staleSchema!.Message.Should().ContainEquivalentOf("locked");
@@ -410,6 +414,8 @@ public sealed class MvccSelectDualCursorRoutingTests
         schemaWriter.ExecuteNonQuery("CREATE TABLE added(v INTEGER);");
         schemaWriter.ExecuteNonQuery("COMMIT;");
         Convert.ToInt64(Scalar(schemaWriter, "SELECT COUNT(*) FROM t WHERE v=99;"))
+            .Should().Be(0L);
+        Convert.ToInt64(Scalar(schemaWriter, "SELECT COUNT(*) FROM t WHERE v=2;"))
             .Should().Be(1L);
     }
 

--- a/src/Ahtola.Tests/MvccSelectDualCursorRoutingTests.cs
+++ b/src/Ahtola.Tests/MvccSelectDualCursorRoutingTests.cs
@@ -313,6 +313,54 @@ public sealed class MvccSelectDualCursorRoutingTests
     }
 
     [Test]
+    public void DeferredClassicWriterBlocksConcurrentSchemaPublicationUntilCommit()
+    {
+        using var db = new RoutingFileDatabase();
+        using var classicWriter = db.Connect();
+        using var schemaWriter = db.Connect();
+
+        classicWriter.ExecuteNonQuery("PRAGMA journal_mode=mvcc;");
+        classicWriter.ExecuteNonQuery("BEGIN;");
+        classicWriter.ExecuteNonQuery("INSERT INTO t VALUES (99);");
+
+        schemaWriter.ExecuteNonQuery("BEGIN CONCURRENT;");
+        var rejected = Capture(
+            () => schemaWriter.ExecuteNonQuery("CREATE TABLE added(v INTEGER);"));
+        rejected.Should().NotBeNull();
+        rejected!.Message.Should().ContainEquivalentOf("locked");
+        schemaWriter.ExecuteNonQuery("ROLLBACK;");
+
+        classicWriter.ExecuteNonQuery("COMMIT;");
+        schemaWriter.ExecuteNonQuery("BEGIN CONCURRENT;");
+        schemaWriter.ExecuteNonQuery("CREATE TABLE added(v INTEGER);");
+        schemaWriter.ExecuteNonQuery("COMMIT;");
+
+        Convert.ToInt64(Scalar(classicWriter, "SELECT COUNT(*) FROM t WHERE v=99;"))
+            .Should().Be(1L);
+    }
+
+    [Test]
+    public void SchemaOwnerBlocksAutocommitClassicWritesUntilPublication()
+    {
+        using var db = new RoutingFileDatabase();
+        using var schemaWriter = db.Connect();
+        using var classicWriter = db.Connect();
+
+        schemaWriter.ExecuteNonQuery("PRAGMA journal_mode=mvcc;");
+        schemaWriter.ExecuteNonQuery("BEGIN CONCURRENT;");
+        schemaWriter.ExecuteNonQuery("CREATE TABLE added(v INTEGER);");
+
+        var rejected = Capture(() => classicWriter.ExecuteNonQuery("INSERT INTO t VALUES (99);"));
+        rejected.Should().NotBeNull();
+        rejected!.Message.Should().ContainEquivalentOf("locked");
+
+        schemaWriter.ExecuteNonQuery("COMMIT;");
+        classicWriter.ExecuteNonQuery("INSERT INTO t VALUES (99);");
+        Convert.ToInt64(Scalar(classicWriter, "SELECT COUNT(*) FROM t WHERE v=99;"))
+            .Should().Be(1L);
+    }
+
+    [Test]
     public void MvccBeginRegistersBeforeCatalogCloneCanRaceSchemaPublication()
     {
         var fileSystem = new Ahtola.Core.Storage.InMemoryFileSystem();
@@ -323,12 +371,14 @@ public sealed class MvccSelectDualCursorRoutingTests
         Execute(reader, "CREATE TABLE t(v INTEGER);");
         Execute(reader, "PRAGMA journal_mode=mvcc;");
         Exception? rejected = null;
+        var snapshotGateHeld = false;
 
         try
         {
             EmbeddedConnection.AfterMvccBeginBeforeCatalogSnapshotForTesting = () =>
             {
                 EmbeddedConnection.AfterMvccBeginBeforeCatalogSnapshotForTesting = null;
+                snapshotGateHeld = database.IsTransactionSnapshotGateHeldForTesting;
                 Execute(schemaWriter, "BEGIN CONCURRENT;");
                 rejected = Capture(
                     () => Execute(schemaWriter, "CREATE TABLE raced(v INTEGER);"));
@@ -341,11 +391,54 @@ public sealed class MvccSelectDualCursorRoutingTests
             EmbeddedConnection.AfterMvccBeginBeforeCatalogSnapshotForTesting = null;
         }
 
+        snapshotGateHeld.Should().BeTrue();
         rejected.Should().NotBeNull();
         rejected!.Message.Should().ContainEquivalentOf("locked");
         ReadEmbeddedScalar(
             reader,
             "SELECT COUNT(*) FROM sqlite_schema WHERE name = 'raced';").Should().Be(0L);
+        Execute(reader, "ROLLBACK;");
+    }
+
+    [Test]
+    public async Task MvccBeginPinsItsCatalogBeforeAPeerCheckpointCanPublish()
+    {
+        var fileSystem = new Ahtola.Core.Storage.InMemoryFileSystem();
+        const string path = "mvcc-begin-checkpoint-race.db";
+        using var database = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var reader = database.Connect();
+        using var peer = database.Connect();
+        Execute(reader, "CREATE TABLE t(v INTEGER);");
+        Execute(reader, "PRAGMA journal_mode=mvcc;");
+        Task? peerCheckpoint = null;
+        using var peerStarted = new ManualResetEventSlim();
+
+        try
+        {
+            EmbeddedConnection.AfterMvccBeginBeforeCatalogSnapshotForTesting = () =>
+            {
+                EmbeddedConnection.AfterMvccBeginBeforeCatalogSnapshotForTesting = null;
+                peerCheckpoint = Task.Run(() =>
+                {
+                    peerStarted.Set();
+                    Execute(peer, "BEGIN CONCURRENT;");
+                    Execute(peer, "INSERT INTO t VALUES (42);");
+                    Execute(peer, "COMMIT;");
+                    Execute(peer, "PRAGMA wal_checkpoint(TRUNCATE);");
+                });
+                peerStarted.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+                Thread.Sleep(100);
+            };
+
+            Execute(reader, "BEGIN CONCURRENT;");
+        }
+        finally
+        {
+            EmbeddedConnection.AfterMvccBeginBeforeCatalogSnapshotForTesting = null;
+        }
+
+        await peerCheckpoint!.WaitAsync(TimeSpan.FromSeconds(5));
+        ReadEmbeddedScalar(reader, "SELECT COUNT(*) FROM t WHERE v=42;").Should().Be(0L);
         Execute(reader, "ROLLBACK;");
     }
 

--- a/src/Ahtola.Tests/MvccStoreUnitTests.cs
+++ b/src/Ahtola.Tests/MvccStoreUnitTests.cs
@@ -137,10 +137,30 @@ public sealed class MvccStoreUnitTests
     }
 
     [Test]
-    public void ActiveTransactionPreventsCheckpointLease()
+    public void ActiveReadOnlyTransactionCanRemainPinnedDuringCheckpoint()
     {
         var store = new MvStore();
         var transaction = store.BeginTransaction();
+
+        store.TryAcquireCheckpoint(out var lease).Should().BeTrue();
+        lease.Should().NotBeNull();
+        ((Action)(() => store.Insert(
+                transaction.Id,
+                new MvccRowId(store.GetOrCreateTableId("t"), 1),
+                [SqlValue.Integer(1)])))
+            .Should().Throw<EmbeddedBusyException>();
+        lease!.Dispose();
+
+        store.Rollback(transaction.Id);
+    }
+
+    [Test]
+    public void ActiveWriterPreventsCheckpointLease()
+    {
+        var store = new MvStore();
+        var transaction = store.BeginTransaction();
+        var table = store.GetOrCreateTableId(transaction.Id, "t");
+        store.Insert(transaction.Id, new MvccRowId(table, 1), [SqlValue.Integer(1)]);
 
         store.TryAcquireCheckpoint(out var lease).Should().BeFalse();
         lease.Should().BeNull();
@@ -280,5 +300,81 @@ public sealed class MvccStoreUnitTests
             .Select(row => row.Key.Integer)
             .Should()
             .Equal(1L);
+    }
+
+    [Test]
+    public void SchemaIdentityChangesOnlyWhenPreparedCatalogIsPublished()
+    {
+        var store = new MvStore(schemaGeneration: 7);
+        var transaction = store.BeginTransaction(expectedSchemaGeneration: 7);
+        var oldIdentity = store.GetOrCreateTableId(transaction.Id, "items");
+
+        store.BeginSchemaChange(transaction.Id);
+        var provisionalIdentity = store.GetOrCreateTableId(transaction.Id, "items");
+        provisionalIdentity.Should().NotBe(oldIdentity);
+        store.SchemaGeneration.Should().Be(7);
+
+        store.CancelSchemaChange(transaction.Id);
+        store.SchemaGeneration.Should().Be(7);
+        store.GetOrCreateTableId(transaction.Id, "items").Should().Be(oldIdentity);
+
+        store.BeginSchemaChange(transaction.Id);
+        var committedIdentity = store.GetOrCreateTableId(transaction.Id, "items");
+        store.PrepareSchemaCommit(transaction.Id);
+        store.SchemaGeneration.Should().Be(7);
+        store.CompleteSchemaCommit(transaction.Id);
+
+        store.SchemaGeneration.Should().Be(8);
+        store.GetOrCreateTableId("items").Should().NotBe(oldIdentity);
+        store.GetOrCreateTableId("items").Should().NotBe(committedIdentity);
+    }
+
+    [Test]
+    public void ExpectedSchemaGenerationRejectsAStaleBegin()
+    {
+        var store = new MvStore(schemaGeneration: 3);
+
+        ((Action)(() => store.BeginTransaction(expectedSchemaGeneration: 2)))
+            .Should().Throw<EmbeddedCatalogSnapshotStaleException>();
+        var current = store.BeginTransaction(expectedSchemaGeneration: 3);
+        current.BeginSchemaGeneration.Should().Be(3);
+        store.Rollback(current.Id);
+    }
+
+    [Test]
+    public void CheckpointGcRetainsHistoryUntilTheOldestSnapshotEnds()
+    {
+        var store = new MvStore();
+        var table = store.GetOrCreateTableId("t");
+        var seed = store.BeginTransaction();
+        store.Insert(seed.Id, new MvccRowId(table, 1), [SqlValue.Text("old")]);
+        store.Commit(seed.Id);
+
+        var oldest = store.BeginTransaction();
+        var writer = store.BeginTransaction();
+        store.Update(writer.Id, new MvccRowId(table, 1), [SqlValue.Text("new")]).Should().BeTrue();
+        store.Commit(writer.Id);
+        store.VersionCount.Should().Be(2);
+
+        store.TryAcquireCheckpoint(out var firstLease).Should().BeTrue();
+        using (firstLease)
+        {
+            var snapshot = store.CollectCheckpointSnapshot();
+            store.GarbageCollectAfterCheckpoint(snapshot);
+        }
+
+        store.TryRead(oldest.Id, new MvccRowId(table, 1), out var oldCells).Should().BeTrue();
+        oldCells![0].Should().Be(SqlValue.Text("old"));
+        store.VersionCount.Should().Be(2);
+
+        store.Rollback(oldest.Id);
+        store.TryAcquireCheckpoint(out var secondLease).Should().BeTrue();
+        using (secondLease)
+        {
+            var snapshot = store.CollectCheckpointSnapshot();
+            store.GarbageCollectAfterCheckpoint(snapshot);
+        }
+
+        store.VersionCount.Should().Be(0);
     }
 }

--- a/src/Ahtola.Tests/PlannerAccessPathDepthTests.cs
+++ b/src/Ahtola.Tests/PlannerAccessPathDepthTests.cs
@@ -155,6 +155,71 @@ public sealed class PlannerAccessPathDepthTests
     }
 
     [Test]
+    public void Stat4SampleValidationReusesOneRowIdMapPerTableRevision()
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE cached_stats(id INTEGER PRIMARY KEY, bucket INTEGER, payload TEXT);");
+        Execute(connection, "CREATE INDEX cached_stats_bucket ON cached_stats(bucket);");
+        Execute(
+            connection,
+            "INSERT INTO cached_stats VALUES "
+            + string.Join(
+                ", ",
+                Enumerable.Range(1, 2_000).Select(value =>
+                    $"({value}, {value % 100}, 'p{value}')"))
+            + ";");
+        Execute(connection, "ANALYZE;");
+        var sampleCount = ReadScalar(
+            connection,
+            "SELECT count(*) FROM sqlite_stat4 WHERE idx='cached_stats_bucket';").AsInteger();
+        sampleCount.Should().Be(24);
+
+        database.ResetJoinOrderDiagnostics();
+        PlanDetail(connection, "SELECT id FROM cached_stats WHERE bucket=42;")
+            .Should().Contain("cached_stats_bucket");
+        PlanDetail(connection, "SELECT id FROM cached_stats WHERE bucket=42;")
+            .Should().Contain("cached_stats_bucket");
+        database.PlannerAccessPathMetrics.Stat4SampleRowIdLookups.Should().Be(sampleCount * 2);
+        database.PlannerAccessPathMetrics.Stat4RowIdCacheRebuilds.Should().Be(1);
+
+        Execute(connection, "UPDATE cached_stats SET payload='changed' WHERE id=1;");
+        database.ResetJoinOrderDiagnostics();
+        PlanDetail(connection, "SELECT id FROM cached_stats WHERE bucket=42;")
+            .Should().Contain("cached_stats_bucket");
+        database.PlannerAccessPathMetrics.Stat4SampleRowIdLookups.Should().Be(sampleCount);
+        database.PlannerAccessPathMetrics.Stat4RowIdCacheRebuilds.Should().Be(1);
+    }
+
+    [Test]
+    public void Stat4VectorDerivationScalesByRowsAndColumnsWithoutSampleMultiplier()
+    {
+        const int columnCount = 4;
+        const int smallRows = 500;
+        const int largeRows = 1_000;
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        CreateCompositeTable(connection, "small_stats", smallRows);
+        CreateCompositeTable(connection, "large_stats", largeRows);
+
+        database.ResetJoinOrderDiagnostics();
+        Execute(connection, "ANALYZE;");
+        var expectedComparisons = columnCount * ((smallRows - 1L) + (largeRows - 1L));
+        database.PlannerAccessPathMetrics.Stat4VectorComparisons.Should().Be(expectedComparisons);
+        database.PlannerAccessPathMetrics.Stat4RowIdSeedPasses.Should().Be(1);
+        database.PlannerAccessPathMetrics.Stat4RowIdSeedRowsVisited.Should().Be(0);
+        database.PlannerAccessPathMetrics.Stat4RowsWritten.Should().Be(48);
+        AssertDuplicateLeadingCompositeStat4Vectors(connection);
+
+        database.ResetJoinOrderDiagnostics();
+        Execute(connection, "ANALYZE;");
+        database.PlannerAccessPathMetrics.Stat4VectorComparisons.Should().Be(expectedComparisons);
+        database.PlannerAccessPathMetrics.Stat4RowIdSeedPasses.Should().Be(1);
+        database.PlannerAccessPathMetrics.Stat4RowIdSeedRowsVisited.Should().Be(48);
+        database.PlannerAccessPathMetrics.Stat4RowsWritten.Should().Be(48);
+    }
+
+    [Test]
     public void ProfitableInnerJoinBuildsOneAutomaticCoveringIndex()
     {
         using var database = new EmbeddedDatabase();
@@ -399,6 +464,44 @@ public sealed class PlannerAccessPathDepthTests
         => ReadRows(connection, "EXPLAIN " + sql)
             .Single(row => row[1].AsText() == "OpenReadCursor")[5]
             .AsText();
+
+    private static void CreateCompositeTable(
+        EmbeddedConnection connection,
+        string tableName,
+        int rowCount)
+    {
+        Execute(
+            connection,
+            $"CREATE TABLE {tableName}(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER, c INTEGER, d INTEGER);");
+        Execute(connection, $"CREATE INDEX {tableName}_abcd ON {tableName}(a,b,c,d);");
+        Execute(
+            connection,
+            $"INSERT INTO {tableName} VALUES "
+            + string.Join(
+                ", ",
+                Enumerable.Range(1, rowCount).Select(value =>
+                    $"({value}, 1, 1, 1, {value})"))
+            + ";");
+    }
+
+    private static void AssertDuplicateLeadingCompositeStat4Vectors(EmbeddedConnection connection)
+    {
+        var rows = ReadRows(
+            connection,
+            "SELECT idx,neq,nlt,ndlt FROM sqlite_stat4 "
+            + "WHERE idx IN ('small_stats_abcd','large_stats_abcd');");
+        rows.Should().HaveCount(48);
+        foreach (var row in rows)
+        {
+            var sourceRows = row[0].AsText() == "small_stats_abcd" ? 500 : 1_000;
+            row[1].AsText().Should().Be($"{sourceRows} {sourceRows} {sourceRows} 1");
+            var less = row[2].AsText().Split(' ');
+            var distinctLess = row[3].AsText().Split(' ');
+            less.Should().HaveCount(4);
+            less.Take(3).Should().OnlyContain(value => value == "0");
+            distinctLess.Should().Equal(less);
+        }
+    }
 
     private static string PlanDetail(EmbeddedConnection connection, string sql)
         => PlanDetails(connection, sql).Single();

--- a/src/Ahtola.Tests/PlannerAccessPathDepthTests.cs
+++ b/src/Ahtola.Tests/PlannerAccessPathDepthTests.cs
@@ -155,53 +155,6 @@ public sealed class PlannerAccessPathDepthTests
     }
 
     [Test]
-    public void Stat4AnalysisAndPlanningUseBoundedTablePasses()
-    {
-        using var database = new EmbeddedDatabase();
-        using var connection = database.Connect();
-        Execute(connection, "CREATE TABLE measured(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER);");
-        Execute(connection, "CREATE INDEX measured_ab ON measured(a, b);");
-        Execute(
-            connection,
-            "INSERT INTO measured "
-            + "SELECT value, value % 101, value % 137 FROM generate_series(1, 10000);");
-
-        database.ResetJoinOrderDiagnostics();
-        Execute(connection, "ANALYZE;");
-        database.PlannerAccessPathMetrics.Stat4AnalysisRowsScanned.Should().Be(20000);
-
-        database.ResetJoinOrderDiagnostics();
-        for (var iteration = 0; iteration < 5; iteration++)
-            PlanDetail(connection, "SELECT id FROM measured WHERE a=7;").Should().Contain("measured_ab");
-
-        database.PlannerAccessPathMetrics.Stat4RowIdMapBuilds.Should().Be(1);
-        database.PlannerAccessPathMetrics.Stat4RowIdsIndexed.Should().Be(10000);
-    }
-
-    [Test]
-    public void Stat4CompositeVectorsMatchSortedPrefixRuns()
-    {
-        using var connection = new EmbeddedDatabase().Connect();
-        Execute(connection, "CREATE TABLE vectors(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER);");
-        Execute(connection, "CREATE INDEX vectors_ab ON vectors(a, b);");
-        Execute(
-            connection,
-            "INSERT INTO vectors VALUES (1,1,1),(2,1,1),(3,1,2),(4,2,1);");
-        Execute(connection, "ANALYZE;");
-
-        ReadRows(
-                connection,
-                "SELECT neq, nlt, ndlt FROM sqlite_stat4 "
-                + "WHERE idx='vectors_ab' ORDER BY rowid;")
-            .Select(row => string.Join("|", row.Select(value => value.AsText())))
-            .Should().Equal(
-                "3 2|0 0|0 0",
-                "3 2|0 0|0 0",
-                "3 1|0 2|0 1",
-                "1 1|3 3|1 2");
-    }
-
-    [Test]
     public void ProfitableInnerJoinBuildsOneAutomaticCoveringIndex()
     {
         using var database = new EmbeddedDatabase();

--- a/src/Ahtola.Tests/PlannerAccessPathDepthTests.cs
+++ b/src/Ahtola.Tests/PlannerAccessPathDepthTests.cs
@@ -155,6 +155,53 @@ public sealed class PlannerAccessPathDepthTests
     }
 
     [Test]
+    public void Stat4AnalysisAndPlanningUseBoundedTablePasses()
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE measured(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER);");
+        Execute(connection, "CREATE INDEX measured_ab ON measured(a, b);");
+        Execute(
+            connection,
+            "INSERT INTO measured "
+            + "SELECT value, value % 101, value % 137 FROM generate_series(1, 10000);");
+
+        database.ResetJoinOrderDiagnostics();
+        Execute(connection, "ANALYZE;");
+        database.PlannerAccessPathMetrics.Stat4AnalysisRowsScanned.Should().Be(20000);
+
+        database.ResetJoinOrderDiagnostics();
+        for (var iteration = 0; iteration < 5; iteration++)
+            PlanDetail(connection, "SELECT id FROM measured WHERE a=7;").Should().Contain("measured_ab");
+
+        database.PlannerAccessPathMetrics.Stat4RowIdMapBuilds.Should().Be(1);
+        database.PlannerAccessPathMetrics.Stat4RowIdsIndexed.Should().Be(10000);
+    }
+
+    [Test]
+    public void Stat4CompositeVectorsMatchSortedPrefixRuns()
+    {
+        using var connection = new EmbeddedDatabase().Connect();
+        Execute(connection, "CREATE TABLE vectors(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER);");
+        Execute(connection, "CREATE INDEX vectors_ab ON vectors(a, b);");
+        Execute(
+            connection,
+            "INSERT INTO vectors VALUES (1,1,1),(2,1,1),(3,1,2),(4,2,1);");
+        Execute(connection, "ANALYZE;");
+
+        ReadRows(
+                connection,
+                "SELECT neq, nlt, ndlt FROM sqlite_stat4 "
+                + "WHERE idx='vectors_ab' ORDER BY rowid;")
+            .Select(row => string.Join("|", row.Select(value => value.AsText())))
+            .Should().Equal(
+                "3 2|0 0|0 0",
+                "3 2|0 0|0 0",
+                "3 1|0 2|0 1",
+                "1 1|3 3|1 2");
+    }
+
+    [Test]
     public void ProfitableInnerJoinBuildsOneAutomaticCoveringIndex()
     {
         using var database = new EmbeddedDatabase();

--- a/src/Ahtola.Tests/PlannerAccessPathDepthTests.cs
+++ b/src/Ahtola.Tests/PlannerAccessPathDepthTests.cs
@@ -1,0 +1,434 @@
+using AwesomeAssertions;
+using Ahtola.Core;
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Tests;
+
+public sealed class PlannerAccessPathDepthTests
+{
+    [Test]
+    public void SelectiveAndTermsUseDistinctIndexesAndIntersectBoundedCandidateSets()
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE items(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER, payload TEXT);");
+        Execute(connection, "CREATE INDEX items_a ON items(a);");
+        Execute(connection, "CREATE INDEX items_b ON items(b);");
+        Execute(
+            connection,
+            "INSERT INTO items VALUES "
+            + string.Join(
+                ", ",
+                Enumerable.Range(1, 1_000).Select(value =>
+                    $"({value}, {value % 100}, {value % 125}, 'p{value}')"))
+            + ";");
+
+        var noStatisticsPlan = PlanDetail(
+            connection,
+            "SELECT id, payload FROM items WHERE a = 7 AND b = 7;");
+        PlanDetail(connection, "SELECT id, payload FROM items WHERE a = 7 AND b = 7;")
+            .Should().Be(noStatisticsPlan);
+        Execute(connection, "ANALYZE;");
+
+        const string sql = "SELECT id, payload FROM items WHERE a = 7 AND b = 7;";
+        PlanDetail(connection, sql).Should().Be("MULTI-INDEX AND items (items_a, items_b)");
+        ExplainOpenTarget(connection, sql).Should().Contain("USING MULTI-INDEX AND items_a&items_b");
+
+        database.ResetJoinOrderDiagnostics();
+        var rows = ReadRows(connection, sql);
+        rows.Select(row => row[0].AsInteger()).Should().BeEquivalentTo([7L, 507L]);
+        database.PlannerAccessPathMetrics.IntersectionsExecuted.Should().Be(1);
+        database.PlannerAccessPathMetrics.IntersectionIndexProbes.Should().Be(2);
+        database.PlannerAccessPathMetrics.IntersectionCandidateRows.Should().BeLessThan(30);
+    }
+
+    [Test]
+    public void IntersectionCostFallsBackForSmallInputsAndCompositePrefixes()
+    {
+        using var connection = new EmbeddedDatabase().Connect();
+        Execute(connection, "CREATE TABLE tiny(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER);");
+        Execute(connection, "CREATE INDEX tiny_a ON tiny(a);");
+        Execute(connection, "CREATE INDEX tiny_b ON tiny(b);");
+        Execute(connection, "INSERT INTO tiny VALUES (1,1,1),(2,1,2),(3,2,1),(4,2,2);");
+        Execute(connection, "ANALYZE;");
+
+        PlanDetail(connection, "SELECT id FROM tiny WHERE a=1 AND b=1;")
+            .Should().NotStartWith("MULTI-INDEX AND");
+
+        Execute(connection, "CREATE INDEX tiny_ab ON tiny(a,b);");
+        Execute(connection, "ANALYZE;");
+        var composite = PlanDetail(connection, "SELECT id FROM tiny WHERE a=1 AND b=1;");
+        composite.Should().NotStartWith("MULTI-INDEX AND");
+        composite.Should().Contain("tiny_ab");
+    }
+
+    [Test]
+    public void ReopenedIntersectionSeeksBothDurableIndexes()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using (var database = EmbeddedDatabase.OpenFile("planner-depth-intersection.db", fileSystem))
+        using (var connection = database.Connect())
+        {
+            Execute(connection, "CREATE TABLE items(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER);");
+            Execute(connection, "CREATE INDEX items_a ON items(a);");
+            Execute(connection, "CREATE INDEX items_b ON items(b);");
+            Execute(
+                connection,
+                "INSERT INTO items VALUES "
+                + string.Join(
+                    ", ",
+                    Enumerable.Range(1, 1_000).Select(value =>
+                        $"({value}, {value % 100}, {value % 125})"))
+                + ";");
+            Execute(connection, "ANALYZE;");
+        }
+
+        using var reopened = EmbeddedDatabase.OpenFile("planner-depth-intersection.db", fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        const string sql = "SELECT id FROM items WHERE a=7 AND b=7;";
+        PlanDetail(reopenedConnection, sql).Should().Be("MULTI-INDEX AND items (items_a, items_b)");
+        reopened.ResetJoinOrderDiagnostics();
+        ReadRows(reopenedConnection, sql).Select(row => row[0].AsInteger())
+            .Should().BeEquivalentTo([7L, 507L]);
+        reopened.PlannerAccessPathMetrics.IntersectionIndexPagesRead.Should().BeGreaterThan(0);
+        reopened.PlannerAccessPathMetrics.IntersectionCandidateRows.Should().BeLessThan(30);
+    }
+
+    [Test]
+    public void Stat4CapturesSkewAndInvalidOrStaleSamplesFallBack()
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE skewed(id INTEGER PRIMARY KEY, bucket INTEGER);");
+        Execute(connection, "CREATE INDEX skewed_bucket ON skewed(bucket);");
+        Execute(
+            connection,
+            "INSERT INTO skewed VALUES "
+            + string.Join(
+                ", ",
+                Enumerable.Range(1, 1_000).Select(value =>
+                    value <= 900
+                        ? $"({value}, 0)"
+                        : $"({value}, {value - 900})"))
+            + ";");
+        Execute(connection, "ANALYZE;");
+
+        ReadScalar(connection, "SELECT count(*) FROM sqlite_stat4 WHERE idx='skewed_bucket';")
+            .AsInteger().Should().BeGreaterThan(1);
+
+        database.ResetJoinOrderDiagnostics();
+        PlanDetail(connection, "SELECT id FROM skewed WHERE bucket=0;")
+            .Should().Contain("skewed_bucket");
+        var commonEstimate = database.PlannerAccessPathMetrics.LastStat4EstimatedRows;
+        commonEstimate.Should().BeGreaterThan(800);
+
+        database.ResetJoinOrderDiagnostics();
+        PlanDetail(connection, "SELECT id FROM skewed WHERE bucket=50;")
+            .Should().Contain("skewed_bucket");
+        database.PlannerAccessPathMetrics.LastStat4EstimatedRows.Should().BeLessThan(commonEstimate);
+
+        database.RegisterCollation("BINARY", string.CompareOrdinal);
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, "SELECT id FROM skewed WHERE bucket=50;").Should().ContainSingle();
+        database.PlannerAccessPathMetrics.Stat4EstimatesUsed.Should().Be(0);
+        database.UnregisterCollation("BINARY").Should().BeTrue();
+
+        Execute(connection, "INSERT INTO skewed VALUES (1001, 50);");
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, "SELECT id FROM skewed WHERE bucket=50;")
+            .Select(row => row[0].AsInteger()).Should().BeEquivalentTo([950L, 1001L]);
+        database.PlannerAccessPathMetrics.Stat4EstimatesUsed.Should().Be(0);
+
+        Execute(connection, "ANALYZE;");
+        Execute(connection, "DROP INDEX skewed_bucket;");
+        Execute(connection, "CREATE INDEX skewed_bucket ON skewed(id);");
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, "SELECT bucket FROM skewed WHERE id=5;")
+            .Single()[0].AsInteger().Should().Be(0);
+        database.PlannerAccessPathMetrics.Stat4EstimatesUsed.Should().Be(0);
+
+        Execute(connection, "ANALYZE;");
+        Execute(connection, "UPDATE sqlite_stat4 SET neq='broken' WHERE idx='skewed_bucket';");
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, "SELECT bucket FROM skewed WHERE id=5;").Should().ContainSingle();
+        database.PlannerAccessPathMetrics.Stat4EstimatesUsed.Should().Be(0);
+    }
+
+    [Test]
+    public void ProfitableInnerJoinBuildsOneAutomaticCoveringIndex()
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE outer_items(k INTEGER, payload TEXT);");
+        Execute(connection, "CREATE TABLE inner_items(k INTEGER, payload TEXT);");
+        Execute(
+            connection,
+            "INSERT INTO outer_items VALUES "
+            + string.Join(", ", Enumerable.Range(1, 100).Select(value => $"({value}, 'o{value}')"))
+            + ";");
+        Execute(
+            connection,
+            "INSERT INTO inner_items VALUES "
+            + string.Join(", ", Enumerable.Range(1, 100).Select(value => $"({value}, 'i{value}')"))
+            + ";");
+        Execute(connection, "ANALYZE;");
+
+        const string sql =
+            """
+            SELECT outer_items.k, inner_items.payload
+            FROM outer_items JOIN inner_items ON outer_items.k=inner_items.k
+            ORDER BY outer_items.k;
+            """;
+        PlanDetail(connection, sql).Should().Be(
+            "SEARCH inner_items USING AUTOMATIC COVERING INDEX (k=?)");
+
+        database.ResetJoinOrderDiagnostics();
+        var rows = ReadRows(connection, sql);
+        rows.Should().HaveCount(100);
+        rows[0].Should().Equal(SqlValue.Integer(1), SqlValue.Text("i1"));
+        rows[^1].Should().Equal(SqlValue.Integer(100), SqlValue.Text("i100"));
+        database.JoinIndexSeekMetrics.AutomaticIndexesBuilt.Should().Be(1);
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(100);
+        database.JoinIndexSeekMetrics.CandidateRowsVisited.Should().Be(100);
+    }
+
+    [Test]
+    public void AutomaticIndexesDoNotCrossOuterNaturalUsingOrNotIndexedBarriers()
+    {
+        using var connection = new EmbeddedDatabase().Connect();
+        Execute(connection, "CREATE TABLE l(k INTEGER, payload TEXT);");
+        Execute(connection, "CREATE TABLE r(k INTEGER, payload TEXT);");
+        Execute(
+            connection,
+            "INSERT INTO l VALUES "
+            + string.Join(", ", Enumerable.Range(1, 100).Select(value => $"({value}, 'l{value}')"))
+            + ";");
+        Execute(
+            connection,
+            "INSERT INTO r VALUES "
+            + string.Join(", ", Enumerable.Range(1, 100).Select(value => $"({value}, 'r{value}')"))
+            + ";");
+        Execute(connection, "ANALYZE;");
+
+        string[] queries =
+        [
+            "SELECT l.k FROM l LEFT JOIN r ON l.k=r.k ORDER BY l.k;",
+            "SELECT k FROM l NATURAL JOIN r ORDER BY k;",
+            "SELECT k FROM l JOIN r USING(k) ORDER BY k;",
+        ];
+        foreach (var query in queries)
+            PlanDetails(connection, query).Should().NotContain(detail => detail.Contains("AUTOMATIC", StringComparison.Ordinal));
+
+        PlanDetails(
+                connection,
+                "SELECT l.k FROM l JOIN r NOT INDEXED ON l.k=r.k ORDER BY l.k;")
+            .Should().NotContain(detail =>
+                detail.StartsWith("SEARCH r USING AUTOMATIC", StringComparison.Ordinal));
+    }
+
+    [Test]
+    public void AutomaticCompositeCandidateCanUseOnlyItsCurrentlyBoundPrefix()
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE first_keys(k1 INTEGER);");
+        Execute(connection, "CREATE TABLE target(k1 INTEGER, k2 INTEGER, payload TEXT);");
+        Execute(connection, "CREATE TABLE second_keys(k2 INTEGER);");
+        Execute(
+            connection,
+            "INSERT INTO first_keys VALUES "
+            + string.Join(", ", Enumerable.Range(1, 100).Select(value => $"({value})"))
+            + ";");
+        Execute(
+            connection,
+            "INSERT INTO target VALUES "
+            + string.Join(", ", Enumerable.Range(1, 100).Select(value => $"({value}, {value}, 'p{value}')"))
+            + ";");
+        Execute(
+            connection,
+            "INSERT INTO second_keys VALUES "
+            + string.Join(", ", Enumerable.Range(1, 100).Select(value => $"({value})"))
+            + ";");
+        Execute(connection, "ANALYZE;");
+
+        const string sql =
+            """
+            SELECT target.payload
+            FROM first_keys
+            JOIN target ON first_keys.k1=target.k1
+            JOIN second_keys ON target.k2=second_keys.k2
+            ORDER BY target.k1;
+            """;
+        PlanDetails(connection, sql).Should().Contain(detail =>
+            detail.StartsWith("SEARCH target USING AUTOMATIC COVERING INDEX", StringComparison.Ordinal));
+        ReadRows(connection, sql).Select(row => row[0].AsText())
+            .Should().Equal(Enumerable.Range(1, 100).Select(value => $"p{value}"));
+    }
+
+    [Test]
+    public void ReopenedDatabaseUsesPagerIndexCursorAndDeferredRowidFetch()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using (var database = EmbeddedDatabase.OpenFile("planner-depth.db", fileSystem))
+        using (var connection = database.Connect())
+        {
+            Execute(connection, "CREATE TABLE outer_items(k INTEGER);");
+            Execute(connection, "CREATE TABLE inner_items(k INTEGER, payload TEXT);");
+            Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k);");
+            Execute(connection, "CREATE INDEX inner_items_k_payload ON inner_items(k,payload);");
+            Execute(connection, "INSERT INTO outer_items VALUES (3),(197),(499);");
+            Execute(
+                connection,
+                "INSERT INTO inner_items VALUES "
+                + string.Join(", ", Enumerable.Range(1, 1_000).Select(value => $"({value}, 'p{value}')"))
+                + ";");
+            Execute(connection, "ANALYZE;");
+        }
+
+        using var reopened = EmbeddedDatabase.OpenFile("planner-depth.db", fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_k ON outer_items.k=inner_items.k
+            ORDER BY outer_items.k;
+            """;
+        PlanDetail(reopenedConnection, sql).Should().Be(
+            "SEARCH inner_items USING INDEX inner_items_k (k=?)");
+        reopened.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+
+        reopened.ResetJoinOrderDiagnostics();
+        ReadRows(reopenedConnection, sql).Select(row => row[0].AsText())
+            .Should().Equal("p3", "p197", "p499");
+        reopened.JoinIndexSeekMetrics.DurableCursorPlans.Should().Be(1);
+        reopened.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+        reopened.JoinIndexSeekMetrics.TableRowsFetched.Should().Be(3);
+        reopened.JoinIndexSeekMetrics.IndexPagesRead.Should().BeLessThan(50);
+        reopened.JoinIndexSeekMetrics.CandidateRowsVisited.Should().Be(3);
+
+        const string coveringSql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_k_payload ON outer_items.k=inner_items.k
+            ORDER BY outer_items.k;
+            """;
+        PlanDetail(reopenedConnection, coveringSql).Should().Be(
+            "SEARCH inner_items USING COVERING INDEX inner_items_k_payload (k=?)");
+        reopened.ResetJoinOrderDiagnostics();
+        ReadRows(reopenedConnection, coveringSql).Select(row => row[0].AsText())
+            .Should().Equal("p3", "p197", "p499");
+        reopened.JoinIndexSeekMetrics.DurableCursorPlans.Should().Be(1);
+        reopened.JoinIndexSeekMetrics.TableRowsFetched.Should().Be(0);
+        reopened.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+    }
+
+    [Test]
+    public void TransactionLocalRowsUseMaterializedIndexFallback()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("planner-depth-transaction.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE outer_items(k INTEGER);");
+        Execute(connection, "CREATE TABLE inner_items(k INTEGER, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k);");
+        Execute(connection, "INSERT INTO outer_items VALUES (2);");
+        Execute(connection, "INSERT INTO inner_items VALUES (1,'one'),(2,'two');");
+        Execute(connection, "ANALYZE;");
+        Execute(connection, "BEGIN;");
+        Execute(connection, "INSERT INTO inner_items VALUES (2,'two-local');");
+
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(
+                connection,
+                """
+                SELECT inner_items.payload
+                FROM outer_items
+                JOIN inner_items INDEXED BY inner_items_k ON outer_items.k=inner_items.k
+                ORDER BY inner_items.payload;
+                """)
+            .Select(row => row[0].AsText())
+            .Should().Equal("two", "two-local");
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().Be(0);
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(3);
+        Execute(connection, "ROLLBACK;");
+    }
+
+    [Test]
+    public void PagerIndexCursorWalksDuplicatePrefixesAcrossInteriorSeparators()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using (var database = EmbeddedDatabase.OpenFile("planner-depth-duplicates.db", fileSystem))
+        using (var connection = database.Connect())
+        {
+            Execute(connection, "CREATE TABLE outer_items(k INTEGER);");
+            Execute(connection, "CREATE TABLE inner_items(k INTEGER, payload TEXT);");
+            Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k);");
+            Execute(connection, "INSERT INTO outer_items VALUES (7);");
+            Execute(
+                connection,
+                "INSERT INTO inner_items VALUES "
+                + string.Join(
+                    ", ",
+                    Enumerable.Range(1, 1_000).Select(value =>
+                        value <= 700
+                            ? $"(7, 'match-{value}')"
+                            : $"({value}, 'noise-{value}')"))
+                + ";");
+            Execute(connection, "ANALYZE;");
+        }
+
+        using var reopened = EmbeddedDatabase.OpenFile("planner-depth-duplicates.db", fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        reopened.ResetJoinOrderDiagnostics();
+        ReadRows(
+                reopenedConnection,
+                """
+                SELECT inner_items.payload
+                FROM outer_items
+                JOIN inner_items INDEXED BY inner_items_k ON outer_items.k=inner_items.k;
+                """)
+            .Should().HaveCount(700);
+        reopened.JoinIndexSeekMetrics.DurableCursorPlans.Should().Be(1);
+        reopened.JoinIndexSeekMetrics.CandidateRowsVisited.Should().Be(700);
+        reopened.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+    }
+
+    private static string ExplainOpenTarget(EmbeddedConnection connection, string sql)
+        => ReadRows(connection, "EXPLAIN " + sql)
+            .Single(row => row[1].AsText() == "OpenReadCursor")[5]
+            .AsText();
+
+    private static string PlanDetail(EmbeddedConnection connection, string sql)
+        => PlanDetails(connection, sql).Single();
+
+    private static string[] PlanDetails(EmbeddedConnection connection, string sql)
+        => ReadRows(connection, "EXPLAIN QUERY PLAN " + sql)
+            .Select(row => row[3].AsText())
+            .ToArray();
+
+    private static SqlValue ReadScalar(EmbeddedConnection connection, string sql)
+        => ReadRows(connection, sql).Single()[0];
+
+    private static void Execute(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        statement.Step().Should().Be(StatementStepResult.Done);
+    }
+
+    private static List<SqlValue[]> ReadRows(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        var rows = new List<SqlValue[]>();
+        while (statement.Step() == StatementStepResult.Row)
+        {
+            var values = new SqlValue[statement.GetColumnCount()];
+            for (var ordinal = 0; ordinal < values.Length; ordinal++)
+                values[ordinal] = statement.GetValue(ordinal);
+            rows.Add(values);
+        }
+
+        return rows;
+    }
+}

--- a/src/Ahtola.Tests/SqliteWalWriterCheckpointCoordinatorTests.cs
+++ b/src/Ahtola.Tests/SqliteWalWriterCheckpointCoordinatorTests.cs
@@ -72,6 +72,31 @@ public sealed class SqliteWalWriterCheckpointCoordinatorTests
 
     [Test]
     [NonParallelizable]
+    public void PassiveCheckpointEvidenceBindsInclusiveWatermarkToWalIncarnation()
+    {
+        RequireCoordinatorSupport();
+        using var artifact = SqliteWalArtifact.Create();
+        using var coordinator = SqliteWalWriterCheckpointCoordinator.Open(artifact.DatabasePath);
+
+        var checkpoint = coordinator.CheckpointPassiveValidated(TimeSpan.Zero);
+
+        checkpoint.IsBusy.Should().BeFalse();
+        checkpoint.HasValidatedWalIncarnation.Should().BeTrue();
+        checkpoint.SyncedFrameInclusive.Should().Be(checkpoint.MaximumFrame);
+        using var wal = OpenWalCopy(artifact.DatabasePath);
+        using var mapping = ((ISqliteWalSharedMemoryFileSystem)PhysicalFileSystem.Instance)
+            .OpenSharedMemory(
+                artifact.DatabasePath + "-shm",
+                FileOpenMode.OpenExisting,
+                readOnly: true);
+        var header = new SqliteWalIndexSharedMemory(mapping).ReadValidatedHeader(wal).Header;
+        checkpoint.WalIndexChangeCounter.Should().Be(header.ChangeCounter);
+        checkpoint.WalSalt1.Should().Be(header.Salt1);
+        checkpoint.WalSalt2.Should().Be(header.Salt2);
+    }
+
+    [Test]
+    [NonParallelizable]
     public void FullCheckpointWaitsInsteadOfCheckpointingPastAHeldSnapshot()
     {
         RequireCoordinatorSupport();


### PR DESCRIPTION
## Summary
- complete planner access-path depth with costed multi-index AND intersections, validated/linear-time STAT4 statistics, transient automatic covering indexes, and direct durable index-btree seeks
- complete page-native MVCC depth with generation-scoped identities, lazy typed base/version cursors, crash-ordered checkpoint/recovery watermarks, reader-generation-aware GC, and cross-handle schema/write admission
- complete managed sync depth with split wait/apply staging, bounded stale-base retries, durable conflict/revert handling, and non-blocking long polls
- update the roadmap and README to describe the implemented safe subsets and explicit fallbacks

This follows the SQL parity baseline merged in #50.

## Validation
- focused planner/MVCC/sync architecture slice: 182 passed
- final MVCC routing/race class: 34 passed
- managed sqltest conformance: 233 passed, 26 skipped
- `pwsh ./build.ps1 validate-trim`: passed; zero Ahtola trim/AOT warnings and ADO NativeAOT consumer executed successfully
- `pwsh ./build.ps1 test`: package closure and net8/net9/net10 packaged consumers passed; full net10 suite had 6,849 passing tests and one unrelated migration-lock timing stress miss
- isolated retry of that migration-lock stress test: passed
- `pwsh ./build.ps1 build`, task-scoped format verification, and `git diff --check`: passed