### PR TITLE
Complete planner access-path parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,15 +339,21 @@ Treat Ahtola as SQLite-*compatible*, not a full SQLite replacement:
   databases and explicit transactions for writes (managed writes are slower
   than native SQLite and the gap grows with table size).
 - **Planner** — `ANALYZE` / `sqlite_stat1` and validated `sqlite_stat4`
-  histograms feed index scoring, System-R DP join reordering for up to eight
-  freely reorderable INNER members (greedy above that), hash-build selection,
+  histograms feed index scoring, System-R DP join reordering for up to twelve
+  freely reorderable INNER members (deterministic greedy planning through
+  SQLite's 64-table limit above that), hash-build selection,
   costed multi-index AND intersections, and transient automatic covering
-  indexes. Committed file-backed rowid-table joins seek durable SQLite index
-  b-trees directly; transaction-local, MVCC, WITHOUT ROWID, partial/expression,
-  custom-collation, and unsupported range shapes retain deterministic
-  materialized/scan fallbacks. OUTER/NATURAL/USING barriers remain
-  correctness-preserving. Prefer `ORDER BY` when order matters (`GROUP BY` is
-  first-encounter order).
+  indexes. Eligible committed, transaction-local, and MVCC joins/scans seek
+  durable SQLite index b-trees directly, including partial and expression
+  indexes and `WITHOUT ROWID` primary/secondary indexes. Transaction and MVCC
+  paths merge their own ordered mutation/version overlays with a pinned pager
+  snapshot instead of rebuilding the index. Registered custom collations are
+  supported by secondary indexes and stay connection-bound; callback changes
+  are revalidated and require `REINDEX` when physical order changes.
+  Custom-collated `WITHOUT ROWID` primary keys and unsupported range shapes
+  retain deterministic fallbacks or fail closed. OUTER/NATURAL/USING barriers
+  remain correctness-preserving. Prefer `ORDER BY` when order matters
+  (`GROUP BY` is first-encounter order).
 - **File-backed platforms** — desktop physical files support Windows, 64-bit
   Linux, and macOS. Browser WebAssembly uses the separate OPFS package and its
   asynchronous data source (with an opt-in synchronous read-mirror profile, see

--- a/docs/mvcc-port-contract.md
+++ b/docs/mvcc-port-contract.md
@@ -35,10 +35,11 @@ original baseline with `git -C turso-src show v0.7.2:<path>`.
    (single write reservation, WAL snapshots).
 6. **Upstream anomaly TODOs.** Do not claim protection against phantoms, cursor
    lost updates, read skew, or write skew beyond Turso v0.7.2.
-7. **Concurrent DDL fails closed.** Turso versions `sqlite_schema` rows through
-   MVCC. Ahtola does not yet version schema rows, so schema-changing statements
-   inside `BEGIN CONCURRENT` are rejected rather than appearing to succeed and
-   then being discarded by the committed-row merge.
+7. **Concurrent DDL is generation gated.** Schema rows and table identities are
+   versioned by schema generation. A schema-changing `BEGIN CONCURRENT`
+   transaction publishes through the pager-first schema path and fails busy
+   while an incompatible peer snapshot is active, rather than exposing or
+   discarding a stale catalog.
 
 ## Phase map
 
@@ -48,9 +49,10 @@ original baseline with `git -C turso-src show v0.7.2:<path>`.
 | **1.5** | Row-version chains (`Insert`/`Update`/`Delete`/`TryRead`/`ScanVisible`), visibility + WW on chains, commit stamp rewrite, rollback drop |
 | **2** | Durable logical log (`*.db-log`) with Turso LML2/MVTX framing constants, CRC32C, upsert/delete ops, replay into `MvStore` on enable; encrypted databases AES-GCM-encrypt row payload chunks while authenticating salt/length/op-count/commit-ts/chunk/version metadata and require exact payload consumption; checkpoint TRUNCATE clears log |
 | **3** | Header version **255** via pager `SwitchJournalMode(Mvcc)`; cold open restores `MvStore`; typed `MvccKey` rows/index objects and V4 logical-log frames cover rowid and composite keys; **shared `MvStore`/log per path** (`EmbeddedMvStoreRegistry`) lets pooled multi-connection concurrent writers share one version store; concurrent commit reloads durable catalog then merges store snapshots |
-| **3.5** | **SQL dual-cursor routing:** under `BEGIN CONCURRENT`, typed base/store overlays cover rowid and `WITHOUT ROWID` primary keys, with materialized index-plan overlays. DML records typed table/index versions through `ReportRowChange`, including trigger and foreign-key actions; peer uncommitted writes remain invisible, snapshot isolation holds after peer commit, and same-key writes conflict. |
-| **3.6 (current)** | **Synchronous page-WAL checkpoint state machine:** `PRAGMA wal_checkpoint` in MVCC mode runs `RunMvccCheckpoint` — AcquireLock → Collect/Materialize (reuse `MergeConcurrentCatalogFromStoreLocked`) → persist pages to WAL **without automatic reset** → backfill and flush the main store → retire/upgrade the logical log → reset the WAL last for TRUNCATE/RESTART/FULL → `GarbageCollectAfterCheckpoint`. Active concurrent txs return busy before mutation. PASSIVE retains both WAL and logical-log recovery evidence. This adapts Turso's cooperative b-tree I/O state machine to managed synchronous `IFileSystem` operations. |
-| **Open** | Concurrent DDL is deliberately exclusive while active MVCC snapshots exist; full lazy per-page B-tree cursor/checkpoint parity with Turso remains deferred if product requires it. |
+| **3.5** | **SQL dual-cursor routing:** under `BEGIN CONCURRENT`, typed base/store overlays cover rowid and `WITHOUT ROWID` primary keys, originally via materialized index-plan overlays (superseded for eligible index paths by the page-native accessor in 3.7). DML records typed table/index versions through `ReportRowChange`, including trigger and foreign-key actions; peer uncommitted writes remain invisible, snapshot isolation holds after peer commit, and same-key writes conflict. |
+| **3.6** | **Synchronous page-WAL checkpoint state machine:** `PRAGMA wal_checkpoint` in MVCC mode runs `RunMvccCheckpoint` — AcquireLock → Collect/Materialize (reuse `MergeConcurrentCatalogFromStoreLocked`) → persist pages to WAL **without automatic reset** → backfill and flush the main store → retire/upgrade the logical log → reset the WAL last for TRUNCATE/RESTART/FULL → `GarbageCollectAfterCheckpoint`. Active concurrent txs return busy before mutation. PASSIVE retains both WAL and logical-log recovery evidence. This adapts Turso's cooperative b-tree I/O state machine to managed synchronous `IFileSystem` operations. Fixed alongside 3.7: the schema owner's own pinned reader snapshot is released *before* the internal TRUNCATE checkpoint that `BeginConcurrentSchemaChange` issues, so a schema-changing connection no longer deadlocks/busy-fails against its own pin (`EmbeddedDatabase.cs`). |
+| **3.7 (current)** | **Page-native direct-index access:** eligible `BEGIN CONCURRENT` index joins/scans (ordinary, partial, expression, `WITHOUT ROWID`, and validated custom-collation secondary indexes) seek and stream the transaction-pinned durable b-tree snapshot (`EmbeddedFileReadSnapshot` captured at `BEGIN CONCURRENT`, generation/root-map bound) directly via the existing page-native cursors (`SqliteIndexBtreeCursor`/`SqliteTableBtreeCursor`), merging lazily with the visible `MvStore` overlay through `MvccDualCursor`'s two-pointer merge (per Turso's `core/mvcc/cursor.rs` two-peek semantics: peek base, peek overlay, emit the lesser typed key, suppress base rows shadowed by an overlay tombstone/replacement). No `table.GetOrCreateIndexScanOrder`/`BuildBaseIndexScanOrder` full-table materialization occurs on these paths. Classic transactions use the same pinned-cursor contract with a savepoint-aware mutation overlay. Custom-collation callbacks remain connection-bound and are generation/version validated; stale physical order stays ineligible until `REINDEX`. `EmbeddedDatabase.JoinIndexSeekMetrics` differentiates durable cursor plans, prohibited full-index materialization, overlay rows examined/emitted, and base rows suppressed. |
+| **Open** | Concurrent DDL remains deliberately exclusive while incompatible MVCC snapshots exist; full cooperative per-page checkpoint-state-machine parity with Turso remains deferred. Custom-collated `WITHOUT ROWID` primary keys remain fail-closed because their comparator is required before the catalog can be reconstructed. |
 
 ## Dual-cursor SQL routing notes
 
@@ -61,9 +63,12 @@ original baseline with `git -C turso-src show v0.7.2:<path>`.
   key or indexed-value changes remove old typed/index keys and insert their replacements.
 - **WW:** `ThrowIfConcurrentWriterOnRow` applies to the typed identity, so pure base tombstones
   cannot bypass first-committer-wins conflict detection.
-- **SELECT:** typed dual-cursor routing covers rowid and `WITHOUT ROWID` primary-key scans, with
-  materialized index-plan overlays. `sqlite_schema` publication is schema-generation gated; DDL
-  remains exclusive against active MVCC snapshots rather than exposing a stale catalog.
+- **SELECT:** typed dual-cursor routing covers rowid and `WITHOUT ROWID` primary-key scans.
+  Eligible index joins/scans (ordinary, partial, expression, `WITHOUT ROWID`) route through the
+  page-native direct-index accessor (phase 3.7): the durable b-tree snapshot is streamed and
+  merged lazily with the visible `MvStore` overlay, with zero full base-index materialization.
+  `sqlite_schema` publication is schema-generation gated; DDL remains exclusive against active
+  MVCC snapshots rather than exposing a stale catalog.
 - **Process-local:** store is not cross-process (same as Turso process MVCC scope here).
 
 ## Checkpoint notes

--- a/docs/turso-gap-analysis.md
+++ b/docs/turso-gap-analysis.md
@@ -847,27 +847,30 @@ is documented in code:
   constants would rank a large build side as cheap, because `hash_lookup_cost`
   exceeds `hash_insert_cost`.
 
-The managed executor does not yet open the persisted B-tree directly, so seek
-cost also includes the one-time O(N log N) projection/sort that reconstructs
-its MVCC-visible index view. This keeps large unhinted joins on the cheaper hash
-shape. A usable mandatory `INDEXED BY` candidate still selects the named seek;
-an unusable hint declines to the directive-aware evaluator rather than silently
-substituting another access method.
+The original implementation reconstructed an O(N log N) MVCC-visible index
+view. The current executor instead opens generation/root-map-bound pager
+cursors for eligible committed, classic-transaction, and MVCC paths and merges
+ordered mutation/version effects lazily. Costing distinguishes that lazy path
+from a remaining materialized fallback. A usable mandatory `INDEXED BY`
+candidate still selects the named seek; an unusable hint declines rather than
+silently substituting another access method.
 
 **Shape selection.** Each step is scored against nested-loop cross scan,
 hash-build-right, hash-build-left, and every executable persisted-index seek.
 A seek requires a contiguous leading equality prefix whose other endpoints are
 already in the outer mask. Its comparison collation must equal the effective
 index collation, and affinity conversion may apply only to the outer probe key,
-never to stored index values. Partial, expression, method, custom/overridden
-collation, missing-statistics, `NOT INDEXED`, prefix-gap, and unsafe-affinity
-candidates decline. The full ON condition remains as a residual predicate.
+never to stored index values. Partial and expression indexes participate after
+implication/expression proofs; registered custom collations participate only
+after their callback and durable tree order are generation/version validated.
+Method indexes, missing-statistics, `NOT INDEXED`, prefix-gap, unsafe-affinity,
+and unresolved or stale collation candidates decline. The full ON condition
+remains as a residual predicate.
 
-`VdbeJoinIndexScanPlan` reconstructs one MVCC-visible index-ordered view per
-statement using the same durable index projection/sort machinery as managed
-index scans. Each outer row then performs a binary lower-bound probe and visits
-only the contiguous equal-prefix candidates; NULL probe keys visit none. This
-is a real bounded seek, but not yet a direct pager/B-tree cursor seek.
+Eligible plans use a direct pager/B-tree cursor and a two-peek merge with the
+classic transaction or MVCC overlay. Each outer row visits only the contiguous
+equal-prefix candidates; NULL probe keys visit none. `VdbeJoinIndexScanPlan`
+remains the deterministic fallback for shapes the direct accessor cannot prove.
 
 **WHERE accounting.** Comparison conjuncts of the statement's WHERE clause that
 reference exactly one member and compare it against a literal or parameter are
@@ -904,12 +907,11 @@ materialized index rows, probes, key comparisons, and candidate rows visited.
 fallbacks, plan shapes, and a work-bound assertion proving probes rather than
 outer-by-inner scans.
 
-**Residual gaps.** Multi-index AND intersection, direct pager/B-tree cursor
-reuse, STAT4 histograms, bloom filters, transient join auto-indexes, and Turso's
-finer-grained outer-join interleaving remain open. The per-member candidate list
-and per-step access-choice union are the extension point for a future
-`MultiIndexIntersectionRight`; its RowSet lifecycle, duplicate suppression,
-costing, and branch-shaped EXPLAIN are intentionally not mixed into this change.
+**Current residuals.** Multi-index AND intersection, STAT4 histograms,
+transient automatic covering indexes, and direct persisted cursors are now
+implemented. Bloom filters, custom-collated `WITHOUT ROWID` primary keys,
+unsupported range shapes, and Turso's finer-grained outer-join interleaving
+remain outside this direct-access closure.
 
 ## 5. Parser / dialect layer
 22 entries — the smallest gap *per failure-line* ratio in the inventory, which
@@ -1483,10 +1485,12 @@ defects, all now closed with regression coverage in
 **Current residual (honest, not scoreboard).** Inventory is **216 closed · 0 open**,
 and the live conformance expected-failures file contains two intentional
 Turso-negative markers for STORED generated columns. “Closed” still includes
-intentional scope and closed-with-residual notes: recursive b-tree
-balancing can still fall back to a catalog rewrite, the general planner lacks
-STAT4/multi-index-AND/direct persisted join cursors, and MVCC lacks Turso's lazy
-per-page checkpoint state machine. The managed vtab/FTS/R-Tree SQL subset has
+intentional scope and closed-with-residual notes: recursive b-tree balancing
+can still fall back to a catalog rewrite, while the planner now includes STAT4,
+multi-index AND, 12-member System-R DP, and direct persisted join cursors across
+committed, classic-transaction, and MVCC paths. The remaining MVCC
+implementation-shape difference is Turso's cooperative per-page checkpoint
+state machine. The managed vtab/FTS/R-Tree SQL subset has
 landed (including streaming VOpen/VFilter/VColumn/VNext SELECTs, direct
 VCreate/VDestroy/VRename lifecycle execution, conflict-aware VUpdate,
 constraint/cost/order planning, shared table-valued-function cursors, R-Tree

--- a/docs/turso-gap-closure-roadmap.md
+++ b/docs/turso-gap-closure-roadmap.md
@@ -50,6 +50,12 @@ classification: ranks 1-7 account for 133 distinct expected-failure entries.
 - 2026-08-29: closed `planner-access-path-depth` with costed AND intersections,
   validated STAT4 selectivity, automatic covering indexes, and direct durable
   index-btree seeks.
+- 2026-08-30: completed planner depth beyond the original workstream: the
+  System-R subset DP now matches Turso's 12-member threshold and deterministic
+  greedy planning covers SQLite's 64-table limit. Direct pager seeks now cover
+  transaction-local and MVCC overlays, `WITHOUT ROWID` primary/secondary
+  indexes, partial/expression indexes, and validated connection-bound custom
+  collations without changing SQLite record bytes.
 - 2026-08-29: closed `mvcc-page-native-depth` with generation-scoped schema
   identities, lazy typed cursors, crash-ordered checkpointing, recovery
   watermarks, and reader-generation-aware GC.
@@ -181,6 +187,14 @@ classification: ranks 1-7 account for 133 distinct expected-failure entries.
 - [x] Build transient automatic indexes for profitable inner join inputs.
 - [x] Replace materialized durable-index probes with lazy pager/index cursors
   where a covering or rowid lookup is proven.
+- [x] Match Turso's 12-member subset-DP threshold and retain deterministic
+  greedy planning through SQLite's 64-table join limit.
+- [x] Extend direct access to transaction-local and MVCC mutation overlays,
+  `WITHOUT ROWID` primary/secondary b-trees, and safe partial/expression-index
+  predicates.
+- [x] Support connection-bound custom collations in secondary indexes with
+  generation/version validation and targeted `REINDEX`, without changing
+  SQLite index record bytes.
 - [x] Preserve deterministic plans without statistics and all existing outer
   join barriers.
 - [x] Extend EXPLAIN QUERY PLAN, selectivity tests, and bounded benchmarks for
@@ -188,12 +202,16 @@ classification: ranks 1-7 account for 133 distinct expected-failure entries.
 
 The managed planner mirrors Turso's `multi_index.rs` row-set costing and
 automatic-index eligibility, while keeping LEFT/RIGHT/FULL, NATURAL, and USING
-subtrees opaque. Committed rowid-table joins now seek the SQLite index b-tree
-directly and defer the table fetch unless the index covers the row; transaction,
-MVCC, unsupported-shape, and unsupported-collation cases retain the materialized
-fallback. The pinned Turso release has no STAT4 reader, so Ahtola's histogram
-extension validates the standard `sqlite_stat4` schema, current `sqlite_stat1`
-row count, built-in collation metadata, and sample record before using it.
+subtrees opaque. Eligible committed, classic-transaction, and MVCC paths seek
+the pinned SQLite index b-tree directly and merge ordered local/version effects
+without rebuilding the complete index. The same access contract covers rowid
+and `WITHOUT ROWID` tables plus safe partial/expression indexes. Custom
+collations remain runtime callbacks: only their names are stored in SQLite
+schema SQL, physical order is generation/version validated, and targeted
+`REINDEX` repairs a stale tree while preserving unrelated unavailable custom
+indexes byte-for-byte. The pinned Turso release has no STAT4 reader, so Ahtola's
+histogram extension validates the standard `sqlite_stat4` schema, current
+`sqlite_stat1` row count, collation metadata, and sample record before using it.
 
 ### 9. Page-native MVCC depth
 

--- a/src/Ahtola.Core/Compilation/JoinOrdering/JoinOrderEnumerator.cs
+++ b/src/Ahtola.Core/Compilation/JoinOrdering/JoinOrderEnumerator.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Numerics;
 
 namespace Ahtola.Core.Compilation.JoinOrdering;
@@ -30,19 +31,17 @@ namespace Ahtola.Core.Compilation.JoinOrdering;
 internal static class JoinOrderEnumerator
 {
     /// <summary>
-    /// Largest segment the subset DP is allowed to enumerate. Chosen below Turso's
-    /// <c>GREEDY_JOIN_THRESHOLD = 12</c> because each managed candidate re-scores two hash
-    /// shapes per step, keeping the worst case (<c>2^8 · 8 · 8</c> state transitions) well
-    /// inside a prepare-time budget.
+    /// Largest segment the subset DP is allowed to enumerate. This matches Turso's
+    /// <c>GREEDY_JOIN_THRESHOLD = 12</c>; larger segments use the deterministic greedy
+    /// build-up below.
     /// </summary>
-    public const int DynamicProgrammingMemberCap = 8;
+    public const int DynamicProgrammingMemberCap = 12;
 
     /// <summary>
-    /// Hard ceiling on segment size. Member masks are <see cref="ulong"/>, and beyond this the
-    /// greedy build-up stops being worth its own quadratic cost, so the caller falls back to the
-    /// unmodified FROM order.
+    /// Hard ceiling on segment size. The managed planner supports the full 64-member SQLite
+    /// join mask; only the first twelve members ever enter subset-DP enumeration.
     /// </summary>
-    public const int MaximumMembers = 32;
+    public const int MaximumMembers = 64;
 
     private const double CostEpsilon = 1e-9;
 
@@ -407,18 +406,26 @@ internal static class JoinOrderEnumerator
         foreach (var term in segment.Terms)
         {
             if ((term.TableMask & ~candidateMask) != 0)
+            {
                 continue;
+            }
 
             // A term whose mask is already covered was attached at an earlier step; the only
             // exception is the very first step, which is where terms local to the leading member
             // (and constant terms) first become attachable to a join node.
             var alreadyApplied = (term.TableMask & ~placedMask) == 0 && BitOperations.PopCount(placedMask) >= 2;
             if (alreadyApplied)
-                continue;
-
-            if (TryGetEqualityMatchRows(term, placedMask, memberBit, out var matchRows))
             {
-                hasEqualityKey = true;
+                continue;
+            }
+
+            if (TryGetEqualityMatchRows(term, placedMask, memberBit, out var matchRows, out var hashable))
+            {
+                // Narrowing the cardinality estimate is safe for any resolved equality, but only
+                // a hashable one may make this step consider a hash-build shape below — a custom
+                // or overridden-built-in collation still reaches the index-seek-or-nested-loop
+                // branch (see the `!hasEqualityKey` check), never the hash cost comparison.
+                hasEqualityKey = hasEqualityKey || hashable;
                 rowsPerOuterRow = Math.Min(rowsPerOuterRow, Math.Max(matchRows, 0.0));
                 continue;
             }
@@ -607,8 +614,13 @@ internal static class JoinOrderEnumerator
         ulong memberBit,
         JoinIndexColumn indexColumn)
     {
+        // Seek binding uses EqualitySeekCollation (populated whenever the equality's operands
+        // structurally resolve) rather than EqualityCollation (populated only when also safe to
+        // hash) — DescribeJoinIndexCandidates already gates which indexes are even offered as
+        // candidates, so a custom or overridden-built-in collation can still bind a direct index
+        // seek here even though TryBuildAutomaticEquiJoinIndexCandidate will never hash it.
         if (!term.IsEquality
-            || !string.Equals(term.EqualityCollation, indexColumn.Collation, StringComparison.OrdinalIgnoreCase))
+            || !string.Equals(term.EqualitySeekCollation, indexColumn.Collation, StringComparison.OrdinalIgnoreCase))
         {
             return false;
         }
@@ -629,15 +641,22 @@ internal static class JoinOrderEnumerator
     /// True when <paramref name="term"/> can serve as this step's hash key: one operand must be
     /// fully covered by the already-placed members and the other must be exactly the member
     /// being added, which is the same left/right split
-    /// <c>EmbeddedDatabase.TryCreateCompiledJoinEquiProbe</c> requires.
+    /// <c>EmbeddedDatabase.TryCreateCompiledJoinEquiProbe</c> requires. <paramref name="hashable"/>
+    /// additionally reports whether <see cref="JoinPredicateTerm.EqualityCollation"/> is set —
+    /// i.e. whether this same equality is also safe to key a hash-build step off of, as opposed
+    /// to only being usable for a direct index seek (<see cref="JoinPredicateTerm.EqualitySeekCollation"/>).
+    /// A custom or overridden-built-in collation match still narrows the cardinality estimate
+    /// (<paramref name="matchRows"/>) but must never make the caller consider a hash shape.
     /// </summary>
     private static bool TryGetEqualityMatchRows(
         JoinPredicateTerm term,
         ulong placedMask,
         ulong memberBit,
-        out double matchRows)
+        out double matchRows,
+        out bool hashable)
     {
         matchRows = 0.0;
+        hashable = term.EqualityCollation is not null;
         if (!term.IsEquality)
             return false;
 

--- a/src/Ahtola.Core/Compilation/JoinOrdering/JoinOrderModel.cs
+++ b/src/Ahtola.Core/Compilation/JoinOrdering/JoinOrderModel.cs
@@ -1,3 +1,5 @@
+using Ahtola.Core.Parsing;
+
 namespace Ahtola.Core.Compilation.JoinOrdering;
 
 /// <summary>
@@ -31,13 +33,23 @@ internal sealed record JoinIndexCandidate(
     bool HasRowIdAlias,
     bool Forced = false,
     bool Automatic = false,
-    bool LazyCursor = false);
+    bool LazyCursor = false,
+    bool IsPrimaryKey = false);
 
-/// <summary>One key column in persisted index order.</summary>
+/// <summary>
+/// One key column in persisted index order. <paramref name="ColumnOrdinal"/> is a real
+/// non-negative table-column ordinal for a plain column, or a negative "expression group"
+/// identity — stable only within one <see cref="EmbeddedTable"/>'s own indexes for one planning
+/// pass — for an expression column, letting <see cref="JoinOrderEnumerator"/> keep comparing
+/// plain <see cref="int"/>s without ever inspecting an AST. <paramref name="IndexExpression"/> is
+/// build-time-only matching metadata (populated for expression columns only) that the enumerator
+/// never reads.
+/// </summary>
 internal readonly record struct JoinIndexColumn(
     int ColumnOrdinal,
     string Collation,
-    bool Descending);
+    bool Descending,
+    Expression? IndexExpression = null);
 
 /// <summary>
 /// One AND-conjunct available to the segment, already resolved to the members it references.
@@ -66,7 +78,26 @@ internal readonly record struct JoinIndexColumn(
 /// <param name="EqualityLeftConvertsNumericToText">Whether comparison affinity textifies the left value.</param>
 /// <param name="EqualityRightConvertsTextToNumeric">Whether comparison affinity converts the right value.</param>
 /// <param name="EqualityRightConvertsNumericToText">Whether comparison affinity textifies the right value.</param>
-/// <param name="EqualityCollation">Resolved built-in comparison collation.</param>
+/// <param name="EqualityCollation">
+/// Resolved comparison collation, but only when it is also safe to hash — i.e.
+/// <c>IsHashableJoinKeyCollation</c> accepts it and it is not an unsafe compiled collation (see
+/// <c>IsUnsafeCompiledCollation</c>). Null whenever the equality resolved to a custom or
+/// overridden-built-in collation, so <c>TryCreateCompiledJoinEquiProbe</c> and automatic
+/// hash-index building never key off an arbitrary application-defined comparator. Use
+/// <see cref="EqualitySeekCollation"/> for direct index-seek binding instead — a custom
+/// collation can still be seeked through a matching persisted index even though it can never be
+/// hashed.
+/// </param>
+/// <param name="EqualitySeekCollation">
+/// Resolved comparison collation for direct index-seek binding (see
+/// <c>JoinOrderEnumerator.CanBindIndexColumn</c>), populated whenever the equality's operands
+/// structurally resolve regardless of hashability. Safe to use unconditionally for seek binding
+/// because a candidate index column is only ever offered by <c>DescribeJoinIndexCandidates</c>
+/// once its own collation has been proven ready for planning (built-in, or a custom/overridden
+/// collation with a registered callback whose durable order has been validated) — matching this
+/// value against that column's declared collation name can never bind an unready index. Equal to
+/// <see cref="EqualityCollation"/> whenever the latter is non-null.
+/// </param>
 internal sealed record JoinPredicateTerm(
     ulong TableMask,
     bool IsEquality,
@@ -81,7 +112,8 @@ internal sealed record JoinPredicateTerm(
     bool EqualityLeftConvertsNumericToText = false,
     bool EqualityRightConvertsTextToNumeric = false,
     bool EqualityRightConvertsNumericToText = false,
-    string? EqualityCollation = null);
+    string? EqualityCollation = null,
+    string? EqualitySeekCollation = null);
 
 /// <summary>
 /// Exact index and equality terms selected for one <c>IndexSeekRight</c> step.

--- a/src/Ahtola.Core/EmbeddedDatabase.JoinOrderRewrites.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.JoinOrderRewrites.cs
@@ -1,6 +1,7 @@
 using Ahtola.Core.Compilation.JoinOrdering;
 using Ahtola.Core.Execution;
 using Ahtola.Core.Parsing;
+using Ahtola.Core.Storage;
 
 namespace Ahtola.Core;
 
@@ -48,6 +49,14 @@ public sealed partial class EmbeddedDatabase
     private long _joinOrderDeclines;
     private long _joinOrderPushedWhereTerms;
     private readonly VdbeJoinIndexSeekMetrics _joinIndexSeekMetrics = new();
+
+    /// <summary>
+    /// First negative "expression group" ordinal <see cref="FindJoinIndexExpressionOrdinal"/>
+    /// hands out for a persisted index's expression column. Real column ordinals are always
+    /// <c>&gt;= 0</c>, so any value at or below this base unambiguously identifies an expression
+    /// group rather than a table column.
+    /// </summary>
+    private const int JoinIndexExpressionOrdinalBase = -1000;
 
     /// <summary>
     /// Counters describing what the join-order stage did on this database instance. Test-only
@@ -137,6 +146,7 @@ public sealed partial class EmbeddedDatabase
             return false;
         }
     }
+
 
     /// <summary>
     /// Re-points a statement's output columns from the original FROM-order slot layout onto the
@@ -238,10 +248,20 @@ public sealed partial class EmbeddedDatabase
         if (sources.Count < 2 || sources.Count > JoinOrderEnumerator.MaximumMembers)
             return false;
 
+        // Partial-index eligibility must be proven from conjuncts already known safe for this
+        // segment: this segment's own ON conjuncts, plus — only for the root segment, mirroring
+        // the existing WHERE-pushing gate below — the top-level WHERE's conjuncts. A conjunct
+        // that reaches outside the table under proof is filtered by
+        // IndexExpressionSemantics.PredicateImplies itself (UsesOnlySourceColumns), so passing
+        // the whole list here is safe even though it is not yet split per member.
+        IReadOnlyList<Expression> impliedByConjuncts = isRoot && state.Where is not null
+            ? [.. conjuncts, .. SplitJoinOrderConjunction(state.Where)]
+            : conjuncts;
+
         var infos = new JoinOrderMemberInfo[sources.Count];
         for (var index = 0; index < sources.Count; index++)
         {
-            if (!TryDescribeJoinOrderMember(sources[index], state.Context, out var info))
+            if (!TryDescribeJoinOrderMember(sources[index], impliedByConjuncts, state.Context, out var info))
                 return false;
 
             infos[index] = info;
@@ -252,7 +272,9 @@ public sealed partial class EmbeddedDatabase
         foreach (var conjunct in conjuncts)
         {
             if (!TryCreateJoinOrderTerm(conjunct, infos, state.Context, out var term))
+            {
                 return false;
+            }
 
             terms.Add(term);
             placements.Add(new JoinOrderTermPlacement(conjunct, term.TableMask));
@@ -475,6 +497,7 @@ public sealed partial class EmbeddedDatabase
     /// </summary>
     private bool TryDescribeJoinOrderMember(
         TableSource source,
+        IReadOnlyList<Expression> impliedByConjuncts,
         QueryContext context,
         out JoinOrderMemberInfo info)
     {
@@ -501,6 +524,7 @@ public sealed partial class EmbeddedDatabase
             return false;
 
         var table = TryResolveJoinOrderBaseTable(source, context);
+        var candidates = DescribeJoinIndexCandidates(source, table, impliedByConjuncts, context);
         info = new JoinOrderMemberInfo(
             qualifiers,
             columnNames,
@@ -508,13 +532,14 @@ public sealed partial class EmbeddedDatabase
             rows,
             width,
             table,
-            DescribeJoinIndexCandidates(source, table, context));
+            candidates);
         return true;
     }
 
     private IReadOnlyList<JoinIndexCandidate> DescribeJoinIndexCandidates(
         TableSource source,
         EmbeddedTable? table,
+        IReadOnlyList<Expression> impliedByConjuncts,
         QueryContext context)
     {
         if (source is not NamedTableSource named
@@ -534,13 +559,30 @@ public sealed partial class EmbeddedDatabase
             }
 
             if (index.Columns.Count == 0
-                || index.IsPartial
                 || index.IsMethodIndex
-                || index.Columns.Any(static column => column.IsExpression)
-                || index.Columns.Any(column =>
-                    !IsBuiltInCollation(IndexExpressionSemantics.GetCollationName(table, column))
-                    || IsOverriddenBuiltInCollation(
-                        IndexExpressionSemantics.GetCollationName(table, column))))
+                || IndexUsesRegisteredFunctions(index)
+                // A built-in, non-overridden index is always ready. A custom or
+                // overridden-built-in index is ready only once every such collation has a
+                // registered callback and the index's durable order/content has been proven
+                // consistent with it (see IsCustomCollationIndexPlanReady) — this is what lets a
+                // clean custom-collation index be offered for direct seeks/plans instead of
+                // being unconditionally excluded, while a dirty or callback-less one still falls
+                // back to a full scan rather than ever being trusted.
+                || !IsCustomCollationIndexPlanReady(table, index))
+            {
+                continue;
+            }
+
+            // A partial index is only a safe candidate once every one of its predicate conjuncts
+            // is proven by the segment's own safe plain-INNER ON/WHERE conjuncts. Uncertain or
+            // unmatched proofs leave the index out of the candidate list entirely — the predicate
+            // then stays a residual filter, never a seek precondition.
+            if (index.IsPartial
+                && !IndexExpressionSemantics.PredicateImplies(
+                    impliedByConjuncts,
+                    index.Where,
+                    named.Name,
+                    named.Alias))
             {
                 continue;
             }
@@ -550,10 +592,14 @@ public sealed partial class EmbeddedDatabase
             for (var position = 0; position < index.Columns.Count; position++)
             {
                 var column = index.Columns[position];
-                columns[position] = new JoinIndexColumn(
-                    column.ColumnIndex,
-                    IndexExpressionSemantics.GetCollationName(table, column).ToUpperInvariant(),
-                    column.Descending);
+                var collation = IndexExpressionSemantics.GetCollationName(table, column).ToUpperInvariant();
+                columns[position] = column.IsExpression
+                    ? new JoinIndexColumn(
+                        FindJoinIndexExpressionOrdinal(table, column.Expression!)!.Value,
+                        collation,
+                        column.Descending,
+                        column.Expression)
+                    : new JoinIndexColumn(column.ColumnIndex, collation, column.Descending);
                 if (!TryGetSqliteStat1PrefixAverage(
                         context,
                         table.Name,
@@ -568,30 +614,185 @@ public sealed partial class EmbeddedDatabase
             }
 
             if (rowsPerPrefix.Count == 0)
+            {
                 continue;
+            }
 
             if (rowsPerPrefix.Count < columns.Length)
                 Array.Resize(ref columns, rowsPerPrefix.Count);
 
             var indexedColumns = columns.Select(static column => column.ColumnOrdinal).ToHashSet();
+            // A WITHOUT ROWID table's secondary-index records always physically carry the table's
+            // full primary key as a locator suffix (see GetWithoutRowidIndexStorageColumns), so
+            // every primary-key column ordinal is present for the covering check even though it is
+            // not one of the index's own declared columns.
+            if (table.WithoutRowid && table.PrimaryKeySchema is { } primaryKeySchemaForCovering)
+            {
+                foreach (var term in primaryKeySchemaForCovering.Terms)
+                    indexedColumns.Add(term.ColumnIndex);
+            }
+
+            // An expression column never contributes a real table-column ordinal (its identity is
+            // a negative synthetic group id), so a covering read would have to re-evaluate the
+            // stored expression instead of the row it was derived from. Keep covering strictly
+            // conservative for expression indexes rather than risk mis-detecting full coverage
+            // when every real column ordinal also happens to be present.
+            var covering = columns.All(static column => column.IndexExpression is null)
+                && Enumerable.Range(0, table.Columns.Length).All(indexedColumns.Contains);
             candidates.Add(new JoinIndexCandidate(
                 index.Name,
                 columns,
                 rowsPerPrefix,
                 index.Unique && columns.Length == index.Columns.Count,
-                Enumerable.Range(0, table.Columns.Length).All(indexedColumns.Contains),
+                covering,
                 table.Columns.Length,
                 table.RowidAliasColumnIndex >= 0,
                 named.IndexDirective is IndexedByDirective,
                 Automatic: false,
-                LazyCursor: context.ConcurrentMvStore is null
-                    && context.ConcurrentMvccTxId is null
-                    && !context.InTransaction
-                    && _fileStore?.CanOpenIndexAccessor(table, index) == true));
+                LazyCursor: CanUseLazyCursorForJoinIndex(table, index, context),
+                IsPrimaryKey: false));
+        }
+
+        // A WITHOUT ROWID table's own root page is itself an index b-tree keyed by the declared
+        // primary key, and the primary key is deliberately never represented as a member of
+        // table.Indexes (see CreateWithoutRowidConstraintIndexes). Offer it as an implicit join
+        // candidate — reusing its real autoindex name so EXPLAIN QUERY PLAN output matches
+        // SQLite's own convention — without fabricating any EmbeddedIndex schema state.
+        if (table.WithoutRowid
+            && table.PrimaryKeySchema is { Terms.Count: > 0 } primaryKeySchema
+            && table.WithoutRowidPrimaryKeyIndexName is { } primaryKeyIndexName
+            && (named.IndexDirective is not IndexedByDirective indexedByPrimaryKey
+                || string.Equals(indexedByPrimaryKey.IndexName, primaryKeyIndexName, StringComparison.OrdinalIgnoreCase))
+            // The table's own root page is never rebuilt/reordered when a collation callback is
+            // registered, replaced, or unregistered (CreatePrimaryKeyComparer always compares
+            // primary-key terms using pure built-in semantics — see its remarks — so the durable
+            // b-tree order can never itself drift away from plain BINARY/NOCASE/RTRIM order).
+            // What *can* drift is a live evaluator: per Compare's collation-resolution order, a
+            // currently-registered callback for a built-in name takes precedence over the
+            // hard-coded fallback that the tree's actual physical order still reflects. Offering
+            // this candidate while any term's collation is presently overridden would let the
+            // planner compute seek bounds under the override's semantics against a b-tree that is
+            // physically ordered by the plain built-in comparison instead — a false-negative (or
+            // outright wrong-row) risk indistinguishable from seeking a stale/mismatched index.
+            // A genuinely unavailable or non-built-in term is equally unproven here (WITHOUT ROWID
+            // primary keys with an actual custom collation are already rejected at CREATE TABLE
+            // time, so this is defensive). Unlike a secondary index, there is no revalidation path
+            // to make this candidate trustworthy again while overridden — REINDEX has no meaning
+            // for the table's own identity b-tree — so removing the override (which immediately
+            // restores agreement between the live evaluator and the tree's fixed physical order)
+            // is the only way this candidate becomes safe again.
+            && !primaryKeySchema.Terms.Any(term =>
+                !term.Collation.IsAvailable || IsUnsafeCompiledCollation(term.Collation.Name)))
+        {
+            var primaryKeyColumns = new JoinIndexColumn[primaryKeySchema.Terms.Count];
+            var primaryKeyRowsPerPrefix = new List<double>(primaryKeySchema.Terms.Count);
+            for (var position = 0; position < primaryKeySchema.Terms.Count; position++)
+            {
+                var term = primaryKeySchema.Terms[position];
+                primaryKeyColumns[position] = new JoinIndexColumn(
+                    term.ColumnIndex,
+                    (term.Collation.Name ?? "BINARY").ToUpperInvariant(),
+                    term.SortOrder == SqliteKeySortOrder.Descending);
+                if (!TryGetSqliteStat1PrefixAverage(
+                        context,
+                        table.Name,
+                        table.Name,
+                        position + 1,
+                        out var average))
+                {
+                    break;
+                }
+
+                primaryKeyRowsPerPrefix.Add(Math.Max(1.0, average));
+            }
+
+            if (primaryKeyRowsPerPrefix.Count > 0)
+            {
+                if (primaryKeyRowsPerPrefix.Count < primaryKeyColumns.Length)
+                    Array.Resize(ref primaryKeyColumns, primaryKeyRowsPerPrefix.Count);
+
+                candidates.Add(new JoinIndexCandidate(
+                    primaryKeyIndexName,
+                    primaryKeyColumns,
+                    primaryKeyRowsPerPrefix,
+                    Unique: true,
+                    Covering: true,
+                    table.Columns.Length,
+                    HasRowIdAlias: false,
+                    Forced: named.IndexDirective is IndexedByDirective,
+                    Automatic: false,
+                    LazyCursor: CanUseLazyCursorForJoinIndex(table, index: null, context),
+                    IsPrimaryKey: true));
+            }
         }
 
         return candidates;
     }
+
+    /// <summary>
+    /// Cost-model hint: can <c>TryCreateCompiledJoinIndexScanPlan</c> seek this candidate's durable
+    /// b-tree directly (a "lazy cursor") instead of materializing/sorting the whole index? True
+    /// either outside a transaction via the plain committed-snapshot accessor, inside a classic
+    /// (non-MVCC) transaction that has pinned a durable snapshot and not yet made a schema change —
+    /// see <see cref="TryOpenTransactionIndexAccessor"/> — or inside a BEGIN CONCURRENT/MVCC
+    /// transaction that has pinned its own durable snapshot — see <see
+    /// cref="TryOpenConcurrentMvccIndexAccessor"/> — which this mirrors so join-order cost
+    /// estimation picks the same plan shape <c>TryCreateCompiledJoinIndexScanPlan</c> will actually
+    /// choose.
+    /// </summary>
+    private bool CanUseLazyCursorForJoinIndex(EmbeddedTable table, EmbeddedIndex? index, QueryContext context)
+    {
+        if (context.ConcurrentMvStore is not null || context.ConcurrentMvccTxId is not null)
+        {
+            return context.TransactionPinnedSnapshot is not null
+                && _fileStore?.CanOpenIndexAccessor(table, index, requireCommittedTableIdentity: false) == true;
+        }
+
+        if (context.TransactionOverlay is not null && context.TransactionPinnedSnapshot is not null)
+            return _fileStore?.CanOpenIndexAccessor(table, index, requireCommittedTableIdentity: false) == true;
+
+        return !context.InTransaction && _fileStore?.CanOpenIndexAccessor(table, index) == true;
+    }
+
+    /// <summary>
+    /// A stable per-table identity for a persisted index expression: the negative ordinal shared
+    /// by every <see cref="JoinIndexColumn"/> whose expression is structurally equal (via
+    /// <see cref="IndexExpressionSemantics.ExpressionsEqual"/>) to <paramref name="expression"/>,
+    /// or <see langword="null"/> when no persisted index on <paramref name="table"/> declares a
+    /// structurally matching expression column. Recomputed deterministically from
+    /// <paramref name="table"/>'s own indexes on every call (first-seen order), so a candidate
+    /// column's ordinal (assigned in <see cref="DescribeJoinIndexCandidates"/>) and a later query
+    /// conjunct's operand (resolved in <see cref="TryCreateJoinOrderTerm"/>) always agree as long
+    /// as the table's index list does not change mid-plan — true within one planning pass. This is
+    /// the "stable term identity" that lets <see cref="JoinOrderEnumerator"/> keep binding
+    /// expression-index terms with a plain <see cref="int"/> comparison, never touching an AST.
+    /// </summary>
+    private static int? FindJoinIndexExpressionOrdinal(EmbeddedTable table, Expression expression)
+    {
+        var seen = new List<Expression>();
+        foreach (var candidateIndex in table.Indexes)
+        {
+            foreach (var candidateColumn in candidateIndex.Columns)
+            {
+                if (candidateColumn.Expression is not { } candidateExpression)
+                    continue;
+
+                var groupIndex = seen.FindIndex(seenExpression =>
+                    IndexExpressionSemantics.ExpressionsEqual(seenExpression, candidateExpression));
+                if (groupIndex < 0)
+                {
+                    groupIndex = seen.Count;
+                    seen.Add(candidateExpression);
+                }
+
+                if (IndexExpressionSemantics.ExpressionsEqual(candidateExpression, expression))
+                    return JoinIndexExpressionOrdinalBase - groupIndex;
+            }
+        }
+
+        return null;
+    }
+
 
     private static JoinIndexCandidate? DescribeAutomaticJoinIndexCandidate(
         TableSource source,
@@ -761,41 +962,47 @@ public sealed partial class EmbeddedDatabase
         var rightConvertsTextToNumeric = false;
         var rightConvertsNumericToText = false;
         string? collation = null;
-        if (conjunct is BinaryExpression { Operator: BinaryOperator.Equal } binary
-            && UnwrapCollation(binary.Left) is ColumnExpression { BooleanKeyword: null } leftColumn
-            && UnwrapCollation(binary.Right) is ColumnExpression { BooleanKeyword: null } rightColumn
-            && TryResolveJoinOrderMember(leftColumn, infos, out var leftMember)
-            && TryResolveJoinOrderMember(rightColumn, infos, out var rightMember)
-            && leftMember != rightMember)
+        string? seekCollation = null;
+        if (conjunct is BinaryExpression { Operator: BinaryOperator.Equal } binary)
         {
-            isEquality = true;
-            leftMask = 1UL << leftMember;
-            rightMask = 1UL << rightMember;
-            leftMatchRows = EstimateJoinOrderMatchRows(infos[leftMember], leftColumn, context);
-            rightMatchRows = EstimateJoinOrderMatchRows(infos[rightMember], rightColumn, context);
-
-            var leftDefinition = TryResolveJoinOrderColumnDefinition(infos[leftMember], leftColumn, context);
-            var rightDefinition = TryResolveJoinOrderColumnDefinition(infos[rightMember], rightColumn, context);
-            if (leftDefinition is not null
-                && rightDefinition is not null
-                && infos[leftMember].Table!.TryGetColumnIndex(leftDefinition.Name, out leftColumnOrdinal)
-                && infos[rightMember].Table!.TryGetColumnIndex(rightDefinition.Name, out rightColumnOrdinal))
+            if (UnwrapCollation(binary.Left) is ColumnExpression { BooleanKeyword: null } leftColumn
+                && UnwrapCollation(binary.Right) is ColumnExpression { BooleanKeyword: null } rightColumn
+                && TryResolveJoinOrderMember(leftColumn, infos, out var leftMember)
+                && TryResolveJoinOrderMember(rightColumn, infos, out var rightMember)
+                && leftMember != rightMember)
             {
-                var leftAffinity = GetJoinKeyAffinity(leftDefinition);
-                var rightAffinity = GetJoinKeyAffinity(rightDefinition);
-                collation = GetExplicitCollation(binary.Left)
-                    ?? GetExplicitCollation(binary.Right)
-                    ?? NormalizeDeclaredCollation(leftDefinition.Collation)
-                    ?? NormalizeDeclaredCollation(rightDefinition.Collation)
-                    ?? "BINARY";
-                if (!IsHashableJoinKeyCollation(collation) || IsUnsafeCompiledCollation(collation))
+                isEquality = true;
+                leftMask = 1UL << leftMember;
+                rightMask = 1UL << rightMember;
+                leftMatchRows = EstimateJoinOrderMatchRows(infos[leftMember], leftColumn, context);
+                rightMatchRows = EstimateJoinOrderMatchRows(infos[rightMember], rightColumn, context);
+
+                var leftDefinition = TryResolveJoinOrderColumnDefinition(infos[leftMember], leftColumn, context);
+                var rightDefinition = TryResolveJoinOrderColumnDefinition(infos[rightMember], rightColumn, context);
+                if (leftDefinition is not null
+                    && rightDefinition is not null
+                    && infos[leftMember].Table!.TryGetColumnIndex(leftDefinition.Name, out leftColumnOrdinal)
+                    && infos[rightMember].Table!.TryGetColumnIndex(rightDefinition.Name, out rightColumnOrdinal))
                 {
-                    leftColumnOrdinal = -1;
-                    rightColumnOrdinal = -1;
-                    collation = null;
-                }
-                else
-                {
+                    // Ordinals and affinity-conversion flags stay populated as soon as the
+                    // equality resolves structurally, regardless of collation hashability — a
+                    // custom-collation index seek needs exactly the same binding shape as a
+                    // built-in one (CanBindIndexColumn matches against EqualitySeekCollation,
+                    // never EqualityCollation). Only the hash-specific EqualityCollation below is
+                    // conditionally cleared, so hashing stays strictly gated to built-in
+                    // collations while seeking does not.
+                    var leftAffinity = GetJoinKeyAffinity(leftDefinition);
+                    var rightAffinity = GetJoinKeyAffinity(rightDefinition);
+                    // NormalizeDeclaredCollation substitutes "BINARY" for a null collation, so it
+                    // must not be chained with ?? here: doing so would short-circuit on the left
+                    // column's absent collation and never fall through to the right column's
+                    // declared collation. Read the raw declared collation instead and only apply
+                    // the BINARY default once, after both operands have been consulted.
+                    var resolvedCollation = (GetExplicitCollation(binary.Left)
+                        ?? GetExplicitCollation(binary.Right)
+                        ?? leftDefinition.Collation
+                        ?? rightDefinition.Collation
+                        ?? "BINARY").ToUpperInvariant();
                     leftConvertsTextToNumeric =
                         IsNumericAffinity(rightAffinity) && !IsNumericAffinity(leftAffinity);
                     leftConvertsNumericToText =
@@ -804,7 +1011,69 @@ public sealed partial class EmbeddedDatabase
                         IsNumericAffinity(leftAffinity) && !IsNumericAffinity(rightAffinity);
                     rightConvertsNumericToText =
                         leftAffinity == ColumnAffinity.Text && rightAffinity is null;
-                    collation = collation.ToUpperInvariant();
+                    seekCollation = resolvedCollation;
+                    collation = !IsHashableJoinKeyCollation(resolvedCollation) || IsUnsafeCompiledCollation(resolvedCollation)
+                        ? null
+                        : resolvedCollation;
+                }
+            }
+            else
+            {
+                var expressionComparisonCollation =
+                    GetExplicitCollation(binary.Left)
+                    ?? GetExplicitCollation(binary.Right)
+                    ?? TryGetJoinOrderInheritedCollation(binary.Left, infos, context)
+                    ?? TryGetJoinOrderInheritedCollation(binary.Right, infos, context);
+                if (TryMatchExpressionIndexOperand(
+                         binary.Left,
+                         binary.Right,
+                         // SQLite's collation-precedence rule (datatype3.html §7.1 rule 2) is
+                         // decided once, from the original left-to-right expression shape, before
+                         // either directional match is attempted below. Resolving it inside
+                         // TryMatchExpressionIndexOperand from (indexedOperand, outerOperand)
+                         // instead would make the winning explicit COLLATE depend on which operand
+                         // happens to structurally match a persisted expression index — e.g. a
+                         // right-side match would consult binary.Right's explicit COLLATE before
+                         // binary.Left's, silently reversing SQLite's left-wins rule whenever the
+                         // indexed expression is on the right. Computing it once here, from
+                         // binary.Left then binary.Right, and threading the same value into both
+                         // directional attempts keeps the outcome independent of which side is
+                         // indexed.
+                         expressionComparisonCollation,
+                         infos,
+                         context,
+                         out var exprLeftMask,
+                         out var exprRightMask,
+                         out var exprLeftOrdinal,
+                         out var exprRightOrdinal,
+                         out var exprLeftMatchRows,
+                         out var exprRightMatchRows,
+                         out var exprCollation,
+                         out var exprSeekCollation)
+                     || TryMatchExpressionIndexOperand(
+                         binary.Right,
+                         binary.Left,
+                         expressionComparisonCollation,
+                         infos,
+                         context,
+                         out exprRightMask,
+                         out exprLeftMask,
+                         out exprRightOrdinal,
+                         out exprLeftOrdinal,
+                         out exprRightMatchRows,
+                         out exprLeftMatchRows,
+                         out exprCollation,
+                         out exprSeekCollation))
+                {
+                    isEquality = true;
+                    leftMask = exprLeftMask;
+                    rightMask = exprRightMask;
+                    leftColumnOrdinal = exprLeftOrdinal;
+                    rightColumnOrdinal = exprRightOrdinal;
+                    leftMatchRows = exprLeftMatchRows;
+                    rightMatchRows = exprRightMatchRows;
+                    collation = exprCollation;
+                    seekCollation = exprSeekCollation;
                 }
             }
         }
@@ -823,9 +1092,163 @@ public sealed partial class EmbeddedDatabase
             leftConvertsNumericToText,
             rightConvertsTextToNumeric,
             rightConvertsNumericToText,
-            collation);
+            collation,
+            seekCollation);
         return true;
     }
+
+    /// <summary>
+    /// Matches one directional reading of an equality conjunct against a persisted expression
+    /// index: <paramref name="indexedOperand"/> must structurally match (via
+    /// <see cref="IndexExpressionSemantics.ExpressionsEqual"/>) an expression column declared on
+    /// exactly one already-described member's table — that member's <see
+    /// cref="FindJoinIndexExpressionOrdinal"/> ordinal becomes the indexed side's column ordinal,
+    /// the same synthetic id <c>DescribeJoinIndexCandidates</c> already assigned the matching
+    /// <see cref="JoinIndexColumn"/>. <paramref name="outerOperand"/> must resolve to a plain
+    /// column of a single, different member (its real table ordinal is kept so an automatic index
+    /// can still be built on it) — the task's "opposite operand may come from already placed
+    /// outer members" is satisfied structurally here and evaluated later, at seek-key build time,
+    /// against the outer row. <paramref name="explicitCollation"/> is resolved once by the
+    /// caller from the original BinaryExpression's left operand then right (SQLite's left-wins
+    /// rule, datatype3.html §7.1 rule 2) — the same value is passed into both directional
+    /// attempts so the winning explicit COLLATE never depends on which operand happens to
+    /// structurally match a persisted expression index. Falling back to the outer column's
+    /// declared collation, then BINARY, mirrors the plain-column path; the persisted index's
+    /// own declared collation for that expression is checked later — by
+    /// <c>CanBindIndexColumn</c>'s exact string comparison against <paramref name="seekCollation"/>,
+    /// not here — so a mismatched expression/collation naturally leaves the term unable to bind to
+    /// that candidate. <paramref name="collation"/> is additionally gated to hashable, non-custom
+    /// collations for automatic hash-index building — it is populated only when the resolved
+    /// collation is also safe to hash (see <see cref="JoinPredicateTerm.EqualityCollation"/>),
+    /// staying <see langword="null"/> for a custom or overridden-built-in collation.
+    /// <paramref name="seekCollation"/> is instead populated whenever the operands structurally
+    /// match, regardless of hashability, and is safe for index-seek binding only (see
+    /// <see cref="JoinPredicateTerm.EqualitySeekCollation"/>).
+    /// </summary>
+    private bool TryMatchExpressionIndexOperand(
+        Expression indexedOperand,
+        Expression outerOperand,
+        string? explicitCollation,
+        JoinOrderMemberInfo[] infos,
+        QueryContext context,
+        out ulong indexedMask,
+        out ulong outerMask,
+        out int indexedColumnOrdinal,
+        out int outerColumnOrdinal,
+        out double indexedMatchRows,
+        out double outerMatchRows,
+        out string? collation,
+        out string? seekCollation)
+    {
+        indexedMask = 0;
+        outerMask = 0;
+        indexedColumnOrdinal = -1;
+        outerColumnOrdinal = -1;
+        indexedMatchRows = 0.0;
+        outerMatchRows = 0.0;
+        collation = null;
+        seekCollation = null;
+
+        var unwrappedOuter = UnwrapCollation(outerOperand);
+        if (unwrappedOuter is not ColumnExpression { BooleanKeyword: null } outerColumn
+            || !TryResolveJoinOrderMember(outerColumn, infos, out var outerMember)
+            || !TryResolveJoinOrderMask(indexedOperand, infos, out var indexedMaskValue)
+            || System.Numerics.BitOperations.PopCount(indexedMaskValue) != 1)
+        {
+            return false;
+        }
+
+        var indexedMember = System.Numerics.BitOperations.TrailingZeroCount(indexedMaskValue);
+        // A persisted expression-index column's own COLLATE is stored as metadata (see
+        // EmbeddedIndexFactory.Create), not retained on its Expression tree, so the stored
+        // candidate expression is always bare. An ON/WHERE conjunct's operand, however, may
+        // still carry an explicit "(...) COLLATE name" wrapper straight from the parser (that
+        // wrapper's name is recovered separately below via GetExplicitCollation). Unwrap it here,
+        // the same way outerOperand already is above, so the structural match in
+        // FindJoinIndexExpressionOrdinal compares like with like instead of always missing.
+        if (indexedMember == outerMember
+            || infos[indexedMember].Table is not { } indexedTable)
+        {
+            return false;
+        }
+        var unwrappedIndexed = UnwrapCollation(indexedOperand);
+        var ordinal = FindJoinIndexExpressionOrdinal(indexedTable, unwrappedIndexed);
+        if (ordinal is not { } expressionOrdinal)
+        {
+            return false;
+        }
+
+        var outerDefinition = TryResolveJoinOrderColumnDefinition(infos[outerMember], outerColumn, context);
+        var outerAffinity = GetJoinKeyAffinity(outerDefinition);
+        // The indexed side is an arbitrary expression: unlike a real column, nothing declares
+        // (or otherwise proves) what storage class its persisted values actually hold, so
+        // nothing coerces those values before a seek. SQLite's comparison-affinity rules
+        // (datatype3.html §7.1) apply the *other* operand's affinity whenever one side is
+        // NUMERIC-ish or TEXT and the other has none: a NUMERIC-ish outer probe would need the
+        // stored expression value normalized as a number, while a TEXT outer probe would need it
+        // normalized as text (e.g. an `x+0` expression storing INTEGER 1 must still compare equal
+        // to a TEXT '1' outer probe, exactly as SQLite's rule 2 requires) — and the
+        // conversion-flag machinery below never runs for this branch, so there is no seek-key
+        // coercion to fall back on for either direction. Only an outer probe that itself carries
+        // no affinity signal (STRICT ANY, i.e. null) or BLOB affinity is safe: SqlValue comparison
+        // already orders those cross-type without help, exactly as a row-by-row scan of the same
+        // predicate would, so a direct seek is safe. Every other affinity (TEXT, INTEGER, REAL,
+        // NUMERIC) must decline unless the expression's own representation is statically proven --
+        // narrowly, a TEXT outer probe against an expression whose top-level operator is `||`
+        // (string concatenation always yields TEXT or NULL, regardless of operand affinities, see
+        // IsIndexedExpressionStaticallyText) needs no coercion either way and remains eligible.
+        if (outerDefinition is null
+            || infos[outerMember].Table is not { } outerTable
+            || !outerTable.TryGetColumnIndex(outerDefinition.Name, out var resolvedOuterOrdinal)
+            || (outerAffinity is not null
+                && outerAffinity != ColumnAffinity.Blob
+                && !(outerAffinity == ColumnAffinity.Text
+                    && IsIndexedExpressionStaticallyText(unwrappedIndexed))))
+        {
+            return false;
+        }
+
+        // explicitCollation is resolved once by the caller from the original BinaryExpression's
+        // left operand then right (SQLite left-wins), independent of which operand this
+        // particular directional attempt treats as "indexed" — see the call sites' comment.
+        var resolvedCollation = (explicitCollation
+            ?? NormalizeDeclaredCollation(outerDefinition.Collation)
+            ?? "BINARY").ToUpperInvariant();
+
+        indexedMask = 1UL << indexedMember;
+        outerMask = 1UL << outerMember;
+        indexedColumnOrdinal = expressionOrdinal;
+        outerColumnOrdinal = resolvedOuterOrdinal;
+        // No persisted stat exists for an arbitrary expression's result distribution; a
+        // conservative per-member rough estimate is enough since this only feeds the enumerator's
+        // cost model, never a correctness check.
+        indexedMatchRows = Math.Max(1.0, infos[indexedMember].RowCount);
+        outerMatchRows = EstimateJoinOrderMatchRows(infos[outerMember], outerColumn, context);
+        // Seek binding is safe unconditionally: DescribeJoinIndexCandidates never offers this
+        // expression as a candidate column unless the persisted index itself is already proven
+        // ready (built-in, or custom-with-validated-callback). Hashing stays strictly gated to
+        // built-in collations, since the outer (real-table) ordinal above — unlike the indexed
+        // side's synthetic negative ordinal — CAN reach automatic hash-index building.
+        seekCollation = resolvedCollation;
+        collation = !IsHashableJoinKeyCollation(resolvedCollation) || IsUnsafeCompiledCollation(resolvedCollation)
+            ? null
+            : resolvedCollation;
+        return true;
+    }
+
+    /// <summary>
+    /// True when <paramref name="expression"/>'s persisted result is provably TEXT (or NULL)
+    /// regardless of its operands' runtime values or declared affinities. Narrowly recognizes
+    /// SQLite's <c>||</c> string-concatenation operator, which always yields TEXT or NULL
+    /// (datatype3.html §3), never NUMERIC/INTEGER/REAL/BLOB -- unlike, say, an arithmetic
+    /// expression such as <c>x+0</c>, whose result is NUMERIC even when it happens to hold a
+    /// value that also parses as text. This is the one arbitrary-expression shape where a
+    /// TEXT-affinity outer probe needs no comparison-affinity coercion against the persisted
+    /// value in either direction, so <see cref="TryMatchExpressionIndexOperand"/> can still treat
+    /// it as seek-eligible even though the expression's storage class is otherwise unproven.
+    /// </summary>
+    private static bool IsIndexedExpressionStaticallyText(Expression expression)
+        => expression is BinaryExpression { Operator: BinaryOperator.Concatenate };
 
     /// <summary>
     /// Accepts a WHERE conjunct as an extra ON condition of the root segment. Restricted to a
@@ -950,6 +1373,25 @@ public sealed partial class EmbeddedDatabase
         }
 
         return null;
+    }
+
+    private static string? TryGetJoinOrderInheritedCollation(
+        Expression expression,
+        JoinOrderMemberInfo[] infos,
+        QueryContext context)
+    {
+        expression = UnwrapCollation(expression);
+        if (expression is CastExpression cast)
+            return TryGetJoinOrderInheritedCollation(cast.Expression, infos, context);
+        if (expression is not ColumnExpression column
+            || !TryResolveJoinOrderMember(column, infos, out var member))
+        {
+            return null;
+        }
+
+        return TryResolveJoinOrderColumnDefinition(infos[member], column, context) is { } definition
+            ? NormalizeDeclaredCollation(definition.Collation)
+            : null;
     }
 
     private static double EstimateJoinOrderSelectivity(Expression conjunct)

--- a/src/Ahtola.Core/EmbeddedDatabase.PlannerAccessPaths.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.PlannerAccessPaths.cs
@@ -668,6 +668,42 @@ public sealed partial class EmbeddedDatabase
                      && value.Kind is SqlValueKind.Integer or SqlValueKind.Real)
                 value = SqlValue.Text(ToSqlText(value));
 
+            if (branch.Index.Columns.Count > 0
+                && branch.Index.Columns[0].ColumnIndex == lookup.ColumnOrdinal
+                && context.ConcurrentMvStore is null
+                && context.ConcurrentMvccTxId is null
+                && TryOpenTransactionIndexAccessor(
+                    plan.Table,
+                    branch.Index,
+                    prefixLength: 1,
+                    covering: false,
+                    context,
+                    out var transactionAccessor))
+            {
+                var qualifier = plan.Source.Alias ?? plan.Source.Name;
+                var qualifiedColumns = BuildQualifiedColumns(qualifier, plan.Table.Columns);
+                var qualifiedDefinitions = BuildQualifiedColumnDefinitions(
+                    qualifier,
+                    plan.Table.ColumnDefinitions);
+                using (transactionAccessor)
+                {
+                    return transactionAccessor.Seek(
+                            [value],
+                            _plannerAccessPathMetrics.IntersectionIndexPageRead,
+                            _plannerAccessPathMetrics.IntersectionKeyCompared)
+                        .Select(row => new SourceRow(
+                            plan.Table.Columns,
+                            row.Values,
+                            qualifiedColumns,
+                            outerRow,
+                            RowId: row.RowId,
+                            RowIdQualifier: qualifier,
+                            ColumnDefinitions: plan.Table.ColumnDefinitions,
+                            QualifiedColumnDefinitions: qualifiedDefinitions))
+                        .ToArray();
+                }
+            }
+
             if (readSnapshot is not null
                 && branch.Index.Columns.Count > 0
                 && branch.Index.Columns[0].ColumnIndex == lookup.ColumnOrdinal

--- a/src/Ahtola.Core/EmbeddedDatabase.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.cs
@@ -265,8 +265,59 @@ public sealed partial class EmbeddedDatabase : IDisposable
     private readonly Dictionary<(string Name, int Arity), Func<IReadOnlyList<SqlValue>, SqlValue>> _scalarFunctions = new();
     private readonly Dictionary<(string Name, int Arity), ManagedAggregateFunction> _aggregateFunctions = new();
     private readonly Dictionary<string, Func<string, string, int>> _collations = new(StringComparer.OrdinalIgnoreCase);
+    /// <summary>
+    /// In-memory-only "is this custom/overridden-collation index currently safe for
+    /// planning/writes" cache, keyed by index name, holding the file store's committed
+    /// generation at the time the index was last proven consistent with the active collation
+    /// callback plus that proof's outcome. Never persisted — usability is tracked purely in
+    /// memory (architecture item 4). Cleared whenever the collation registry or the attached
+    /// file store changes; see <see cref="RefreshCollationResolverBinding"/>. A cache miss (or
+    /// a stale generation) lazily re-derives the answer via
+    /// <see cref="EmbeddedFileStore.RevalidateIndexOrderAndContent"/> instead of trusting a
+    /// possibly outdated result, so REINDEX, a callback replacement, or an ordinary commit
+    /// that happens to touch the index all naturally invalidate it without any explicit
+    /// "mark clean" hook.
+    /// </summary>
+    private readonly Dictionary<string, (long Generation, long RegistryVersion, bool Clean)> _customCollationIndexClean = new(StringComparer.OrdinalIgnoreCase);
+    /// <summary>
+    /// Monotonically increasing version bumped by <see cref="RefreshCollationResolverBinding"/>
+    /// (i.e. every registration, replacement, or unregistration of a collation callback).
+    /// <see cref="IsCustomCollationIndexPlanReady"/> captures this alongside the file store's
+    /// committed generation before revalidating an index, and only trusts/publishes the result
+    /// if both are still unchanged afterward — guarding against a reentrant or concurrent
+    /// callback replacement racing the very validation it is supposed to gate.
+    /// </summary>
+    private long _collationRegistryVersion;
+    /// <summary>
+    /// Every built-in collation name (BINARY/NOCASE/RTRIM) that has ever been registered as a
+    /// custom override on this connection, even if it has since been unregistered. Never
+    /// cleared. Without this, <see cref="IsCustomCollationIndexPlanReady"/> could not tell "this
+    /// name was never overridden, so any durable index using it was always built under pure
+    /// built-in semantics" (safe to skip revalidation) apart from "this name's override was just
+    /// unregistered, so a durable index using it may still be physically ordered/uniqued the way
+    /// the removed callback saw the world, not the way the just-restored built-in comparer does"
+    /// (unsafe to skip — must revalidate against the restored built-in semantics before being
+    /// trusted again).
+    /// </summary>
+    private readonly HashSet<string> _everOverriddenBuiltInCollations = new(StringComparer.OrdinalIgnoreCase);
     private bool _hasScalarFunctions;
     private bool _hasCustomCollations;
+    /// <summary>
+    /// Fallback collation lookup consulted only when this instance's own <see cref="_collations"/>
+    /// registry has no entry for a requested name. Unset on every ordinary connection; wired up
+    /// exclusively by <see cref="EmbeddedFileStore"/> on its private
+    /// <c>_indexExpressionEvaluator</c> — a throwaway <see cref="EmbeddedDatabase"/> constructed
+    /// solely to evaluate partial-index predicates and index expressions, which therefore never
+    /// receives an application's <see cref="RegisterCollation"/> calls directly. Routing it through
+    /// <see cref="EmbeddedFileStore.SetCollationResolver"/> gives that evaluator visibility into
+    /// whichever custom collations are actually active on the owning connection, through the same
+    /// safe callback wrapper (<see cref="InvokeManagedCallback{T}"/>) real value comparisons use,
+    /// so a partial predicate or expression-index key containing a custom COLLATE evaluates
+    /// correctly instead of always failing "no such collation sequence". A missing callback still
+    /// fails closed, but only lazily — the first time <see cref="Compare"/> or
+    /// <see cref="ValidateCollation"/> actually needs that specific name, never eagerly.
+    /// </summary>
+    private Func<string, Func<string, string, int>?>? _externalCollationResolver;
     private EmbeddedFileStore? _fileStore;
     private readonly string _databasePath = string.Empty;
     private readonly IFileSystem? _fileSystem;
@@ -710,7 +761,9 @@ public sealed partial class EmbeddedDatabase : IDisposable
         ChangeDataCaptureSession? ChangeDataCapture = null,
         VdbeExecutionOptions? VdbeExecutionOptions = null,
         CteMutationState? CteMutationState = null,
-        EmbeddedDatabase? Database = null)
+        EmbeddedDatabase? Database = null,
+        TransactionMutationOverlay? TransactionOverlay = null,
+        EmbeddedFileReadSnapshot? TransactionPinnedSnapshot = null)
     {
         /// <summary>
         /// Per-statement cache of opened managed index-method scan state. Derived contexts created
@@ -848,6 +901,14 @@ public sealed partial class EmbeddedDatabase : IDisposable
 
             if (recordChangeDataCapture)
                 ChangeDataCapture?.RecordRow(this, operation, tableName, table, rowId, before, after);
+
+            // Feed the classic (non-MVCC) transaction's mutation overlay so a durable index seek
+            // can suppress stale base rows and splice in this transaction's own current values
+            // without materializing the whole index. Same funnel as the method-index maintenance
+            // call below: plain INSERT/UPDATE/DELETE, REPLACE/UPSERT conflict resolution, trigger
+            // bodies, and foreign-key cascade actions all arrive here.
+            if (TransactionOverlay is not null && Database is not null)
+                TransactionOverlay.RecordRowChange(Database, table, tableName, operation, rowId, before, after);
 
             // Feed incremental method-index maintenance. This is the one place every DML path
             // funnels through — plain INSERT/UPDATE/DELETE, REPLACE and UPSERT conflict resolution,
@@ -1187,11 +1248,29 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 return;
 
             _ownsVirtualTableInstances = false;
+            // Ownership is already relinquished above regardless of outcome below, so every
+            // instance must get a disconnect attempt even if an earlier one throws — otherwise a
+            // single misbehaving virtual table instance would leak every later one in the same
+            // catalog (never disconnected, but also never retried since _ownsVirtualTableInstances
+            // is now false). Capture only the first failure and keep going, then rethrow once all
+            // instances have been attempted.
+            ExceptionDispatchInfo? failure = null;
             foreach (var definition in VirtualTables.Values)
             {
-                if (transaction?.IsParticipating(definition.Table) != true)
+                if (transaction?.IsParticipating(definition.Table) == true)
+                    continue;
+
+                try
+                {
                     definition.Table.DisconnectInstance();
+                }
+                catch (Exception exception)
+                {
+                    failure ??= ExceptionDispatchInfo.Capture(exception);
+                }
             }
+
+            failure?.Throw();
         }
     }
 
@@ -1639,10 +1718,27 @@ public sealed partial class EmbeddedDatabase : IDisposable
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
         ArgumentNullException.ThrowIfNull(compare);
 
+        var normalizedName = name.ToUpperInvariant();
         lock (_gate)
         {
-            _collations[name.ToUpperInvariant()] = compare;
+            _collations[normalizedName] = compare;
             _hasCustomCollations = true;
+            // Remembered permanently (never removed on unregister): once a built-in name has
+            // been overridden, any durable index using it can no longer be assumed to have been
+            // built under pure built-in semantics just because no override is currently active.
+            // See IsCustomCollationIndexPlanReady and _everOverriddenBuiltInCollations.
+            if (IsBuiltInCollation(normalizedName))
+                _everOverriddenBuiltInCollations.Add(normalizedName);
+
+            // A first registration, or replacing an already-registered callback, both leave every
+            // existing durable index using this name unproven against the (possibly new)
+            // callback. RefreshCollationResolverBindingLocked bumps the registry version, drops
+            // the in-memory clean/dirty cache, and rebinds the file store's resolver in the SAME
+            // lock scope as the dictionary mutation above: no statement running on another thread
+            // can ever observe the new comparator in _collations while _collationRegistryVersion
+            // / _customCollationIndexClean still describe the previous registration (which would
+            // let a stale "clean" proof be trusted against a new comparator).
+            RefreshCollationResolverBindingLocked();
         }
     }
 
@@ -1651,12 +1747,287 @@ public sealed partial class EmbeddedDatabase : IDisposable
         ThrowIfRecursiveTriggerCallbackReentry();
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
+        bool removed;
         lock (_gate)
         {
-            var removed = _collations.Remove(name.ToUpperInvariant());
+            removed = _collations.Remove(name.ToUpperInvariant());
             _hasCustomCollations = _collations.Count != 0;
-            return removed;
+
+            // Every index that depends on the now-unregistered name must stop being offered to
+            // the planner (IsCustomCollationIndexPlanReady fails closed the moment its collation
+            // has no registered callback), so the stale "clean" cache entries for it must go too
+            // — under the same lock scope as the dictionary mutation above, for the same reason
+            // RegisterCollation does.
+            if (removed)
+                RefreshCollationResolverBindingLocked();
         }
+
+        return removed;
+    }
+
+    /// <summary>
+    /// Attaches (or clears, when <paramref name="resolver"/> is <see langword="null"/>) the
+    /// fallback collation resolver this instance consults when a requested name has no entry in
+    /// its own <see cref="_collations"/> registry. See <see cref="_externalCollationResolver"/>
+    /// for why this exists: it is how <see cref="EmbeddedFileStore"/> gives its private index-
+    /// expression/predicate evaluator visibility into the owning connection's actual custom
+    /// collations, without that throwaway instance ever calling <see cref="RegisterCollation"/>
+    /// itself.
+    /// </summary>
+    internal void SetExternalCollationResolver(Func<string, Func<string, string, int>?>? resolver)
+        => _externalCollationResolver = resolver;
+
+    /// <summary>
+    /// Rebinds the attached file store's runtime collation resolver to the current registry and
+    /// drops the in-memory clean/dirty cache for every custom/overridden-collation index. Called
+    /// after every point that swaps in a different <see cref="EmbeddedFileStore"/> instance (a
+    /// reopen following an externally observed commit), so a reopened store immediately sees
+    /// whichever callbacks are already registered on this connection instead of only picking them
+    /// up on the next explicit Register call. Never touches durable storage: this is exactly the
+    /// "in memory only" tracking architecture item 4 requires.
+    /// </summary>
+    private void RefreshCollationResolverBinding()
+    {
+        lock (_gate)
+        {
+            RefreshCollationResolverBindingLocked();
+        }
+    }
+
+    /// <summary>
+    /// Same work as <see cref="RefreshCollationResolverBinding"/>, but assumes <see cref="_gate"/>
+    /// is already held by the caller. <see cref="RegisterCollation"/> and
+    /// <see cref="UnregisterCollation"/> call this from inside their own callback-dictionary-
+    /// mutating lock scope so the dictionary write, the registry-version bump, the clean-cache
+    /// invalidation, and the file store's resolver rebind all happen as one atomic step under a
+    /// single acquisition of <see cref="_gate"/> — required so no statement can ever observe a
+    /// new comparator in <see cref="_collations"/> together with a stale (pre-update)
+    /// <see cref="_collationRegistryVersion"/> or <see cref="_customCollationIndexClean"/> entry.
+    /// This never invokes an application-defined callback itself: building the resolver only
+    /// constructs a lookup lambda (see <see cref="BuildCollationResolver"/>), and rebinding the
+    /// file store's resolver field is a trivial assignment (see
+    /// <see cref="EmbeddedFileStore.SetCollationResolver"/>) — so running this under <see cref="_gate"/>
+    /// cannot deadlock or execute arbitrary callback code while the lock is held.
+    /// </summary>
+    private void RefreshCollationResolverBindingLocked()
+    {
+        _collationRegistryVersion++;
+        _customCollationIndexClean.Clear();
+        _fileStore?.SetCollationResolver(_hasCustomCollations ? BuildCollationResolver() : null);
+    }
+
+    /// <summary>
+    /// Builds the runtime collation resolver <see cref="EmbeddedFileStore"/> uses to compare
+    /// durable index/table records for a non-built-in (or overridden built-in) collation name.
+    /// Every invocation of the resolved comparison delegate is routed through
+    /// <see cref="InvokeManagedCallback{T}"/>, matching how every other application-defined
+    /// callback on this connection is dispatched (see <see cref="Compare"/>), so recursive-trigger
+    /// re-entrancy guarding and callback exception propagation behave identically for durable
+    /// index-order comparisons as for ordinary value comparisons.
+    /// </summary>
+    private Func<string, Func<string, string, int>?> BuildCollationResolver()
+        => name =>
+        {
+            Func<string, string, int>? compare;
+            lock (_gate)
+            {
+                _collations.TryGetValue(name, out compare);
+            }
+
+            if (compare is null)
+                return null;
+
+            return (left, right) => InvokeManagedCallback(() => compare(left, right));
+        };
+
+    /// <summary>
+    /// True when <paramref name="index"/> is safe to offer the planner for direct index seeks
+    /// and to accept writes against, given its declared column collations, every collation
+    /// embedded inside a partial-index predicate or expression-index body (see
+    /// <see cref="IndexExpressionSemantics.CollectEmbeddedCollationNames"/>), and the collation
+    /// callbacks currently registered on this connection.
+    /// </summary>
+    /// <remarks>
+    /// An index whose columns are all built-in and not overridden is always eligible — this is
+    /// the ordinary SQLite-compatible path and needs no tracking. An index that uses a custom
+    /// collation, or a built-in name an application has overridden with
+    /// <see cref="RegisterCollation"/>, is eligible only once every such name has a registered
+    /// callback <em>and</em> the index's durable order/content has been proven consistent with
+    /// that callback (see <see cref="EmbeddedFileStore.RevalidateIndexOrderAndContent"/>). That
+    /// proof is cached per index, keyed by both the file store's committed generation and the
+    /// collation registry version in effect when the proof was captured, and is held in memory
+    /// only — never persisted (architecture item 4). Any commit, REINDEX, callback
+    /// registration/replacement, or unregistration invalidates the relevant cache entry (a commit
+    /// changes the generation; Register/Unregister call <see cref="RefreshCollationResolverBinding"/>,
+    /// which bumps the registry version and clears the whole cache), so the next planning attempt
+    /// or write re-derives the answer instead of trusting a stale one. Never falls back to
+    /// treating an unresolved custom collation's index as if it were ordered by BINARY.
+    /// This applies identically to a collation named only inside a partial index's WHERE
+    /// predicate or an expression index's column body — an embedded name never surfaced by
+    /// <see cref="IndexExpressionSemantics.GetCollationName"/> — because replacing or
+    /// unregistering the callback such a name depends on can change which rows the predicate
+    /// admits, or what key an expression column projects, exactly as a change to an indexed-term
+    /// collation could: this method must dirty/disable the cached "ready" answer for that
+    /// membership/key relationship until the same revalidation (or a REINDEX) proves it again.
+    /// Because a collation callback can (directly, or indirectly through another callback it
+    /// invokes) itself register, replace, or unregister a collation while this method's
+    /// revalidation call is still running, both the generation and the registry version are
+    /// captured before validating and re-checked immediately after: the result is only ever
+    /// published to the cache when neither moved during validation. If either moved, the
+    /// just-computed answer reflects a state that no longer holds, so it is discarded and
+    /// validation retries against whatever is current, bounded so sustained churn fails closed
+    /// (declines) rather than loops forever or trusts a racy result.
+    /// </remarks>
+    internal bool IsCustomCollationIndexPlanReady(EmbeddedTable table, EmbeddedIndex index)
+    {
+        ArgumentNullException.ThrowIfNull(table);
+        ArgumentNullException.ThrowIfNull(index);
+
+        var embeddedCollationNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        IndexExpressionSemantics.CollectEmbeddedCollationNames(index, embeddedCollationNames);
+
+        const int maxAttempts = 8;
+        for (var attempt = 0; attempt < maxAttempts; attempt++)
+        {
+            var needsValidation = false;
+            long registryVersion;
+            lock (_gate)
+            {
+                registryVersion = _collationRegistryVersion;
+                foreach (var column in index.Columns)
+                {
+                    var collationName = IndexExpressionSemantics.GetCollationName(table, column);
+                    switch (EvaluateCollationNameReadinessLocked(collationName))
+                    {
+                        case CollationNameReadiness.Unavailable:
+                            return false;
+                        case CollationNameReadiness.NeedsValidation:
+                            needsValidation = true;
+                            break;
+                    }
+                }
+
+                // A partial index's WHERE predicate or an expression index's column body can
+                // embed its own COLLATE reference distinct from every trailing COLLATE already
+                // checked above (see IndexExpressionSemantics.CollectEmbeddedCollationNames):
+                // apply the exact same readiness rule to those, so a callback replacement or
+                // unregistration that only an embedded name depends on still dirties this
+                // index's cached membership/key proof until it is revalidated.
+                foreach (var collationName in embeddedCollationNames)
+                {
+                    switch (EvaluateCollationNameReadinessLocked(collationName))
+                    {
+                        case CollationNameReadiness.Unavailable:
+                            return false;
+                        case CollationNameReadiness.NeedsValidation:
+                            needsValidation = true;
+                            break;
+                    }
+                }
+            }
+
+            if (!needsValidation)
+                return true;
+            // An in-memory (temp/attached-memory) catalog has no durable index image that could ever
+            // drift from the current comparer: every scan/seek already rebuilds its ordering live
+            // from the active callback, so there is nothing to prove stale.
+            if (_fileStore is null)
+                return true;
+
+            var generation = _fileStore.CommittedViewGeneration;
+            lock (_gate)
+            {
+                if (_customCollationIndexClean.TryGetValue(index.Name, out var cached)
+                    && cached.Generation == generation
+                    && cached.RegistryVersion == registryVersion)
+                {
+                    return cached.Clean;
+                }
+            }
+
+            // A durable-order/content proof is only meaningful against what is actually
+            // committed to disk. `table` here may be a per-transaction catalog clone with
+            // uncommitted DML already applied in place (the classic transaction overlay), in
+            // which case its in-memory row count races ahead of the durable b-tree this
+            // check reads via EmbeddedFileStore. `_tables` is this database's
+            // last-published (committed) catalog — untouched by any open transaction's
+            // clone until that transaction commits and republishes it — so it is the
+            // correct source for the row content this proof must match against.
+            var committedTable = _tables.TryGetValue(table.Name, out var published) ? published : table;
+            var clean = _fileStore.RevalidateIndexOrderAndContent(committedTable.Name, committedTable, index, out _);
+
+            long registryVersionAfter;
+            lock (_gate)
+            {
+                registryVersionAfter = _collationRegistryVersion;
+            }
+            var generationAfter = _fileStore?.CommittedViewGeneration ?? generation;
+
+            if (registryVersionAfter != registryVersion || generationAfter != generation)
+            {
+                // A reentrant or concurrent callback registration/replacement/unregistration
+                // (or an intervening commit) happened while validating: the answer just
+                // computed no longer reflects the current state, so it must not be published.
+                // Retry against whatever is current instead of trusting or caching it.
+                continue;
+            }
+
+            lock (_gate)
+            {
+                _customCollationIndexClean[index.Name] = (generation, registryVersion, clean);
+            }
+
+            return clean;
+        }
+
+        // Sustained concurrent/reentrant registry churn never let validation settle long enough
+        // to publish a trustworthy result: fail closed rather than offer a possibly-stale answer.
+        return false;
+    }
+
+    private enum CollationNameReadiness
+    {
+        /// <summary>Built-in, never overridden on this connection: no proof needed.</summary>
+        Skip,
+
+        /// <summary>
+        /// Either a custom/overridden collation with an active callback, or a built-in name that
+        /// has been overridden at some point (even if not right now): the index must be proven
+        /// consistent with the currently active semantics before it is trusted.
+        /// </summary>
+        NeedsValidation,
+
+        /// <summary>No callback is registered for a non-built-in (or overridden built-in) name.</summary>
+        Unavailable,
+    }
+
+    /// <summary>
+    /// Classifies one collation name a durable index depends on — whether it qualifies an
+    /// indexed term (<see cref="IndexExpressionSemantics.GetCollationName"/>) or is embedded
+    /// inside a partial-index predicate or expression-index body
+    /// (<see cref="IndexExpressionSemantics.CollectEmbeddedCollationNames"/>) — against the
+    /// collation callbacks currently registered on this connection. Must be called with
+    /// <see cref="_gate"/> already held: it reads <see cref="_collations"/> and
+    /// <see cref="_everOverriddenBuiltInCollations"/>.
+    /// </summary>
+    private CollationNameReadiness EvaluateCollationNameReadinessLocked(string collationName)
+    {
+        var isBuiltIn = IsBuiltInCollation(collationName);
+        var hasCallback = _collations.ContainsKey(collationName);
+        if (isBuiltIn && !hasCallback)
+        {
+            // Built-in name with no override currently active. Only safe to skip outright if
+            // this name has never been overridden on this connection: otherwise the durable
+            // index may still be physically ordered/uniqued (or, for an embedded predicate
+            // name, may still admit/reject rows) per the just-removed callback's semantics
+            // rather than the restored built-in ones, so it must go through the same
+            // revalidation as an active override (see _everOverriddenBuiltInCollations).
+            return _everOverriddenBuiltInCollations.Contains(collationName)
+                ? CollationNameReadiness.NeedsValidation
+                : CollationNameReadiness.Skip;
+        }
+
+        return hasCallback ? CollationNameReadiness.NeedsValidation : CollationNameReadiness.Unavailable;
     }
 
     internal ExecutionResult Execute(
@@ -1884,7 +2255,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
                                 PersistFileCatalog(
                                     cancellableWorking,
                                     forceFullRewrite: cancellableResult.ForceFullCatalogRewrite,
-                                    busyTimeout: GetRemainingBusyTimeout(busyRetryDeadline));
+                                    busyTimeout: GetRemainingBusyTimeout(busyRetryDeadline),
+                                    targetedIndexRebuild: cancellableResult.TargetedIndexRebuild);
                             }
 
                             if (ownsVirtualTableTransaction)
@@ -2008,7 +2380,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
                             PersistFileCatalog(
                                 working,
                                 forceFullRewrite: result.ForceFullCatalogRewrite,
-                                busyTimeout: GetRemainingBusyTimeout(busyRetryDeadline));
+                                busyTimeout: GetRemainingBusyTimeout(busyRetryDeadline),
+                                targetedIndexRebuild: result.TargetedIndexRebuild);
                         }
                         else if (!inTransaction)
                         {
@@ -2491,7 +2864,96 @@ public sealed partial class EmbeddedDatabase : IDisposable
         }
     }
 
-    internal (MvccTxId TransactionId, TransactionSnapshot Snapshot)
+    /// <summary>
+    /// Clones the catalog exactly like <see cref="CreateTransactionSnapshot"/> and, for a
+    /// file-backed database, additionally pins a durable pager read snapshot at the same locked
+    /// version — the snapshot a classic (non-MVCC) transaction reads through for its whole
+    /// lifetime, immune to any later peer commit. Returns a <see langword="null"/> pinned snapshot
+    /// for an in-memory/temp database, which has nothing to pin.
+    /// </summary>
+    internal (TransactionSnapshot Snapshot, EmbeddedFileReadSnapshot? PinnedSnapshot) CreateTransactionSnapshotWithPin(
+        TimeSpan busyTimeout = default)
+    {
+        lock (_gate)
+        {
+            if (_fileStore is null)
+            {
+                RefreshTransactionSnapshotCatalogLocked(busyTimeout);
+                return (CloneTransactionSnapshotLocked(), null);
+            }
+
+            if (_fileCatalogWriteLock is null)
+                throw new InvalidOperationException("The managed file catalog persistence state is not initialized.");
+
+            // Hold the per-file catalog lock across the refresh, the catalog clone, and the
+            // pager read-snapshot pin below. Releasing it in between (as an earlier version of
+            // this method did) let a peer connection commit and durably persist new WAL frames
+            // after this transaction's catalog was already cloned but before its pager read
+            // snapshot was opened, pinning a snapshot generation that no longer matched the
+            // cloned catalog. PersistFileCatalog holds this exact same lock for its whole
+            // commit, so holding it here fully serializes this snapshot against any peer
+            // commit — the catalog clone and the pinned pager snapshot are guaranteed to
+            // observe the same generation. Lock order stays _gate outer, _fileCatalogWriteLock
+            // inner, matching every other caller (e.g. BeginConcurrentTransactionSnapshot), so
+            // this does not introduce a new deadlock risk.
+            using (_fileCatalogWriteLock.Enter(Timeout.InfiniteTimeSpan))
+            {
+                RefreshTransactionSnapshotCatalogUnderWriteLockLocked(busyTimeout);
+                var snapshot = CloneTransactionSnapshotLocked();
+                try
+                {
+                    BeforePinningTransactionSnapshotForTesting?.Invoke();
+                    EmbeddedFileReadSnapshot? pinnedSnapshot = null;
+                    if (_fileStore.TryOpenReadSnapshot(out var opened))
+                        pinnedSnapshot = opened;
+                    return (snapshot, pinnedSnapshot);
+                }
+                catch (Exception primaryFailure)
+                {
+                    // The pager snapshot failed to open after the catalog was already cloned
+                    // and this transaction's active count already bumped by
+                    // CloneTransactionSnapshotLocked; undo both so a failed pin leaves no trace
+                    // of a transaction that never actually began. Both cleanup steps must be
+                    // attempted even if the first one throws: EndTransaction has to run
+                    // unconditionally so a failing virtual-table disconnect can never leak the
+                    // active-transaction count registration this method already bumped. Cleanup
+                    // failures are collected and combined with the original failure instead of
+                    // letting an earlier throw skip the remaining cleanup.
+                    List<Exception>? cleanupFailures = null;
+                    try
+                    {
+                        snapshot.Catalog.DisconnectOwnedVirtualTables();
+                    }
+                    catch (Exception exception)
+                    {
+                        (cleanupFailures ??= []).Add(exception);
+                    }
+
+                    try
+                    {
+                        EndTransaction();
+                    }
+                    catch (Exception exception)
+                    {
+                        (cleanupFailures ??= []).Add(exception);
+                    }
+
+                    if (cleanupFailures is null)
+                        throw;
+
+                    throw new AggregateException([primaryFailure, .. cleanupFailures]);
+                }
+            }
+        }
+    }
+
+    /// <summary>Builds a primary-key record comparer for a WITHOUT ROWID table's mutation overlay.</summary>
+    internal SqliteIndexRecordComparer CreatePrimaryKeyRecordComparer(SqlitePrimaryKeySchema schema)
+        => _fileStore?.CreatePrimaryKeyComparer(schema)
+            ?? throw new InvalidOperationException(
+                "A primary-key record comparer requires a file-backed managed store.");
+
+    internal (MvccTxId TransactionId, TransactionSnapshot Snapshot, EmbeddedFileReadSnapshot? PinnedSnapshot)
         BeginConcurrentTransactionSnapshot(
             TimeSpan busyTimeout,
             Action? afterBegin)
@@ -2522,21 +2984,95 @@ public sealed partial class EmbeddedDatabase : IDisposable
 
     internal bool IsTransactionSnapshotGateHeldForTesting => Monitor.IsEntered(_gate);
 
-    private (MvccTxId TransactionId, TransactionSnapshot Snapshot)
+    /// <summary>
+    /// Fires inside <see cref="CreateTransactionSnapshotWithPin"/> and
+    /// <see cref="BeginConcurrentTransactionSnapshotLocked"/> after the catalog clone but
+    /// before the pager read-snapshot pin, while <see cref="_fileCatalogWriteLock"/> is still
+    /// held. Tests use this to prove the lock genuinely serializes a peer's commit out of the
+    /// window between clone and pin (the peer's commit attempt must block until this callback
+    /// returns and the lock is released), or to inject a pin failure and assert the resulting
+    /// cleanup (active-transaction count, cloned virtual tables, and -- for the BEGIN CONCURRENT
+    /// path -- the MvStore transaction being rolled back).
+    /// </summary>
+    [field: ThreadStatic]
+    internal static Action? BeforePinningTransactionSnapshotForTesting { get; set; }
+
+    private (MvccTxId TransactionId, TransactionSnapshot Snapshot, EmbeddedFileReadSnapshot? PinnedSnapshot)
         BeginConcurrentTransactionSnapshotLocked(
             MvStore store,
             Action? afterBegin)
     {
         var transaction = store.BeginTransaction(store.SchemaGeneration);
+        TransactionSnapshot? snapshot = null;
+        EmbeddedFileReadSnapshot? pinnedSnapshot = null;
         try
         {
             afterBegin?.Invoke();
-            return (transaction.Id, CloneTransactionSnapshotLocked());
+            snapshot = CloneTransactionSnapshotLocked();
+            // Pin the same durable pager read snapshot a classic (non-MVCC) transaction pins,
+            // at the same locked point in time as the cloned catalog and this MvStore
+            // transaction's begin timestamp. CommitTransaction's MergeConcurrentCatalogFromStoreLocked
+            // folds every peer's committed MvStore rows into the durable file image at commit
+            // time, so this snapshot already reflects every commit that happened before this
+            // transaction began; only this transaction's own writes and any peer commits during
+            // its lifetime need MvStore version-chain visibility, which BeginTimestamp/commit
+            // timestamp rules gate separately (see MvStore.IsVisibleTo). Null for an in-memory
+            // database, which has no durable pager to pin.
+            BeforePinningTransactionSnapshotForTesting?.Invoke();
+            if (_fileStore is not null && _fileStore.TryOpenReadSnapshot(out var opened))
+                pinnedSnapshot = opened;
+            return (transaction.Id, snapshot.Value, pinnedSnapshot);
         }
-        catch
+        catch (Exception primaryFailure)
         {
-            store.Rollback(transaction.Id);
-            throw;
+            pinnedSnapshot?.Dispose();
+
+            // If CloneTransactionSnapshotLocked already succeeded -- this transaction's active
+            // count already bumped and, for a database with virtual tables, its catalog clone
+            // already owning cloned virtual-table instances -- before the durable pager snapshot
+            // pin above failed, both must be unwound so a failed pin leaves no trace of a
+            // transaction that never actually began, exactly like the equivalent failure window
+            // in CreateTransactionSnapshotWithPin. Every cleanup step below must be attempted
+            // even if an earlier one throws, and the MvStore transaction must always be rolled
+            // back regardless of whether the catalog clone ever ran, so a failing virtual-table
+            // disconnect or EndTransaction call can never leak the MvStore transaction or its
+            // active read mark. Cleanup failures are collected and combined with the original
+            // failure instead of letting an earlier throw skip the remaining cleanup.
+            List<Exception>? cleanupFailures = null;
+            if (snapshot is { } clonedSnapshot)
+            {
+                try
+                {
+                    clonedSnapshot.Catalog.DisconnectOwnedVirtualTables();
+                }
+                catch (Exception exception)
+                {
+                    (cleanupFailures ??= []).Add(exception);
+                }
+
+                try
+                {
+                    EndTransaction();
+                }
+                catch (Exception exception)
+                {
+                    (cleanupFailures ??= []).Add(exception);
+                }
+            }
+
+            try
+            {
+                store.Rollback(transaction.Id);
+            }
+            catch (Exception exception)
+            {
+                (cleanupFailures ??= []).Add(exception);
+            }
+
+            if (cleanupFailures is null)
+                throw;
+
+            throw new AggregateException([primaryFailure, .. cleanupFailures]);
         }
     }
 
@@ -2834,7 +3370,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
         TimeSpan busyTimeout = default,
         bool concurrent = false,
         bool containsSchemaChanges = false,
-        SqliteSynchronousMode synchronousMode = SqliteSynchronousMode.Full)
+        SqliteSynchronousMode synchronousMode = SqliteSynchronousMode.Full,
+        IReadOnlySet<string>? targetedIndexRebuildNames = null)
     {
         synchronousMode.Validate(nameof(synchronousMode));
 
@@ -2879,13 +3416,53 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 }
 
                 _fileStore.SetSynchronousMode(synchronousMode);
-                PersistFileCatalog(publishCatalog, pragmaHeader, forceFullRewrite, busyTimeout);
+                // Resolve targeted REINDEX names against publishCatalog -- the exact object
+                // about to be persisted, after any concurrent MVCC merge above -- rather than
+                // against the caller's original catalog. This is the one place a transaction's
+                // per-statement TargetedIndexRebuildNames (see TransactionDatabaseState) can be
+                // turned into (TableName, Table, Index) tuples without risking a stale capture:
+                // a name that no longer resolves (dropped/renamed) is silently skipped here, and
+                // is independently caught by EmbeddedFileStore.HasCurrentSchemaShape's own
+                // schema-signature check, which safely widens to the full-catalog rewrite that
+                // forceFullRewrite already forces for any REINDEX.
+                var targetedIndexRebuild = ResolveTargetedIndexRebuild(targetedIndexRebuildNames, publishCatalog);
+                PersistFileCatalog(publishCatalog, pragmaHeader, forceFullRewrite, busyTimeout, targetedIndexRebuild: targetedIndexRebuild);
             }
             finally
             {
                 ownedPublishCatalog?.DisconnectOwnedVirtualTables();
             }
         }
+    }
+
+    /// <summary>
+    /// Turns the index names a transaction's REINDEX statements tracked
+    /// (<c>TransactionDatabaseState.TargetedIndexRebuildNames</c>) into fresh
+    /// (TableName, Table, Index) tuples resolved against <paramref name="catalog"/> -- the exact
+    /// catalog object about to be persisted. Index names are unique across an entire schema, so a
+    /// single dictionary walk is enough to find each target regardless of which table it lives on.
+    /// A name that no longer resolves is simply omitted from the result.
+    /// </summary>
+    private static IReadOnlyList<(string TableName, EmbeddedTable Table, EmbeddedIndex Index)>? ResolveTargetedIndexRebuild(
+        IReadOnlySet<string>? targetedIndexRebuildNames,
+        SchemaCatalog catalog)
+    {
+        if (targetedIndexRebuildNames is not { Count: > 0 })
+            return null;
+
+        List<(string TableName, EmbeddedTable Table, EmbeddedIndex Index)>? resolved = null;
+        foreach (var (tableName, table) in catalog.Tables)
+        {
+            foreach (var index in table.Indexes)
+            {
+                if (!targetedIndexRebuildNames.Contains(index.Name))
+                    continue;
+                resolved ??= [];
+                resolved.Add((tableName, table, index));
+            }
+        }
+
+        return resolved;
     }
 
     /// <summary>
@@ -3766,7 +4343,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
         PragmaHeaderMetadata? pragmaHeader = null,
         bool forceFullRewrite = false,
         TimeSpan busyTimeout = default,
-        bool checkpointAfterCommit = true)
+        bool checkpointAfterCommit = true,
+        IReadOnlyList<(string TableName, EmbeddedTable Table, EmbeddedIndex Index)>? targetedIndexRebuild = null)
     {
         if (_fileStore is null || _fileSystem is null || _fileCatalogWriteLock is null)
             throw new InvalidOperationException("The managed file catalog persistence state is not initialized.");
@@ -3786,7 +4364,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
                         catalog.VirtualTables,
                         pragmaHeader,
                         forceFullRewrite,
-                        previousTables: _tables)
+                        previousTables: _tables,
+                        targetedIndexRebuild: targetedIndexRebuild)
                     : _fileStore.PersistForMvccCheckpoint(
                         catalog.Tables,
                         catalog.Views,
@@ -3903,6 +4482,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
             var previous = _fileStore!;
             _fileStore = replacement;
             replacement = null;
+            RefreshCollationResolverBinding();
             PublishCatalog(replacementCatalog, loadedVersion);
             previous.Dispose();
             return true;
@@ -4043,6 +4623,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
             var previous = _fileStore;
             _fileStore = replacement;
             replacement = null;
+            RefreshCollationResolverBinding();
             _fileCatalogVersion = ReadFileCatalogVersion(_fileSystem, _databasePath, foreignReadOnly: true);
             PublishCatalog(replacementCatalog);
             _foreignViewToken = _fileStore.CaptureCommittedViewToken();
@@ -4124,6 +4705,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
                     var previous = _fileStore;
                     _fileStore = replacement;
                     replacement = null;
+                    RefreshCollationResolverBinding();
                     _fileCatalogVersion = ReadFileCatalogVersion(_fileSystem, _databasePath);
                     PublishCatalog(replacementCatalog);
                     previous.Dispose();
@@ -4201,6 +4783,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
                     var previous = _fileStore;
                     _fileStore = replacement;
                     replacement = null;
+                    RefreshCollationResolverBinding();
                     PublishCatalog(replacementCatalog, loadedVersion);
                     previous.Dispose();
                 }
@@ -4560,7 +5143,9 @@ public sealed partial class EmbeddedDatabase : IDisposable
         MvccTxId? concurrentMvccTxId = null,
         ChangeDataCaptureSession? changeDataCapture = null,
         VdbeExecutionOptions? vdbeExecutionOptions = null,
-        ManagedVirtualTableTransaction? virtualTableTransaction = null)
+        ManagedVirtualTableTransaction? virtualTableTransaction = null,
+        TransactionMutationOverlay? transactionOverlay = null,
+        EmbeddedFileReadSnapshot? transactionPinnedSnapshot = null)
     {
         ThrowIfRecursiveTriggerCallbackReentry();
         if (RequiresRecursiveTriggerStack(
@@ -4589,7 +5174,9 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 concurrentMvccTxId,
                 changeDataCapture,
                 vdbeExecutionOptions,
-                virtualTableTransaction));
+                virtualTableTransaction,
+                transactionOverlay,
+                transactionPinnedSnapshot));
         }
 
         cancellationToken.ThrowIfCancellationRequested();
@@ -4636,7 +5223,9 @@ public sealed partial class EmbeddedDatabase : IDisposable
             CteMutationState: statement is QueryStatement && statementMayMutate
                 ? new CteMutationState()
                 : null,
-            Database: this);
+            Database: this,
+            TransactionOverlay: transactionOverlay,
+            TransactionPinnedSnapshot: transactionPinnedSnapshot);
         try
         {
             EnsureConcurrentMvccDmlTargetIsSupported(statement, tables, context);
@@ -5987,6 +6576,19 @@ public sealed partial class EmbeddedDatabase : IDisposable
             throw new EmbeddedSqlException(
                 "application-defined functions are prohibited in index expressions and partial index WHERE clauses");
         }
+        foreach (var column in definition.Columns)
+        {
+            // Building an index requires ordering its rows by every declared column's collation.
+            // A name that resolves to neither a SQLite built-in nor an already-registered
+            // application-defined callback can never be honored, so CREATE INDEX must fail closed
+            // here with the SQLite-style message instead of publishing an index that would silently
+            // fall back to BINARY ordering (or simply sit unusable) the first time it is planned or
+            // written to. This applies uniformly whether the catalog is file-backed or in-memory
+            // only, matching a bare custom-collation table/column CREATE TABLE rejection.
+            var collationName = IndexExpressionSemantics.GetCollationName(table, column);
+            if (!HasCollation(collationName))
+                throw new EmbeddedSqlException($"no such collation sequence: {collationName}");
+        }
         IndexExpressionSemantics.ValidateRoundTrip(statement.TableName, table, definition);
         if (definition.Unique)
             ValidateUniqueIndex(statement.TableName, table, definition, table.Rows);
@@ -6093,18 +6695,42 @@ public sealed partial class EmbeddedDatabase : IDisposable
 
         var rebuiltMethodIndex = selected.Any(static entry => entry.Index.IsMethodIndex);
 
+        if (_fileStore is null)
+        {
+            return rebuiltMethodIndex
+                ? new ExecutionResult([], [], 0, Changed: true)
+                : ExecutionResult.Empty;
+        }
+
+        // A targeted REINDEX of index/table/collation only ever needs to rebuild the
+        // selected ordinary index trees: rebuilding them in place, reusing each root
+        // page, leaves every other table and index — including one whose custom
+        // collation is not currently registered — completely untouched, so it never
+        // requires that collation's callback and never binary-compares its keys.
+        // Persistence itself has to happen where every other mutation is committed —
+        // inside EmbeddedFileStore.Persist, at the same point ForceFullCatalogRewrite
+        // is consumed — not here: a statement's Execute() runs before the catalog is
+        // durably written, so this only records the targets to attempt. Bare REINDEX
+        // (no target) still forces the unconditional full-catalog rewrite, since it may
+        // need every collation or touch every index anyway; a selection that includes a
+        // method index does too, since those are rebuilt above via their cursor, not
+        // through this file-store b-tree path. If the targeted attempt is not eligible
+        // or fails (for example because a targeted tree's on-disk image is itself
+        // corrupted and cannot be traversed to find its stale pages), ForceFullCatalogRewrite
+        // still guarantees the exact pre-existing repair behavior.
+        var targetedIndexRebuild = statement.Target is not null && selected.Count > 0 && !rebuiltMethodIndex
+            ? selected
+            : null;
+
         // The file writer's unchanged-schema full rewrite rebuilds every index tree in one
         // pager transaction. In-memory catalogs have no physical index image to rebuild.
-        return _fileStore is null
-            ? rebuiltMethodIndex
-                ? new ExecutionResult([], [], 0, Changed: true)
-                : ExecutionResult.Empty
-            : new ExecutionResult(
-                [],
-                [],
-                0,
-                Changed: true,
-                ForceFullCatalogRewrite: true);
+        return new ExecutionResult(
+            [],
+            [],
+            0,
+            Changed: true,
+            ForceFullCatalogRewrite: true,
+            TargetedIndexRebuild: targetedIndexRebuild);
     }
 
     private ExecutionResult ExecuteOptimizeIndex(OptimizeIndexStatement statement, SchemaCatalog catalog)
@@ -6232,12 +6858,6 @@ public sealed partial class EmbeddedDatabase : IDisposable
         if (targets.Count == 0)
             return new ExecutionResult([], [], 0, Changed: true);
 
-        foreach (var target in targets)
-        {
-            if (!target.Table.HasRowid)
-                throw new EmbeddedSqlException("ANALYZE on tables without rowid is not supported");
-        }
-
         var statistics = GetOrCreateSqliteStat1Table(catalog);
         var histogramStatistics = GetOrCreateSqliteStat4Table(catalog);
         var stat4RowIds = new Stat4RowIdAllocator(
@@ -6344,7 +6964,10 @@ public sealed partial class EmbeddedDatabase : IDisposable
     private void AddTableStatistics(EmbeddedTable statistics, EmbeddedTable table)
     {
         var indexes = table.Indexes.ToArray();
-        if (!indexes.Any(static index => !index.IsPartial))
+        var hasImplicitPrimaryKeyIndex = table.WithoutRowid
+            && table.PrimaryKeySchema is { Terms.Count: > 0 }
+            && table.WithoutRowidPrimaryKeyIndexName is not null;
+        if (!hasImplicitPrimaryKeyIndex && !indexes.Any(static index => !index.IsPartial))
         {
             if (table.Rows.Count > 0)
             {
@@ -6356,8 +6979,90 @@ public sealed partial class EmbeddedDatabase : IDisposable
             }
         }
 
+        if (hasImplicitPrimaryKeyIndex)
+        {
+            AddPrimaryKeyStatistic(
+                statistics,
+                table,
+                table.PrimaryKeySchema!);
+        }
+
         foreach (var index in indexes)
             AddIndexStatistic(statistics, table, index);
+    }
+
+    /// <summary>
+    /// Emits a <c>sqlite_stat1</c> row for a WITHOUT ROWID table's implicit primary-key
+    /// b-tree, mirroring <see cref="AddIndexStatistic"/> but projecting keys through the
+    /// table's <see cref="SqlitePrimaryKeySchema"/> instead of an <see cref="EmbeddedIndex"/>,
+    /// since the primary key is never represented as a member of <c>table.Indexes</c>.
+    /// </summary>
+    private void AddPrimaryKeyStatistic(
+        EmbeddedTable statistics,
+        EmbeddedTable table,
+        SqlitePrimaryKeySchema primaryKeySchema)
+    {
+        if (table.Rows.Count == 0 || primaryKeySchema.Terms.Count == 0)
+            return;
+
+        var keys = new List<SqlValue[]>(table.Rows.Count);
+        foreach (var row in table.Rows)
+            keys.Add(primaryKeySchema.ProjectKey(row));
+
+        keys.Sort((left, right) => ComparePrimaryKeyStatisticKeys(primaryKeySchema, left, right));
+        var statParts = new List<string>(primaryKeySchema.Terms.Count + 1)
+        {
+            keys.Count.ToString(CultureInfo.InvariantCulture)
+        };
+
+        for (var prefixLength = 1; prefixLength <= primaryKeySchema.Terms.Count; prefixLength++)
+        {
+            var distinctPrefixCount = 1;
+            for (var keyIndex = 1; keyIndex < keys.Count; keyIndex++)
+            {
+                if (!PrimaryKeyPrefixesEqual(primaryKeySchema, keys[keyIndex - 1], keys[keyIndex], prefixLength))
+                    distinctPrefixCount++;
+            }
+
+            var averageRowsPerDistinctPrefix = (keys.Count + distinctPrefixCount - 1) / distinctPrefixCount;
+            statParts.Add(averageRowsPerDistinctPrefix.ToString(CultureInfo.InvariantCulture));
+        }
+
+        // SQLite stores the table name, not sqlite_autoindex_<table>_1, in sqlite_stat1.idx
+        // for a WITHOUT ROWID table's primary b-tree.
+        AddStatisticRow(statistics, table.Name, SqlValue.Text(table.Name), string.Join(" ", statParts));
+    }
+
+    private int ComparePrimaryKeyStatisticKeys(
+        SqlitePrimaryKeySchema primaryKeySchema,
+        SqlValue[] left,
+        SqlValue[] right)
+    {
+        for (var position = 0; position < primaryKeySchema.Terms.Count; position++)
+        {
+            var term = primaryKeySchema.Terms[position];
+            var comparison = Compare(left[position], right[position], term.Collation.Name);
+            if (comparison != 0)
+                return term.SortOrder == SqliteKeySortOrder.Descending ? -comparison : comparison;
+        }
+
+        return 0;
+    }
+
+    private bool PrimaryKeyPrefixesEqual(
+        SqlitePrimaryKeySchema primaryKeySchema,
+        SqlValue[] left,
+        SqlValue[] right,
+        int prefixLength)
+    {
+        for (var position = 0; position < prefixLength; position++)
+        {
+            var term = primaryKeySchema.Terms[position];
+            if (Compare(left[position], right[position], term.Collation.Name) != 0)
+                return false;
+        }
+
+        return true;
     }
 
     private void AddIndexStatistic(EmbeddedTable statistics, EmbeddedTable table, EmbeddedIndex index)
@@ -18947,14 +19652,31 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 return false;
             }
 
-            return table.Indexes.Any(index =>
+            // Partial and expression indexes are analyzed candidates too now (the shared costed
+            // planner proves partial-index implication and matches expression-index equalities
+            // itself); only a method (virtual-table) index is still categorically unsupported.
+            if (table.Indexes.Any(index =>
                 (named.IndexDirective is not IndexedByDirective indexedBy
                     || string.Equals(index.Name, indexedBy.IndexName, StringComparison.OrdinalIgnoreCase))
-                && !index.IsPartial
                 && !index.IsMethodIndex
                 && index.Columns.Count > 0
-                && index.Columns.All(static column => !column.IsExpression)
-                && TryGetSqliteStat1PrefixAverage(queryContext, table.Name, index.Name, 1, out _));
+                && TryGetSqliteStat1PrefixAverage(queryContext, table.Name, index.Name, 1, out _)))
+            {
+                return true;
+            }
+
+            return table.WithoutRowidPrimaryKeyIndexName is { } primaryKeyIndexName
+                && (named.IndexDirective is not IndexedByDirective indexedByPrimaryKey
+                    || string.Equals(
+                        indexedByPrimaryKey.IndexName,
+                        primaryKeyIndexName,
+                        StringComparison.OrdinalIgnoreCase))
+                && TryGetSqliteStat1PrefixAverage(
+                    queryContext,
+                    table.Name,
+                    table.Name,
+                    1,
+                    out _);
         }
 
         // Build the combined (left ++ right) row shape exactly as GetJoinRows does, so a
@@ -19365,8 +20087,11 @@ public sealed partial class EmbeddedDatabase : IDisposable
                     term.Expression,
                     IsRegisteredScalarFunction)
                 || !IsSafeCompiledJoinOrderTerm(term, source))
+            {
                 return false;
+            }
         }
+
 
         VdbeJoinedRowPredicate? filter = null;
         if (select.Where is not null)
@@ -19629,7 +20354,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
             && source.ResolveColumnIndex(column.Name) is not null;
     }
 
-    private static bool IsSafeCompiledJoinPredicate(
+    private bool IsSafeCompiledJoinPredicate(
         Expression expression,
         CompiledJoinSource source)
         => IsSafeCompiledJoinPredicate(
@@ -19637,7 +20362,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
             source.ResolveColumnIndex,
             source.ResolveColumnDefinition);
 
-    private static bool IsSafeCompiledJoinPredicate(
+    private bool IsSafeCompiledJoinPredicate(
         Expression expression,
         string[] columns,
         IReadOnlyDictionary<string, int> qualifiedColumns,
@@ -19693,7 +20418,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
         return IsSafeCompiledJoinPredicate(expression, ResolveIndex, ResolveDefinition);
     }
 
-    private static bool IsSafeCompiledJoinPredicate(
+    private bool IsSafeCompiledJoinPredicate(
         Expression expression,
         Func<string, int?> resolveColumnIndex,
         Func<Expression, EmbeddedColumn?> resolveColumnDefinition)
@@ -19733,7 +20458,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 resolveColumnDefinition);
     }
 
-    private static bool IsSafeCompiledJoinOperand(
+    private bool IsSafeCompiledJoinOperand(
         Expression expression,
         Func<string, int?> resolveColumnIndex,
         Func<Expression, EmbeddedColumn?> resolveColumnDefinition)
@@ -19747,6 +20472,16 @@ public sealed partial class EmbeddedDatabase : IDisposable
 
         if (expression is LiteralExpression or ParameterExpression)
             return true;
+        if (expression is FunctionExpression function)
+        {
+            return !IsRegisteredScalarFunction(function.Name, function.Arguments.Count)
+                && IndexExpressionSemantics.IsDeterministicBuiltin(function)
+                && function.Filter is null
+                && function.Window is null
+                && function.Arguments.All(argument =>
+                    IsSafeCompiledJoinOperand(argument, resolveColumnIndex, resolveColumnDefinition));
+        }
+
         if (expression is not ColumnExpression column || resolveColumnIndex(column.Name) is null)
             return false;
 
@@ -19852,6 +20587,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 return false;
             }
 
+
             var leafRowIdIndices = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             if (target.HasRowId)
                 leafRowIdIndices.Add(target.Qualifier, 0);
@@ -19926,7 +20662,14 @@ public sealed partial class EmbeddedDatabase : IDisposable
         var outputColumns = GetOutputColumns(join, context);
         var rawOutputColumns = GetRawOutputColumns(join, context);
         var joinPairs = BuildJoinPairs(join, context);
+        // A join node the cost-based rewrite selected for a durable index seek never falls back
+        // to the hash-equijoin probe below (equiProbe stays null once indexSeekDescription is
+        // set), so the streaming-safe-collation gate — which exists solely to protect that hash
+        // path from an arbitrary custom comparator — does not apply here. The per-row residual
+        // check still runs through Evaluate/JoinPairMatches, which already resolve the callback.
+        var hasSelectedIndexSeek = indexSeekSelections is not null && indexSeekSelections.ContainsKey(join);
         if (join.Condition is not null
+            && !hasSelectedIndexSeek
             && !IsSafeCompiledJoinPredicate(
                 join.Condition,
                 columns,
@@ -20086,34 +20829,102 @@ public sealed partial class EmbeddedDatabase : IDisposable
         }
 
         EmbeddedIndex? index = null;
-        if (!selection.Candidate.Automatic)
+        if (selection.Candidate.IsPrimaryKey)
+        {
+            if (!table.WithoutRowid
+                || table.PrimaryKeySchema is not { Terms.Count: > 0 }
+                || table.WithoutRowidPrimaryKeyIndexName is null)
+            {
+                return false;
+            }
+        }
+        else if (!selection.Candidate.Automatic)
         {
             index = table.Indexes.FirstOrDefault(candidate =>
                 string.Equals(candidate.Name, selection.Candidate.Name, StringComparison.OrdinalIgnoreCase));
-            if (index is null
-                || index.IsPartial
-                || index.IsMethodIndex
-                || index.Columns.Any(static column => column.IsExpression))
+            if (index is null || index.IsMethodIndex)
             {
                 return false;
             }
         }
 
-        var keys = new EquiJoinKey[selection.EqualityTerms.Count];
+        var indexName = index?.Name ?? selection.Candidate.Name;
+        var keys = new EquiJoinKey?[selection.EqualityTerms.Count];
+        // Set only for a position whose candidate column is an expression column: the resolved
+        // ordinal (within left.OutputColumns) of the plain-column "outer" operand that was
+        // matched against the persisted index expression back in TryCreateJoinOrderTerm. Exactly
+        // one of keys[position]/expressionOuterOrdinal[position] is populated per position.
+        var expressionOuterOrdinal = new int?[selection.EqualityTerms.Count];
         for (var position = 0; position < keys.Length; position++)
         {
+            var candidateColumn = selection.Candidate.Columns[position];
+            if (candidateColumn.IndexExpression is { } indexExpression)
+            {
+                // The enumerator only binds this candidate column to a term shaped as an equality
+                // whose one operand structurally matches the persisted index expression (see
+                // TryMatchExpressionIndexOperand); re-derive which operand that is here rather
+                // than trust position alone, so a mismatched rewrite fails closed instead of
+                // silently seeking on the wrong value.
+                if (selection.EqualityTerms[position] is not BinaryExpression { Operator: BinaryOperator.Equal } binary)
+                {
+                    return false;
+                }
+
+                // Like TryMatchExpressionIndexOperand's own match, the persisted index's stored
+                // expression is always bare (its COLLATE is peeled off into metadata at parse
+                // time — see EmbeddedIndexFactory.Create), while this ON/WHERE operand may still
+                // carry an explicit "(...) COLLATE name" wrapper straight from the parser. Unwrap
+                // before comparing so this re-derivation agrees with the match that selected this
+                // candidate in the first place, instead of failing structurally here.
+                Expression outerOperand;
+                if (IndexExpressionSemantics.ExpressionsEqual(UnwrapCollation(binary.Left), indexExpression))
+                    outerOperand = binary.Right;
+                else if (IndexExpressionSemantics.ExpressionsEqual(UnwrapCollation(binary.Right), indexExpression))
+                    outerOperand = binary.Left;
+                else
+                {
+                    return false;
+                }
+
+                if (UnwrapCollation(outerOperand) is not ColumnExpression { BooleanKeyword: null } outerColumnExpression
+                    || ResolveJoinSideColumn(outerColumnExpression, left.OutputColumns) is not { } outerColumn)
+                {
+                    return false;
+                }
+
+                var outerDefinition = GetOutputColumnDefinition(join.Left, outerColumn, context);
+                var explicitCollation = GetExplicitCollation(binary.Left) ?? GetExplicitCollation(binary.Right);
+                var resolvedCollation = (explicitCollation
+                    ?? (outerDefinition is not null ? NormalizeDeclaredCollation(outerDefinition.Collation) : null)
+                    ?? "BINARY").ToUpperInvariant();
+                if (!string.Equals(resolvedCollation, candidateColumn.Collation, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+
+                expressionOuterOrdinal[position] = outerColumn.Index;
+                continue;
+            }
+
             if (TryCreateEquiJoinKey(
                     selection.EqualityTerms[position],
                     join,
                     left.OutputColumns,
                     right.OutputColumns,
-                    context) is not { } key
-                || key.RightColumn.Index != selection.Candidate.Columns[position].ColumnOrdinal
+                    context,
+                    // A real persisted index/PK seeks with Compare(...) against the durable
+                    // order, never a hash bucket, so an application-defined collation is fine
+                    // here as long as it matches the candidate column's declared collation
+                    // (checked below). The synthetic "automatic covering index" path still
+                    // canonicalizes keys into a hash bucket (CanonicalizeAutomaticKey), so it
+                    // keeps requiring a built-in hashable collation.
+                    allowUnhashableCollation: !selection.Candidate.Automatic) is not { } key
+                || key.RightColumn.Index != candidateColumn.ColumnOrdinal
                 || key.RightConvertsTextToNumeric
                 || key.RightConvertsNumericToText
                 || !string.Equals(
                     key.Collation,
-                    selection.Candidate.Columns[position].Collation,
+                    candidateColumn.Collation,
                     StringComparison.OrdinalIgnoreCase))
             {
                 return false;
@@ -20129,7 +20940,9 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 context,
                 maximumRows: null,
                 outerRow).Rows;
-            var entries = GetManagedIndexEntries(table, index!, visibleRows, context);
+            var entries = index is not null
+                ? GetManagedIndexEntries(table, index, visibleRows, context)
+                : GetManagedPrimaryKeyEntries(table, visibleRows, context);
             var rows = entries.Select(static entry => entry.Row.Values).ToArray();
             var rowIds = table.HasRowid
                 ? entries.Select(static entry => entry.Row.RowId ?? 0L).ToArray()
@@ -20170,7 +20983,23 @@ public sealed partial class EmbeddedDatabase : IDisposable
             var result = new SqlValue[keys.Length];
             for (var position = 0; position < keys.Length; position++)
             {
-                var key = keys[position];
+                if (expressionOuterOrdinal[position] is { } ordinal)
+                {
+                    if (ordinal < 0 || ordinal >= outer.Values.Length)
+                        return null;
+
+                    var exprValue = outer.Values[ordinal];
+                    if (exprValue.Kind == SqlValueKind.Null)
+                        return null;
+
+                    // TryCreateJoinOrderTerm never enables numeric/text conversion for an
+                    // expression-index term (the persisted expression's result type is not
+                    // statically known), so the outer value is used verbatim.
+                    result[position] = exprValue;
+                    continue;
+                }
+
+                var key = keys[position]!;
                 if (key.LeftColumn.Index < 0 || key.LeftColumn.Index >= outer.Values.Length)
                     return null;
 
@@ -20225,12 +21054,14 @@ public sealed partial class EmbeddedDatabase : IDisposable
             ", ",
             selection.Candidate.Columns
                 .Take(keys.Length)
-                .Select(column => $"{table.Columns[column.ColumnOrdinal]}=?"));
+                .Select((column, position) => column.IndexExpression is not null
+                    ? $"{(index!.Columns[position].ExpressionSql ?? "expr")}=?"
+                    : $"{table.Columns[column.ColumnOrdinal]}=?"));
         var usingClause = selection.Candidate.Automatic
             ? "USING AUTOMATIC COVERING INDEX"
             : selection.Candidate.Covering
-                ? $"USING COVERING INDEX {index!.Name}"
-                : $"USING INDEX {index!.Name}";
+                ? $"USING COVERING INDEX {indexName}"
+                : $"USING INDEX {indexName}";
         var searchDescription = $"SEARCH {table.Name} {usingClause} ({prefix})";
         if (selection.Candidate.Automatic)
         {
@@ -20246,12 +21077,84 @@ public sealed partial class EmbeddedDatabase : IDisposable
             return true;
         }
 
+        if (context.ConcurrentMvStore is not null
+            && context.ConcurrentMvccTxId is not null
+            && TryOpenConcurrentMvccIndexAccessor(
+                table,
+                index,
+                keys.Length,
+                selection.Candidate.Covering,
+                context,
+                out var concurrentMvccAccessor))
+        {
+            IEnumerable<VdbeJoinRow> SeekConcurrentMvcc(SqlValue[] seekKey)
+            {
+                foreach (var row in concurrentMvccAccessor.Seek(
+                             seekKey,
+                             _joinIndexSeekMetrics.IndexPageRead,
+                             _joinIndexSeekMetrics.KeyCompared,
+                             _joinIndexSeekMetrics.TableRowFetched))
+                {
+                    yield return new VdbeJoinRow(row.Values, [row.RowId]);
+                }
+            }
+
+            plan = new VdbeJoinPagerIndexSeekPlan(
+                table.Name,
+                indexName,
+                searchDescription,
+                table.Columns.Length,
+                BuildSeekKey,
+                SeekConcurrentMvcc,
+                concurrentMvccAccessor.Open,
+                concurrentMvccAccessor.Dispose,
+                _joinIndexSeekMetrics);
+            description = $"pager-index-seek {table.Name} {usingClause} ({prefix})";
+            return true;
+        }
+
+        if (context.ConcurrentMvStore is null
+            && context.ConcurrentMvccTxId is null
+            && TryOpenTransactionIndexAccessor(
+                table,
+                index,
+                keys.Length,
+                selection.Candidate.Covering,
+                context,
+                out var transactionAccessor))
+        {
+            IEnumerable<VdbeJoinRow> SeekTransactionPager(SqlValue[] seekKey)
+            {
+                foreach (var row in transactionAccessor.Seek(
+                             seekKey,
+                             _joinIndexSeekMetrics.IndexPageRead,
+                             _joinIndexSeekMetrics.KeyCompared,
+                             _joinIndexSeekMetrics.TableRowFetched))
+                {
+                    yield return new VdbeJoinRow(row.Values, [row.RowId]);
+                }
+            }
+
+            plan = new VdbeJoinPagerIndexSeekPlan(
+                table.Name,
+                indexName,
+                searchDescription,
+                table.Columns.Length,
+                BuildSeekKey,
+                SeekTransactionPager,
+                transactionAccessor.Open,
+                transactionAccessor.Dispose,
+                _joinIndexSeekMetrics);
+            description = $"pager-index-seek {table.Name} {usingClause} ({prefix})";
+            return true;
+        }
+
         if (context.ConcurrentMvStore is null
             && context.ConcurrentMvccTxId is null
             && !context.InTransaction
             && _fileStore?.TryOpenIndexAccessor(
                 table,
-                index!,
+                index,
                 keys.Length,
                 selection.Candidate.Covering,
                 sharedSnapshot: null,
@@ -20271,7 +21174,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
 
             plan = new VdbeJoinPagerIndexSeekPlan(
                 table.Name,
-                index!.Name,
+                indexName,
                 searchDescription,
                 table.Columns.Length,
                 BuildSeekKey,
@@ -20285,7 +21188,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
 
         plan = new VdbeJoinIndexScanPlan(
             table.Name,
-            index!.Name,
+            indexName,
             searchDescription,
             table.Columns.Length,
             MaterializeDurable,
@@ -20294,6 +21197,304 @@ public sealed partial class EmbeddedDatabase : IDisposable
             _joinIndexSeekMetrics);
         description = $"materialized-index-seek {table.Name} {usingClause} ({prefix})";
         return true;
+    }
+
+    /// <summary>
+    /// Opens a durable index accessor over a classic (non-MVCC) file-backed transaction's own
+    /// pinned pager snapshot, merged with that transaction's <see cref="TransactionMutationOverlay"/>
+    /// so a compiled-join index seek sees read-your-writes without materializing or re-sorting the
+    /// whole index. Requires <see cref="QueryContext.TransactionOverlay"/> and
+    /// <see cref="QueryContext.TransactionPinnedSnapshot"/> — both are populated only for a durable
+    /// classic transaction that has made no schema changes since BEGIN (see
+    /// <c>EmbeddedConnection</c>'s in-transaction <c>Execute</c> dispatch, which nulls the pinned
+    /// snapshot once <c>HasSchemaChanges</c> is set, automatically falling back to
+    /// <see cref="VdbeJoinIndexScanPlan"/>'s full materialization for the remainder of the
+    /// transaction).
+    /// </summary>
+    private bool TryOpenTransactionIndexAccessor(
+        EmbeddedTable table,
+        EmbeddedIndex? index,
+        int prefixLength,
+        bool covering,
+        QueryContext context,
+        out EmbeddedFileIndexAccessor accessor)
+    {
+        accessor = null!;
+        if (_fileStore is null
+            || context.TransactionOverlay is not { } overlay
+            || context.TransactionPinnedSnapshot is not { } pinnedSnapshot)
+        {
+            return false;
+        }
+
+        if (!_fileStore.TryOpenIndexAccessor(
+                table,
+                index,
+                prefixLength,
+                covering,
+                sharedSnapshot: pinnedSnapshot,
+                out var baseAccessor,
+                requireCommittedTableIdentity: false))
+        {
+            return false;
+        }
+
+        if (!overlay.TryGet(table.Name, out var tableOverlay) || tableOverlay.IsEmpty)
+        {
+            // Nothing this transaction touched for this table: the pinned base snapshot alone is
+            // already correct and read-your-writes is trivially satisfied.
+            accessor = baseAccessor;
+            return true;
+        }
+
+        if (table.WithoutRowid && table.PrimaryKeySchema is null)
+        {
+            // Unreachable in practice (CanOpenIndexAccessor already requires primary-key metadata
+            // for a WITHOUT ROWID table), but fail closed rather than risk an incorrect merge.
+            return false;
+        }
+
+        var mergeComparer = index is not null
+            ? _fileStore.CreateIndexComparer(table, index)
+            : _fileStore.CreatePrimaryKeyComparer(table.PrimaryKeySchema!);
+
+        IEnumerable<EmbeddedFileIndexSeekRow> MergeSeek(
+            SqlValue[] prefix,
+            Action? pageRead,
+            Action? keyCompared,
+            Action? tableRowFetched)
+        {
+            // Bounded by this transaction's own mutation count, never by the whole table or index.
+            var candidates = new List<(SqlValue[] Key, EmbeddedFileIndexSeekRow Row)>();
+            foreach (var candidateRow in tableOverlay.EnumerateCurrentRows())
+            {
+                if (index is not null
+                    && !IndexExpressionSemantics.Qualifies(
+                        index, table, candidateRow.Values, candidateRow.RowId, EvaluateIndexExpression))
+                {
+                    continue;
+                }
+
+                var key = _fileStore.BuildIndexMergeKey(
+                    table, index, candidateRow.Values, candidateRow.RowId, EvaluateIndexExpression);
+                if (!IndexKeyPrefixMatches(mergeComparer, key, prefix))
+                    continue;
+
+                candidates.Add((key, candidateRow));
+            }
+
+            candidates.Sort((left, right) => mergeComparer.Compare(left.Key, right.Key));
+
+            return MergeTransactionIndexRows(
+                baseAccessor.Seek(prefix, pageRead, keyCompared, tableRowFetched),
+                candidates,
+                mergeComparer,
+                table,
+                index,
+                tableOverlay);
+        }
+
+        accessor = new EmbeddedFileIndexAccessor(MergeSeek, baseAccessor.Open, baseAccessor.Dispose);
+        return true;
+    }
+
+    /// <summary>
+    /// Lazily merge-joins the pinned base pager's sorted seek stream with this transaction's own
+    /// sorted overlay candidates for the same seek prefix, suppressing any base row identity this
+    /// transaction has touched — whether it now reads live under a new key or was deleted — so the
+    /// caller never observes a stale entry alongside its replacement, while preserving the durable
+    /// pager's exact SQLite key order and duplicate handling.
+    /// </summary>
+    private IEnumerable<EmbeddedFileIndexSeekRow> MergeTransactionIndexRows(
+        IEnumerable<EmbeddedFileIndexSeekRow> baseRows,
+        List<(SqlValue[] Key, EmbeddedFileIndexSeekRow Row)> candidates,
+        SqliteIndexRecordComparer comparer,
+        EmbeddedTable table,
+        EmbeddedIndex? index,
+        TransactionTableOverlay tableOverlay)
+    {
+        using var baseEnumerator = baseRows.GetEnumerator();
+        var candidateIndex = 0;
+        var hasBase = baseEnumerator.MoveNext();
+        while (true)
+        {
+            while (hasBase && IsSuppressedByTransactionOverlay(tableOverlay, table, baseEnumerator.Current))
+                hasBase = baseEnumerator.MoveNext();
+
+            if (!hasBase && candidateIndex >= candidates.Count)
+                yield break;
+
+            if (!hasBase)
+            {
+                yield return candidates[candidateIndex++].Row;
+                continue;
+            }
+
+            if (candidateIndex >= candidates.Count)
+            {
+                yield return baseEnumerator.Current;
+                hasBase = baseEnumerator.MoveNext();
+                continue;
+            }
+
+            var baseKey = _fileStore!.BuildIndexMergeKey(
+                table, index, baseEnumerator.Current.Values, baseEnumerator.Current.RowId, EvaluateIndexExpression);
+            if (comparer.Compare(baseKey, candidates[candidateIndex].Key) <= 0)
+            {
+                yield return baseEnumerator.Current;
+                hasBase = baseEnumerator.MoveNext();
+            }
+            else
+            {
+                yield return candidates[candidateIndex++].Row;
+            }
+        }
+    }
+
+    private static bool IsSuppressedByTransactionOverlay(
+        TransactionTableOverlay tableOverlay,
+        EmbeddedTable table,
+        EmbeddedFileIndexSeekRow row)
+    {
+        if (table.HasRowid)
+            return row.RowId is { } rowId && tableOverlay.TryGetByRowId(rowId, out _);
+
+        var primaryKey = table.PrimaryKeySchema!.ProjectKey(row.Values);
+        return tableOverlay.TryGetByPrimaryKey(primaryKey, out _);
+    }
+
+    /// <summary>
+    /// Opens a durable index accessor over a BEGIN CONCURRENT transaction's own pinned durable
+    /// b-tree snapshot (<see cref="QueryContext.TransactionPinnedSnapshot"/>, captured at BEGIN
+    /// CONCURRENT — see <c>BeginConcurrentTransactionSnapshotLocked</c>), merged lazily with this
+    /// transaction's visible <see cref="MvStore"/> effects via <see
+    /// cref="MvccDualCursor.EnumerateVisibleIndexRows"/> — the same two-peek merge primitive the
+    /// single-table <see cref="GetConcurrentMvccIndexRows"/> path uses — so a compiled-join index
+    /// seek sees read-your-writes (and any peer transaction committed before this reader's begin
+    /// timestamp) without materializing or re-sorting the whole durable index. Mirrors <see
+    /// cref="TryOpenTransactionIndexAccessor"/>, substituting the concurrent version store for the
+    /// classic <see cref="TransactionMutationOverlay"/>.
+    /// </summary>
+    private bool TryOpenConcurrentMvccIndexAccessor(
+        EmbeddedTable table,
+        EmbeddedIndex? index,
+        int prefixLength,
+        bool covering,
+        QueryContext context,
+        out EmbeddedFileIndexAccessor accessor)
+    {
+        accessor = null!;
+        if (_fileStore is not { } fileStore
+            || context.ConcurrentMvStore is not { } store
+            || context.ConcurrentMvccTxId is not { } txId
+            || context.TransactionPinnedSnapshot is not { } pinnedSnapshot)
+        {
+            return false;
+        }
+
+        if (!fileStore.TryOpenIndexAccessor(
+                table,
+                index,
+                prefixLength,
+                covering,
+                sharedSnapshot: pinnedSnapshot,
+                out var baseAccessor,
+                requireCommittedTableIdentity: false))
+        {
+            return false;
+        }
+
+        if (table.WithoutRowid && table.PrimaryKeySchema is null)
+        {
+            // Unreachable in practice (CanOpenIndexAccessor already requires primary-key metadata
+            // for a WITHOUT ROWID table), but fail closed rather than risk an incorrect merge.
+            return false;
+        }
+
+        IComparer<MvccKey> tableKeyComparer = MvccKeyComparer.Integer;
+        if (!table.HasRowid)
+        {
+            var primaryKey = table.PrimaryKeySchema!;
+            tableKeyComparer = MvccKeyComparer.ForRecord(
+                new SqliteIndexRecordComparer(
+                    context.MvccTextEncoding,
+                    primaryKey.Terms.Select(term =>
+                        new SqliteIndexComparisonTerm(term.SortOrder, term.Collation)).ToArray()));
+        }
+
+        var mergeComparer = index is not null
+            ? fileStore.CreateIndexComparer(table, index)
+            : fileStore.CreatePrimaryKeyComparer(table.PrimaryKeySchema!);
+        var indexComparer = Comparer<MvccDualCursor.IndexRow>.Create(
+            (left, right) => mergeComparer.Compare(left.IndexKey, right.IndexKey));
+        var tableId = store.GetOrCreateTableId(txId, table.Name);
+
+        IEnumerable<EmbeddedFileIndexSeekRow> MergeSeek(
+            SqlValue[] prefix,
+            Action? pageRead,
+            Action? keyCompared,
+            Action? tableRowFetched)
+        {
+            IEnumerable<MvccDualCursor.IndexRow> EnumerateBaseRows()
+            {
+                foreach (var row in baseAccessor.Seek(prefix, pageRead, keyCompared, tableRowFetched))
+                {
+                    var rowId = row.RowId ?? 0L;
+                    yield return new MvccDualCursor.IndexRow(
+                        GetMvccTableKey(table, row.Values, rowId),
+                        fileStore.BuildIndexMergeKey(table, index, row.Values, row.RowId, EvaluateIndexExpression),
+                        row.Values);
+                }
+            }
+
+            MvccDualCursor.IndexRow? ProjectOverlay(MvccVisibleRow visible)
+            {
+                var cells = visible.Cells
+                    ?? throw new InvalidOperationException("A visible MVCC index row has no payload.");
+                var rowId = table.HasRowid ? visible.Key.Integer : (long?)null;
+                if (index is not null
+                    && !IndexExpressionSemantics.Qualifies(index, table, cells, rowId, EvaluateIndexExpression))
+                {
+                    return null;
+                }
+
+                var key = fileStore.BuildIndexMergeKey(table, index, cells, rowId, EvaluateIndexExpression);
+                if (!IndexKeyPrefixMatches(mergeComparer, key, prefix))
+                    return null;
+
+                return new MvccDualCursor.IndexRow(visible.Key, key, cells);
+            }
+
+            foreach (var merged in MvccDualCursor.EnumerateVisibleIndexRows(
+                         store,
+                         txId,
+                         tableId,
+                         EnumerateBaseRows(),
+                         ProjectOverlay,
+                         indexComparer,
+                         tableKeyComparer,
+                         _joinIndexSeekMetrics.BaseRowSuppressed,
+                         _joinIndexSeekMetrics.OverlayRowExamined))
+            {
+                yield return new EmbeddedFileIndexSeekRow(
+                    merged.Cells,
+                    table.HasRowid ? merged.TableKey.Integer : null);
+            }
+        }
+
+        accessor = new EmbeddedFileIndexAccessor(MergeSeek, baseAccessor.Open, baseAccessor.Dispose);
+        return true;
+    }
+
+    private static bool IndexKeyPrefixMatches(SqliteIndexRecordComparer comparer, SqlValue[] key, SqlValue[] prefix)
+    {
+        if (prefix.Length == 0)
+            return true;
+        if (key.Length < prefix.Length)
+            return false;
+
+        var slice = key.Length == prefix.Length ? key : key[..prefix.Length];
+        return comparer.Compare(slice, prefix) == 0;
     }
 
     /// <summary>
@@ -21058,6 +22259,15 @@ public sealed partial class EmbeddedDatabase : IDisposable
         && !collation.Equals("BINARY", StringComparison.OrdinalIgnoreCase)
         && !collation.Equals("NOCASE", StringComparison.OrdinalIgnoreCase)
         && !collation.Equals("RTRIM", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// True when <paramref name="collation"/> can be handed to <see cref="Compare"/> without it
+    /// throwing "no such collation sequence": every built-in name always resolves (falling back
+    /// to its built-in behavior if not overridden), and a custom name resolves once it has a
+    /// registered <see cref="RegisterCollation"/> callback.
+    /// </summary>
+    private bool IsCollationResolvable(string? collation)
+        => IsBuiltInCollation(collation) || _collations.ContainsKey(collation!);
 
     private static bool CollationsEquivalent(string? left, string? right) =>
         string.Equals(
@@ -24868,6 +26078,12 @@ out bool hasReturning)
 
         var index = table.Indexes.FirstOrDefault(candidate =>
             string.Equals(candidate.Name, indexedBy.IndexName, StringComparison.OrdinalIgnoreCase));
+        if (index is null
+            && table.WithoutRowidPrimaryKeyIndexName is { } primaryKeyIndexName
+            && string.Equals(primaryKeyIndexName, indexedBy.IndexName, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
         if (index is null)
             throw new EmbeddedSqlException($"no such index: {indexedBy.IndexName}");
         if (index.Where is null)
@@ -25153,12 +26369,14 @@ out bool hasReturning)
         // Score favors equality SEARCH depth, ORDER BY elision, and covering projection.
         foreach (var index in table.Indexes)
         {
-            // Skip indexes the managed planner cannot evaluate (registered functions /
-            // overridden collations), and skip partial indexes whose WHERE is not
-            // implied by the query predicate. Plain (non-partial, non-expression)
-            // indexes are eligible for SEARCH and ORDER BY elision.
+            // Skip indexes the managed planner cannot evaluate (registered functions), and
+            // indexes whose custom/overridden collation has no registered callback yet or is
+            // marked dirty pending REINDEX (see IsCustomCollationIndexPlanReady) — a clean
+            // custom-collation index is fully eligible here, same as a built-in one. Also skip
+            // partial indexes whose WHERE is not implied by the query predicate. Plain
+            // (non-partial, non-expression) indexes are eligible for SEARCH and ORDER BY elision.
             if (IndexUsesRegisteredFunctions(index)
-                || IndexUsesOverriddenBuiltInCollation(index, table)
+                || !IsCustomCollationIndexPlanReady(table, index)
                 || !IndexExpressionSemantics.PredicateImplies(
                     statement.Where,
                     index.Where,
@@ -25749,10 +26967,6 @@ out bool hasReturning)
             || index.Where is not null
                 && IndexExpressionSemantics.ContainsFunction(index.Where, IsRegisteredScalarFunction);
 
-    private bool IndexUsesOverriddenBuiltInCollation(EmbeddedIndex index, EmbeddedTable table)
-        => index.Columns.Any(term =>
-            IsOverriddenBuiltInCollation(IndexExpressionSemantics.GetCollationName(table, term)));
-
     private static bool WhereUsesIndexTerm(
         Expression? expression,
         EmbeddedTable table,
@@ -25879,16 +27093,63 @@ out bool hasReturning)
                 left,
                 right));
         var tableId = store.GetOrCreateTableId(txId, plan.Source.Name);
-        var baseOrder = table.GetOrCreateIndexScanOrder(
-            plan.Index.Name,
-            () => BuildBaseIndexScanOrder(
-                table,
-                plan.Index,
-                context,
-                indexComparer));
 
+        // Prefer the transaction's own pinned durable b-tree snapshot: an unconditional ascending
+        // scan of the committed index (see EmbeddedFileStore.ScanCommittedRowidIndexAscending et
+        // al.) whose physical key order is provably identical to indexComparer (both derive from
+        // the same declared collation/sort-direction terms — see CreateIndexComparer), so no
+        // in-memory sort/materialization of the base index is needed. Only when the file store is
+        // unavailable, the pinned snapshot was invalidated by a schema change, or the table/index
+        // is otherwise ineligible (e.g. an in-memory table) does this fall back to the classic
+        // table.GetOrCreateIndexScanOrder full-heap materialization.
         IEnumerable<MvccDualCursor.IndexRow> EnumerateBaseRows()
         {
+            if (_fileStore is { } fileStore
+                && context.TransactionPinnedSnapshot is { } pinnedSnapshot
+                && fileStore.TryOpenIndexFullScanAccessor(
+                    table,
+                    plan.Index,
+                    covering: false,
+                    pinnedSnapshot,
+                    out var scanAccessor,
+                    requireCommittedTableIdentity: false))
+            {
+                _joinIndexSeekMetrics.DurableCursorPlanCreated();
+                scanAccessor.Open();
+                try
+                {
+                    foreach (var row in scanAccessor.Scan(
+                                 _joinIndexSeekMetrics.IndexPageRead,
+                                 _joinIndexSeekMetrics.TableRowFetched))
+                    {
+                        context.CheckInterrupt();
+                        var rowId = row.RowId ?? 0L;
+                        yield return new MvccDualCursor.IndexRow(
+                            GetMvccTableKey(table, row.Values, rowId),
+                            IndexExpressionSemantics.ProjectKey(
+                                plan.Index,
+                                table,
+                                row.Values,
+                                table.HasRowid ? rowId : null,
+                                EvaluateIndexExpression),
+                            row.Values);
+                    }
+                }
+                finally
+                {
+                    scanAccessor.Dispose();
+                }
+
+                yield break;
+            }
+
+            var baseOrder = table.GetOrCreateIndexScanOrder(
+                plan.Index.Name,
+                () => BuildBaseIndexScanOrder(
+                    table,
+                    plan.Index,
+                    context,
+                    indexComparer));
             foreach (var position in baseOrder)
             {
                 context.CheckInterrupt();
@@ -25946,7 +27207,9 @@ out bool hasReturning)
             EnumerateBaseRows(),
             ProjectOverlay,
             indexComparer,
-            tableKeyComparer);
+            tableKeyComparer,
+            _joinIndexSeekMetrics.BaseRowSuppressed,
+            _joinIndexSeekMetrics.OverlayRowExamined);
 
         IEnumerable<SourceRow> EnumerateSourceRows()
         {
@@ -26065,7 +27328,12 @@ out bool hasReturning)
                     EvaluateIndexExpression)));
         }
 
-        entries.Sort((left, right) => CompareManagedIndexEntries(table, index, left, right));
+        // See EmbeddedFileStore.SortPropagatingComparerExceptions: List<T>.Sort wraps any
+        // exception the comparison delegate throws (for example an application-defined
+        // collation callback) in an opaque InvalidOperationException, so callers must go
+        // through the unwrapping helper to observe the callback's real exception.
+        EmbeddedFileStore.SortPropagatingComparerExceptions(
+            entries, (left, right) => CompareManagedIndexEntries(table, index, left, right));
         return entries;
     }
 
@@ -26155,7 +27423,7 @@ out bool hasReturning)
         foreach (var candidate in table.Indexes)
         {
             if (IndexUsesRegisteredFunctions(candidate)
-                || IndexUsesOverriddenBuiltInCollation(candidate, table)
+                || !IsCustomCollationIndexPlanReady(table, candidate)
                 || candidate.IsPartial
                 || !IndexExpressionSemantics.PredicateImplies(
                     branch,
@@ -26260,10 +27528,24 @@ out bool hasReturning)
         for (var position = 0; position < index.Columns.Count; position++)
         {
             var term = index.Columns[position];
-            var comparison = Compare(
-                left.Key[position],
-                right.Key[position],
-                IndexExpressionSemantics.GetCollationName(table, term));
+            var collationName = IndexExpressionSemantics.GetCollationName(table, term);
+
+            // This managed in-memory index emulation (used for e.g. INDEXED BY forced scans)
+            // recomputes its key order live from the currently visible rows on every call -- it
+            // never reads a possibly-stale durable image, so it has nothing to defer via REINDEX.
+            // But a term whose collation has no registered callback yet must still not throw the
+            // whole scan closed the way a genuine seek/build against durable storage would
+            // (architecture item 3 is about writes/builds/seeks, not a plain unordered scan): skip
+            // it, exactly like SqliteIndexRecordComparer.HasDeferredTerms treats an unresolvable
+            // durable term as "no discrimination", falling through to the next term or the
+            // rowid/primary-key tiebreaker. The rows produced are unaffected -- only their
+            // relative order might not reflect that term -- and any caller that actually needs
+            // this index's collation-defined order gates on IsCustomCollationIndexPlanReady
+            // before ever choosing this in-memory path over a durable direct seek.
+            if (!IsCollationResolvable(collationName))
+                continue;
+
+            var comparison = Compare(left.Key[position], right.Key[position], collationName);
             if (comparison != 0)
                 return term.Descending ? -comparison : comparison;
         }
@@ -26295,6 +27577,46 @@ out bool hasReturning)
                     ? -comparison
                     : comparison;
             }
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// The <see cref="GetManagedIndexEntries"/> analog for the implicit primary-key join
+    /// candidate: keys are projected through the table's <see cref="SqlitePrimaryKeySchema"/>
+    /// rather than an <see cref="EmbeddedIndex"/>, since the primary key is never one of
+    /// <c>table.Indexes</c>. Every visible row qualifies (a primary key has no partial predicate).
+    /// </summary>
+    private List<(SourceRow Row, SqlValue[] Key)> GetManagedPrimaryKeyEntries(
+        EmbeddedTable table,
+        IReadOnlyList<SourceRow> visibleRows,
+        QueryContext context)
+    {
+        var primaryKeySchema = table.PrimaryKeySchema
+            ?? throw new InvalidOperationException("WITHOUT ROWID table has no primary-key metadata.");
+        var entries = new List<(SourceRow Row, SqlValue[] Key)>(visibleRows.Count);
+        foreach (var row in visibleRows)
+        {
+            context.CheckInterrupt();
+            entries.Add((row, primaryKeySchema.ProjectKey(row.Values)));
+        }
+
+        entries.Sort((left, right) => ComparePrimaryKeyEntries(primaryKeySchema, left, right));
+        return entries;
+    }
+
+    private int ComparePrimaryKeyEntries(
+        SqlitePrimaryKeySchema primaryKeySchema,
+        (SourceRow Row, SqlValue[] Key) left,
+        (SourceRow Row, SqlValue[] Key) right)
+    {
+        for (var position = 0; position < primaryKeySchema.Terms.Count; position++)
+        {
+            var term = primaryKeySchema.Terms[position];
+            var comparison = Compare(left.Key[position], right.Key[position], term.Collation.Name);
+            if (comparison != 0)
+                return term.SortOrder == SqliteKeySortOrder.Descending ? -comparison : comparison;
         }
 
         return 0;
@@ -30898,7 +32220,8 @@ out bool hasReturning)
         JoinTableSource source,
         IReadOnlyList<OutputColumn> leftColumns,
         IReadOnlyList<OutputColumn> rightColumns,
-        QueryContext context)
+        QueryContext context,
+        bool allowUnhashableCollation = false)
     {
         if (conjunct is not BinaryExpression { Operator: BinaryOperator.Equal } binary)
             return null;
@@ -30939,7 +32262,8 @@ out bool hasReturning)
             leftColumn,
             rightColumn,
             context,
-            explicitCollation);
+            explicitCollation,
+            allowUnhashableCollation);
     }
 
     private EquiJoinKey? TryCreateEquiJoinKey(
@@ -30947,17 +32271,25 @@ out bool hasReturning)
         OutputColumn leftColumn,
         OutputColumn rightColumn,
         QueryContext context,
-        string? explicitCollation = null)
+        string? explicitCollation = null,
+        bool allowUnhashableCollation = false)
     {
         var leftDefinition = GetOutputColumnDefinition(source.Left, leftColumn, context);
         var rightDefinition = GetOutputColumnDefinition(source.Right, rightColumn, context);
         var leftAffinity = GetJoinKeyAffinity(leftDefinition);
         var rightAffinity = GetJoinKeyAffinity(rightDefinition);
+        // Read the raw declared collation directly rather than routing each operand through
+        // NormalizeDeclaredCollation first: that helper substitutes "BINARY" for a null/absent
+        // collation, so chaining NormalizeDeclaredCollation(left) ?? NormalizeDeclaredCollation(right)
+        // would short-circuit on "BINARY" whenever the left side has no explicit COLLATE and never
+        // consult the right side's declared collation, contradicting SQLite's actual resolution
+        // order (explicit COLLATE > left declared > right declared > BINARY default).
         var collation = explicitCollation
-            ?? (leftDefinition is not null ? NormalizeDeclaredCollation(leftDefinition.Collation) : null)
-            ?? (rightDefinition is not null ? NormalizeDeclaredCollation(rightDefinition.Collation) : null)
+            ?? leftDefinition?.Collation
+            ?? rightDefinition?.Collation
             ?? "BINARY";
-        if (!IsHashableJoinKeyCollation(collation) || IsUnsafeCompiledCollation(collation))
+        if (!allowUnhashableCollation
+            && (!IsHashableJoinKeyCollation(collation) || IsUnsafeCompiledCollation(collation)))
         {
             return null;
         }
@@ -30971,6 +32303,7 @@ out bool hasReturning)
             RightConvertsNumericToText: leftAffinity == ColumnAffinity.Text && rightAffinity is null,
             Collation: collation.ToUpperInvariant());
     }
+
 
     private static OutputColumn? ResolveJoinSideColumn(
         ColumnExpression operand,
@@ -39778,8 +41111,18 @@ out bool hasReturning)
             return;
         }
 
-        if (!_collations.ContainsKey(collation))
-            throw new EmbeddedSqlException($"no such collation sequence: {collation}");
+        if (_collations.ContainsKey(collation))
+            return;
+
+        // See _externalCollationResolver: an instance with no registrations of its own (the
+        // index-expression/predicate evaluator EmbeddedFileStore owns) still needs to recognize a
+        // name the owning connection has actually registered, or every partial-index predicate and
+        // expression-index key using a custom COLLATE would fail closed even while the callback is
+        // live.
+        if (_externalCollationResolver?.Invoke(collation) is not null)
+            return;
+
+        throw new EmbeddedSqlException($"no such collation sequence: {collation}");
     }
 
     private bool TryGetAggregateFunction(string name, int arity, out ManagedAggregateFunction function)
@@ -39806,6 +41149,26 @@ out bool hasReturning)
                 return InvokeManagedCallback(
                     () => compare(left.AsText(), right.AsText()));
             }
+
+            // Consult the external resolver BEFORE the built-in BINARY/NOCASE/RTRIM fallback.
+            // The own-registry check above only sees registrations made directly on this
+            // instance; the private index-expression/partial-predicate evaluator (see
+            // _externalCollationResolver) never registers anything of its own and relies
+            // entirely on this resolver to see the owning connection's actual collations —
+            // including an application override of a built-in name. Checking the hard-coded
+            // fallback first would let such a BINARY/NOCASE/RTRIM override silently miss inside
+            // a partial-index predicate or expression-index key while it is honored everywhere
+            // else. On the owning connection itself _externalCollationResolver is always null
+            // (it is only ever set via SetExternalCollationResolver on a throwaway evaluator
+            // instance) and any override is already caught by the own-registry check above, so
+            // this preserves ordinary EmbeddedDatabase.Compare precedence there. The resolver's
+            // own delegate already routes the invocation through the owning connection's
+            // InvokeManagedCallback (see BuildCollationResolver), so it is called directly
+            // rather than re-wrapped here.
+            var external = _externalCollationResolver?.Invoke(collation ?? "BINARY");
+            if (external is not null)
+                return external(left.AsText(), right.AsText());
+
             if (collation is null || string.Equals(collation, "BINARY", StringComparison.OrdinalIgnoreCase))
                 return string.CompareOrdinal(left.AsText(), right.AsText());
             if (string.Equals(collation, "NOCASE", StringComparison.OrdinalIgnoreCase))
@@ -46356,6 +47719,10 @@ public sealed partial class EmbeddedConnection : IDisposable
                     transaction.Catalog = pair.Value.Catalog;
                     previous.DisconnectOwnedVirtualTables(transaction.VirtualTableTransaction);
                     transaction.HasChanges = true;
+                    // Publishing a replaced trigger-body catalog is not a targeted index
+                    // rebuild: an earlier REINDEX in this same transaction must not cause
+                    // commit to skip persisting this catalog swap.
+                    transaction.HasNonTargetedIndexRebuildChange = true;
                     transaction.ForceFullCatalogRewrite |= pair.Value.ForceFullCatalogRewrite;
                     if (!ReferenceEquals(pair.Key, connection._tempDatabase))
                         connection._transactionWriteDatabase = pair.Key;
@@ -46492,7 +47859,14 @@ public sealed partial class EmbeddedConnection : IDisposable
         if (GetTransactionState(_tempDatabase) is { } state)
         {
             if (EmbeddedDatabase.RemoveForeignTargetTriggers(state.Catalog, schema, droppedName))
+            {
+                // Pruning a dangling temp trigger is a catalog mutation, not a targeted index
+                // rebuild: an earlier REINDEX in this same transaction must not cause commit
+                // to skip persisting this removal.
                 state.HasChanges = true;
+                state.HasNonTargetedIndexRebuildChange = true;
+            }
+
             return;
         }
 
@@ -47006,6 +48380,10 @@ public sealed partial class EmbeddedConnection : IDisposable
             state.Catalog = pending.Catalog;
             previous.DisconnectOwnedVirtualTables(state.VirtualTableTransaction);
             state.HasChanges = true;
+            // Rewriting the temp trigger catalog for a rename is not a targeted index
+            // rebuild: an earlier REINDEX in this same transaction must not cause commit
+            // to skip persisting this rewrite.
+            state.HasNonTargetedIndexRebuildChange = true;
             state.PragmaHeader = state.PragmaHeader with
             {
                 SchemaVersion = unchecked(state.PragmaHeader.SchemaVersion + 1),
@@ -47089,9 +48467,62 @@ public sealed partial class EmbeddedConnection : IDisposable
         public bool HasSnapshotPragmaHeader { get; set; }
         public bool HasSchemaChanges { get; set; }
         public bool ForceFullCatalogRewrite { get; set; }
+
+        /// <summary>
+        /// Index names a REINDEX statement anywhere in this transaction (or an enclosing
+        /// savepoint) targeted for an in-place rebuild, unioned across every such statement.
+        /// Deliberately just names, never the <see cref="EmbeddedTable"/>/<see
+        /// cref="EmbeddedIndex"/> objects a statement's <c>ExecutionResult</c> captured at the
+        /// time it ran: a later statement in the same transaction can still mutate that same
+        /// table, which would leave a captured object stale. Resolving these names against the
+        /// transaction's actual final catalog at commit (see the <c>CommitTransaction</c>
+        /// overload below) means intervening DML can never be rebuilt from stale data, and an
+        /// intervening schema/index change that drops or redefines the target is caught by
+        /// <c>EmbeddedFileStore.HasCurrentSchemaShape</c>'s existing schema-signature check,
+        /// which safely widens to the unconditional full-catalog rewrite
+        /// <see cref="ForceFullCatalogRewrite"/> already guarantees for any REINDEX.
+        /// </summary>
+        public HashSet<string> TargetedIndexRebuildNames { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Set whenever this transaction changed anything other than the ordinary index trees
+        /// named by <see cref="TargetedIndexRebuildNames"/> -- any INSERT/UPDATE/DELETE, pragma
+        /// header write, schema change, CDC record, virtual-table mutation, bare/collation
+        /// REINDEX, or a REINDEX that rebuilt a method index. A targeted, in-place index rebuild
+        /// (<c>EmbeddedFileStore.TryPersistTargetedIndexRebuild</c>) only ever rewrites the named
+        /// index trees themselves; it never re-derives or rewrites any table's row storage. If
+        /// commit only checked <see cref="TargetedIndexRebuildNames"/> for emptiness it would
+        /// silently drop every other durable change the moment a targeted REINDEX shares a
+        /// transaction with them -- the in-memory catalog would look correct until the store is
+        /// reopened, at which point the un-persisted DML/schema/CDC/virtual-table changes are
+        /// simply gone. Commit must therefore widen to the full-catalog rewrite (which
+        /// <see cref="ForceFullCatalogRewrite"/> already guarantees runs for any REINDEX) whenever
+        /// this is true, by treating <see cref="TargetedIndexRebuildNames"/> as empty.
+        /// </summary>
+        public bool HasNonTargetedIndexRebuildChange { get; set; }
         public HashSet<EmbeddedDatabase.ForeignKeyViolation> PendingDeferredViolations { get; } = [];
         public EmbeddedDatabase.ManagedVirtualTableTransaction VirtualTableTransaction { get; } = new();
+
+        /// <summary>
+        /// The durable pager read snapshot pinned at BEGIN for a file-backed transaction, coupled
+        /// to <see cref="Catalog"/>/<see cref="Version"/> at the same locked point in time. Also
+        /// populated for a concurrent (MVCC) transaction — a durable index accessor opened
+        /// against this snapshot merges lazily with visible <c>MvStore</c> effects instead of
+        /// materializing the base index (see <c>TryOpenConcurrentMvccIndexAccessor</c>). Null for
+        /// an in-memory/temp database. Disposed centrally in ResetTransactionState.
+        /// </summary>
+        public EmbeddedFileReadSnapshot? PinnedSnapshot { get; set; }
+
+        /// <summary>
+        /// Per-table mutation bookkeeping fed by every DML path a classic (non-MVCC) transaction
+        /// executes, so a durable index seek against <see cref="PinnedSnapshot"/> can merge in
+        /// read-your-writes without materializing the whole index. Always null for a concurrent
+        /// (MVCC) transaction — that transaction's own writes live in the attached <c>MvStore</c>
+        /// instead and are merged in via <c>ConcurrentMvStore</c>/<c>ConcurrentMvccTxId</c>.
+        /// </summary>
+        public TransactionMutationOverlay? Overlay { get; set; }
     }
+
 
     private readonly record struct RoutedStatement(
         EmbeddedDatabase Database,
@@ -47781,6 +49212,13 @@ public sealed partial class EmbeddedConnection : IDisposable
                 routed.Database.TransactionLock.ThrowIfReadBlocked(this, BusyTimeout);
                 TransactionDatabaseState? transactionState = null;
                 EmbeddedDatabase.SchemaCatalog? statementCatalog = null;
+                // Mirrors statementCatalog: captured before a mutating statement runs so every
+                // failure path that discards the cloned catalog also discards this statement's
+                // overlay writes (QueryContext.ReportRowChange mutates the overlay in place, with
+                // no clone-on-write of its own), and left alone on every path that keeps the
+                // catalog (success, and SQLite's ON CONFLICT FAIL / trigger-depth PreserveChanges
+                // semantics, which likewise keep the statement's partial catalog changes).
+                TransactionMutationOverlayCheckpoint? statementOverlayCheckpoint = null;
                 int? virtualTableTransactionCheckpoint = null;
                 var retainVirtualTableParticipation = false;
                 HashSet<EmbeddedDatabase.ForeignKeyViolation>? deferredBefore = null;
@@ -47888,6 +49326,9 @@ public sealed partial class EmbeddedConnection : IDisposable
                             statementCatalog = routedMayMutate
                                 ? transactionState.Catalog.Clone()
                                 : transactionState.Catalog;
+                            statementOverlayCheckpoint = routedMayMutate
+                                ? transactionState.Overlay?.CreateCheckpoint()
+                                : null;
                             result = routed.Database.Execute(
                                 routed.Statement,
                                 parameters,
@@ -47909,7 +49350,11 @@ public sealed partial class EmbeddedConnection : IDisposable
                                 concurrentMvccTxId: concurrentTxId,
                                 changeDataCapture: changeDataCapture,
                                 vdbeExecutionOptions: vdbeExecutionOptions,
-                                virtualTableTransaction: transactionState.VirtualTableTransaction);
+                                virtualTableTransaction: transactionState.VirtualTableTransaction,
+                                transactionOverlay: transactionState.Overlay,
+                                transactionPinnedSnapshot: transactionState.HasSchemaChanges
+                                    ? null
+                                    : transactionState.PinnedSnapshot);
                             if (routedMayMutate)
                                 cancellationToken.ThrowIfCancellationRequested();
                             // The catalog overload used for transactional statements does not
@@ -47948,6 +49393,20 @@ public sealed partial class EmbeddedConnection : IDisposable
                             retainVirtualTableParticipation = true;
                             transactionState.HasChanges = true;
                             transactionState.ForceFullCatalogRewrite |= result.ForceFullCatalogRewrite;
+                            if (result.TargetedIndexRebuild is { Count: > 0 } targetedThisStatement)
+                            {
+                                foreach (var target in targetedThisStatement)
+                                    transactionState.TargetedIndexRebuildNames.Add(target.Index.Name);
+                            }
+                            else
+                            {
+                                // Anything that changed but was not itself a pure, in-place
+                                // targeted index rebuild -- DML, schema/pragma changes, a
+                                // bare/collation REINDEX, or a REINDEX that rebuilt a method
+                                // index -- must widen commit off the targeted-rebuild-only
+                                // persistence path (see HasNonTargetedIndexRebuildChange).
+                                transactionState.HasNonTargetedIndexRebuildChange = true;
+                            }
                             if (!ReferenceEquals(routed.Database, _tempDatabase))
                                 _transactionWriteDatabase = routed.Database;
                             if (EmbeddedDatabase.MayChangeSchema(routed.Statement))
@@ -48011,6 +49470,10 @@ public sealed partial class EmbeddedConnection : IDisposable
                         concurrentStore,
                         concurrentTxId,
                         mvccStatementSavepoint);
+                    // The statement's cloned catalog is discarded (never written back), so its
+                    // overlay writes must be discarded too.
+                    if (statementOverlayCheckpoint is not null)
+                        transactionState?.Overlay?.RestoreCheckpoint(statementOverlayCheckpoint);
                     ReleaseConcurrentSchemaGateIfUnused();
                     throw new EmbeddedSqlException(exception.Message, exception.InnerException ?? exception);
                 }
@@ -48023,6 +49486,10 @@ public sealed partial class EmbeddedConnection : IDisposable
                         concurrentStore,
                         concurrentTxId,
                         mvccStatementSavepoint);
+                    // The statement's cloned catalog is discarded (never written back), so its
+                    // overlay writes must be discarded too.
+                    if (statementOverlayCheckpoint is not null)
+                        transactionState?.Overlay?.RestoreCheckpoint(statementOverlayCheckpoint);
                     ReleaseConcurrentSchemaGateIfUnused();
                     ExceptionDispatchInfo.Capture(exception.Failure).Throw();
                     throw new InvalidOperationException("ExceptionDispatchInfo.Throw unexpectedly returned.");
@@ -48046,6 +49513,11 @@ public sealed partial class EmbeddedConnection : IDisposable
                             transactionState.VirtualTableTransaction);
                         retainVirtualTableParticipation = true;
                         transactionState.HasChanges = true;
+                        // A conflict-fail rollback still preserves earlier statements' partial
+                        // row changes in this transaction: that is table DML, never a targeted
+                        // index rebuild, so an earlier REINDEX in this transaction must not
+                        // cause commit to silently omit it (see HasNonTargetedIndexRebuildChange).
+                        transactionState.HasNonTargetedIndexRebuildChange = true;
                         if (!ReferenceEquals(routed.Database, _tempDatabase))
                             _transactionWriteDatabase = routed.Database;
                     }
@@ -48080,6 +49552,10 @@ public sealed partial class EmbeddedConnection : IDisposable
                             transactionState.VirtualTableTransaction);
                         retainVirtualTableParticipation = true;
                         transactionState.HasChanges = true;
+                        // Preserving the partial recursive-trigger mutation is table DML, never
+                        // a targeted index rebuild: an earlier REINDEX in this same transaction
+                        // must not cause commit to silently omit it.
+                        transactionState.HasNonTargetedIndexRebuildChange = true;
                         if (!ReferenceEquals(routed.Database, _tempDatabase))
                             _transactionWriteDatabase = routed.Database;
                         tempTriggerSession?.Commit();
@@ -48095,6 +49571,11 @@ public sealed partial class EmbeddedConnection : IDisposable
                             concurrentStore,
                             concurrentTxId,
                             mvccStatementSavepoint);
+                        // The catalog is discarded (never written back) when a recursive-trigger
+                        // abort does not preserve changes, so the overlay must discard this
+                        // statement's writes too.
+                        if (statementOverlayCheckpoint is not null)
+                            transactionState?.Overlay?.RestoreCheckpoint(statementOverlayCheckpoint);
                     }
                     else
                     {
@@ -48130,6 +49611,10 @@ public sealed partial class EmbeddedConnection : IDisposable
                         concurrentStore,
                         concurrentTxId,
                         mvccStatementSavepoint);
+                    // Any other statement failure discards the cloned catalog (never written
+                    // back), so the overlay must discard this statement's writes too.
+                    if (statementOverlayCheckpoint is not null)
+                        transactionState?.Overlay?.RestoreCheckpoint(statementOverlayCheckpoint);
                     ReleaseConcurrentSchemaGateIfUnused();
                     throw;
                 }
@@ -48358,6 +49843,9 @@ public sealed partial class EmbeddedConnection : IDisposable
         _transactionWriteDatabase = _database;
         state.PragmaHeader = new PragmaHeaderMetadata(schemaVersion, userVersion, applicationId);
         state.HasChanges = true;
+        // A pragma header write is never a targeted index rebuild: an earlier REINDEX in this
+        // same transaction must not cause commit to skip persisting this header change.
+        state.HasNonTargetedIndexRebuildChange = true;
         state.HasSnapshotPragmaHeader = true;
     }
 
@@ -48907,6 +50395,18 @@ public sealed partial class EmbeddedConnection : IDisposable
                             catalog = null;
                             state.HasChanges = true;
                             state.ForceFullCatalogRewrite |= result.ForceFullCatalogRewrite;
+                            if (result.TargetedIndexRebuild is { Count: > 0 } targetedThisDatabase)
+                            {
+                                foreach (var target in targetedThisDatabase)
+                                    state.TargetedIndexRebuildNames.Add(target.Index.Name);
+                            }
+                            else
+                            {
+                                // A bare/collation REINDEX that fanned out to this database, or one
+                                // that rebuilt a method index, is not a pure targeted rebuild -- see
+                                // HasNonTargetedIndexRebuildChange.
+                                state.HasNonTargetedIndexRebuildChange = true;
+                            }
                             if (!ReferenceEquals(database, _tempDatabase))
                                 _transactionWriteDatabase = database;
                         }
@@ -48984,6 +50484,11 @@ public sealed partial class EmbeddedConnection : IDisposable
                             previous.DisconnectOwnedVirtualTables(state.VirtualTableTransaction);
                             catalog = null;
                             state.HasChanges = true;
+                            // PRAGMA optimize never reports a TargetedIndexRebuild (only the
+                            // REINDEX statement path populates that): any change here is a full
+                            // schema/index rebuild, so an earlier REINDEX in this same
+                            // transaction must not cause commit to skip persisting it.
+                            state.HasNonTargetedIndexRebuildChange = true;
                             if (!ReferenceEquals(database, _tempDatabase))
                                 _transactionWriteDatabase = database;
                         }
@@ -51030,14 +52535,53 @@ Func<string, ParsedStatement> rewrite)
                         states.Add(database, new TransactionDatabaseState(
                             concurrentSnapshot.Snapshot.Catalog,
                             concurrentSnapshot.Snapshot.Version,
-                            concurrentSnapshot.Snapshot.PragmaHeader));
+                            concurrentSnapshot.Snapshot.PragmaHeader)
+                        {
+                            // MVCC-eligible index joins/scans read through this pinned durable
+                            // snapshot merged lazily with visible MvStore effects instead of
+                            // materializing the base index; Overlay stays null for a concurrent
+                            // transaction (that gate is exclusively for the classic path).
+                            PinnedSnapshot = concurrentSnapshot.PinnedSnapshot,
+                        });
                     }
-                    catch
+                    catch (Exception primaryFailure)
                     {
                         mvccTxs.Remove(database);
-                        database.MvStore?.Rollback(concurrentSnapshot.TransactionId);
-                        database.EndTransaction();
-                        throw;
+                        // Both cleanup steps must be attempted even if the first throws: a
+                        // failing MVCC rollback must never skip EndTransaction and leak this
+                        // database's active-transaction count registration.
+                        List<Exception>? cleanupFailures = null;
+                        try
+                        {
+                            concurrentSnapshot.PinnedSnapshot?.Dispose();
+                        }
+                        catch (Exception exception)
+                        {
+                            (cleanupFailures ??= []).Add(exception);
+                        }
+
+                        try
+                        {
+                            database.MvStore?.Rollback(concurrentSnapshot.TransactionId);
+                        }
+                        catch (Exception exception)
+                        {
+                            (cleanupFailures ??= []).Add(exception);
+                        }
+
+                        try
+                        {
+                            database.EndTransaction();
+                        }
+                        catch (Exception exception)
+                        {
+                            (cleanupFailures ??= []).Add(exception);
+                        }
+
+                        if (cleanupFailures is null)
+                            throw;
+
+                        throw new AggregateException([primaryFailure, .. cleanupFailures]);
                     }
                     continue;
                 }
@@ -51049,23 +52593,130 @@ Func<string, ParsedStatement> rewrite)
                     mvccTxs.Add(database, tx.Id);
                 }
 
-                var snapshot = database.CreateTransactionSnapshot(busyTimeout: BusyTimeout);
-                states.Add(database, new TransactionDatabaseState(
-                    snapshot.Catalog,
-                    snapshot.Version,
-                    snapshot.PragmaHeader));
+                var (snapshot, pinnedSnapshot) = database.CreateTransactionSnapshotWithPin(busyTimeout: BusyTimeout);
+                try
+                {
+                    states.Add(database, new TransactionDatabaseState(
+                        snapshot.Catalog,
+                        snapshot.Version,
+                        snapshot.PragmaHeader)
+                    {
+                        PinnedSnapshot = pinnedSnapshot,
+                        Overlay = pinnedSnapshot is not null ? new TransactionMutationOverlay() : null,
+                    });
+                }
+                catch (Exception primaryFailure)
+                {
+                    // CreateTransactionSnapshotWithPin already registered this database as an
+                    // active transaction and cloned its catalog before returning; if adding the
+                    // resulting state fails, this database is never recorded in states, so the
+                    // outer catch below (which only walks states.Values/Keys) would otherwise
+                    // never see it and would leak the pinned snapshot and the active-transaction
+                    // count for it. Every cleanup step below must be attempted even if an earlier
+                    // one throws — in particular EndTransaction must always run, so a failing
+                    // virtual-table disconnect can never leak the active-transaction count this
+                    // method already bumped — so failures are collected and combined with the
+                    // original failure rather than one throw short-circuiting the rest.
+                    List<Exception>? cleanupFailures = null;
+                    try
+                    {
+                        pinnedSnapshot?.Dispose();
+                    }
+                    catch (Exception exception)
+                    {
+                        (cleanupFailures ??= []).Add(exception);
+                    }
+
+                    try
+                    {
+                        snapshot.Catalog.DisconnectOwnedVirtualTables();
+                    }
+                    catch (Exception exception)
+                    {
+                        (cleanupFailures ??= []).Add(exception);
+                    }
+
+                    try
+                    {
+                        database.EndTransaction();
+                    }
+                    catch (Exception exception)
+                    {
+                        (cleanupFailures ??= []).Add(exception);
+                    }
+
+                    if (cleanupFailures is null)
+                        throw;
+
+                    throw new AggregateException([primaryFailure, .. cleanupFailures]);
+                }
             }
         }
-        catch
+        catch (Exception primaryFailure)
         {
+            // Every step below must be attempted for every database/state even if an earlier
+            // one throws: a failing disconnect/dispose for one database must never skip
+            // EndTransaction (leaking its active-transaction count) or
+            // ReleaseTransactionWriteReservations (leaking a write reservation) for the rest.
+            List<Exception>? cleanupFailures = null;
             foreach (var (database, txId) in mvccTxs)
-                database.MvStore?.Rollback(txId);
+            {
+                try
+                {
+                    database.MvStore?.Rollback(txId);
+                }
+                catch (Exception exception)
+                {
+                    (cleanupFailures ??= []).Add(exception);
+                }
+            }
+
             foreach (var state in states.Values)
-                state.Catalog.DisconnectOwnedVirtualTables();
+            {
+                try
+                {
+                    state.Catalog.DisconnectOwnedVirtualTables();
+                }
+                catch (Exception exception)
+                {
+                    (cleanupFailures ??= []).Add(exception);
+                }
+
+                try
+                {
+                    state.PinnedSnapshot?.Dispose();
+                }
+                catch (Exception exception)
+                {
+                    (cleanupFailures ??= []).Add(exception);
+                }
+            }
+
             foreach (var database in states.Keys)
-                database.EndTransaction();
-            ReleaseTransactionWriteReservations();
-            throw;
+            {
+                try
+                {
+                    database.EndTransaction();
+                }
+                catch (Exception exception)
+                {
+                    (cleanupFailures ??= []).Add(exception);
+                }
+            }
+
+            try
+            {
+                ReleaseTransactionWriteReservations();
+            }
+            catch (Exception exception)
+            {
+                (cleanupFailures ??= []).Add(exception);
+            }
+
+            if (cleanupFailures is null)
+                throw;
+
+            throw new AggregateException([primaryFailure, .. cleanupFailures]);
         }
 
         _transactionDatabases = states;
@@ -51372,6 +53023,26 @@ Func<string, ParsedStatement> rewrite)
         store.BeginSchemaChange(txId, BusyTimeout);
         try
         {
+            // The durable pager read snapshot pinned at BEGIN CONCURRENT (see
+            // BeginConcurrentTransactionSnapshotLocked) holds an open pager read
+            // transaction on this very connection. A schema-changing transaction's
+            // frozen snapshot predates the schema generation it is about to publish,
+            // so a page-native index join/scan has nothing useful left to read from
+            // it anyway once DDL starts. Release it before the TRUNCATE checkpoint
+            // below so this transaction's own reader can never be mistaken for a
+            // foreign one blocking its own schema-change checkpoint — TRUNCATE
+            // requires zero active pager readers, and before this snapshot existed
+            // an MVCC transaction never held one, so this call always used to see
+            // zero readers from itself. Falling back to the non-page-native merge
+            // path for the remainder of this (already schema-changing) transaction
+            // is the correct, conservative behavior here.
+            if (_transactionDatabases is not null
+                && _transactionDatabases.TryGetValue(_database, out var schemaOwnerState))
+            {
+                schemaOwnerState.PinnedSnapshot?.Dispose();
+                schemaOwnerState.PinnedSnapshot = null;
+            }
+
             // Retire every older logical frame before the private catalog can
             // diverge. The owner transaction is admitted only as a frozen
             // snapshot; its uncommitted versions are excluded from collection.
@@ -51428,6 +53099,10 @@ Func<string, ParsedStatement> rewrite)
             if (changeDataCapture.CompleteExplicitTransaction(cdcState.Catalog.Tables, cdcStore, cdcTxId))
             {
                 cdcState.HasChanges = true;
+                // Appending a CDC record is never a targeted index rebuild: an earlier
+                // REINDEX in this same transaction must not cause commit to skip
+                // persisting it.
+                cdcState.HasNonTargetedIndexRebuildChange = true;
                 _transactionWriteDatabase = _database;
             }
         }
@@ -51494,6 +53169,17 @@ Func<string, ParsedStatement> rewrite)
             .Where(pair => ReferenceEquals(pair.Key, _tempDatabase))
             .Select(pair => pair.Value)
             .SingleOrDefault();
+
+        // Release every pinned snapshot before the durable WAL commit below: post-commit
+        // checkpoint maintenance requires that this connection hold no outstanding pager reader
+        // of its own, and by this point deferred FK validation and the commit hook have already
+        // run any query that might have needed the transaction's own read-your-writes overlay.
+        foreach (var pinnedState in _transactionDatabases.Values)
+        {
+            pinnedState.PinnedSnapshot?.Dispose();
+            pinnedState.PinnedSnapshot = null;
+        }
+
         ExceptionDispatchInfo? deferredMaintenanceFailure = null;
         var schemaCatalogWasPublished = false;
         try
@@ -51513,7 +53199,18 @@ Func<string, ParsedStatement> rewrite)
                         busyTimeout: BusyTimeout,
                         concurrent: _transactionIsConcurrent,
                         containsSchemaChanges: state.HasSchemaChanges,
-                        synchronousMode: GetSynchronousMode(database));
+                        synchronousMode: GetSynchronousMode(database),
+                        // A targeted, in-place index rebuild never rewrites table row storage, so
+                        // it must never be attempted as the sole persistence path when anything
+                        // else in this transaction also changed durable state -- see
+                        // HasNonTargetedIndexRebuildChange. Passing null here (rather than an
+                        // empty set) makes EmbeddedFileStore.PersistCore skip the targeted attempt
+                        // entirely and fall through to the full-catalog rewrite that
+                        // ForceFullCatalogRewrite already forces for any REINDEX, so every
+                        // coexisting change is persisted atomically alongside the rebuilt index.
+                        targetedIndexRebuildNames: state.HasNonTargetedIndexRebuildChange
+                            ? null
+                            : state.TargetedIndexRebuildNames);
                 }
                 catch (EmbeddedPostCommitMaintenanceException failure)
                 {
@@ -51725,6 +53422,9 @@ Func<string, ParsedStatement> rewrite)
             EnsureTransactionMayMutate(database, statement);
             transactionState.PragmaHeader = updated;
             transactionState.HasChanges = true;
+            // A pragma header write is never a targeted index rebuild: an earlier REINDEX in
+            // this same transaction must not cause commit to skip persisting this header change.
+            transactionState.HasNonTargetedIndexRebuildChange = true;
             transactionState.HasSnapshotPragmaHeader = true;
             if (!ReferenceEquals(database, _tempDatabase))
                 _transactionWriteDatabase = database;
@@ -52449,7 +54149,12 @@ Func<string, ParsedStatement> rewrite)
                         pair.Value.ForceFullCatalogRewrite,
                         pair.Value.VirtualTableTransaction.CreateCheckpoint(),
                         new HashSet<EmbeddedDatabase.ForeignKeyViolation>(
-                            pair.Value.PendingDeferredViolations)));
+                            pair.Value.PendingDeferredViolations),
+                        pair.Value.Overlay?.CreateCheckpoint(),
+                        new HashSet<string>(
+                            pair.Value.TargetedIndexRebuildNames,
+                            StringComparer.OrdinalIgnoreCase),
+                        pair.Value.HasNonTargetedIndexRebuildChange));
             }
 
             _savepoints.Add(new SavepointEntry(
@@ -52513,6 +54218,21 @@ Func<string, ParsedStatement> rewrite)
             state.ForceFullCatalogRewrite = savedState.ForceFullCatalogRewrite;
             state.PendingDeferredViolations.Clear();
             state.PendingDeferredViolations.UnionWith(savedState.PendingDeferredViolations);
+            state.TargetedIndexRebuildNames.Clear();
+            state.TargetedIndexRebuildNames.UnionWith(savedState.TargetedIndexRebuildNames);
+            state.HasNonTargetedIndexRebuildChange = savedState.HasNonTargetedIndexRebuildChange;
+            if (state.Overlay is not null && savedState.OverlayCheckpoint is not null)
+            {
+                state.Overlay.RestoreCheckpoint(
+                    savedState.OverlayCheckpoint,
+                    tableName => database.CreatePrimaryKeyRecordComparer(
+                        state.Catalog.Tables.TryGetValue(tableName, out var restoredTable)
+                            ? restoredTable.PrimaryKeySchema
+                                ?? throw new InvalidOperationException(
+                                    $"WITHOUT ROWID table '{tableName}' is missing its primary-key metadata.")
+                            : throw new InvalidOperationException(
+                                $"Restoring the mutation overlay for table '{tableName}' requires it to exist in the restored catalog.")));
+            }
         }
         _transactionWriteDatabase = savepoint.WriteDatabase;
         if (_changeDataCapture is { } changeDataCapture
@@ -52577,23 +54297,69 @@ Func<string, ParsedStatement> rewrite)
             _mvccTransactions.Clear();
         }
 
+        // Every step below must run even if an earlier one throws — most notably a
+        // virtual-table module's own Rollback callback, which is arbitrary user/extension code.
+        // Losing the rest of this cleanup to one throwing callback would leak pinned snapshots
+        // (an open pager read mark) and write reservations, and would skip EndTransaction,
+        // leaking the active-transaction count forever. Only the first exception is preserved
+        // (matching the ManagedVirtualTableTransaction.Complete idiom used elsewhere in this
+        // file) and rethrown only after every deterministic cleanup step below has run.
+        ExceptionDispatchInfo? failure = null;
+
         if (transactionDatabases is not null)
         {
             if (rollbackVirtualTables)
             {
                 foreach (var state in transactionDatabases.Values)
-                    state.VirtualTableTransaction.Rollback(state.Catalog);
+                {
+                    try
+                    {
+                        state.VirtualTableTransaction.Rollback(state.Catalog);
+                    }
+                    catch (Exception exception)
+                    {
+                        failure ??= ExceptionDispatchInfo.Capture(exception);
+                    }
+                }
             }
 
             foreach (var state in transactionDatabases.Values)
-                state.Catalog.DisconnectOwnedVirtualTables();
+            {
+                try
+                {
+                    state.Catalog.DisconnectOwnedVirtualTables();
+                }
+                catch (Exception exception)
+                {
+                    failure ??= ExceptionDispatchInfo.Capture(exception);
+                }
+
+                try
+                {
+                    state.PinnedSnapshot?.Dispose();
+                }
+                catch (Exception exception)
+                {
+                    failure ??= ExceptionDispatchInfo.Capture(exception);
+                }
+            }
         }
 
         foreach (var savepoint in _savepoints)
         {
             foreach (var state in savepoint.Databases.Values)
-                state.Catalog.DisconnectOwnedVirtualTables();
+            {
+                try
+                {
+                    state.Catalog.DisconnectOwnedVirtualTables();
+                }
+                catch (Exception exception)
+                {
+                    failure ??= ExceptionDispatchInfo.Capture(exception);
+                }
+            }
         }
+
         _savepoints.Clear();
         _changeDataCapture?.ResetTransaction();
         _deferForeignKeys = false;
@@ -52601,8 +54367,19 @@ Func<string, ParsedStatement> rewrite)
         if (transactionDatabases is not null)
         {
             foreach (var database in transactionDatabases.Keys)
-                database.EndTransaction();
+            {
+                try
+                {
+                    database.EndTransaction();
+                }
+                catch (Exception exception)
+                {
+                    failure ??= ExceptionDispatchInfo.Capture(exception);
+                }
+            }
         }
+
+        failure?.Throw();
     }
 
     private sealed record SavepointEntry(
@@ -52619,7 +54396,10 @@ Func<string, ParsedStatement> rewrite)
         bool HasSchemaChanges,
         bool ForceFullCatalogRewrite,
         int VirtualTableTransactionCheckpoint,
-        IReadOnlySet<EmbeddedDatabase.ForeignKeyViolation> PendingDeferredViolations);
+        IReadOnlySet<EmbeddedDatabase.ForeignKeyViolation> PendingDeferredViolations,
+        TransactionMutationOverlayCheckpoint? OverlayCheckpoint,
+        IReadOnlySet<string> TargetedIndexRebuildNames,
+        bool HasNonTargetedIndexRebuildChange);
 
     private void ThrowIfRecursiveTriggerCallbackReentry()
     {
@@ -53108,9 +54888,35 @@ public sealed class EmbeddedStatement : IDisposable
 // without hunting down each individual mutation site.
 internal sealed class RowStore : IList<SqlValue[]>, IReadOnlyList<SqlValue[]>
 {
+    private static long _lineageSequence;
+
     private readonly List<SqlValue[]> _rows = [];
 
     public long Revision { get; private set; }
+
+    /// <summary>
+    /// Identifies this specific RowStore instance's physical storage lineage, distinct from
+    /// <see cref="Revision"/>. Assigned fresh, process-uniquely, whenever a RowStore is
+    /// constructed, and copied forward only by <see cref="ReplaceContentsPreservingRevision"/> —
+    /// i.e. only <see cref="EmbeddedTable.Clone"/>'s same-statement working copy carries the
+    /// same LineageId as its source; every other path that builds a replacement
+    /// <see cref="EmbeddedTable"/> (ALTER COLUMN, ADD/DROP COLUMN, or any other full rebuild that
+    /// re-adds every row into a brand-new RowStore) gets a distinct one.
+    /// </summary>
+    /// <remarks>
+    /// Revision alone cannot distinguish "the same physical row store, unchanged since the
+    /// previous commit" from "a brand-new row store that coincidentally replayed the same number
+    /// of mutations." For example, <c>EmbeddedTable.CreateWithAlteredColumn</c> rebuilds every row
+    /// via <see cref="Add"/> into a fresh RowStore: a table with N rows and no prior
+    /// updates/deletes has Revision == N both before and after an ALTER COLUMN, even though every
+    /// row's bytes may have changed under the new column's affinity/type — and the table's
+    /// <c>Indexes</c> list is carried forward by reference, so an index-reference check alone
+    /// would not catch it either. Comparing LineageId closes that gap: it can only ever match
+    /// when the very same in-memory RowStore was carried forward, never across a rebuild that
+    /// constructs a new one — see
+    /// <see cref="EmbeddedFileStore.IsTableRowStorageUnchangedFromPrevious"/>.
+    /// </remarks>
+    public long LineageId { get; private set; } = Interlocked.Increment(ref _lineageSequence);
 
     public int Count => _rows.Count;
 
@@ -53172,6 +54978,27 @@ internal sealed class RowStore : IList<SqlValue[]>, IReadOnlyList<SqlValue[]>
     {
         _rows.RemoveAt(index);
         Revision++;
+    }
+
+    // EmbeddedTable.Clone() deep-copies every table in the working catalog on every
+    // statement (so a rolled-back statement never mutates the live, published catalog),
+    // even tables the statement never touches. Populating the clone through the ordinary
+    // Add() path would bump Revision once per copied row, making a fully-untouched clone's
+    // Revision diverge from its source (row count vs. the source's full mutation history)
+    // and defeating any same-instance staleness check built on it. Copying the rows
+    // directly and assigning Revision verbatim instead means an untouched clone keeps
+    // exactly its source's Revision, so a later mutation (via the ordinary Add/Insert/
+    // Remove/indexer members, all of which still bump Revision as usual) is the only thing
+    // that can make it diverge again. LineageId is carried forward the same way, so a
+    // same-statement clone also keeps proving "this is still the very same physical row
+    // store" even when Revision alone would be ambiguous (see LineageId's doc comment).
+    internal void ReplaceContentsPreservingRevision(RowStore source)
+    {
+        _rows.Clear();
+        foreach (var row in source._rows)
+            _rows.Add(row.ToArray());
+        Revision = source.Revision;
+        LineageId = source.LineageId;
     }
 
     System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
@@ -55400,8 +57227,7 @@ internal sealed class EmbeddedTable
             Strict);
         clone.SchemaSqlCompact = SchemaSqlCompact;
         clone.Sql = Sql;
-        foreach (var row in Rows)
-            clone.Rows.Add(row.ToArray());
+        clone.Rows.ReplaceContentsPreservingRevision(Rows);
 
         clone.RowIds.AddRange(RowIds);
         clone.Indexes.RemoveAll(index => index.Origin == EmbeddedIndexOrigin.Explicit);
@@ -55781,7 +57607,8 @@ internal sealed record ExecutionResult(
     IReadOnlyList<SqlValue[]> Rows,
     int RowsAffected,
     bool Changed = false,
-    bool ForceFullCatalogRewrite = false)
+    bool ForceFullCatalogRewrite = false,
+    IReadOnlyList<(string TableName, EmbeddedTable Table, EmbeddedIndex Index)>? TargetedIndexRebuild = null)
 {
     public static ExecutionResult Empty { get; } = new([], [], 0);
 

--- a/src/Ahtola.Core/EmbeddedFileStore.cs
+++ b/src/Ahtola.Core/EmbeddedFileStore.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Runtime.ExceptionServices;
+using System.Text;
 using Ahtola.Core.Parsing;
 using Ahtola.Core.Storage;
 
@@ -13,7 +14,7 @@ internal sealed record EmbeddedFileCatalog(
     Dictionary<string, TriggerDefinition> Triggers,
     Dictionary<string, EmbeddedDatabase.VirtualTableDefinition> VirtualTables);
 
-internal sealed record EmbeddedFileIndexSeekRow(SqlValue[] Values, long RowId);
+internal sealed record EmbeddedFileIndexSeekRow(SqlValue[] Values, long? RowId);
 
 internal sealed class EmbeddedFileIndexAccessor(
     Func<
@@ -37,14 +38,51 @@ internal sealed class EmbeddedFileIndexAccessor(
     public void Dispose() => close();
 }
 
+/// <summary>
+/// Durable full-ascending-order scan handle over an index's (or a WITHOUT ROWID table's own
+/// primary-key b-tree's) entire committed b-tree — the "no known equality prefix" sibling of
+/// <see cref="EmbeddedFileIndexAccessor"/>, used for ORDER BY elision / unconstrained MVCC merge
+/// scans that would otherwise have to materialize and sort every row in memory.
+/// </summary>
+internal sealed class EmbeddedFileIndexFullScanAccessor(
+    Func<Action?, Action?, IEnumerable<EmbeddedFileIndexSeekRow>> scan,
+    Action open,
+    Action close) : IDisposable
+{
+    public void Open() => open();
+
+    public IEnumerable<EmbeddedFileIndexSeekRow> Scan(
+        Action? pageRead = null,
+        Action? tableRowFetched = null)
+        => scan(pageRead, tableRowFetched);
+
+    public void Dispose() => close();
+}
+
 internal sealed class EmbeddedFileReadSnapshot(
     EmbeddedFileStore owner,
     SqlitePagerReadTransaction transaction,
-    ISqliteBtreePageIo pageIo) : IDisposable
+    ISqliteBtreePageIo pageIo,
+    IReadOnlyDictionary<string, uint> tableRootPages,
+    IReadOnlyDictionary<string, uint> indexRootPages) : IDisposable
 {
     internal EmbeddedFileStore Owner { get; } = owner;
 
     internal ISqliteBtreePageIo PageIo { get; } = pageIo;
+
+    /// <summary>
+    /// The table root-page mapping captured atomically with <see cref="PageIo"/>'s pager
+    /// transaction (same locked section as the catalog clone — see
+    /// <see cref="EmbeddedDatabase.CreateTransactionSnapshotWithPin"/>). A pinned classic
+    /// transaction must resolve root pages from here, never from the store's live
+    /// <c>_tableRootPages</c>, so a peer's later DDL — including a drop/recreate that reuses the
+    /// same table name with a new root page — cannot redirect this snapshot's pager reads onto a
+    /// page that has nothing to do with the table this snapshot was pinned against.
+    /// </summary>
+    internal IReadOnlyDictionary<string, uint> TableRootPages { get; } = tableRootPages;
+
+    /// <summary>Same generation-bound guarantee as <see cref="TableRootPages"/>, for named secondary indexes.</summary>
+    internal IReadOnlyDictionary<string, uint> IndexRootPages { get; } = indexRootPages;
 
     public void Dispose() => transaction.Dispose();
 }
@@ -167,6 +205,17 @@ internal sealed class EmbeddedFileStore : IDisposable
     private Dictionary<string, uint> _indexRootPages = new(StringComparer.OrdinalIgnoreCase);
     private string _lastSchemaSignature = string.Empty;
 
+    // Resolves an application-defined (non-built-in) collation name to a
+    // ready-to-call comparison delegate, or null when no callback is
+    // currently registered for that name. Attached by EmbeddedDatabase after
+    // construction, because this store opens and loads the file catalog
+    // before any owning database exists to register collation callbacks
+    // against. A store with no resolver attached (the true cold-start path)
+    // structurally validates custom-collation index pages/records but defers
+    // ordering/content/uniqueness validation for them; see
+    // ValidateIndexRepresentable and ValidateStoredIndex.
+    private Func<string, Func<string, string, int>?>? _collationResolver;
+
     // The exact table dictionary whose contents this store last made durable.
     // Reference identity is the only admissible proof that a caller's "previous"
     // catalog really is the committed one, so an incremental write can compute
@@ -191,6 +240,31 @@ internal sealed class EmbeddedFileStore : IDisposable
     }
 
     /// <summary>
+    /// Attaches (or clears, when <paramref name="resolver"/> is
+    /// <see langword="null"/>) the runtime collation resolver used to bind
+    /// application-defined collation names to comparison delegates for
+    /// index build/write/seek. The owning <c>EmbeddedDatabase</c> calls this
+    /// immediately after construction and again whenever a collation
+    /// callback is registered, replaced, or unregistered.
+    /// </summary>
+    /// <remarks>
+    /// Also forwards the same resolver to <see cref="_indexExpressionEvaluator"/> — a private,
+    /// throwaway <c>EmbeddedDatabase</c> this store owns purely to evaluate partial-index
+    /// predicates and index expressions, which never receives the application's
+    /// <c>RegisterCollation</c> calls directly. Without this, a partial predicate or expression
+    /// index key referencing a custom COLLATE would fail "no such collation sequence" while
+    /// evaluating through that private instance even though the exact same collation is fully
+    /// registered and active on the owning connection. A missing callback still fails closed,
+    /// but only lazily: the first time the affected expression/predicate is actually evaluated,
+    /// never eagerly at store-open time.
+    /// </remarks>
+    internal void SetCollationResolver(Func<string, Func<string, string, int>?>? resolver)
+    {
+        _collationResolver = resolver;
+        _indexExpressionEvaluator.SetExternalCollationResolver(resolver);
+    }
+
+    /// <summary>
     /// Opens (or creates) the managed file database and reconstructs its catalog
     /// from the committed SQLite pages.
     /// </summary>
@@ -204,7 +278,8 @@ internal sealed class EmbeddedFileStore : IDisposable
         SqliteTextEncoding? initialTextEncoding = null,
         bool foreignReadOnly = false,
         IPageCodec? pageCodec = null,
-        bool createRollbackJournalMode = false)
+        bool createRollbackJournalMode = false,
+        Func<string, Func<string, string, int>?>? collationResolver = null)
     {
         ArgumentException.ThrowIfNullOrEmpty(path);
         ArgumentNullException.ThrowIfNull(fileSystem);
@@ -286,6 +361,14 @@ internal sealed class EmbeddedFileStore : IDisposable
         {
             var header = SqliteDatabaseHeader.Parse(pager.ReadCommittedPage(SchemaRootPage));
             var store = new EmbeddedFileStore(fileSystem, path, walPath, pager, header);
+            // Attaching the resolver before the catalog load lets a reopen on an
+            // existing connection (which already knows its registered
+            // collations) validate custom-collation index order/content/
+            // uniqueness immediately instead of deferring; the true cold-start
+            // path (a brand-new connection with no owning EmbeddedDatabase yet)
+            // passes null here and defers structurally, per
+            // ValidateIndexRepresentable/ValidateStoredIndex.
+            store.SetCollationResolver(collationResolver);
             catalog = store.Load();
             return store;
         }
@@ -315,20 +398,53 @@ internal sealed class EmbeddedFileStore : IDisposable
     /// </summary>
     internal long CommittedViewGeneration => _pager.CommittedViewGeneration;
 
-    internal bool CanOpenIndexAccessor(EmbeddedTable table, EmbeddedIndex index)
+    /// <summary>
+    /// Answers "can the pager physically seek this table's committed durable b-tree", either for
+    /// a named secondary index (<paramref name="index"/> non-null, rowid or WITHOUT ROWID) or, when
+    /// <paramref name="index"/> is <see langword="null"/>, for a WITHOUT ROWID table's own primary-key
+    /// b-tree (the table's root page, which the managed engine already stores as an index b-tree keyed
+    /// by <see cref="EmbeddedTable.PrimaryKeySchema"/>).
+    /// </summary>
+    internal bool CanOpenIndexAccessor(
+        EmbeddedTable table,
+        EmbeddedIndex? index,
+        bool requireCommittedTableIdentity = true)
     {
         ArgumentNullException.ThrowIfNull(table);
-        ArgumentNullException.ThrowIfNull(index);
-        return !_disposed
-            && table.HasRowid
+        // A classic transaction's QueryContext.Tables is built from a cloned SchemaCatalog, so its
+        // EmbeddedTable is never the same object as the one this store committed even when nothing
+        // schema-relevant changed. The transaction-overlay caller passes false here and instead
+        // relies on the transaction's own "no schema changes this transaction" gate for safety, so
+        // relaxing this check to a name-based existence test is sound: everything downstream already
+        // matches indexes/tables by name (see the persistedIndex lookup below), not by reference.
+        var committed = !_disposed
+            && _committedTables is not null
+            && (requireCommittedTableIdentity
+                ? _committedTables.TryGetValue(table.Name, out var committedTable) && ReferenceEquals(committedTable, table)
+                : _committedTables.ContainsKey(table.Name))
+            && _tableRootPages.ContainsKey(table.Name);
+        if (index is null)
+        {
+            return committed
+                && table.WithoutRowid
+                && table.PrimaryKeySchema is { Terms.Count: > 0 };
+        }
+
+        // Partial and expression index columns are both safe to seek here: the persisted b-tree
+        // holds whatever rows/values were computed when the row was written (see
+        // TryBuildIndexRecord), so a seek never has to re-evaluate a predicate or an expression at
+        // read time. Query-level safety (partial-predicate implication, expression-operand
+        // matching, keeping expression indexes non-covering) is enforced by the caller before it
+        // ever asks to open an accessor; this method only answers "can the pager physically seek
+        // this index's committed b-tree". WITHOUT ROWID secondary indexes are just as physically
+        // seekable as rowid ones: their records always carry the table's primary-key columns
+        // (see GetWithoutRowidIndexStorageColumns), so the PK-driven table-root lookup they need
+        // for a non-covering fetch is always possible.
+        return committed
             && !index.IsMethodIndex
             && index.Columns.Count > 0
-            && index.Columns.All(static column => !column.IsExpression)
-            && _committedTables is not null
-            && _committedTables.TryGetValue(table.Name, out var committed)
-            && ReferenceEquals(committed, table)
-            && _tableRootPages.ContainsKey(table.Name)
-            && _indexRootPages.ContainsKey(index.Name);
+            && _indexRootPages.ContainsKey(index.Name)
+            && (!table.WithoutRowid || table.PrimaryKeySchema is { Terms.Count: > 0 });
     }
 
     internal bool TryOpenReadSnapshot(
@@ -346,6 +462,21 @@ internal sealed class EmbeddedFileStore : IDisposable
             return false;
         }
 
+        return TryOpenReadSnapshot(out snapshot);
+    }
+
+    /// <summary>
+    /// Opens a pager read snapshot independent of any single table, for pinning at the start of a
+    /// classic (non-MVCC) transaction. The snapshot is coupled to whatever catalog/version was
+    /// cloned in the same locked section (see <see cref="EmbeddedDatabase.CreateTransactionSnapshotWithPin"/>)
+    /// and, once opened, is unaffected by any later peer commit until it is disposed.
+    /// </summary>
+    internal bool TryOpenReadSnapshot(out EmbeddedFileReadSnapshot snapshot)
+    {
+        snapshot = null!;
+        if (_disposed || _committedTables is null)
+            return false;
+
         var transaction = _pager.BeginReadTransaction();
         try
         {
@@ -354,7 +485,12 @@ internal sealed class EmbeddedFileStore : IDisposable
                 transaction.PageCount,
                 _pageSize,
                 _usableSpace);
-            snapshot = new EmbeddedFileReadSnapshot(this, transaction, pageIo);
+            // Capturing the field references (not a defensive copy) is sound: every writer
+            // replaces _tableRootPages/_indexRootPages wholesale with a brand-new dictionary
+            // rather than mutating one in place (see RefreshCommittedCatalog and the VACUUM
+            // rewrite path), so the dictionary this snapshot now holds a reference to can never
+            // change out from under it once captured.
+            snapshot = new EmbeddedFileReadSnapshot(this, transaction, pageIo, _tableRootPages, _indexRootPages);
             return true;
         }
         catch
@@ -366,20 +502,31 @@ internal sealed class EmbeddedFileStore : IDisposable
 
     internal bool TryOpenIndexAccessor(
         EmbeddedTable table,
-        EmbeddedIndex index,
+        EmbeddedIndex? index,
         int prefixLength,
         bool covering,
         EmbeddedFileReadSnapshot? sharedSnapshot,
-        out EmbeddedFileIndexAccessor accessor)
+        out EmbeddedFileIndexAccessor accessor,
+        bool requireCommittedTableIdentity = true)
     {
         ArgumentNullException.ThrowIfNull(table);
-        ArgumentNullException.ThrowIfNull(index);
         accessor = null!;
-        if (!CanOpenIndexAccessor(table, index)
-            || prefixLength < 1
-            || prefixLength > index.Columns.Count
-            || !_tableRootPages.TryGetValue(table.Name, out var tableRootPage)
-            || !_indexRootPages.TryGetValue(index.Name, out var indexRootPage))
+        if (!CanOpenIndexAccessor(table, index, requireCommittedTableIdentity) || prefixLength < 1)
+            return false;
+
+        if (index is null)
+            return TryOpenPrimaryKeyIndexAccessor(table, prefixLength, sharedSnapshot, out accessor);
+
+        // A shared (pinned) snapshot resolves roots from the mapping it captured atomically with
+        // its pager transaction, never from the store's live _tableRootPages/_indexRootPages: a
+        // peer's DDL committed after this snapshot was pinned — including a drop/recreate that
+        // reuses the same name with a new root page — must not redirect this snapshot's reads
+        // onto a page number that has nothing to do with what it was pinned against.
+        var tableRootPages = sharedSnapshot?.TableRootPages ?? _tableRootPages;
+        var indexRootPages = sharedSnapshot?.IndexRootPages ?? _indexRootPages;
+        if (prefixLength > index.Columns.Count
+            || !tableRootPages.TryGetValue(table.Name, out var tableRootPage)
+            || !indexRootPages.TryGetValue(index.Name, out var indexRootPage))
         {
             return false;
         }
@@ -391,6 +538,215 @@ internal sealed class EmbeddedFileStore : IDisposable
             return false;
 
         var comparer = CreateIndexComparer(table, persistedIndex);
+        var (getPageIo, openSnapshot, closeSnapshot) = CreateIndexAccessorSnapshotAdapter(sharedSnapshot);
+
+        if (table.WithoutRowid)
+        {
+            var primaryKeySchema = table.PrimaryKeySchema
+                ?? throw new InvalidDataException(
+                    $"WITHOUT ROWID table '{table.Name}' is missing its primary-key metadata.");
+            var storageColumns = GetWithoutRowidIndexStorageColumns(table, persistedIndex);
+            var primaryKeyComparer = CreatePrimaryKeyComparer(primaryKeySchema);
+            accessor = new EmbeddedFileIndexAccessor(
+                (prefix, pageRead, keyCompared, tableRowFetched) => SeekCommittedWithoutRowidIndex(
+                    table,
+                    persistedIndex,
+                    storageColumns,
+                    primaryKeySchema,
+                    tableRootPage,
+                    indexRootPage,
+                    prefixLength,
+                    covering,
+                    getPageIo(),
+                    comparer,
+                    primaryKeyComparer,
+                    prefix,
+                    pageRead,
+                    keyCompared,
+                    tableRowFetched),
+                openSnapshot,
+                closeSnapshot);
+            return true;
+        }
+
+        accessor = new EmbeddedFileIndexAccessor(
+            (prefix, pageRead, keyCompared, tableRowFetched) => SeekCommittedRowidIndex(
+                table,
+                persistedIndex,
+                tableRootPage,
+                indexRootPage,
+                prefixLength,
+                covering,
+                getPageIo(),
+                comparer,
+                prefix,
+                pageRead,
+                keyCompared,
+                tableRowFetched),
+            openSnapshot,
+            closeSnapshot);
+        return true;
+    }
+
+    private bool TryOpenPrimaryKeyIndexAccessor(
+        EmbeddedTable table,
+        int prefixLength,
+        EmbeddedFileReadSnapshot? sharedSnapshot,
+        out EmbeddedFileIndexAccessor accessor)
+    {
+        accessor = null!;
+        var primaryKeySchema = table.PrimaryKeySchema;
+        // See the identical comment in TryOpenIndexAccessor: a shared snapshot's own captured
+        // root-page mapping must win over the store's live one.
+        var tableRootPages = sharedSnapshot?.TableRootPages ?? _tableRootPages;
+        if (primaryKeySchema is null
+            || prefixLength > primaryKeySchema.Terms.Count
+            || !tableRootPages.TryGetValue(table.Name, out var tableRootPage))
+        {
+            return false;
+        }
+
+        var comparer = CreatePrimaryKeyComparer(primaryKeySchema);
+        var (getPageIo, openSnapshot, closeSnapshot) = CreateIndexAccessorSnapshotAdapter(sharedSnapshot);
+        accessor = new EmbeddedFileIndexAccessor(
+            (prefix, pageRead, keyCompared, _) => SeekCommittedPrimaryKeyIndex(
+                table,
+                primaryKeySchema,
+                tableRootPage,
+                prefixLength,
+                getPageIo(),
+                comparer,
+                prefix,
+                pageRead,
+                keyCompared),
+            openSnapshot,
+            closeSnapshot);
+        return true;
+    }
+
+    /// <summary>
+    /// Opens a durable full-ascending-order scan accessor over an index's (or a WITHOUT ROWID
+    /// table's own primary-key b-tree's) entire committed b-tree — the "no known equality prefix"
+    /// counterpart of <see cref="TryOpenIndexAccessor"/>. A caller with no seek prefix (e.g. an
+    /// ORDER BY-elision full scan, or an MVCC merge that must visit every base row) uses this to
+    /// stream the base table's natural key order lazily instead of materializing and sorting every
+    /// row in memory first.
+    /// </summary>
+    internal bool TryOpenIndexFullScanAccessor(
+        EmbeddedTable table,
+        EmbeddedIndex? index,
+        bool covering,
+        EmbeddedFileReadSnapshot? sharedSnapshot,
+        out EmbeddedFileIndexFullScanAccessor accessor,
+        bool requireCommittedTableIdentity = true)
+    {
+        ArgumentNullException.ThrowIfNull(table);
+        accessor = null!;
+        if (!CanOpenIndexAccessor(table, index, requireCommittedTableIdentity))
+            return false;
+
+        if (index is null)
+            return TryOpenPrimaryKeyIndexFullScanAccessor(table, sharedSnapshot, out accessor);
+
+        // See the identical comment in TryOpenIndexAccessor: a shared snapshot's own captured
+        // root-page mapping must win over the store's live one.
+        var tableRootPages = sharedSnapshot?.TableRootPages ?? _tableRootPages;
+        var indexRootPages = sharedSnapshot?.IndexRootPages ?? _indexRootPages;
+        if (!tableRootPages.TryGetValue(table.Name, out var tableRootPage)
+            || !indexRootPages.TryGetValue(index.Name, out var indexRootPage))
+        {
+            return false;
+        }
+
+        var persistedIndex = table.Indexes.FirstOrDefault(candidate =>
+            ReferenceEquals(candidate, index)
+            || string.Equals(candidate.Name, index.Name, StringComparison.OrdinalIgnoreCase));
+        if (persistedIndex is null)
+            return false;
+
+        var comparer = CreateIndexComparer(table, persistedIndex);
+        var (getPageIo, openSnapshot, closeSnapshot) = CreateIndexAccessorSnapshotAdapter(sharedSnapshot);
+
+        if (table.WithoutRowid)
+        {
+            var primaryKeySchema = table.PrimaryKeySchema
+                ?? throw new InvalidDataException(
+                    $"WITHOUT ROWID table '{table.Name}' is missing its primary-key metadata.");
+            var storageColumns = GetWithoutRowidIndexStorageColumns(table, persistedIndex);
+            var primaryKeyComparer = CreatePrimaryKeyComparer(primaryKeySchema);
+            accessor = new EmbeddedFileIndexFullScanAccessor(
+                (pageRead, tableRowFetched) => ScanCommittedWithoutRowidIndexAscending(
+                    table,
+                    persistedIndex,
+                    storageColumns,
+                    primaryKeySchema,
+                    tableRootPage,
+                    indexRootPage,
+                    covering,
+                    getPageIo(),
+                    comparer,
+                    primaryKeyComparer,
+                    pageRead,
+                    tableRowFetched),
+                openSnapshot,
+                closeSnapshot);
+            return true;
+        }
+
+        accessor = new EmbeddedFileIndexFullScanAccessor(
+            (pageRead, tableRowFetched) => ScanCommittedRowidIndexAscending(
+                table,
+                persistedIndex,
+                tableRootPage,
+                indexRootPage,
+                covering,
+                getPageIo(),
+                comparer,
+                pageRead,
+                tableRowFetched),
+            openSnapshot,
+            closeSnapshot);
+        return true;
+    }
+
+    private bool TryOpenPrimaryKeyIndexFullScanAccessor(
+        EmbeddedTable table,
+        EmbeddedFileReadSnapshot? sharedSnapshot,
+        out EmbeddedFileIndexFullScanAccessor accessor)
+    {
+        accessor = null!;
+        var primaryKeySchema = table.PrimaryKeySchema;
+        // See the identical comment in TryOpenIndexAccessor: a shared snapshot's own captured
+        // root-page mapping must win over the store's live one.
+        var tableRootPages = sharedSnapshot?.TableRootPages ?? _tableRootPages;
+        if (primaryKeySchema is null || !tableRootPages.TryGetValue(table.Name, out var tableRootPage))
+            return false;
+
+        var comparer = CreatePrimaryKeyComparer(primaryKeySchema);
+        var (getPageIo, openSnapshot, closeSnapshot) = CreateIndexAccessorSnapshotAdapter(sharedSnapshot);
+        accessor = new EmbeddedFileIndexFullScanAccessor(
+            (pageRead, _) => ScanCommittedPrimaryKeyIndexAscending(
+                table,
+                primaryKeySchema,
+                tableRootPage,
+                getPageIo(),
+                comparer,
+                pageRead),
+            openSnapshot,
+            closeSnapshot);
+        return true;
+    }
+
+    /// <summary>
+    /// Builds the shared lazy-open/close committed-page-snapshot plumbing used by every durable
+    /// index accessor (secondary index, or WITHOUT ROWID primary-key b-tree). When
+    /// <paramref name="sharedSnapshot"/> is supplied the accessor reuses its page I/O and never
+    /// opens or closes a transaction of its own; otherwise a fresh read transaction is opened
+    /// lazily on first use and disposed when the accessor is disposed.
+    /// </summary>
+    private (Func<ISqliteBtreePageIo> GetPageIo, Action Open, Action Close) CreateIndexAccessorSnapshotAdapter(
+        EmbeddedFileReadSnapshot? sharedSnapshot)
+    {
         var snapshotGate = new object();
         SqlitePagerReadTransaction? snapshot = null;
         ISqliteBtreePageIo? pageIo = null;
@@ -429,26 +785,13 @@ internal sealed class EmbeddedFileStore : IDisposable
             }
         }
 
-        accessor = new EmbeddedFileIndexAccessor(
-            (prefix, pageRead, keyCompared, tableRowFetched) => SeekCommittedIndex(
-                table,
-                persistedIndex,
-                tableRootPage,
-                indexRootPage,
-                prefixLength,
-                covering,
-                GetPageIo(),
-                comparer,
-                prefix,
-                pageRead,
-                keyCompared,
-                tableRowFetched),
+        return (
+            GetPageIo,
             sharedSnapshot is null ? () => _ = GetPageIo() : static () => { },
             CloseSnapshot);
-        return true;
     }
 
-    private IEnumerable<EmbeddedFileIndexSeekRow> SeekCommittedIndex(
+    private IEnumerable<EmbeddedFileIndexSeekRow> SeekCommittedRowidIndex(
         EmbeddedTable table,
         EmbeddedIndex index,
         uint tableRootPage,
@@ -502,6 +845,273 @@ internal sealed class EmbeddedFileStore : IDisposable
                 row[table.RowidAliasColumnIndex] = SqlValue.Integer(rowId);
             EmbeddedDatabase.RecomputeVirtualGeneratedColumns(table, table.Name, row);
             yield return new EmbeddedFileIndexSeekRow(row, rowId);
+        }
+    }
+
+    /// <summary>
+    /// Seeks a WITHOUT ROWID table's secondary index. Every persisted record for such an index
+    /// always carries the table's full primary-key columns as a locator suffix (see
+    /// <see cref="GetWithoutRowidIndexStorageColumns"/>), never a rowid: a non-covering match
+    /// re-seeks the table's own root page — which the managed engine stores as an index b-tree
+    /// keyed by the declared primary key — using that locator instead of <see cref="SqliteTableBtreeCursor"/>.
+    /// </summary>
+    private IEnumerable<EmbeddedFileIndexSeekRow> SeekCommittedWithoutRowidIndex(
+        EmbeddedTable table,
+        EmbeddedIndex index,
+        IReadOnlyList<EmbeddedIndexColumn> storageColumns,
+        SqlitePrimaryKeySchema primaryKeySchema,
+        uint tableRootPage,
+        uint indexRootPage,
+        int prefixLength,
+        bool covering,
+        ISqliteBtreePageIo pageIo,
+        SqliteIndexRecordComparer comparer,
+        SqliteIndexRecordComparer primaryKeyComparer,
+        SqlValue[] prefix,
+        Action? pageRead,
+        Action? keyCompared,
+        Action? tableRowFetched)
+    {
+        if (prefix.Length != prefixLength)
+            throw new ArgumentException("The index seek key does not match the planned prefix length.", nameof(prefix));
+
+        var indexCursor = new SqliteIndexBtreeCursor(pageIo, comparer, _textEncoding);
+        var tableCursor = covering ? null : new SqliteIndexBtreeCursor(pageIo, primaryKeyComparer, _textEncoding);
+        foreach (var record in indexCursor.SeekPrefix(indexRootPage, prefix, pageRead, keyCompared))
+        {
+            var indexValues = SqliteRecordCodec.Decode(record, _textEncoding);
+            if (indexValues.Length != storageColumns.Count)
+            {
+                throw new InvalidDataException(
+                    $"SQLite index '{index.Name}' record does not carry its declared storage columns.");
+            }
+
+            // Scatter every non-expression storage column (the declared index columns plus the
+            // always-present primary-key suffix) into a partial row. Expression-index columns
+            // (ColumnIndex < 0) key the index but are never real table columns, and a covering
+            // plan never includes one (see CanOpenIndexAccessor); they contribute to neither the
+            // covering projection nor primary-key reconstruction.
+            var partialRow = new SqlValue[table.Columns.Length];
+            Array.Fill(partialRow, SqlValue.Null);
+            for (var position = 0; position < storageColumns.Count; position++)
+            {
+                var columnIndex = storageColumns[position].ColumnIndex;
+                if (columnIndex >= 0)
+                    partialRow[columnIndex] = indexValues[position];
+            }
+
+            SqlValue[] row;
+            if (covering)
+            {
+                row = partialRow;
+            }
+            else
+            {
+                var primaryKey = primaryKeySchema.ProjectKey(partialRow);
+                byte[]? tableRecord = null;
+                foreach (var candidate in tableCursor!.SeekPrefix(tableRootPage, primaryKey, pageRead, keyCompared))
+                {
+                    tableRecord = candidate;
+                    break;
+                }
+
+                if (tableRecord is null)
+                {
+                    throw new InvalidDataException(
+                        $"SQLite index '{index.Name}' references a missing primary key in table '{table.Name}'.");
+                }
+
+                tableRowFetched?.Invoke();
+                row = RestoreWithoutRowidRecord(
+                    table.Name,
+                    table,
+                    primaryKeySchema,
+                    SqliteRecordCodec.Decode(tableRecord, _textEncoding));
+            }
+
+            EmbeddedDatabase.RecomputeVirtualGeneratedColumns(table, table.Name, row);
+            yield return new EmbeddedFileIndexSeekRow(row, RowId: null);
+        }
+    }
+
+    /// <summary>
+    /// Seeks a WITHOUT ROWID table's own primary-key b-tree (its root page) directly, driving an
+    /// equality join lookup on the table's leading primary-key term(s) without materializing an
+    /// index view. The primary key already carries the full row, so this is always covering.
+    /// </summary>
+    private IEnumerable<EmbeddedFileIndexSeekRow> SeekCommittedPrimaryKeyIndex(
+        EmbeddedTable table,
+        SqlitePrimaryKeySchema primaryKeySchema,
+        uint tableRootPage,
+        int prefixLength,
+        ISqliteBtreePageIo pageIo,
+        SqliteIndexRecordComparer comparer,
+        SqlValue[] prefix,
+        Action? pageRead,
+        Action? keyCompared)
+    {
+        if (prefix.Length != prefixLength)
+            throw new ArgumentException("The index seek key does not match the planned prefix length.", nameof(prefix));
+
+        var cursor = new SqliteIndexBtreeCursor(pageIo, comparer, _textEncoding);
+        foreach (var record in cursor.SeekPrefix(tableRootPage, prefix, pageRead, keyCompared))
+        {
+            var storedValues = SqliteRecordCodec.Decode(record, _textEncoding);
+            var row = RestoreWithoutRowidRecord(table.Name, table, primaryKeySchema, storedValues);
+            EmbeddedDatabase.RecomputeVirtualGeneratedColumns(table, table.Name, row);
+            yield return new EmbeddedFileIndexSeekRow(row, RowId: null);
+        }
+    }
+
+    /// <summary>
+    /// Ascending-order sibling of <see cref="SeekCommittedRowidIndex"/>: materializes every row in
+    /// the index's committed b-tree, in the index's own key order, instead of only the rows
+    /// matching an equality prefix. Used by ORDER BY-elision and MVCC merge scans that have no
+    /// known seek prefix.
+    /// </summary>
+    private IEnumerable<EmbeddedFileIndexSeekRow> ScanCommittedRowidIndexAscending(
+        EmbeddedTable table,
+        EmbeddedIndex index,
+        uint tableRootPage,
+        uint indexRootPage,
+        bool covering,
+        ISqliteBtreePageIo pageIo,
+        SqliteIndexRecordComparer comparer,
+        Action? pageRead,
+        Action? tableRowFetched)
+    {
+        var indexCursor = new SqliteIndexBtreeCursor(pageIo, comparer, _textEncoding);
+        var tableCursor = covering ? null : new SqliteTableBtreeCursor(pageIo);
+        foreach (var record in indexCursor.ScanAscending(indexRootPage, pageRead))
+        {
+            var indexValues = SqliteRecordCodec.Decode(record, _textEncoding);
+            if (indexValues.Length <= index.Columns.Count
+                || indexValues[^1].Kind != SqlValueKind.Integer)
+            {
+                throw new InvalidDataException(
+                    $"SQLite index '{index.Name}' record is missing its rowid suffix.");
+            }
+
+            var rowId = indexValues[^1].AsInteger();
+            SqlValue[] row;
+            if (covering)
+            {
+                row = new SqlValue[table.Columns.Length];
+                Array.Fill(row, SqlValue.Null);
+                for (var position = 0; position < index.Columns.Count; position++)
+                    row[index.Columns[position].ColumnIndex] = indexValues[position];
+            }
+            else
+            {
+                if (!tableCursor!.TrySeek(tableRootPage, rowId, out var tableRecord))
+                {
+                    throw new InvalidDataException(
+                        $"SQLite index '{index.Name}' references missing rowid {rowId} in table '{table.Name}'.");
+                }
+
+                tableRowFetched?.Invoke();
+                row = RestoreRowidTableRecord(table, SqliteRecordCodec.Decode(tableRecord, _textEncoding));
+            }
+
+            if (table.RowidAliasColumnIndex >= 0)
+                row[table.RowidAliasColumnIndex] = SqlValue.Integer(rowId);
+            EmbeddedDatabase.RecomputeVirtualGeneratedColumns(table, table.Name, row);
+            yield return new EmbeddedFileIndexSeekRow(row, rowId);
+        }
+    }
+
+    /// <summary>
+    /// Ascending-order sibling of <see cref="SeekCommittedWithoutRowidIndex"/>. See that method's
+    /// doc comment for the record shape; this variant walks the whole index instead of an equality
+    /// prefix range.
+    /// </summary>
+    private IEnumerable<EmbeddedFileIndexSeekRow> ScanCommittedWithoutRowidIndexAscending(
+        EmbeddedTable table,
+        EmbeddedIndex index,
+        IReadOnlyList<EmbeddedIndexColumn> storageColumns,
+        SqlitePrimaryKeySchema primaryKeySchema,
+        uint tableRootPage,
+        uint indexRootPage,
+        bool covering,
+        ISqliteBtreePageIo pageIo,
+        SqliteIndexRecordComparer comparer,
+        SqliteIndexRecordComparer primaryKeyComparer,
+        Action? pageRead,
+        Action? tableRowFetched)
+    {
+        var indexCursor = new SqliteIndexBtreeCursor(pageIo, comparer, _textEncoding);
+        var tableCursor = covering ? null : new SqliteIndexBtreeCursor(pageIo, primaryKeyComparer, _textEncoding);
+        foreach (var record in indexCursor.ScanAscending(indexRootPage, pageRead))
+        {
+            var indexValues = SqliteRecordCodec.Decode(record, _textEncoding);
+            if (indexValues.Length != storageColumns.Count)
+            {
+                throw new InvalidDataException(
+                    $"SQLite index '{index.Name}' record does not carry its declared storage columns.");
+            }
+
+            var partialRow = new SqlValue[table.Columns.Length];
+            Array.Fill(partialRow, SqlValue.Null);
+            for (var position = 0; position < storageColumns.Count; position++)
+            {
+                var columnIndex = storageColumns[position].ColumnIndex;
+                if (columnIndex >= 0)
+                    partialRow[columnIndex] = indexValues[position];
+            }
+
+            SqlValue[] row;
+            if (covering)
+            {
+                row = partialRow;
+            }
+            else
+            {
+                var primaryKey = primaryKeySchema.ProjectKey(partialRow);
+                byte[]? tableRecord = null;
+                foreach (var candidate in tableCursor!.SeekPrefix(tableRootPage, primaryKey, pageRead, keyCompared: null))
+                {
+                    tableRecord = candidate;
+                    break;
+                }
+
+                if (tableRecord is null)
+                {
+                    throw new InvalidDataException(
+                        $"SQLite index '{index.Name}' references a missing primary key in table '{table.Name}'.");
+                }
+
+                tableRowFetched?.Invoke();
+                row = RestoreWithoutRowidRecord(
+                    table.Name,
+                    table,
+                    primaryKeySchema,
+                    SqliteRecordCodec.Decode(tableRecord, _textEncoding));
+            }
+
+            EmbeddedDatabase.RecomputeVirtualGeneratedColumns(table, table.Name, row);
+            yield return new EmbeddedFileIndexSeekRow(row, RowId: null);
+        }
+    }
+
+    /// <summary>
+    /// Ascending-order sibling of <see cref="SeekCommittedPrimaryKeyIndex"/>: walks a WITHOUT
+    /// ROWID table's own primary-key b-tree in full instead of seeking an equality prefix.
+    /// </summary>
+    private IEnumerable<EmbeddedFileIndexSeekRow> ScanCommittedPrimaryKeyIndexAscending(
+        EmbeddedTable table,
+        SqlitePrimaryKeySchema primaryKeySchema,
+        uint tableRootPage,
+        ISqliteBtreePageIo pageIo,
+        SqliteIndexRecordComparer comparer,
+        Action? pageRead)
+    {
+        var cursor = new SqliteIndexBtreeCursor(pageIo, comparer, _textEncoding);
+        foreach (var record in cursor.ScanAscending(tableRootPage, pageRead))
+        {
+            var storedValues = SqliteRecordCodec.Decode(record, _textEncoding);
+            var row = RestoreWithoutRowidRecord(table.Name, table, primaryKeySchema, storedValues);
+            EmbeddedDatabase.RecomputeVirtualGeneratedColumns(table, table.Name, row);
+            yield return new EmbeddedFileIndexSeekRow(row, RowId: null);
         }
     }
 
@@ -618,8 +1228,8 @@ internal sealed class EmbeddedFileStore : IDisposable
                     var candidatePages = new HashSet<uint>(occupiedBtreePages);
                     try
                     {
-                        ValidateIndexRepresentable(entry.TableName, table, candidate);
-                        ValidateStoredIndex(entry, table, candidate, candidatePages);
+                        ValidateIndexRepresentable(entry.TableName, table, candidate, structuralOnly: _collationResolver is null);
+                        ValidateStoredIndex(entry, table, candidate, candidatePages, structuralOnly: _collationResolver is null);
                         occupiedBtreePages.UnionWith(candidatePages);
                         validatedIndex = candidate;
                         break;
@@ -663,8 +1273,8 @@ internal sealed class EmbeddedFileStore : IDisposable
             }
 
             var index = CreateIndexDefinition(entry.TableName, table, create);
-            ValidateIndexRepresentable(entry.TableName, table, index);
-            ValidateStoredIndex(entry, table, index, occupiedBtreePages);
+            ValidateIndexRepresentable(entry.TableName, table, index, structuralOnly: _collationResolver is null);
+            ValidateStoredIndex(entry, table, index, occupiedBtreePages, structuralOnly: _collationResolver is null);
             if (index.IsMethodIndex)
             {
                 ManagedIndexMethodSemantics
@@ -783,7 +1393,11 @@ internal sealed class EmbeddedFileStore : IDisposable
                             activePages,
                             pageCount,
                             overflowReader,
-                            CreateIndexComparer(indexedTable, index));
+                            // ValidateAllocationMap only runs from Load(), before EmbeddedDatabase
+                            // wires up a runtime collation resolver, so a not-yet-resolvable custom
+                            // collation must defer here exactly like the other Load() validation
+                            // calls above (structural page-reachability only, never ordering).
+                            CreateIndexComparer(indexedTable, index, allowDeferredCustomCollation: _collationResolver is null));
                         break;
                 }
             }
@@ -1025,6 +1639,363 @@ internal sealed class EmbeddedFileStore : IDisposable
                 throw new InvalidDataException(
                     $"Stored {treeDescription} {owner} page {pageNumber} has unsupported type {header.PageType}.");
         }
+    }
+
+    /// <summary>
+    /// Collects every page one index's b-tree currently occupies EXCEPT its
+    /// root — interior, leaf, and overflow pages — reading through
+    /// <paramref name="pageIo"/> rather than the committed pager directly, so
+    /// this is safe to call against a <see cref="SqliteStagedBtreePageIo"/>
+    /// mid-transaction as well as against committed state.
+    /// </summary>
+    /// <remarks>
+    /// A targeted REINDEX frees the pages this collects and then writes the
+    /// index's replacement tree, reusing the same root page number so the
+    /// schema catalog's root-page pointer never has to change. <paramref
+    /// name="comparer"/> should be built with
+    /// <c>allowDeferredCustomCollation: true</c> AND
+    /// <c>forceDeferCustomCollation: true</c>: this traversal only needs to
+    /// prove page/record shape, never real ordering, so an index whose
+    /// custom collation callback is not currently registered — or whose
+    /// currently-registered callback is a replacement that no longer agrees
+    /// with the tree's existing physical order, which is precisely why a
+    /// REINDEX is often requested in the first place — can still have its
+    /// stale tree freed without ever binary-comparing its keys under either
+    /// the old or the new semantics.
+    /// </remarks>
+    private void CollectIndexTreeNonRootPagesForFree(
+        uint rootPage,
+        ISqliteBtreePageIo pageIo,
+        SqliteOverflowChainReader overflowReader,
+        SqliteIndexRecordComparer comparer,
+        ISet<uint> pages)
+    {
+        CollectIndexTreeNodePagesForFree(rootPage, pageIo.ReadPage(rootPage), pageIo, overflowReader, comparer, pages);
+    }
+
+    private void CollectIndexTreeNodePagesForFree(
+        uint pageNumber,
+        ReadOnlySpan<byte> pageImage,
+        ISqliteBtreePageIo pageIo,
+        SqliteOverflowChainReader overflowReader,
+        SqliteIndexRecordComparer comparer,
+        ISet<uint> pages)
+    {
+        var header = SqliteBtreePageHeader.Parse(pageImage);
+        switch (header.PageType)
+        {
+            case SqliteBtreePageType.IndexLeaf:
+                CollectIndexLeafOverflowPages(
+                    SqliteIndexLeafPageView.Parse(
+                        pageImage,
+                        _usableSpace,
+                        _textEncoding,
+                        overflowReader: overflowReader,
+                        recordComparer: comparer),
+                    pages,
+                    pageIo.PageCount,
+                    overflowReader,
+                    $"stale index page {pageNumber}");
+                return;
+            case SqliteBtreePageType.IndexInterior:
+                {
+                    var interior = SqliteIndexInteriorPageView.Parse(
+                        pageImage,
+                        _usableSpace,
+                        _textEncoding,
+                        overflowReader: overflowReader,
+                        recordComparer: comparer);
+                    foreach (var cell in interior.Cells)
+                    {
+                        CollectIndexOverflowPages(
+                            cell.Cell.Key,
+                            pages,
+                            pageIo.PageCount,
+                            overflowReader,
+                            $"stale index page {pageNumber} separator");
+                    }
+
+                    foreach (var childPage in interior.Cells
+                                 .Select(cell => cell.Cell.LeftChildPage)
+                                 .Append(interior.Header.RightMostChildPage))
+                    {
+                        AddOwnedPage(pages, childPage, pageIo.PageCount, $"stale index page {pageNumber} child");
+                        CollectIndexTreeNodePagesForFree(
+                            childPage,
+                            pageIo.ReadPage(childPage),
+                            pageIo,
+                            overflowReader,
+                            comparer,
+                            pages);
+                    }
+
+                    return;
+                }
+            default:
+                throw new InvalidDataException(
+                    $"Stale index page {pageNumber} has unsupported type {header.PageType}.");
+        }
+    }
+
+    /// <summary>
+    /// Finds indexes whose collation is currently unavailable — nothing has registered a
+    /// callback for a custom name, or an application override is bound but this store cannot
+    /// prove it still agrees with the tree's existing physical order — but whose owning table
+    /// has not changed since the previous commit, and clones their existing committed b-tree
+    /// byte-for-byte so a full rewrite never has to call <see cref="BuildIndexTree"/> — which
+    /// unconditionally requires a working comparator — for them. This is what lets an unrelated
+    /// <c>CREATE TABLE</c> or a sibling <c>CREATE INDEX</c> succeed even while another index
+    /// depends on a collation nothing has registered right now.
+    /// </summary>
+    /// <remarks>
+    /// Only ever engaged for a plain full rewrite (see the <c>!reclaimTrailingPages</c> caller
+    /// in <see cref="PersistCore"/>): VACUUM / page-size migration compute their target page
+    /// count from <see cref="RebuildPageAllocator.HighestAllocatedPage"/>, which never accounts
+    /// for a page this method asks the allocator to leave untouched, so a preserved index's
+    /// existing (possibly high-numbered) page could then land outside the shrunk target range
+    /// and fail <see cref="ValidateRewritePlan"/>.
+    /// </remarks>
+    private Dictionary<string, PreservedIndexTree> TryPreserveUnavailableIndexTrees(
+        IReadOnlyList<IndexDefinition> indexes,
+        IReadOnlyDictionary<string, EmbeddedTable>? previousTables,
+        SqliteDatabaseHeader currentHeader)
+    {
+        var preserved = new Dictionary<string, PreservedIndexTree>(StringComparer.OrdinalIgnoreCase);
+        foreach (var definition in indexes)
+        {
+            if (definition.Index.IsMethodIndex)
+                continue;
+            if (!IsIndexUnchangedFromPrevious(definition.TableName, definition.Table, definition.Index, previousTables))
+                continue;
+            if (!_indexRootPages.TryGetValue(definition.Index.Name, out var rootPage)
+                || rootPage < 2
+                || rootPage > _pager.CommittedPageCount)
+            {
+                continue;
+            }
+
+            // A comparer built with no deferred flags is exactly this store's
+            // "is this index's collation fully usable right now" probe (see
+            // CreateIndexComparer / CreateIndexComparerOrThrowNoSuchCollation).
+            // When it succeeds there is nothing to preserve: the ordinary
+            // BuildIndexTree path below already handles this index correctly —
+            // and, unlike this preserving path, also re-proves its order —
+            // so only genuinely unavailable collations reach the clone below.
+            // That probe only ever looks at indexed-term (column-level)
+            // collations, though: a partial index's WHERE predicate or an
+            // expression index's column body can embed its own COLLATE
+            // reference that CreateIndexComparer never sees at all (it is
+            // never handed to the SqliteIndexRecordComparer constructor).
+            // TryFindUnresolvedEmbeddedIndexCollation is the same check
+            // ValidateStoredIndex uses to defer judgement on those, so an
+            // index unavailable for that reason must be preserved here too —
+            // otherwise BuildIndexRecords below would call into the
+            // predicate/expression evaluator and fail hard with "no such
+            // collation sequence", turning an unrelated CREATE TABLE / CREATE
+            // INDEX into a hard failure instead of leaving this index alone.
+            if (!TryFindUnresolvedEmbeddedIndexCollation(definition.Index, out _))
+            {
+                try
+                {
+                    CreateIndexComparer(definition.Table, definition.Index);
+                    continue;
+                }
+                catch (EmbeddedSqlException)
+                {
+                    // Falls through to attempt preservation.
+                }
+            }
+
+            try
+            {
+                var structuralComparer = CreateIndexComparer(
+                    definition.Table,
+                    definition.Index,
+                    allowDeferredCustomCollation: true,
+                    forceDeferCustomCollation: true);
+                var tree = ClonePreservedIndexTree(rootPage, structuralComparer, currentHeader);
+                preserved[definition.Index.Name] = new PreservedIndexTree(rootPage, tree);
+            }
+            catch (InvalidDataException)
+            {
+                // The committed tree itself is not safely traversable
+                // (physically corrupted, or truncated). Fall back to the
+                // ordinary rebuild path, which will then correctly throw the
+                // same no-such-collation-sequence failure BuildIndexTree
+                // already produces for an index whose collation truly is
+                // unavailable: preservation is only ever a byte-for-byte
+                // optimization, never a way to paper over real corruption.
+            }
+        }
+
+        return preserved;
+    }
+
+    /// <summary>
+    /// Reads one index's complete committed b-tree — root, every interior/leaf/overflow page —
+    /// into a <see cref="PreparedIndexTree"/> without ever trusting <paramref
+    /// name="structuralComparer"/> to compare key ordering (it must be built with
+    /// <c>forceDeferCustomCollation: true</c>). Applies the same duplicate/out-of-range page
+    /// checks <see cref="CollectIndexTreeNodePagesForFree"/> applies when freeing a stale tree,
+    /// so a physically corrupted committed image is rejected here exactly as it would be there,
+    /// rather than silently copied forward.
+    /// </summary>
+    private PreparedIndexTree ClonePreservedIndexTree(
+        uint rootPage,
+        SqliteIndexRecordComparer structuralComparer,
+        SqliteDatabaseHeader currentHeader)
+    {
+        var overflowReader = new SqliteOverflowChainReader(_pager, currentHeader);
+        var visited = new HashSet<uint> { rootPage };
+        var interiorPages = new List<PageImage>();
+        var leafPages = new List<PageImage>();
+        var overflowPages = new List<PageImage>();
+        var rootImage = _pager.ReadCommittedPage(rootPage);
+        ClonePreservedIndexNode(
+            rootPage,
+            rootImage,
+            isRoot: true,
+            overflowReader,
+            structuralComparer,
+            visited,
+            interiorPages,
+            leafPages,
+            overflowPages);
+        return new PreparedIndexTree(rootImage, interiorPages, leafPages, overflowPages);
+    }
+
+    private void ClonePreservedIndexNode(
+        uint pageNumber,
+        byte[] pageImage,
+        bool isRoot,
+        SqliteOverflowChainReader overflowReader,
+        SqliteIndexRecordComparer comparer,
+        HashSet<uint> visited,
+        List<PageImage> interiorPages,
+        List<PageImage> leafPages,
+        List<PageImage> overflowPages)
+    {
+        var header = SqliteBtreePageHeader.Parse(pageImage);
+        switch (header.PageType)
+        {
+            case SqliteBtreePageType.IndexLeaf:
+                {
+                    if (!isRoot)
+                        leafPages.Add(new PageImage(pageNumber, pageImage));
+
+                    var leaf = SqliteIndexLeafPageView.Parse(
+                        pageImage,
+                        _usableSpace,
+                        _textEncoding,
+                        overflowReader: overflowReader,
+                        recordComparer: comparer);
+                    foreach (var cell in leaf.Cells)
+                    {
+                        CloneIndexOverflowPages(
+                            cell.Cell,
+                            overflowReader,
+                            visited,
+                            overflowPages,
+                            $"preserved index page {pageNumber}");
+                    }
+
+                    return;
+                }
+            case SqliteBtreePageType.IndexInterior:
+                {
+                    if (!isRoot)
+                        interiorPages.Add(new PageImage(pageNumber, pageImage));
+
+                    var interior = SqliteIndexInteriorPageView.Parse(
+                        pageImage,
+                        _usableSpace,
+                        _textEncoding,
+                        overflowReader: overflowReader,
+                        recordComparer: comparer);
+                    foreach (var cell in interior.Cells)
+                    {
+                        CloneIndexOverflowPages(
+                            cell.Cell.Key,
+                            overflowReader,
+                            visited,
+                            overflowPages,
+                            $"preserved index page {pageNumber} separator");
+                    }
+
+                    foreach (var childPage in interior.Cells
+                                 .Select(cell => cell.Cell.LeftChildPage)
+                                 .Append(interior.Header.RightMostChildPage))
+                    {
+                        AddOwnedPage(visited, childPage, _pager.CommittedPageCount, $"preserved index page {pageNumber} child");
+                        ClonePreservedIndexNode(
+                            childPage,
+                            _pager.ReadCommittedPage(childPage),
+                            isRoot: false,
+                            overflowReader,
+                            comparer,
+                            visited,
+                            interiorPages,
+                            leafPages,
+                            overflowPages);
+                    }
+
+                    return;
+                }
+            default:
+                throw new InvalidDataException(
+                    $"Stored preserved index page {pageNumber} has unsupported type {header.PageType}.");
+        }
+    }
+
+    private void CloneIndexOverflowPages(
+        SqliteIndexLeafCell cell,
+        SqliteOverflowChainReader overflowReader,
+        HashSet<uint> visited,
+        List<PageImage> overflowPages,
+        string owner)
+    {
+        var overflowLength = GetOverflowLength(cell.PayloadLength, cell.LocalPayload.Length, owner);
+        if (overflowLength == 0)
+        {
+            if (cell.FirstOverflowPage is not null)
+                throw new InvalidDataException($"SQLite {owner} cell has an unnecessary overflow page.");
+            return;
+        }
+
+        if (cell.FirstOverflowPage is not { } firstOverflowPage)
+            throw new InvalidDataException($"SQLite {owner} cell is missing its overflow page.");
+
+        foreach (var overflowPage in overflowReader.Traverse(firstOverflowPage, overflowLength))
+        {
+            AddOwnedPage(visited, overflowPage, _pager.CommittedPageCount, $"{owner} overflow");
+            overflowPages.Add(new PageImage(overflowPage, _pager.ReadCommittedPage(overflowPage)));
+        }
+    }
+
+    /// <summary>
+    /// Unions every root/interior/leaf/overflow page number a set of preserved index trees
+    /// occupies, so <see cref="RebuildPageAllocator"/> can be told to leave all of them alone.
+    /// Also re-validates there is no collision ACROSS different preserved indexes: each tree's
+    /// own clone already guarantees no duplicate WITHIN itself (see the <c>visited</c> set in
+    /// <see cref="ClonePreservedIndexTree"/>), but two indexes should never legitimately share a
+    /// page, so a collision here would mean the committed catalog itself is corrupted.
+    /// </summary>
+    private static HashSet<uint> CollectPreservedIndexTreePages(
+        IReadOnlyDictionary<string, PreservedIndexTree> preservedIndexTrees)
+    {
+        var pages = new HashSet<uint>();
+        foreach (var preserved in preservedIndexTrees.Values)
+        {
+            AddOwnedPage(pages, preserved.RootPage, uint.MaxValue, "preserved index root");
+            foreach (var page in preserved.Tree.InteriorPages)
+                AddOwnedPage(pages, page.PageNumber, uint.MaxValue, "preserved index page");
+            foreach (var page in preserved.Tree.LeafPages)
+                AddOwnedPage(pages, page.PageNumber, uint.MaxValue, "preserved index page");
+            foreach (var page in preserved.Tree.OverflowPages)
+                AddOwnedPage(pages, page.PageNumber, uint.MaxValue, "preserved index overflow page");
+        }
+
+        return pages;
     }
 
     private static void CollectTableLeafOverflowPages(
@@ -1643,7 +2614,8 @@ internal sealed class EmbeddedFileStore : IDisposable
         IReadOnlyDictionary<string, EmbeddedDatabase.VirtualTableDefinition> virtualTables,
         PragmaHeaderMetadata? pragmaHeader = null,
         bool forceFullRewrite = false,
-        IReadOnlyDictionary<string, EmbeddedTable>? previousTables = null)
+        IReadOnlyDictionary<string, EmbeddedTable>? previousTables = null,
+        IReadOnlyList<(string TableName, EmbeddedTable Table, EmbeddedIndex Index)>? targetedIndexRebuild = null)
         => PersistCore(
             tables,
             views,
@@ -1653,7 +2625,8 @@ internal sealed class EmbeddedFileStore : IDisposable
             incrementSchemaCookie: false,
             pragmaHeader,
             forceFullRewrite,
-            previousTables);
+            previousTables,
+            targetedIndexRebuild: targetedIndexRebuild);
 
     /// <summary>
     /// Materializes an MVCC checkpoint into pager WAL pages without reclaiming
@@ -2030,14 +3003,15 @@ internal sealed class EmbeddedFileStore : IDisposable
         bool forceFullRewrite,
         IReadOnlyDictionary<string, EmbeddedTable>? previousTables = null,
         bool checkpointAfterCommit = true,
-        SqliteDatabaseHeader? vacuumSourceHeader = null)
+        SqliteDatabaseHeader? vacuumSourceHeader = null,
+        IReadOnlyList<(string TableName, EmbeddedTable Table, EmbeddedIndex Index)>? targetedIndexRebuild = null)
     {
         ThrowIfDisposed();
         ThrowIfPostCommitMaintenanceFaulted();
 
         // Validate first: a reject must leave the existing database untouched.
         foreach (var (name, table) in tables)
-            EmbeddedFileStore.ValidateTableRepresentable(name, table);
+            ValidateTableRepresentable(name, table, previousTables);
         EmbeddedDatabase.ValidateSqliteSequenceCatalog(tables);
         ValidateSchemaDefinitions(tables, views, triggers, virtualTables);
 
@@ -2072,25 +3046,84 @@ internal sealed class EmbeddedFileStore : IDisposable
             }
         }
 
+        // A targeted REINDEX only ever needs to rebuild the selected ordinary index
+        // trees in place: everything else — including a table whose index uses a
+        // custom collation with no callback registered right now — must remain
+        // byte-for-byte untouched. This has to be attempted here, at the same point
+        // every other mutation is actually committed to the pager/WAL, rather than
+        // eagerly inside statement execution: the statement only records which
+        // targets to rebuild, and ForceFullCatalogRewrite is still requested as the
+        // guaranteed fallback in case the rebuild is not eligible (schema changed
+        // concurrently, a pragma header write is also pending) or fails structurally
+        // (for example the old tree's on-disk image cannot be traversed because it
+        // is itself corrupted, which the full rewrite already knows how to repair).
+        if (forceFullRewrite
+            && !reclaimTrailingPages
+            && pragmaHeader is null
+            && targetedIndexRebuild is { Count: > 0 }
+            && TryPersistTargetedIndexRebuild(
+                tables,
+                views,
+                triggers,
+                virtualTables,
+                targetedIndexRebuild,
+                checkpointAfterCommit,
+                previousTables))
+        {
+            _committedTables = tables;
+            return CommittedCatalogVersion;
+        }
+
         var currentHeader = SqliteDatabaseHeader.Parse(_pager.ReadCommittedPage(SchemaRootPage));
         var currentFreelist = SqliteFreelist.Read(
             currentHeader,
             _pager.CommittedPageCount,
             _pager.ReadCommittedPage);
+        var tableNames = tables.Keys.OrderBy(name => name, StringComparer.OrdinalIgnoreCase).ToArray();
+        // previousTables lets GetIndexDefinitions defer validation for an index
+        // whose own row/tree has not changed since the previous commit even while
+        // this rewrite's connection has some OTHER custom collation resolver
+        // attached (see IsIndexUnchangedFromPrevious / structuralOnly below);
+        // omitting it here used to silently force full validation of every
+        // index on every full rewrite, defeating that deferral exactly when an
+        // unrelated CREATE TABLE / CREATE INDEX needed it most.
+        var indexes = GetIndexDefinitions(tableNames, tables, views, triggers, virtualTables, previousTables);
+
+        // An index whose custom collation nothing has registered right now
+        // must never block an unrelated schema change as long as its own
+        // table has not changed since the previous commit: its existing
+        // committed b-tree is cloned byte-for-byte below instead of being
+        // rebuilt through BuildIndexTree, which unconditionally requires a
+        // working comparator. Gated to a plain full rewrite (never VACUUM /
+        // page-size migration): those compute their target page count from
+        // the allocator's own high-water mark, which would not account for a
+        // page this preserves without ever handing out.
+        var preservedIndexTrees = reclaimTrailingPages
+            ? new Dictionary<string, PreservedIndexTree>(StringComparer.OrdinalIgnoreCase)
+            : TryPreserveUnavailableIndexTrees(indexes, previousTables, currentHeader);
+        var reservedPages = preservedIndexTrees.Count == 0
+            ? null
+            : CollectPreservedIndexTreePages(preservedIndexTrees);
+
         // Only a fully rebuilt page map can safely repurpose existing freelist
         // pages: all new data, trunks, leaves, and page 1 are one WAL commit.
         var allocator = new RebuildPageAllocator(
             _pager.CommittedPageCount,
             currentFreelist.LeafPageNumbers,
-            reclaimTrailingPages);
-        var tableNames = tables.Keys.OrderBy(name => name, StringComparer.OrdinalIgnoreCase).ToArray();
-        var indexes = GetIndexDefinitions(tableNames, tables, views, triggers, virtualTables);
+            reclaimTrailingPages,
+            reservedPages);
         var rootPages = new Dictionary<string, uint>(StringComparer.OrdinalIgnoreCase);
         var indexRootPages = new Dictionary<string, uint>(StringComparer.OrdinalIgnoreCase);
         foreach (var name in tableNames)
             rootPages[name] = allocator.ReservePage();
         foreach (var definition in indexes)
-            indexRootPages[definition.Index.Name] = allocator.ReservePage();
+        {
+            indexRootPages[definition.Index.Name] = preservedIndexTrees.TryGetValue(
+                definition.Index.Name,
+                out var preservedRoot)
+                ? preservedRoot.RootPage
+                : allocator.ReservePage();
+        }
 
         // Build every page image up front so a build failure also rejects cleanly.
         var tablePages = new Dictionary<uint, PreparedTableTree>();
@@ -2104,11 +3137,15 @@ internal sealed class EmbeddedFileStore : IDisposable
         }
         foreach (var definition in indexes)
         {
-            indexPages[indexRootPages[definition.Index.Name]] = BuildIndexTree(
-                definition.TableName,
-                definition.Table,
-                definition.Index,
-                allocator);
+            indexPages[indexRootPages[definition.Index.Name]] = preservedIndexTrees.TryGetValue(
+                definition.Index.Name,
+                out var preservedTree)
+                ? preservedTree.Tree
+                : BuildIndexTree(
+                    definition.TableName,
+                    definition.Table,
+                    definition.Index,
+                    allocator);
         }
 
         var schemaEntries = BuildSchemaEntries(
@@ -2396,7 +3433,7 @@ internal sealed class EmbeddedFileStore : IDisposable
         IReadOnlyDictionary<string, EmbeddedTable> previousTables,
         bool checkpointAfterCommit)
     {
-        if (!HasCurrentSchemaShape(tables, views, triggers, virtualTables))
+        if (!HasCurrentSchemaShape(tables, views, triggers, virtualTables, previousTables))
             return false;
 
         var currentHeader = SqliteDatabaseHeader.Parse(_pager.ReadCommittedPage(SchemaRootPage));
@@ -2417,7 +3454,7 @@ internal sealed class EmbeddedFileStore : IDisposable
             return false;
 
         var tableNames = tables.Keys.OrderBy(name => name, StringComparer.OrdinalIgnoreCase).ToArray();
-        var indexesByTable = GetIndexDefinitions(tableNames, tables, views, triggers, virtualTables)
+        var indexesByTable = GetIndexDefinitions(tableNames, tables, views, triggers, virtualTables, previousTables)
             .GroupBy(definition => definition.TableName, StringComparer.OrdinalIgnoreCase)
             .ToDictionary(
                 group => group.Key,
@@ -2480,6 +3517,179 @@ internal sealed class EmbeddedFileStore : IDisposable
 
             // Page one publishes the new database size, so it must be the frame
             // that makes every page this mutation allocated reachable.
+            transaction.WritePage(SchemaRootPage, pageOne);
+            transaction.Commit(_synchronousMode);
+        }
+
+        _header = newHeader;
+        if (checkpointAfterCommit)
+            CheckpointCommittedMutation(reclaimTrailingPages: false);
+        return true;
+    }
+
+    /// <summary>
+    /// Rebuilds only the b-tree of each targeted, ordinary index in place —
+    /// reusing its existing root page number and freeing its old
+    /// interior/leaf/overflow pages — in one pager/WAL transaction, without
+    /// touching any other table or index tree and without requiring any
+    /// collation other than each targeted index's own.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the persistence path for a targeted <c>REINDEX
+    /// index|table|collation</c>. Every targeted index's replacement tree is
+    /// written to the SAME root page number it already occupies — real SQLite
+    /// roots change shape between leaf and interior in place as a tree grows
+    /// or shrinks, so this mirrors ordinary b-tree behavior rather than
+    /// inventing a new one — which means the schema catalog's root-page
+    /// pointer, and therefore the schema tree itself, never needs to change.
+    /// </para>
+    /// <para>
+    /// Every OTHER index's pages — including one whose custom collation is
+    /// not currently registered — are never read, freed, or rewritten by this
+    /// method, so they are never binary-compared and never require their
+    /// callback. A caller must not include a method index in
+    /// <paramref name="targets"/>: method indexes are rebuilt through their
+    /// cursor, not through this file-store b-tree path.
+    /// </para>
+    /// </remarks>
+    internal bool TryPersistTargetedIndexRebuild(
+        IReadOnlyDictionary<string, EmbeddedTable> tables,
+        IReadOnlyDictionary<string, ViewDefinition> views,
+        IReadOnlyDictionary<string, TriggerDefinition> triggers,
+        IReadOnlyDictionary<string, EmbeddedDatabase.VirtualTableDefinition> virtualTables,
+        IReadOnlyList<(string TableName, EmbeddedTable Table, EmbeddedIndex Index)> targets,
+        bool checkpointAfterCommit = true,
+        IReadOnlyDictionary<string, EmbeddedTable>? previousTables = null)
+    {
+        if (targets.Count == 0)
+            return true;
+        if (targets.Any(target => target.Index.IsMethodIndex))
+            return false;
+        if (!HasCurrentSchemaShape(tables, views, triggers, virtualTables, previousTables))
+            return false;
+
+        var distinctTargets = targets
+            .GroupBy(target => target.Index.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.First())
+            .ToArray();
+
+        var rootPages = new Dictionary<string, uint>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (_, _, index) in distinctTargets)
+        {
+            if (!_indexRootPages.TryGetValue(index.Name, out var rootPage)
+                || rootPage < 2
+                || rootPage > _pager.CommittedPageCount)
+            {
+                return false;
+            }
+
+            rootPages[index.Name] = rootPage;
+        }
+
+        var currentHeader = SqliteDatabaseHeader.Parse(_pager.ReadCommittedPage(SchemaRootPage));
+        if (currentHeader.PageSize != _pageSize
+            || currentHeader.UsableSpace != _usableSpace
+            || currentHeader.VersionValidFor != currentHeader.ChangeCounter
+            || currentHeader.DatabaseSizeInPages != _pager.CommittedPageCount
+            || currentHeader.LargestRootBtreePage != 0
+            || currentHeader.IncrementalVacuumEnabled != 0)
+        {
+            return false;
+        }
+
+        var pageIo = new SqliteStagedBtreePageIo(
+            pageNumber => _pager.ReadCommittedPage(pageNumber),
+            _pager.CommittedPageCount,
+            _pageSize,
+            _usableSpace,
+            currentHeader.FirstFreelistTrunkPage,
+            currentHeader.FreelistPageCount);
+        var overflowReader = new SqliteOverflowChainReader(pageIo);
+
+        try
+        {
+            // Free every non-root page each targeted index's OLD tree
+            // occupies before rebuilding, so the replacement tree below can
+            // reuse them. forceDeferCustomCollation keeps this a pure
+            // structural traversal: it proves page/record shape only, never
+            // ordering, regardless of whether the target's own callback
+            // happens to be registered right now. A REINDEX is frequently
+            // triggered precisely because a replacement callback no longer
+            // agrees with the OLD tree's physical order (that mismatch is
+            // exactly what makes the index stale) — trusting the currently
+            // bound delegate to validate the old tree's order would either
+            // throw on a false "corruption" or, worse, silently misjudge
+            // which pages are stale, so this pass must never binary-compare
+            // keys under any delegate, old or new.
+            var freedPages = new HashSet<uint>();
+            foreach (var (_, table, index) in distinctTargets)
+            {
+                var freeComparer = CreateIndexComparer(
+                    table,
+                    index,
+                    allowDeferredCustomCollation: true,
+                    forceDeferCustomCollation: true);
+                CollectIndexTreeNonRootPagesForFree(rootPages[index.Name], pageIo, overflowReader, freeComparer, freedPages);
+            }
+
+            foreach (var pageNumber in freedPages.Order())
+                pageIo.FreePage(pageNumber);
+
+            var allocator = new StagedIndexRebuildPageAllocator(pageIo);
+            foreach (var (tableName, table, index) in distinctTargets)
+            {
+                // Resolving this comparer requires only the targeted index's
+                // own collation — never any other index's — so an unrelated
+                // index whose custom collation is not registered is untouched
+                // by this call.
+                var tree = BuildIndexTree(tableName, table, index, allocator);
+                var rootPage = rootPages[index.Name];
+                pageIo.WritePage(rootPage, tree.RootPage);
+                foreach (var page in tree.InteriorPages)
+                    pageIo.WritePage(page.PageNumber, page.Page);
+                foreach (var page in tree.LeafPages)
+                    pageIo.WritePage(page.PageNumber, page.Page);
+                foreach (var page in tree.OverflowPages)
+                    pageIo.WritePage(page.PageNumber, page.Page);
+            }
+        }
+        catch (SqliteBtreeMaintenanceRequiredException)
+        {
+            return false;
+        }
+        catch (InvalidDataException)
+        {
+            // Free-page collection walks the OLD tree to discover its stale
+            // pages, which requires that tree's stored bytes to still parse as
+            // a well-formed b-tree. REINDEX must also repair a physically
+            // corrupted index, so a target whose on-disk image is not safely
+            // traversable falls back to the full-catalog rewrite, which never
+            // reads the old tree and always succeeds by reallocating fresh.
+            return false;
+        }
+
+        if (pageIo.StagedPages.Count == 0 || pageIo.StagedPages.ContainsKey(SchemaRootPage))
+            return false;
+
+        var target = pageIo.PageCount;
+        var newChangeCounter = currentHeader.ChangeCounter + 1;
+        var newHeader = currentHeader with
+        {
+            ChangeCounter = newChangeCounter,
+            VersionValidFor = newChangeCounter,
+            DatabaseSizeInPages = target,
+            FirstFreelistTrunkPage = pageIo.FirstFreelistTrunkPage,
+            FreelistPageCount = pageIo.FreelistPageCount,
+        };
+        var pageOne = _pager.ReadCommittedPage(SchemaRootPage);
+        newHeader.WriteTo(pageOne);
+
+        using (var transaction = _pager.BeginTransaction(target))
+        {
+            foreach (var (pageNumber, image) in pageIo.StagedPages)
+                transaction.WritePage(pageNumber, image);
+
             transaction.WritePage(SchemaRootPage, pageOne);
             transaction.Commit(_synchronousMode);
         }
@@ -2757,7 +3967,7 @@ internal sealed class EmbeddedFileStore : IDisposable
             return false;
 
         var persisted = Load();
-        if (!HasCurrentSchemaShape(tables, views, triggers, virtualTables)
+        if (!HasCurrentSchemaShape(tables, views, triggers, virtualTables, persisted.Tables)
             || !TryGetSingleChangedTable(tables, persisted.Tables, out var tableName, out var table))
         {
             return false;
@@ -2773,7 +3983,7 @@ internal sealed class EmbeddedFileStore : IDisposable
         }
 
         var tableNames = tables.Keys.OrderBy(name => name, StringComparer.OrdinalIgnoreCase).ToArray();
-        var indexes = GetIndexDefinitions(tableNames, tables, views, triggers, virtualTables)
+        var indexes = GetIndexDefinitions(tableNames, tables, views, triggers, virtualTables, persisted.Tables)
             .Where(index => string.Equals(index.TableName, tableName, StringComparison.OrdinalIgnoreCase))
             .ToArray();
         if (indexes.Length != table.Indexes.Count
@@ -7867,7 +9077,8 @@ internal sealed class EmbeddedFileStore : IDisposable
         IReadOnlyDictionary<string, EmbeddedTable> tables,
         IReadOnlyDictionary<string, ViewDefinition> views,
         IReadOnlyDictionary<string, TriggerDefinition> triggers,
-        IReadOnlyDictionary<string, EmbeddedDatabase.VirtualTableDefinition> virtualTables)
+        IReadOnlyDictionary<string, EmbeddedDatabase.VirtualTableDefinition> virtualTables,
+        IReadOnlyDictionary<string, EmbeddedTable>? previousTables = null)
     {
         if (tables.Count != _tableRootPages.Count
             || tables.Keys.Any(name => !_tableRootPages.ContainsKey(name)))
@@ -7876,7 +9087,7 @@ internal sealed class EmbeddedFileStore : IDisposable
         }
 
         var tableNames = tables.Keys.OrderBy(name => name, StringComparer.OrdinalIgnoreCase).ToArray();
-        var indexes = GetIndexDefinitions(tableNames, tables, views, triggers, virtualTables);
+        var indexes = GetIndexDefinitions(tableNames, tables, views, triggers, virtualTables, previousTables);
         if (indexes.Count != _indexRootPages.Count
             || indexes.Any(index => !_indexRootPages.ContainsKey(index.Index.Name)))
         {
@@ -8298,6 +9509,17 @@ internal sealed class EmbeddedFileStore : IDisposable
         {
             _pager.CheckpointToMainStoreAndResetWal(synchronousMode: _synchronousMode);
         }
+        catch (SqlitePagerBusyException)
+        {
+            // A peer connection's pinned durable transaction snapshot (or another
+            // in-flight checkpoint) is legitimately holding a WAL read mark right now.
+            // This is ordinary SQLite PASSIVE-checkpoint contention, not a maintenance
+            // failure: the mutation above is already durable, and the WAL simply keeps
+            // the frames around for the next opportunistic checkpoint to reclaim. Do
+            // not escalate this to EmbeddedPostCommitMaintenanceException regardless of
+            // reclaimTrailingPages, since surfacing it would make an unrelated reader's
+            // still-open transaction fail an otherwise-successful peer commit.
+        }
         catch (IOException exception) when (!reclaimTrailingPages)
         {
             throw RecordPostCommitMaintenanceFailure(exception);
@@ -8472,11 +9694,102 @@ internal sealed class EmbeddedFileStore : IDisposable
         }
     }
 
-    private static void ValidateTableRepresentable(string name, EmbeddedTable table)
+    /// <summary>
+    /// Reports whether <paramref name="table"/>'s row storage — <see cref="RowStore.LineageId"/>
+    /// and <see cref="RowStore.Revision"/> — is unchanged relative to the entry recorded for
+    /// <paramref name="name"/> in <paramref name="previousTables"/>, and returns that previous
+    /// entry via <paramref name="previous"/> for a caller to then check individual indexes
+    /// against (see <see cref="IsIndexUnchangedFromPrevious(EmbeddedIndex,EmbeddedTable?)"/>).
+    /// Deliberately says nothing about the table's current index *list*: a sibling
+    /// <c>CREATE INDEX</c>/<c>DROP INDEX</c> only ever appends to or removes an entry from
+    /// <see cref="EmbeddedTable.Indexes"/> without touching the table's row storage, so gating
+    /// this proof on the index list being identical (as an earlier version of this method did)
+    /// would defeat every pre-existing index's preservation/deferred-validation exemption the
+    /// moment any one index on the same table was added or dropped — forcing an unrelated
+    /// <c>CREATE INDEX new_binary ON t(...)</c> to rebuild (and therefore require a working
+    /// comparator for) every other index on <c>t</c>, including one whose collation is not
+    /// currently available.
+    /// </summary>
+    /// <remarks>
+    /// The working catalog for an ordinary statement is built via
+    /// <c>SchemaCatalog.Clone()</c>, which unconditionally deep-clones every table (so a
+    /// failed/rolled-back statement never mutates the published catalog) — even tables
+    /// the statement never touches. That means <paramref name="table"/> is essentially
+    /// never reference-identical to the previously-recorded entry even when nothing about
+    /// it changed, so a plain reference check alone would defeat this exemption for every
+    /// commit. <see cref="EmbeddedTable.Clone"/> preserves the source's exact
+    /// <see cref="RowStore.Revision"/> *and* <see cref="RowStore.LineageId"/> (rather than
+    /// rebuilding the row store row by row), so comparing those cheap, already-tracked signals
+    /// detects "row storage genuinely untouched since the previous commit" without an
+    /// O(row count) content diff.
+    /// <para>
+    /// Revision equality alone is not collision-resistant: a full table rebuild (e.g.
+    /// <c>EmbeddedTable.CreateWithAlteredColumn</c> for <c>ALTER TABLE ... ALTER COLUMN</c>,
+    /// or DROP/ADD COLUMN) constructs a brand-new <see cref="RowStore"/> and re-adds every
+    /// existing row into it via <see cref="RowStore.Add"/> — so a table with N rows and no
+    /// prior updates/deletes ends up with the identical Revision (== N) both before and after
+    /// the rebuild, even though every row's bytes may have changed under a column's new
+    /// affinity/type. Requiring <see cref="RowStore.LineageId"/> equality as well closes that
+    /// gap: it can only ever match when the exact same in-memory RowStore was carried forward
+    /// (Clone), never across a rebuild that constructs a new one.
+    /// </para>
+    /// </remarks>
+    private static bool IsTableRowStorageUnchangedFromPrevious(
+        string name,
+        EmbeddedTable table,
+        IReadOnlyDictionary<string, EmbeddedTable>? previousTables,
+        out EmbeddedTable? previous)
+    {
+        if (previousTables is null || !previousTables.TryGetValue(name, out previous))
+        {
+            previous = null;
+            return false;
+        }
+
+        return ReferenceEquals(previous, table)
+            || (table.Rows.LineageId == previous.Rows.LineageId
+                && table.Rows.Revision == previous.Rows.Revision);
+    }
+
+    /// <summary>
+    /// Reports whether <paramref name="index"/> — one specific index, not its owning table's
+    /// entire index list — is the exact same <see cref="EmbeddedIndex"/> instance carried
+    /// forward on <paramref name="previous"/> (the table entry recorded at the previous
+    /// commit; see <see cref="IsTableRowStorageUnchangedFromPrevious"/>). A brand-new index
+    /// added by this statement's own <c>CREATE INDEX</c> (<c>table.Indexes.Add(definition)</c>
+    /// in EmbeddedDatabase.cs) is never present by reference in <paramref name="previous"/>'s
+    /// list and so correctly reports "changed" here even while every pre-existing index on the
+    /// same table — carried forward unmodified — still reports "unchanged". Combined with
+    /// row-storage-unchanged, this is what proves a specific index's already-committed b-tree
+    /// is still exactly what was durably written for it, independent of whether some other
+    /// index on the same table was just added or dropped.
+    /// </summary>
+    private static bool IsIndexUnchangedFromPrevious(EmbeddedIndex index, EmbeddedTable? previous)
+        => previous is not null
+            && previous.Indexes.Contains(index, ReferenceEqualityComparer.Instance);
+
+    /// <summary>
+    /// Combines <see cref="IsTableRowStorageUnchangedFromPrevious"/> and
+    /// <see cref="IsIndexUnchangedFromPrevious(EmbeddedIndex,EmbeddedTable?)"/> into the single
+    /// per-index "is this index's committed b-tree still trustworthy/preservable" proof callers
+    /// need. See both for why this is scoped to one index rather than the table as a whole.
+    /// </summary>
+    private static bool IsIndexUnchangedFromPrevious(
+        string tableName,
+        EmbeddedTable table,
+        EmbeddedIndex index,
+        IReadOnlyDictionary<string, EmbeddedTable>? previousTables)
+        => IsTableRowStorageUnchangedFromPrevious(tableName, table, previousTables, out var previous)
+            && IsIndexUnchangedFromPrevious(index, previous);
+
+    private void ValidateTableRepresentable(
+        string name,
+        EmbeddedTable table,
+        IReadOnlyDictionary<string, EmbeddedTable>? previousTables = null)
     {
         if (table.WithoutRowid)
         {
-            _ = ValidateWithoutRowidTableRepresentable(name, table);
+            _ = ValidateWithoutRowidTableRepresentable(name, table, previousTables);
             return;
         }
 
@@ -8534,7 +9847,11 @@ internal sealed class EmbeddedFileStore : IDisposable
         }
 
         foreach (var index in table.Indexes)
-            ValidateIndexRepresentable(name, table, index);
+        {
+            var structuralOnly = _collationResolver is null
+                || IsIndexUnchangedFromPrevious(name, table, index, previousTables);
+            ValidateIndexRepresentable(name, table, index, structuralOnly: structuralOnly);
+        }
     }
 
     private static void ValidatePrimaryKeyIndexPrerequisites(
@@ -8578,9 +9895,10 @@ internal sealed class EmbeddedFileStore : IDisposable
         }
     }
 
-    private static SqlitePrimaryKeySchema ValidateWithoutRowidTableRepresentable(
+    private SqlitePrimaryKeySchema ValidateWithoutRowidTableRepresentable(
         string tableName,
-        EmbeddedTable table)
+        EmbeddedTable table,
+        IReadOnlyDictionary<string, EmbeddedTable>? previousTables = null)
     {
         ValidatePrimaryKeyIndexPrerequisites(
             tableName,
@@ -8615,7 +9933,11 @@ internal sealed class EmbeddedFileStore : IDisposable
         }
 
         foreach (var index in table.Indexes)
-            ValidateIndexRepresentable(tableName, table, index);
+        {
+            var structuralOnly = _collationResolver is null
+                || IsIndexUnchangedFromPrevious(tableName, table, index, previousTables);
+            ValidateIndexRepresentable(tableName, table, index, structuralOnly: structuralOnly);
+        }
 
         return primaryKeySchema;
     }
@@ -9601,7 +10923,7 @@ internal sealed class EmbeddedFileStore : IDisposable
         string tableName,
         EmbeddedTable table,
         EmbeddedIndex index,
-        RebuildPageAllocator allocator)
+        IIndexRebuildPageAllocator allocator)
     {
         var comparer = CreateIndexComparer(table, index);
         var leafGroups = PartitionIndexLeafRecords(
@@ -9619,7 +10941,7 @@ internal sealed class EmbeddedFileStore : IDisposable
         string treeDescription,
         IReadOnlyList<List<byte[]>> leafGroups,
         SqliteIndexRecordComparer comparer,
-        RebuildPageAllocator allocator)
+        IIndexRebuildPageAllocator allocator)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(treeDescription);
         ArgumentNullException.ThrowIfNull(leafGroups);
@@ -10144,7 +11466,7 @@ internal sealed class EmbeddedFileStore : IDisposable
     private byte[] BuildIndexInteriorPage(
         IndexInteriorPlan plan,
         SqliteIndexRecordComparer comparer,
-        RebuildPageAllocator allocator,
+        IIndexRebuildPageAllocator allocator,
         ICollection<PageImage> overflowPages)
     {
         if (plan.Separators.Count != plan.Children.Count - 1)
@@ -10170,7 +11492,7 @@ internal sealed class EmbeddedFileStore : IDisposable
     private void MaterializeIndexTreeChildren(
         IReadOnlyList<IndexTreeNode> children,
         SqliteIndexRecordComparer comparer,
-        RebuildPageAllocator allocator,
+        IIndexRebuildPageAllocator allocator,
         ICollection<PageImage> overflowPages,
         ICollection<PageImage> interiorPages,
         ICollection<PageImage> leafPages)
@@ -10320,7 +11642,7 @@ internal sealed class EmbeddedFileStore : IDisposable
     private byte[] BuildIndexLeafPage(
         IReadOnlyList<byte[]> records,
         SqliteIndexRecordComparer comparer,
-        RebuildPageAllocator allocator,
+        IIndexRebuildPageAllocator allocator,
         ICollection<PageImage> overflowPages)
     {
         var builder = new SqliteIndexLeafPageBuilder(_pageSize, _usableSpace, comparer);
@@ -10381,7 +11703,7 @@ internal sealed class EmbeddedFileStore : IDisposable
 
     private SqliteIndexLeafCell CreateIndexLeafCell(
         byte[] record,
-        RebuildPageAllocator allocator,
+        IIndexRebuildPageAllocator allocator,
         ICollection<PageImage> overflowPages)
     {
         var layout = SqlitePayloadLayout.Calculate(
@@ -10702,7 +12024,7 @@ internal sealed class EmbeddedFileStore : IDisposable
             decorated.Add((values, record));
         }
 
-        decorated.Sort((left, right) => comparer.Compare(left.SortKey, right.SortKey));
+        SortPropagatingComparerExceptions(decorated, (left, right) => comparer.Compare(left.SortKey, right.SortKey));
         var records = new List<byte[]>(decorated.Count);
         for (var indexPosition = 0; indexPosition < decorated.Count; indexPosition++)
         {
@@ -10719,14 +12041,46 @@ internal sealed class EmbeddedFileStore : IDisposable
         return records;
     }
 
-    private SqliteIndexRecordComparer CreateIndexComparer(EmbeddedTable table, EmbeddedIndex index)
+    /// <summary>
+    /// Sorts <paramref name="list"/> with <paramref name="comparison"/>, unwrapping the
+    /// <see cref="InvalidOperationException"/> ("Failed to compare two elements in the
+    /// array.") that <see cref="List{T}.Sort(Comparison{T})"/> wraps around any exception a
+    /// comparison delegate throws. An application-defined collation callback registered via
+    /// <c>RegisterCollation</c> can throw arbitrary exceptions (including
+    /// non-Ahtola ones), and callers must see that original exception, not an opaque
+    /// sort-failure wrapper that discards it as an inner exception.
+    /// </summary>
+    internal static void SortPropagatingComparerExceptions<T>(List<T> list, Comparison<T> comparison)
+    {
+        try
+        {
+            list.Sort(comparison);
+        }
+        catch (InvalidOperationException exception) when (exception.InnerException is not null)
+        {
+            ExceptionDispatchInfo.Capture(exception.InnerException).Throw();
+            throw;
+        }
+    }
+
+    internal SqliteIndexRecordComparer CreateIndexComparer(
+        EmbeddedTable table,
+        EmbeddedIndex index,
+        bool allowDeferredCustomCollation = false,
+        bool forceDeferCustomCollation = false)
     {
         if (!table.WithoutRowid)
         {
-            return new SqliteIndexRecordComparer(
-                _textEncoding,
-                index.Columns.Select(column => column.Descending).ToArray(),
-                index.Columns.Select(column => column.Collation).ToArray());
+            var rowidTerms = index.Columns
+                .Select(column => new SqliteIndexComparisonTerm(
+                    column.Descending ? SqliteKeySortOrder.Descending : SqliteKeySortOrder.Ascending,
+                    GetIndexCollation(table, column)))
+                .ToArray();
+            return CreateIndexComparerOrThrowNoSuchCollation(
+                index,
+                rowidTerms,
+                allowDeferredCustomCollation,
+                forceDeferCustomCollation);
         }
 
         var terms = GetWithoutRowidIndexStorageColumns(table, index)
@@ -10734,15 +12088,104 @@ internal sealed class EmbeddedFileStore : IDisposable
                 column.Descending ? SqliteKeySortOrder.Descending : SqliteKeySortOrder.Ascending,
                 GetIndexCollation(table, column)))
             .ToArray();
-        return new SqliteIndexRecordComparer(_textEncoding, terms);
+        return CreateIndexComparerOrThrowNoSuchCollation(
+            index,
+            terms,
+            allowDeferredCustomCollation,
+            forceDeferCustomCollation);
     }
 
-    private SqliteIndexRecordComparer CreatePrimaryKeyComparer(SqlitePrimaryKeySchema schema)
+    /// <summary>
+    /// Builds the comparer for <paramref name="index"/>'s complete key terms, converting the
+    /// <see cref="SqliteIndexRecordComparer"/> constructor's <see cref="NotSupportedException"/>
+    /// (thrown only when <paramref name="allowDeferredCustomCollation"/> is <see langword="false"/>
+    /// and a term names a collation with neither a built-in implementation nor a bound
+    /// application-defined callback) into the SQLite-style
+    /// <see cref="EmbeddedSqlException"/> a write against this index must fail closed with —
+    /// never a raw <see cref="NotSupportedException"/> that leaks a managed-engine implementation
+    /// detail to callers expecting SQLite's "no such collation sequence" wording.
+    /// </summary>
+    private SqliteIndexRecordComparer CreateIndexComparerOrThrowNoSuchCollation(
+        EmbeddedIndex index,
+        SqliteIndexComparisonTerm[] terms,
+        bool allowDeferredCustomCollation,
+        bool forceDeferCustomCollation = false)
+    {
+        try
+        {
+            return new SqliteIndexRecordComparer(
+                _textEncoding,
+                terms,
+                allowDeferredCustomCollation,
+                forceDeferCustomCollation);
+        }
+        catch (NotSupportedException exception)
+        {
+            var unavailable = terms.FirstOrDefault(
+                term => !term.Collation.IsAvailable || !term.Collation.IsSupportedByManagedIndexWriter);
+            var name = unavailable?.Collation.Name ?? "?";
+            throw new EmbeddedSqlException(
+                $"The managed file engine cannot use index '{index.Name}' because no such collation sequence: {name}",
+                exception);
+        }
+    }
+
+    internal SqliteIndexRecordComparer CreatePrimaryKeyComparer(SqlitePrimaryKeySchema schema)
         => new(
             _textEncoding,
             schema.Terms.Select(term => new SqliteIndexComparisonTerm(term.SortOrder, term.Collation)).ToArray());
 
-    private static IReadOnlyList<EmbeddedIndexColumn> GetWithoutRowidIndexStorageColumns(
+    /// <summary>
+    /// Projects a row into the exact comparison-key shape the durable pager uses when persisting
+    /// <paramref name="index"/> (or, when <paramref name="index"/> is <see langword="null"/>, the
+    /// table's own WITHOUT ROWID primary-key b-tree), so a transaction's mutation-overlay rows sort
+    /// identically to — and merge deterministically with — rows read from the committed b-tree via
+    /// <see cref="CreateIndexComparer"/> / <see cref="CreatePrimaryKeyComparer"/>.
+    /// </summary>
+    internal SqlValue[] BuildIndexMergeKey(
+        EmbeddedTable table,
+        EmbeddedIndex? index,
+        SqlValue[] values,
+        long? rowId,
+        Func<Expression, EmbeddedTable, SqlValue[], long?, SqlValue> evaluateExpression)
+    {
+        ArgumentNullException.ThrowIfNull(table);
+        ArgumentNullException.ThrowIfNull(values);
+        ArgumentNullException.ThrowIfNull(evaluateExpression);
+
+        if (index is null)
+        {
+            var primaryKeySchema = table.PrimaryKeySchema
+                ?? throw new InvalidOperationException(
+                    $"WITHOUT ROWID table '{table.Name}' is missing its primary-key metadata.");
+            return primaryKeySchema.ProjectKey(values);
+        }
+
+        if (!table.WithoutRowid)
+        {
+            var key = IndexExpressionSemantics.ProjectKey(index, table, values, rowId, evaluateExpression);
+            var withRowId = new SqlValue[key.Length + 1];
+            Array.Copy(key, withRowId, key.Length);
+            withRowId[^1] = SqlValue.Integer(
+                rowId ?? throw new InvalidOperationException(
+                    $"Rowid table '{table.Name}' index seek requires a rowid."));
+            return withRowId;
+        }
+
+        var storageColumns = GetWithoutRowidIndexStorageColumns(table, index);
+        var storageKey = new SqlValue[storageColumns.Count];
+        for (var position = 0; position < storageColumns.Count; position++)
+        {
+            var column = storageColumns[position];
+            storageKey[position] = column.ColumnIndex >= 0
+                ? values[column.ColumnIndex]
+                : evaluateExpression(column.Expression!, table, values, rowId);
+        }
+
+        return storageKey;
+    }
+
+    private IReadOnlyList<EmbeddedIndexColumn> GetWithoutRowidIndexStorageColumns(
         EmbeddedTable table,
         EmbeddedIndex index)
     {
@@ -10774,8 +12217,65 @@ internal sealed class EmbeddedFileStore : IDisposable
         return columns;
     }
 
-    private static SqliteKeyCollation GetIndexCollation(EmbeddedTable table, EmbeddedIndexColumn column)
-        => SqliteKeyCollation.FromName(IndexExpressionSemantics.GetCollationName(table, column));
+    /// <summary>
+    /// Resolves the collation to use for one index storage column, binding
+    /// an application-defined comparison delegate when a runtime resolver is
+    /// attached and a callback is registered under the collation's name.
+    /// This also lets an application override BINARY/NOCASE/RTRIM by
+    /// registering a callback under that exact name; ordinary built-in
+    /// columns are unaffected because no callback is registered for them,
+    /// so the resolver returns <see langword="null"/> and default built-in
+    /// behavior is preserved. With no resolver attached (the true
+    /// cold-start catalog-load path) or no callback registered under the
+    /// name, this returns a collation descriptor with no bound delegate;
+    /// callers decide whether that is fatal (write/plan/seek) or
+    /// deferrable (initial structural catalog load).
+    /// </summary>
+    private SqliteKeyCollation GetIndexCollation(EmbeddedTable table, EmbeddedIndexColumn column)
+    {
+        var collation = SqliteKeyCollation.FromName(IndexExpressionSemantics.GetCollationName(table, column));
+        if (_collationResolver is null || collation.Name is null)
+            return collation;
+
+        var comparison = _collationResolver(collation.Name);
+        return comparison is null ? collation : collation.WithComparison(comparison);
+    }
+
+    /// <summary>
+    /// Checks whether <paramref name="index"/>'s partial-index predicate or index-expression
+    /// bodies embed a <c>COLLATE</c> reference that this store cannot currently resolve — neither
+    /// a built-in collation nor one bound via <see cref="SetCollationResolver"/> — so that
+    /// <see cref="ValidateStoredIndex"/> can decline to (re)evaluate the predicate/expression
+    /// through <see cref="BuildIndexRecords"/> before the caller has a chance to register it.
+    /// This mirrors <see cref="SqliteIndexRecordComparer.HasDeferredTerms"/>, which covers only
+    /// collations trailing an indexed term (column-level), never ones nested inside a predicate
+    /// or expression body.
+    /// </summary>
+    private bool TryFindUnresolvedEmbeddedIndexCollation(EmbeddedIndex index, out string? unresolvedName)
+    {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        IndexExpressionSemantics.CollectEmbeddedCollationNames(index, names);
+        foreach (var name in names)
+        {
+            if (IsCollationNameResolvable(name))
+                continue;
+
+            unresolvedName = name;
+            return true;
+        }
+
+        unresolvedName = null;
+        return false;
+    }
+
+    private bool IsCollationNameResolvable(string name)
+    {
+        var collation = SqliteKeyCollation.FromName(name);
+        if (collation.IsSupportedByManagedIndexWriter)
+            return true;
+
+        return _collationResolver is not null && _collationResolver(name) is not null;
+    }
 
     private PreparedSchemaTree BuildSchemaTree(
         IReadOnlyList<SchemaEntry> entries,
@@ -10984,12 +12484,13 @@ internal sealed class EmbeddedFileStore : IDisposable
         return entries;
     }
 
-    private static IReadOnlyList<IndexDefinition> GetIndexDefinitions(
+    private IReadOnlyList<IndexDefinition> GetIndexDefinitions(
         IReadOnlyList<string> tableNames,
         IReadOnlyDictionary<string, EmbeddedTable> tables,
         IReadOnlyDictionary<string, ViewDefinition> views,
         IReadOnlyDictionary<string, TriggerDefinition> triggers,
-        IReadOnlyDictionary<string, EmbeddedDatabase.VirtualTableDefinition> virtualTables)
+        IReadOnlyDictionary<string, EmbeddedDatabase.VirtualTableDefinition> virtualTables,
+        IReadOnlyDictionary<string, EmbeddedTable>? previousTables = null)
     {
         var names = new HashSet<string>(tables.Keys, StringComparer.OrdinalIgnoreCase);
         foreach (var name in views.Keys)
@@ -11014,7 +12515,9 @@ internal sealed class EmbeddedFileStore : IDisposable
             var table = tables[tableName];
             foreach (var index in table.Indexes)
             {
-                ValidateIndexRepresentable(tableName, table, index);
+                var structuralOnly = _collationResolver is null
+                    || IsIndexUnchangedFromPrevious(tableName, table, index, previousTables);
+                ValidateIndexRepresentable(tableName, table, index, structuralOnly: structuralOnly);
                 if (!names.Add(index.Name))
                 {
                     throw new EmbeddedSqlException(
@@ -11028,10 +12531,11 @@ internal sealed class EmbeddedFileStore : IDisposable
         return definitions;
     }
 
-    private static void ValidateIndexRepresentable(
+    private void ValidateIndexRepresentable(
         string tableName,
         EmbeddedTable table,
-        EmbeddedIndex index)
+        EmbeddedIndex index,
+        bool structuralOnly = false)
     {
         ArgumentNullException.ThrowIfNull(index);
         IndexExpressionSemantics.ValidateDefinition(tableName, table, index);
@@ -11046,13 +12550,24 @@ internal sealed class EmbeddedFileStore : IDisposable
                     $"The managed file engine cannot persist index '{index.Name}' because its column metadata is inconsistent.");
             }
             var collation = GetIndexCollation(table, column);
-            if (!collation.IsSupportedByManagedIndexWriter)
-            {
-                throw new EmbeddedSqlException(
-                    table.WithoutRowid
-                        ? $"The managed file engine cannot persist index '{index.Name}' because application-defined collation '{collation.Name}' cannot be restored before the file catalog is loaded."
-                        : $"The managed file engine cannot persist index '{index.Name}' because collation '{collation.Name}' is not a supported SQLite built-in collation.");
-            }
+            if (collation.IsSupportedByManagedIndexWriter)
+                continue;
+
+            // A structural-only pass (initial catalog load, before this store
+            // has a runtime collation resolver) can neither prove nor
+            // disprove that the durable order/content for this
+            // application-defined collation is still valid, so it defers
+            // that judgement instead of failing the whole catalog open.
+            // Everything else about the index — page layout, cell/record
+            // decodability, schema round-trip — is still fully validated.
+            // Ordering, content, and uniqueness are (re)validated once a
+            // matching collation callback is registered; see
+            // EmbeddedDatabase.RegisterCollation.
+            if (structuralOnly)
+                continue;
+
+            throw new EmbeddedSqlException(
+                $"The managed file engine cannot persist index '{index.Name}' because no such collation sequence: {collation.Name}");
         }
 
         if (table.WithoutRowid)
@@ -11083,7 +12598,8 @@ internal sealed class EmbeddedFileStore : IDisposable
         SchemaEntry entry,
         EmbeddedTable table,
         EmbeddedIndex index,
-        ISet<uint> occupiedBtreePages)
+        ISet<uint> occupiedBtreePages,
+        bool structuralOnly = false)
     {
         if (entry.RootPage < 2 || entry.RootPage > _pager.CommittedPageCount)
         {
@@ -11092,7 +12608,7 @@ internal sealed class EmbeddedFileStore : IDisposable
         }
 
         var overflowReader = new SqliteOverflowChainReader(_pager, _header);
-        var comparer = CreateIndexComparer(table, index);
+        var comparer = CreateIndexComparer(table, index, allowDeferredCustomCollation: structuralOnly);
         IReadOnlyList<byte[]> actualRecords;
         try
         {
@@ -11116,6 +12632,36 @@ internal sealed class EmbeddedFileStore : IDisposable
             throw new EmbeddedSqlException(
                 $"Stored index '{entry.Name}' is not a valid supported SQLite index b-tree.",
                 exception);
+        }
+
+        if (comparer.HasDeferredTerms)
+        {
+            // Page shape and record decodability are proven above, but this
+            // index depends on an application-defined collation with no
+            // registered callback yet, so its order, content, and uniqueness
+            // cannot be checked here. It stays unusable for planning/writes
+            // until EmbeddedDatabase.RegisterCollation revalidates it with a
+            // real callback (see RevalidateIndexOrderAndContent).
+            return;
+        }
+
+        if (TryFindUnresolvedEmbeddedIndexCollation(index, out var unresolvedName))
+        {
+            // The partial-index predicate or index-expression body itself embeds a
+            // COLLATE reference (as opposed to a trailing COLLATE on an indexed term,
+            // already covered by comparer.HasDeferredTerms above) that has no bound
+            // callback yet. Evaluating BuildIndexRecords below would call into
+            // EmbeddedDatabase's private expression evaluator and fail hard with "no
+            // such collation sequence" — before the caller ever gets a chance to
+            // register it. Structural passes defer judgement the same way deferred
+            // column terms do; a live re-check (structuralOnly: false, from
+            // RegisterCollation/RevalidateIndexOrderAndContent) still fails closed so
+            // a genuinely-missing collation is never silently treated as valid.
+            if (structuralOnly)
+                return;
+
+            throw new EmbeddedSqlException(
+                $"The managed file engine cannot persist index '{entry.Name}' because no such collation sequence: {unresolvedName}");
         }
 
         ValidateUniqueIndexRecords(entry.TableName, table, index, actualRecords);
@@ -11170,6 +12716,50 @@ internal sealed class EmbeddedFileStore : IDisposable
             }
 
             previousKey = key;
+        }
+    }
+
+    /// <summary>
+    /// Re-validates one durable index's on-disk order, content, and
+    /// uniqueness using the collation resolver currently attached to this
+    /// store, without re-running the full catalog-load pass. Called by
+    /// <c>EmbeddedDatabase</c> when a collation callback is registered,
+    /// replaced, or unregistered, to decide whether an existing
+    /// custom-collation index becomes eligible for planning/writes (clean)
+    /// or must be treated as unusable until REINDEX rebuilds it (dirty).
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> when the index's durable order/content/
+    /// uniqueness is proven consistent with the active collation callback;
+    /// <see langword="false"/> otherwise, with <paramref name="failureReason"/>
+    /// set to a human-readable explanation.
+    /// </returns>
+    internal bool RevalidateIndexOrderAndContent(
+        string tableName,
+        EmbeddedTable table,
+        EmbeddedIndex index,
+        out string? failureReason)
+    {
+        ArgumentNullException.ThrowIfNull(table);
+        ArgumentNullException.ThrowIfNull(index);
+        if (!_indexRootPages.TryGetValue(index.Name, out var rootPage))
+        {
+            failureReason = $"Index '{index.Name}' has no durable root page to revalidate.";
+            return false;
+        }
+
+        try
+        {
+            ValidateIndexRepresentable(tableName, table, index, structuralOnly: false);
+            var entry = new SchemaEntry("index", index.Name, tableName, rootPage, index.Sql);
+            ValidateStoredIndex(entry, table, index, new HashSet<uint>(), structuralOnly: false);
+            failureReason = null;
+            return true;
+        }
+        catch (EmbeddedSqlException exception)
+        {
+            failureReason = exception.Message;
+            return false;
         }
     }
 
@@ -11331,7 +12921,7 @@ internal sealed class EmbeddedFileStore : IDisposable
             if (childIndex < interior.Cells.Count)
             {
                 var separator = interior.GetRecord(childIndex);
-                if (comparer.Compare(childResult.Records[^1], separator) >= 0)
+                if (!comparer.HasDeferredTerms && comparer.Compare(childResult.Records[^1], separator) >= 0)
                 {
                     throw new InvalidDataException(
                         $"Stored index '{entry.Name}' interior page {pageNumber} separator {childIndex} does not follow child page {childPage}.");
@@ -11373,7 +12963,7 @@ internal sealed class EmbeddedFileStore : IDisposable
         ref byte[]? previousRecord,
         string level)
     {
-        if (previousRecord is not null && comparer.Compare(previousRecord, value) >= 0)
+        if (!comparer.HasDeferredTerms && previousRecord is not null && comparer.Compare(previousRecord, value) >= 0)
         {
             throw new InvalidDataException(
                 $"Stored index '{indexName}' {level} are not globally ordered by their declared complete keys.");
@@ -11535,19 +13125,51 @@ internal sealed class EmbeddedFileStore : IDisposable
     /// proves its entire active/freelist partition before its WAL commit marker.
     /// It is not an in-place page allocator.
     /// </remarks>
-    private sealed class RebuildPageAllocator
+    /// <summary>
+    /// The minimal surface an index-tree builder needs from whatever page
+    /// allocator is driving it: a way to reserve one fresh page number.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="RebuildPageAllocator"/> implements this for the whole-catalog
+    /// rewrite, and <see cref="StagedIndexRebuildPageAllocator"/> implements it
+    /// for a single targeted index rebuild through
+    /// <see cref="SqliteStagedBtreePageIo"/>, so the index-tree builders
+    /// (<see cref="BuildIndexTree"/> and everything it calls) stay unaware of
+    /// which persistence path is driving them.
+    /// </remarks>
+    private interface IIndexRebuildPageAllocator
+    {
+        uint ReservePage();
+    }
+
+    /// <summary>
+    /// Adapts <see cref="SqliteStagedBtreePageIo.AllocatePage"/> — which
+    /// prefers freelist reuse over growing the file, exactly like real SQLite
+    /// allocation — to <see cref="IIndexRebuildPageAllocator"/>, so a targeted
+    /// REINDEX can drive the same index-tree builders the whole-catalog
+    /// rewrite uses without allocating from that rewrite's naive full-range
+    /// scan, which assumes it owns every page in the database.
+    /// </summary>
+    private sealed class StagedIndexRebuildPageAllocator(ISqliteBtreePageIo pageIo) : IIndexRebuildPageAllocator
+    {
+        public uint ReservePage() => pageIo.AllocatePage();
+    }
+
+    private sealed class RebuildPageAllocator : IIndexRebuildPageAllocator
     {
         private readonly uint _sourcePageCount;
         private readonly bool _compact;
         private readonly Queue<uint> _reusableLeaves;
         private readonly HashSet<uint> _reusableLeafSet;
+        private readonly HashSet<uint> _reservedPages;
         private uint _nextExistingPage;
         private uint _nextAppendedPage;
 
         public RebuildPageAllocator(
             uint sourcePageCount,
             IReadOnlyList<uint> reusableLeaves,
-            bool compact)
+            bool compact,
+            IReadOnlyCollection<uint>? reservedPages = null)
         {
             ArgumentOutOfRangeException.ThrowIfZero(sourcePageCount);
             ArgumentNullException.ThrowIfNull(reusableLeaves);
@@ -11556,6 +13178,17 @@ internal sealed class EmbeddedFileStore : IDisposable
             _compact = compact;
             _reusableLeafSet = new HashSet<uint>();
             _reusableLeaves = new Queue<uint>();
+            // Pages a caller has already committed to a preserved-in-place index
+            // tree (see EmbeddedFileStore.TryPreserveUnavailableIndexTrees) must
+            // never also be handed out here as free/reusable: that would mean
+            // this rebuild's own recomputed freelist and a preserved index tree
+            // disagree about who owns the page, which is exactly the kind of
+            // silent page-ownership corruption ValidateRewritePlan/AddActivePage
+            // exist to catch elsewhere. compact (VACUUM/page-size migration)
+            // never receives reserved pages — see the PersistCore call site.
+            _reservedPages = reservedPages is { Count: > 0 }
+                ? new HashSet<uint>(reservedPages)
+                : new HashSet<uint>();
             if (!compact)
             {
                 foreach (var pageNumber in reusableLeaves.Order())
@@ -11564,6 +13197,12 @@ internal sealed class EmbeddedFileStore : IDisposable
                     {
                         throw new InvalidDataException(
                             "Managed file rebuild received an invalid or duplicate validated freelist leaf.");
+                    }
+
+                    if (_reservedPages.Contains(pageNumber))
+                    {
+                        throw new InvalidDataException(
+                            $"Managed file rebuild freelist page {pageNumber} collides with a preserved index page.");
                     }
 
                     _reusableLeaves.Enqueue(pageNumber);
@@ -11586,7 +13225,7 @@ internal sealed class EmbeddedFileStore : IDisposable
             {
                 var existingPage = _nextExistingPage;
                 _nextExistingPage = existingPage == _sourcePageCount ? 0 : existingPage + 1;
-                if (!_reusableLeafSet.Contains(existingPage))
+                if (!_reusableLeafSet.Contains(existingPage) && !_reservedPages.Contains(existingPage))
                     return RecordAllocation(existingPage);
             }
 
@@ -11648,6 +13287,14 @@ internal sealed class EmbeddedFileStore : IDisposable
         IReadOnlyList<PageImage> InteriorPages,
         IReadOnlyList<PageImage> LeafPages,
         IReadOnlyList<PageImage> OverflowPages);
+
+    /// <summary>
+    /// Bundles a preserved-in-place index's existing root page number together with a
+    /// byte-for-byte clone of its tree read from committed storage, so a full rewrite never has
+    /// to re-derive one from the other — or risk them getting out of sync — once
+    /// <see cref="TryPreserveUnavailableIndexTrees"/> has decided to preserve it.
+    /// </summary>
+    private sealed record PreservedIndexTree(uint RootPage, PreparedIndexTree Tree);
 
     private sealed record IndexTreeReadResult(IReadOnlyList<byte[]> Records, int Height);
 

--- a/src/Ahtola.Core/Execution/VdbeProgram.cs
+++ b/src/Ahtola.Core/Execution/VdbeProgram.cs
@@ -979,6 +979,8 @@ public sealed class VdbeJoinIndexSeekMetrics
     private long _durableCursorPlans;
     private long _indexPagesRead;
     private long _tableRowsFetched;
+    private long _overlayRowsExamined;
+    private long _baseRowsSuppressed;
 
     public long PlansCreated => Interlocked.Read(ref _plansCreated);
 
@@ -997,6 +999,12 @@ public sealed class VdbeJoinIndexSeekMetrics
     public long IndexPagesRead => Interlocked.Read(ref _indexPagesRead);
 
     public long TableRowsFetched => Interlocked.Read(ref _tableRowsFetched);
+
+    /// <summary>Visible MVCC/overlay candidate rows examined while merging a durable base stream.</summary>
+    public long OverlayRowsExamined => Interlocked.Read(ref _overlayRowsExamined);
+
+    /// <summary>Durable base rows skipped because a visible overlay effect shadows their identity.</summary>
+    public long BaseRowsSuppressed => Interlocked.Read(ref _baseRowsSuppressed);
 
     internal void PlanCreated(int rowCount, bool automatic = false)
     {
@@ -1018,6 +1026,10 @@ public sealed class VdbeJoinIndexSeekMetrics
 
     internal void TableRowFetched() => Interlocked.Increment(ref _tableRowsFetched);
 
+    internal void OverlayRowExamined() => Interlocked.Increment(ref _overlayRowsExamined);
+
+    internal void BaseRowSuppressed() => Interlocked.Increment(ref _baseRowsSuppressed);
+
     internal void Reset()
     {
         Interlocked.Exchange(ref _plansCreated, 0);
@@ -1029,6 +1041,8 @@ public sealed class VdbeJoinIndexSeekMetrics
         Interlocked.Exchange(ref _durableCursorPlans, 0);
         Interlocked.Exchange(ref _indexPagesRead, 0);
         Interlocked.Exchange(ref _tableRowsFetched, 0);
+        Interlocked.Exchange(ref _overlayRowsExamined, 0);
+        Interlocked.Exchange(ref _baseRowsSuppressed, 0);
     }
 }
 

--- a/src/Ahtola.Core/IndexSemantics.cs
+++ b/src/Ahtola.Core/IndexSemantics.cs
@@ -1,5 +1,4 @@
 using Ahtola.Core.Parsing;
-using Ahtola.Core.Storage;
 
 namespace Ahtola.Core;
 
@@ -223,7 +222,6 @@ internal static class IndexExpressionSemantics
                 }
             }
 
-            ValidateCollation(index.Name, GetCollationName(table, term));
         }
 
         if ((index.Where is null) != (index.WhereSql is null))
@@ -266,6 +264,90 @@ internal static class IndexExpressionSemantics
         => term.Collation
             ?? (term.IsExpression ? null : table.ColumnDefinitions[term.ColumnIndex].Collation)
             ?? "BINARY";
+
+    /// <summary>
+    /// Collects the names of every application-defined collation embedded *inside* a partial
+    /// index's WHERE predicate or an expression-index column's expression tree — i.e. a
+    /// <c>COLLATE</c> clause nested within the expression body, as opposed to a trailing
+    /// <c>COLLATE</c> that qualifies an entire indexed term (already captured separately by
+    /// <see cref="GetCollationName"/> via <see cref="EmbeddedIndexColumn.Collation"/> and excluded
+    /// from the stored expression tree by <c>EmbeddedIndexFactory.Create</c>).
+    /// <para>
+    /// Callers use this to detect a durable index whose stored predicate/expression cannot be
+    /// safely (re)evaluated — for structural revalidation on reopen, or for live writes — until a
+    /// matching collation callback is registered, mirroring the deferred-term handling
+    /// <see cref="EmbeddedFileStore.CreateIndexComparer"/> already applies to column-level
+    /// collations.
+    /// </para>
+    /// </summary>
+    public static void CollectEmbeddedCollationNames(EmbeddedIndex index, ISet<string> names)
+    {
+        ArgumentNullException.ThrowIfNull(index);
+        ArgumentNullException.ThrowIfNull(names);
+        if (index.Where is not null)
+            CollectCollationNames(index.Where, names);
+        foreach (var column in index.Columns)
+        {
+            if (column.Expression is { } expression)
+                CollectCollationNames(expression, names);
+        }
+    }
+
+    private static void CollectCollationNames(Expression expression, ISet<string> names)
+    {
+        switch (expression)
+        {
+            case CollationExpression collation:
+                names.Add(collation.Name);
+                CollectCollationNames(collation.Expression, names);
+                return;
+            case FunctionExpression function:
+                foreach (var argument in function.Arguments)
+                    CollectCollationNames(argument, names);
+                return;
+            case CastExpression cast:
+                CollectCollationNames(cast.Expression, names);
+                return;
+            case CaseExpression @case:
+                if (@case.Operand is not null)
+                    CollectCollationNames(@case.Operand, names);
+                foreach (var clause in @case.Clauses)
+                {
+                    CollectCollationNames(clause.When, names);
+                    CollectCollationNames(clause.Then, names);
+                }
+                if (@case.Else is not null)
+                    CollectCollationNames(@case.Else, names);
+                return;
+            case LikeExpression like:
+                CollectCollationNames(like.Value, names);
+                CollectCollationNames(like.Pattern, names);
+                if (like.Escape is not null)
+                    CollectCollationNames(like.Escape, names);
+                return;
+            case GlobExpression glob:
+                CollectCollationNames(glob.Value, names);
+                CollectCollationNames(glob.Pattern, names);
+                return;
+            case InExpression @in:
+                CollectCollationNames(@in.Value, names);
+                foreach (var value in @in.Values)
+                    CollectCollationNames(value, names);
+                return;
+            case BetweenExpression between:
+                CollectCollationNames(between.Value, names);
+                CollectCollationNames(between.Lower, names);
+                CollectCollationNames(between.Upper, names);
+                return;
+            case UnaryExpression unary:
+                CollectCollationNames(unary.Operand, names);
+                return;
+            case BinaryExpression binary:
+                CollectCollationNames(binary.Left, names);
+                CollectCollationNames(binary.Right, names);
+                return;
+        }
+    }
 
     internal static bool MethodParametersEqual(
         IReadOnlyList<Indexing.ManagedIndexMethodParameter>? left,
@@ -363,10 +445,29 @@ internal static class IndexExpressionSemantics
         if (queryPredicate is null)
             return false;
 
-        var queryTerms = SplitConjuncts(queryPredicate);
+        return PredicateImplies(SplitConjuncts(queryPredicate), indexPredicate, tableName, alias);
+    }
+
+    /// <summary>
+    /// Same proof as the single-predicate overload, but for callers that already hold their
+    /// candidate conjuncts as a flat list — e.g. a join segment's combined safe plain-INNER
+    /// ON/WHERE conjuncts, which were never reconstructed into one AND-tree. Every required
+    /// partial-index conjunct must be matched by some query conjunct that mentions only
+    /// <paramref name="tableName"/>/<paramref name="alias"/>'s columns; an unmatched conjunct (or
+    /// one that reaches outside this table) leaves the predicate unproven.
+    /// </summary>
+    public static bool PredicateImplies(
+        IReadOnlyList<Expression> queryConjuncts,
+        Expression? indexPredicate,
+        string tableName,
+        string? alias)
+    {
+        if (indexPredicate is null)
+            return true;
+
         foreach (var required in SplitConjuncts(indexPredicate))
         {
-            if (!queryTerms.Any(candidate =>
+            if (!queryConjuncts.Any(candidate =>
                     UsesOnlySourceColumns(candidate, tableName, alias)
                     && PredicateTermsEqual(candidate, required)))
                 return false;
@@ -509,8 +610,6 @@ internal static class IndexExpressionSemantics
 
                     throw new EmbeddedSqlException($"no such column: {name}");
                 }
-                if (table.ColumnDefinitions[columnIndex].Collation is { } columnCollation)
-                    ValidateCollation("expression", columnCollation);
                 return;
             case ParameterExpression:
                 throw new EmbeddedSqlException($"parameters are prohibited in {context}");
@@ -531,7 +630,6 @@ internal static class IndexExpressionSemantics
                     ValidateExpression(tableName, table, argument, context);
                 return;
             case CollationExpression collation:
-                ValidateCollation("expression", collation.Name);
                 ValidateExpression(tableName, table, collation.Expression, context);
                 return;
             case CastExpression cast:
@@ -600,7 +698,7 @@ internal static class IndexExpressionSemantics
     // window implementations never qualify (MIN/MAX resolve to scalars only with
     // two or more arguments), and the non-deterministic built-in set is excluded
     // by the registry lookup.
-    private static bool IsDeterministicBuiltin(FunctionExpression function)
+    internal static bool IsDeterministicBuiltin(FunctionExpression function)
     {
         if (!SqliteBuiltinFunctions.AcceptsCall(
                 function.Name,
@@ -616,17 +714,6 @@ internal static class IndexExpressionSemantics
         // Date/time functions are deterministic only when they cannot read the
         // wall clock or the local timezone (mirrors generated-column validation).
         return EmbeddedTable.IsDeterministicSchemaFunction(function);
-    }
-
-    private static void ValidateCollation(string indexName, string name)
-    {
-        var collation = SqliteKeyCollation.FromName(name);
-        if (!collation.IsSupportedByManagedIndexWriter)
-        {
-            throw new EmbeddedSqlException(
-                $"Index '{indexName}' uses application-defined collation '{name}', "
-                + "which is not a supported SQLite built-in collation.");
-        }
     }
 
     public static IReadOnlyList<Expression> SplitConjuncts(Expression expression)

--- a/src/Ahtola.Core/Mvcc/MvccDualCursor.cs
+++ b/src/Ahtola.Core/Mvcc/MvccDualCursor.cs
@@ -135,7 +135,9 @@ internal static class MvccDualCursor
         IEnumerable<IndexRow> baseRows,
         Func<MvccVisibleRow, IndexRow?> projectOverlay,
         IComparer<IndexRow> indexComparer,
-        IComparer<MvccKey> tableKeyComparer)
+        IComparer<MvccKey> tableKeyComparer,
+        Action? baseRowSuppressed = null,
+        Action? overlayRowExamined = null)
     {
         ArgumentNullException.ThrowIfNull(store);
         ArgumentNullException.ThrowIfNull(baseRows);
@@ -147,14 +149,16 @@ internal static class MvccDualCursor
             store,
             txId,
             tableId,
-            baseRows).GetEnumerator();
+            baseRows,
+            baseRowSuppressed).GetEnumerator();
         using var overlayCursor = EnumerateOverlayIndexRows(
             store,
             txId,
             tableId,
             projectOverlay,
             indexComparer,
-            tableKeyComparer).GetEnumerator();
+            tableKeyComparer,
+            overlayRowExamined).GetEnumerator();
         var hasBase = baseCursor.MoveNext();
         var hasOverlay = overlayCursor.MoveNext();
         while (hasBase || hasOverlay)
@@ -192,7 +196,8 @@ internal static class MvccDualCursor
         MvStore store,
         MvccTxId txId,
         long tableId,
-        IEnumerable<IndexRow> baseRows)
+        IEnumerable<IndexRow> baseRows,
+        Action? baseRowSuppressed)
     {
         foreach (var row in baseRows)
         {
@@ -202,6 +207,7 @@ internal static class MvccDualCursor
                     out _,
                     out _))
             {
+                baseRowSuppressed?.Invoke();
                 continue;
             }
 
@@ -218,7 +224,8 @@ internal static class MvccDualCursor
         long tableId,
         Func<MvccVisibleRow, IndexRow?> projectOverlay,
         IComparer<IndexRow> indexComparer,
-        IComparer<MvccKey> tableKeyComparer)
+        IComparer<MvccKey> tableKeyComparer,
+        Action? overlayRowExamined)
     {
         var projected = new List<IndexRow>();
         foreach (var visible in store.EnumerateVisible(
@@ -226,6 +233,7 @@ internal static class MvccDualCursor
                      tableId,
                      tableKeyComparer))
         {
+            overlayRowExamined?.Invoke();
             if (!visible.IsDelete && projectOverlay(visible) is { } candidate)
                 projected.Add(candidate);
         }

--- a/src/Ahtola.Core/Storage/SqliteIndexBtreeCursor.cs
+++ b/src/Ahtola.Core/Storage/SqliteIndexBtreeCursor.cs
@@ -52,6 +52,76 @@ public sealed class SqliteIndexBtreeCursor
         return EnumerateNode(rootPage, seek, depth: 0, pageRead, keyCompared);
     }
 
+    /// <summary>
+    /// Enumerates every complete index record in ascending SQLite key order, with no equality
+    /// prefix filtering. Unlike <see cref="SeekPrefix"/>, this always descends into every child in
+    /// left-to-right order rather than binary-searching for a matching separator, so it visits
+    /// every leaf and interior separator exactly once — the natural in-order traversal a caller
+    /// merging a full ORDER BY-elision scan against an overlay needs, without materializing and
+    /// sorting the whole table in memory first.
+    /// </summary>
+    public IEnumerable<byte[]> ScanAscending(uint rootPage, Action? pageRead = null)
+    {
+        if (rootPage == 0 || rootPage > _io.PageCount)
+            throw new ArgumentOutOfRangeException(nameof(rootPage));
+
+        return EnumerateNodeAscending(rootPage, depth: 0, pageRead);
+    }
+
+    private IEnumerable<byte[]> EnumerateNodeAscending(uint pageNumber, int depth, Action? pageRead)
+    {
+        if (depth >= MaximumDepth)
+        {
+            throw new InvalidDataException(
+                $"SQLite index b-tree rooted above page {pageNumber} is deeper than {MaximumDepth} levels.");
+        }
+
+        var image = _io.ReadPage(pageNumber);
+        pageRead?.Invoke();
+        switch (SqliteBtreePageHeader.Parse(image).PageType)
+        {
+            case SqliteBtreePageType.IndexLeaf:
+                {
+                    var leaf = SqliteIndexLeafPageView.Parse(
+                        image,
+                        _io.UsableSpace,
+                        _textEncoding,
+                        overflowReader: _overflowReader,
+                        recordComparer: _comparer);
+                    for (var index = 0; index < leaf.Cells.Count; index++)
+                        yield return leaf.GetRecord(index);
+                    yield break;
+                }
+
+            case SqliteBtreePageType.IndexInterior:
+                {
+                    var interior = SqliteIndexInteriorPageView.Parse(
+                        image,
+                        _io.UsableSpace,
+                        _textEncoding,
+                        overflowReader: _overflowReader,
+                        recordComparer: _comparer);
+                    for (var childIndex = 0; childIndex <= interior.Cells.Count; childIndex++)
+                    {
+                        var childPage = childIndex == interior.Cells.Count
+                            ? interior.Header.RightMostChildPage
+                            : interior.Cells[childIndex].Cell.LeftChildPage;
+                        foreach (var record in EnumerateNodeAscending(childPage, depth + 1, pageRead))
+                            yield return record;
+
+                        if (childIndex < interior.Cells.Count)
+                            yield return interior.GetRecord(childIndex);
+                    }
+
+                    yield break;
+                }
+
+            default:
+                throw new InvalidDataException(
+                    $"SQLite page {pageNumber} is not part of an index b-tree.");
+        }
+    }
+
     private IEnumerable<byte[]> EnumerateNode(
         uint pageNumber,
         SqlValue[] prefix,

--- a/src/Ahtola.Core/Storage/SqliteIndexInteriorPage.cs
+++ b/src/Ahtola.Core/Storage/SqliteIndexInteriorPage.cs
@@ -370,7 +370,7 @@ public sealed class SqliteIndexInteriorPageView
         for (var index = 0; index < pointers.Count; index++)
         {
             var offset = pointers[index];
-            var cell = SqliteIndexInteriorCell.Decode(snapshot[offset..usableSpace], usableSpace);
+            var cell = SqliteIndexInteriorCell.Decode(snapshot.AsSpan(offset, usableSpace - offset), usableSpace);
             var end = checked(offset + cell.EncodedLength);
             if (end > usableSpace)
                 throw new InvalidDataException("SQLite index-interior cell extends into reserved page space.");
@@ -454,18 +454,25 @@ public sealed class SqliteIndexInteriorPageView
             return null;
 
         var records = new byte[cells.Count][];
-        byte[]? previousRecord = null;
+        SqlValue[]? previousDecoded = null;
+        // See the identical HasDeferredTerms comment in SqliteIndexLeafPageView.ReadAndValidateRecords:
+        // a deferred comparer's "equal" result is inconclusive (no collation callback registered
+        // yet), not a genuine duplicate, so the strict-order check must be skipped entirely.
+        var validateOrder = !comparer.HasDeferredTerms;
         for (var index = 0; index < cells.Count; index++)
         {
             var pageCell = cells[index];
             var record = pageCell.Cell.Key.FirstOverflowPage is null
                 ? pageCell.Cell.Key.LocalPayload.ToArray()
                 : overflowReader!.ReadPayload(pageCell.Cell.Key);
-            comparer.Validate(record);
-            if (previousRecord is not null && comparer.Compare(previousRecord, record) >= 0)
+            // See the identical comment in SqliteIndexLeafPageView.ReadAndValidateRecords:
+            // decode once and reuse the decoded values instead of decoding each record up
+            // to three times per cell via separate Validate/Compare calls.
+            var decoded = SqliteRecordCodec.Decode(record, comparer.TextEncoding);
+            if (validateOrder && previousDecoded is not null && comparer.Compare(previousDecoded, decoded) >= 0)
                 throw new InvalidDataException("SQLite index-interior records are not in strictly increasing configured order.");
 
-            previousRecord = record;
+            previousDecoded = decoded;
             records[index] = record;
         }
 

--- a/src/Ahtola.Core/Storage/SqliteIndexLeafPageView.cs
+++ b/src/Ahtola.Core/Storage/SqliteIndexLeafPageView.cs
@@ -93,7 +93,7 @@ public sealed class SqliteIndexLeafPageView
         for (var index = 0; index < pointers.Count; index++)
         {
             var offset = pointers[index];
-            var cell = SqliteIndexLeafCell.Decode(snapshot[offset..usableSpace], usableSpace);
+            var cell = SqliteIndexLeafCell.Decode(snapshot.AsSpan(offset, usableSpace - offset), usableSpace);
             var end = checked(offset + cell.EncodedLength);
             if (end > usableSpace)
                 throw new InvalidDataException("SQLite index-leaf cell extends into reserved page space.");
@@ -170,19 +170,33 @@ public sealed class SqliteIndexLeafPageView
             return null;
 
         var records = new byte[cells.Count][];
-        byte[]? previousRecord = null;
+        SqlValue[]? previousDecoded = null;
+        // A deferred comparer (no collation callback registered yet) always reports "equal" for
+        // the term it cannot resolve, which is an inconclusive answer, not a genuine duplicate:
+        // per SqliteIndexRecordComparer's contract this mode exists solely to validate
+        // page/record shape while the required collation callback is unavailable, never to
+        // decide ordering. Skip the strict-order check entirely in that case; the real order is
+        // proven later, once RegisterCollation supplies the callback (EmbeddedFileStore
+        // revalidates order/content/uniqueness with the real comparer at that point).
+        var validateOrder = !comparer.HasDeferredTerms;
         for (var index = 0; index < cells.Count; index++)
         {
             var pageCell = cells[index];
             var record = pageCell.Cell.FirstOverflowPage is null
                 ? pageCell.Cell.LocalPayload.ToArray()
                 : overflowReader!.ReadPayload(pageCell.Cell);
-            comparer.Validate(record);
-            if (previousRecord is not null && comparer.Compare(previousRecord, record) >= 0)
+            // Decode once and reuse the decoded values for both this record's own
+            // validation and the ordering comparison against the previous record.
+            // Calling comparer.Validate(record) followed by comparer.Compare(previousRecord, record)
+            // would otherwise decode every record up to three times per cell (once to
+            // validate it, once as "previous", once as "current"), which dominates
+            // allocation on a fully-populated page.
+            var decoded = SqliteRecordCodec.Decode(record, comparer.TextEncoding);
+            if (validateOrder && previousDecoded is not null && comparer.Compare(previousDecoded, decoded) >= 0)
                 throw new InvalidDataException(
                     $"SQLite index-leaf records are not in strictly increasing declared order at cell {index}.");
 
-            previousRecord = record;
+            previousDecoded = decoded;
             records[index] = record;
         }
 

--- a/src/Ahtola.Core/Storage/SqliteIndexRecordComparer.cs
+++ b/src/Ahtola.Core/Storage/SqliteIndexRecordComparer.cs
@@ -17,6 +17,7 @@ public sealed class SqliteIndexRecordComparer
     private static readonly UnicodeEncoding StrictUtf16BigEndian = new(true, false, true);
 
     private readonly SqliteIndexComparisonTerm[] _terms;
+    private readonly bool[] _deferredTerms;
 
     /// <summary>Creates a comparer for records encoded using <paramref name="textEncoding"/>.</summary>
     public SqliteIndexRecordComparer(SqliteTextEncoding textEncoding = SqliteTextEncoding.Utf8)
@@ -51,9 +52,39 @@ public sealed class SqliteIndexRecordComparer
     }
 
     /// <summary>Creates a comparer for schema-aware leading index terms.</summary>
+    /// <param name="textEncoding">The database text encoding used to interpret text record fields.</param>
+    /// <param name="terms">The leading comparison terms, in record order.</param>
+    /// <param name="allowDeferredCustomCollation">
+    /// When <see langword="true"/>, a term whose collation is neither a
+    /// built-in nor bound to an application-defined comparison delegate is
+    /// accepted instead of rejected. Comparisons against a deferred term
+    /// always report equal, so this mode may only be used for structural
+    /// validation (page/record shape) while the required collation callback
+    /// is not yet registered — never for ordering, uniqueness, or content
+    /// decisions that stand in for the real comparison.
+    /// </param>
+    /// <param name="forceDeferCustomCollation">
+    /// When <see langword="true"/>, EVERY leading term is treated as
+    /// deferred — including a BINARY/NOCASE/RTRIM term — regardless of
+    /// whether a callback happens to be bound right now, implying
+    /// <paramref name="allowDeferredCustomCollation"/>. Use this for a
+    /// purely structural traversal (for example collecting a stale index
+    /// tree's non-root pages before a targeted rebuild) that must never
+    /// compare old physical ordering under ANY term's currently-registered
+    /// semantics: a plain built-in name can itself have been overridden via
+    /// <c>RegisterCollation("BINARY", ...)</c> and no longer agree with the
+    /// tree's existing on-disk order — exactly the same hazard a genuinely
+    /// custom-named collation poses, and exactly why a REINDEX is often
+    /// requested in the first place. Deferring only non-built-in terms would
+    /// let an overridden built-in leading term still invoke its (possibly
+    /// mismatched) comparator against stale physical order during what is
+    /// supposed to be a decode/validate-structure-only pass.
+    /// </param>
     public SqliteIndexRecordComparer(
         SqliteTextEncoding textEncoding,
-        IReadOnlyList<SqliteIndexComparisonTerm> terms)
+        IReadOnlyList<SqliteIndexComparisonTerm> terms,
+        bool allowDeferredCustomCollation = false,
+        bool forceDeferCustomCollation = false)
     {
         ArgumentNullException.ThrowIfNull(terms);
         TextEncoding = textEncoding is SqliteTextEncoding.Unset
@@ -61,21 +92,50 @@ public sealed class SqliteIndexRecordComparer
             : textEncoding;
         _ = GetTextEncoding(TextEncoding);
         _terms = terms.ToArray();
-        foreach (var term in _terms)
+        _deferredTerms = new bool[_terms.Length];
+        for (var index = 0; index < _terms.Length; index++)
         {
+            var term = _terms[index];
             ArgumentNullException.ThrowIfNull(term.Collation);
             if (!term.Collation.IsAvailable)
                 throw new NotSupportedException("SQLite index comparison requires concrete collation metadata.");
+            if (forceDeferCustomCollation)
+            {
+                // Defer ALL leading terms unconditionally — including a plain
+                // BINARY/NOCASE/RTRIM term — because a built-in name can itself
+                // have been overridden (see WithComparison / RegisterCollation)
+                // and would otherwise still invoke its bound delegate against
+                // stale physical order during what must be a structure-only
+                // decode/validate pass.
+                _deferredTerms[index] = true;
+                continue;
+            }
+
             if (!term.Collation.IsSupportedByManagedIndexWriter)
             {
-                throw new NotSupportedException(
-                    $"SQLite index comparison does not support application-defined collation {term.Collation.Name}.");
+                if (!allowDeferredCustomCollation)
+                {
+                    throw new NotSupportedException(
+                        $"SQLite index comparison does not support application-defined collation {term.Collation.Name}.");
+                }
+
+                _deferredTerms[index] = true;
             }
         }
     }
 
     /// <summary>The database text encoding used to interpret text record fields.</summary>
     public SqliteTextEncoding TextEncoding { get; }
+
+    /// <summary>
+    /// Whether this comparer was constructed with
+    /// <c>allowDeferredCustomCollation: true</c> and at least one term could
+    /// not be resolved to a built-in collation or a bound application-defined
+    /// delegate. A deferred comparer treats the unresolved term(s) as always
+    /// equal and must only be used to validate b-tree/record shape, never to
+    /// answer ordering, uniqueness, or content-equivalence questions.
+    /// </summary>
+    public bool HasDeferredTerms => Array.IndexOf(_deferredTerms, true) >= 0;
 
     internal bool HasSameSemantics(SqliteIndexRecordComparer other)
     {
@@ -102,6 +162,8 @@ public sealed class SqliteIndexRecordComparer
         var count = Math.Min(left.Length, right.Length);
         for (var index = 0; index < count; index++)
         {
+            if (index < _deferredTerms.Length && _deferredTerms[index])
+                continue;
             var term = index < _terms.Length
                 ? _terms[index]
                 : SqliteIndexComparisonTerm.BinaryAscending;
@@ -124,6 +186,8 @@ public sealed class SqliteIndexRecordComparer
         var count = Math.Min(left.Count, right.Count);
         for (var index = 0; index < count; index++)
         {
+            if (index < _deferredTerms.Length && _deferredTerms[index])
+                continue;
             var term = index < _terms.Length
                 ? _terms[index]
                 : SqliteIndexComparisonTerm.BinaryAscending;
@@ -174,6 +238,14 @@ public sealed class SqliteIndexRecordComparer
 
     private int CompareText(string left, string right, SqliteKeyCollation collation)
     {
+        // An explicitly bound application-defined delegate always takes
+        // priority, including when it overrides a built-in name (BINARY,
+        // NOCASE, RTRIM): the override was requested for this comparer
+        // instance, so built-in behavior only applies when no delegate is
+        // bound.
+        if (collation.Comparison is { } comparison)
+            return comparison(left, right);
+
         if (collation.IsNoCase)
             return CompareNoCaseText(left, right);
 

--- a/src/Ahtola.Core/Storage/SqlitePrimaryKeySchema.cs
+++ b/src/Ahtola.Core/Storage/SqlitePrimaryKeySchema.cs
@@ -12,7 +12,11 @@ namespace Ahtola.Core.Storage;
 /// </remarks>
 public sealed record SqliteKeyCollation
 {
-    private SqliteKeyCollation(string? name) => Name = name;
+    private SqliteKeyCollation(string? name, Func<string, string, int>? comparison = null)
+    {
+        Name = name;
+        Comparison = comparison;
+    }
 
     /// <summary>A key term whose collation was not retained by its caller.</summary>
     public static SqliteKeyCollation Unavailable { get; } = new(name: null);
@@ -26,6 +30,16 @@ public sealed record SqliteKeyCollation
     /// </summary>
     public string? Name { get; }
 
+    /// <summary>
+    /// An optional connection/database-bound string comparison delegate that
+    /// reproduces an application-defined (non-built-in) collation. When
+    /// present, the managed index writer treats this collation as supported
+    /// even though it is not one of SQLite's built-in BINARY/NOCASE/RTRIM
+    /// sequences. The delegate is never serialized; only <see cref="Name"/>
+    /// is persisted to durable schema metadata.
+    /// </summary>
+    public Func<string, string, int>? Comparison { get; }
+
     /// <summary>Whether the source supplied a concrete collation name.</summary>
     public bool IsAvailable => Name is not null;
 
@@ -38,8 +52,20 @@ public sealed record SqliteKeyCollation
     /// <summary>Whether this is SQLite's built-in RTRIM collation.</summary>
     public bool IsRTrim => string.Equals(Name, "RTRIM", StringComparison.Ordinal);
 
-    /// <summary>Whether the managed index writer can reproduce this collation.</summary>
-    public bool IsSupportedByManagedIndexWriter => IsBinary || IsNoCase || IsRTrim;
+    /// <summary>
+    /// Whether this collation is one of SQLite's three built-in sequences,
+    /// regardless of whether an application has also registered a callback
+    /// under the same name (see <see cref="SqliteIndexRecordComparer"/> for
+    /// the "overridden built-in" safety rule).
+    /// </summary>
+    public bool IsBuiltIn => IsBinary || IsNoCase || IsRTrim;
+
+    /// <summary>
+    /// Whether the managed index writer can reproduce this collation: either
+    /// it is one of SQLite's built-ins, or a bound application-defined
+    /// comparison delegate is available for it.
+    /// </summary>
+    public bool IsSupportedByManagedIndexWriter => IsBuiltIn || Comparison is not null;
 
     /// <summary>Creates a descriptor for a concrete SQLite collation name.</summary>
     public static SqliteKeyCollation FromName(string name)
@@ -48,6 +74,19 @@ public sealed record SqliteKeyCollation
         return string.Equals(name, "BINARY", StringComparison.OrdinalIgnoreCase)
             ? Binary
             : new SqliteKeyCollation(name.ToUpperInvariant());
+    }
+
+    /// <summary>
+    /// Returns a copy of this descriptor bound to an application-defined
+    /// comparison delegate. Built-in BINARY/NOCASE/RTRIM collations may also
+    /// carry a bound delegate when the application has explicitly overridden
+    /// them; callers decide whether the override applies (see
+    /// <see cref="SqliteIndexRecordComparer"/>).
+    /// </summary>
+    public SqliteKeyCollation WithComparison(Func<string, string, int> comparison)
+    {
+        ArgumentNullException.ThrowIfNull(comparison);
+        return new SqliteKeyCollation(Name, comparison);
     }
 }
 

--- a/src/Ahtola.Core/Storage/SqliteTableBtreeCursor.cs
+++ b/src/Ahtola.Core/Storage/SqliteTableBtreeCursor.cs
@@ -52,11 +52,11 @@ public sealed class SqliteTableBtreeCursor
                     }
 
                 case SqliteBtreePageType.TableInterior:
-                    pageNumber = SqliteTableInteriorPageView
-                        .Parse(image, _io.UsableSpace, isFirstPage)
-                        .SearchChild(rowId)
-                        .ChildPage;
-                    break;
+                    {
+                        var interior = SqliteTableInteriorPageView.Parse(image, _io.UsableSpace, isFirstPage);
+                        pageNumber = interior.SearchChild(rowId).ChildPage;
+                        break;
+                    }
 
                 default:
                     throw new InvalidDataException(

--- a/src/Ahtola.Core/Storage/SqliteTableInteriorPage.cs
+++ b/src/Ahtola.Core/Storage/SqliteTableInteriorPage.cs
@@ -295,7 +295,7 @@ public sealed class SqliteTableInteriorPageView
         for (var index = 0; index < pointers.Count; index++)
         {
             var offset = pointers[index];
-            var cell = SqliteTableInteriorCell.Decode(snapshot[offset..usableSpace]);
+            var cell = SqliteTableInteriorCell.Decode(snapshot.AsSpan(offset, usableSpace - offset));
             var end = checked(offset + cell.EncodedLength);
             if (end > usableSpace)
                 throw new InvalidDataException("SQLite table-interior cell extends into reserved page space.");

--- a/src/Ahtola.Core/Storage/SqliteTableLeafPageView.cs
+++ b/src/Ahtola.Core/Storage/SqliteTableLeafPageView.cs
@@ -63,7 +63,7 @@ public sealed class SqliteTableLeafPageView
         for (var index = 0; index < pointers.Count; index++)
         {
             var offset = pointers[index];
-            var cell = SqliteTableLeafCell.Decode(snapshot[offset..usableSpace], usableSpace);
+            var cell = SqliteTableLeafCell.Decode(snapshot.AsSpan(offset, usableSpace - offset), usableSpace);
             var end = checked(offset + cell.EncodedLength);
             if (end > usableSpace)
                 throw new InvalidDataException("SQLite table-leaf cell extends into reserved page space.");

--- a/src/Ahtola.Core/TransactionMutationOverlay.cs
+++ b/src/Ahtola.Core/TransactionMutationOverlay.cs
@@ -1,0 +1,368 @@
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Core;
+
+/// <summary>
+/// Per-table mutation bookkeeping for one classic (non-MVCC) file-backed transaction. Tracks the
+/// final effect of every row this transaction has touched, keyed by the row's identity — its
+/// rowid for an ordinary table, its primary-key tuple for a WITHOUT ROWID table — so a durable
+/// index seek can suppress stale base rows and splice in this transaction's own current values
+/// without materializing or re-sorting the whole index.
+/// </summary>
+/// <remarks>
+/// Existence of an entry — tombstoned (<c>Current</c> is <see langword="null"/>) or live — is
+/// itself the suppression signal: any row the pinned base pager snapshot would otherwise yield
+/// for that identity is stale as of this transaction and must never surface unfiltered. Fed
+/// exclusively through <see cref="TransactionMutationOverlay.RecordRowChange"/>, which every DML
+/// path funnels through via <c>QueryContext.ReportRowChange</c> — plain statements, REPLACE/UPSERT
+/// conflict resolution, trigger bodies, and foreign-key cascade actions alike.
+/// </remarks>
+internal sealed class TransactionTableOverlay
+{
+    private readonly Dictionary<long, SqlValue[]?>? _byRowId;
+    private readonly List<(SqlValue[] Key, SqlValue[]? Current)>? _byPrimaryKey;
+    private readonly SqliteIndexRecordComparer? _primaryKeyComparer;
+
+    public TransactionTableOverlay(bool hasRowid, SqliteIndexRecordComparer? primaryKeyComparer = null)
+    {
+        HasRowid = hasRowid;
+        if (hasRowid)
+        {
+            _byRowId = new Dictionary<long, SqlValue[]?>();
+        }
+        else
+        {
+            _byPrimaryKey = new List<(SqlValue[] Key, SqlValue[]? Current)>();
+            _primaryKeyComparer = primaryKeyComparer
+                ?? throw new ArgumentNullException(
+                    nameof(primaryKeyComparer),
+                    "A WITHOUT ROWID table overlay requires a primary-key comparer.");
+        }
+    }
+
+    public bool HasRowid { get; }
+
+    public bool IsEmpty => HasRowid ? _byRowId!.Count == 0 : _byPrimaryKey!.Count == 0;
+
+    public void SetRowId(long rowId, SqlValue[]? current)
+    {
+        if (!HasRowid)
+            throw new InvalidOperationException("This overlay tracks primary keys, not rowids.");
+        _byRowId![rowId] = current;
+    }
+
+    public bool TryGetByRowId(long rowId, out SqlValue[]? current)
+    {
+        if (!HasRowid)
+        {
+            current = null;
+            return false;
+        }
+
+        return _byRowId!.TryGetValue(rowId, out current);
+    }
+
+    public void SetPrimaryKey(SqlValue[] key, SqlValue[]? current)
+    {
+        if (HasRowid)
+            throw new InvalidOperationException("This overlay tracks rowids, not primary keys.");
+
+        var entries = _byPrimaryKey!;
+        for (var position = 0; position < entries.Count; position++)
+        {
+            if (_primaryKeyComparer!.Compare(entries[position].Key, key) == 0)
+            {
+                entries[position] = (key, current);
+                return;
+            }
+        }
+
+        entries.Add((key, current));
+    }
+
+    public bool TryGetByPrimaryKey(SqlValue[] key, out SqlValue[]? current)
+    {
+        if (HasRowid)
+        {
+            current = null;
+            return false;
+        }
+
+        var entries = _byPrimaryKey!;
+        for (var position = 0; position < entries.Count; position++)
+        {
+            if (_primaryKeyComparer!.Compare(entries[position].Key, key) == 0)
+            {
+                current = entries[position].Current;
+                return true;
+            }
+        }
+
+        current = null;
+        return false;
+    }
+
+    /// <summary>Whether two projected primary-key tuples identify the same WITHOUT ROWID row.</summary>
+    public bool PrimaryKeyEquals(SqlValue[] left, SqlValue[] right)
+    {
+        if (HasRowid)
+            throw new InvalidOperationException("This overlay tracks rowids, not primary keys.");
+        return _primaryKeyComparer!.Compare(left, right) == 0;
+    }
+
+    /// <summary>Enumerates this table's current (non-tombstoned) overlay rows.</summary>
+    public IEnumerable<EmbeddedFileIndexSeekRow> EnumerateCurrentRows()
+    {
+        if (HasRowid)
+        {
+            foreach (var pair in _byRowId!)
+            {
+                if (pair.Value is { } values)
+                    yield return new EmbeddedFileIndexSeekRow(values, pair.Key);
+            }
+
+            yield break;
+        }
+
+        foreach (var entry in _byPrimaryKey!)
+        {
+            if (entry.Current is { } values)
+                yield return new EmbeddedFileIndexSeekRow(values, RowId: null);
+        }
+    }
+
+    /// <summary>Captures a point-in-time copy of this table's overlay for a SAVEPOINT.</summary>
+    public TransactionTableOverlayCheckpoint CreateCheckpoint()
+        => HasRowid
+            ? new TransactionTableOverlayCheckpoint(true, new Dictionary<long, SqlValue[]?>(_byRowId!), null)
+            : new TransactionTableOverlayCheckpoint(
+                false,
+                null,
+                new List<(SqlValue[] Key, SqlValue[]? Current)>(_byPrimaryKey!));
+
+    /// <summary>
+    /// Restores this table's overlay from a previously captured checkpoint without mutating the
+    /// checkpoint, so a later ROLLBACK TO the same savepoint remains valid (mirrors
+    /// <c>SchemaCatalog.Clone()</c> for the catalog snapshot).
+    /// </summary>
+    public void RestoreCheckpoint(TransactionTableOverlayCheckpoint checkpoint)
+    {
+        if (HasRowid)
+        {
+            _byRowId!.Clear();
+            if (checkpoint.ByRowId is { } byRowId)
+            {
+                foreach (var pair in byRowId)
+                    _byRowId[pair.Key] = pair.Value;
+            }
+
+            return;
+        }
+
+        _byPrimaryKey!.Clear();
+        if (checkpoint.ByPrimaryKey is { } byPrimaryKey)
+            _byPrimaryKey.AddRange(byPrimaryKey);
+    }
+
+    /// <summary>Discards all recorded mutations, used when restoring a checkpoint predating this table's first touch.</summary>
+    public void Clear()
+    {
+        _byRowId?.Clear();
+        _byPrimaryKey?.Clear();
+    }
+}
+
+/// <summary>An immutable point-in-time copy of one table's mutation overlay for SAVEPOINT support.</summary>
+internal sealed record TransactionTableOverlayCheckpoint(
+    bool HasRowid,
+    Dictionary<long, SqlValue[]?>? ByRowId,
+    List<(SqlValue[] Key, SqlValue[]? Current)>? ByPrimaryKey);
+
+/// <summary>
+/// Owns one <see cref="TransactionTableOverlay"/> per table touched by a classic (non-MVCC)
+/// file-backed transaction. Attached to <c>TransactionDatabaseState</c> and threaded through
+/// <c>QueryContext</c> so every DML path can feed it via <see cref="RecordRowChange"/> and every
+/// eligible index seek can consult it while the pinned durable pager snapshot is open.
+/// </summary>
+internal sealed class TransactionMutationOverlay
+{
+    private readonly Dictionary<string, TransactionTableOverlay> _tables = new(StringComparer.OrdinalIgnoreCase);
+
+    public TransactionTableOverlay GetOrCreate(EmbeddedDatabase database, EmbeddedTable table, string tableName)
+    {
+        if (_tables.TryGetValue(tableName, out var existing))
+        {
+            if (existing.HasRowid == table.HasRowid)
+                return existing;
+
+            // DDL can replace a table inside one transaction. The pinned direct-access path is
+            // already disabled after a schema change, but DML still reports through this shared
+            // funnel; replace incompatible bookkeeping rather than throwing on the next write.
+            _tables.Remove(tableName);
+        }
+
+        var overlay = table.HasRowid
+            ? new TransactionTableOverlay(hasRowid: true)
+            : new TransactionTableOverlay(
+                hasRowid: false,
+                primaryKeyComparer: database.CreatePrimaryKeyRecordComparer(
+                    table.PrimaryKeySchema
+                        ?? throw new InvalidOperationException(
+                            $"WITHOUT ROWID table '{tableName}' is missing its primary-key metadata.")));
+        _tables[tableName] = overlay;
+        return overlay;
+    }
+
+    public bool TryGet(string tableName, out TransactionTableOverlay overlay)
+        => _tables.TryGetValue(tableName, out overlay!);
+
+    /// <summary>
+    /// Records the final effect of one row change reported through
+    /// <c>QueryContext.ReportRowChange</c>, the common DML funnel for plain INSERT/UPDATE/DELETE,
+    /// REPLACE/UPSERT conflict resolution, trigger bodies, and foreign-key cascade actions.
+    /// </summary>
+    public void RecordRowChange(
+        EmbeddedDatabase database,
+        EmbeddedTable table,
+        string tableName,
+        SqliteChangeOperation operation,
+        long rowId,
+        SqlValue[]? before,
+        SqlValue[]? after)
+    {
+        var overlay = GetOrCreate(database, table, tableName);
+        if (table.HasRowid)
+        {
+            switch (operation)
+            {
+                case SqliteChangeOperation.Delete:
+                    overlay.SetRowId(rowId, null);
+                    break;
+                case SqliteChangeOperation.Insert:
+                    if ((after ?? LookupCurrentRow(table, rowId)) is { } insertedValues)
+                        overlay.SetRowId(rowId, insertedValues);
+                    break;
+                case SqliteChangeOperation.Update:
+                    // A rowid-changing UPDATE decomposes into paired Delete+Insert calls plus an
+                    // informational no-op Update (before and after both null) that this overlay
+                    // does not need: the Delete/Insert calls already recorded both identities.
+                    if (before is null && after is null)
+                        break;
+                    if ((after ?? LookupCurrentRow(table, rowId)) is { } updatedValues)
+                        overlay.SetRowId(rowId, updatedValues);
+                    break;
+            }
+
+            return;
+        }
+
+        var primaryKeySchema = table.PrimaryKeySchema
+            ?? throw new InvalidOperationException(
+                $"WITHOUT ROWID table '{tableName}' is missing its primary-key metadata.");
+        switch (operation)
+        {
+            case SqliteChangeOperation.Delete:
+                if ((before ?? LookupCurrentRow(table, rowId)) is { } deletedValues)
+                    overlay.SetPrimaryKey(primaryKeySchema.ProjectKey(deletedValues), null);
+                break;
+            case SqliteChangeOperation.Insert:
+                if ((after ?? LookupCurrentRow(table, rowId)) is { } insertedValues)
+                    overlay.SetPrimaryKey(primaryKeySchema.ProjectKey(insertedValues), insertedValues);
+                break;
+            case SqliteChangeOperation.Update:
+                if (before is null && after is null)
+                    break;
+                if ((after ?? LookupCurrentRow(table, rowId)) is not { } newValues)
+                    break;
+
+                var newKey = primaryKeySchema.ProjectKey(newValues);
+                if (before is not null)
+                {
+                    var oldKey = primaryKeySchema.ProjectKey(before);
+                    if (!overlay.PrimaryKeyEquals(oldKey, newKey))
+                        overlay.SetPrimaryKey(oldKey, null);
+                }
+
+                overlay.SetPrimaryKey(newKey, newValues);
+                break;
+        }
+    }
+
+    private static SqlValue[]? LookupCurrentRow(EmbeddedTable table, long rowId)
+    {
+        var index = table.RowIds.IndexOf(rowId);
+        return index >= 0 && index < table.Rows.Count ? table.Rows[index] : null;
+    }
+
+    /// <summary>Captures a point-in-time copy of every table's overlay for a SAVEPOINT.</summary>
+    public TransactionMutationOverlayCheckpoint CreateCheckpoint()
+    {
+        var tables = new Dictionary<string, TransactionTableOverlayCheckpoint>(StringComparer.OrdinalIgnoreCase);
+        foreach (var pair in _tables)
+            tables[pair.Key] = pair.Value.CreateCheckpoint();
+        return new TransactionMutationOverlayCheckpoint(tables);
+    }
+
+    /// <summary>
+    /// Restores every table's overlay from a previously captured checkpoint for ROLLBACK TO. A
+    /// table first touched only after the checkpoint was taken has no entry in it and is removed
+    /// outright, matching "nothing had happened to it yet" at checkpoint time — leaving a
+    /// stale-but-cleared entry behind would keep it around under the wrong identity forever. A
+    /// table whose rowid-vs-WITHOUT-ROWID shape no longer matches the checkpoint — because it was
+    /// dropped and recreated with a different shape after the checkpoint was taken but before this
+    /// rollback — is replaced with a freshly shaped overlay rather than restored in place, since an
+    /// overlay's internal storage (a by-rowid dictionary vs. a by-primary-key list plus comparer)
+    /// is tied to its current shape and cannot represent the checkpoint's rows under the wrong one.
+    /// </summary>
+    /// <param name="checkpoint">The point-in-time overlay state to restore.</param>
+    /// <param name="primaryKeyComparerResolver">
+    /// Resolves the primary-key record comparer for a WITHOUT ROWID table by name. Consulted only
+    /// when a replacement overlay must be constructed for a checkpointed WITHOUT ROWID table that
+    /// is missing or shape-mismatched in the live overlay; a caller that cannot reach this
+    /// situation (e.g. no schema changes could have occurred since the checkpoint) may omit it.
+    /// </param>
+    public void RestoreCheckpoint(
+        TransactionMutationOverlayCheckpoint checkpoint,
+        Func<string, SqliteIndexRecordComparer>? primaryKeyComparerResolver = null)
+    {
+        List<string>? stale = null;
+        foreach (var name in _tables.Keys)
+        {
+            if (!checkpoint.Tables.ContainsKey(name))
+                (stale ??= new List<string>()).Add(name);
+        }
+
+        if (stale is not null)
+        {
+            foreach (var name in stale)
+                _tables.Remove(name);
+        }
+
+        foreach (var pair in checkpoint.Tables)
+        {
+            var tableCheckpoint = pair.Value;
+            if (_tables.TryGetValue(pair.Key, out var existing) && existing.HasRowid == tableCheckpoint.HasRowid)
+            {
+                existing.RestoreCheckpoint(tableCheckpoint);
+                continue;
+            }
+
+            // Either this table has no live overlay at all yet, or its shape changed since the
+            // checkpoint (dropped and recreated with a different rowid-ness). Build a fresh
+            // overlay in the checkpoint's own shape instead of forcing mismatched data into the
+            // wrong storage.
+            var comparer = tableCheckpoint.HasRowid
+                ? null
+                : primaryKeyComparerResolver?.Invoke(pair.Key)
+                    ?? throw new InvalidOperationException(
+                        $"Restoring the mutation overlay for WITHOUT ROWID table '{pair.Key}' requires a primary-key comparer.");
+            var replacement = new TransactionTableOverlay(tableCheckpoint.HasRowid, comparer);
+            replacement.RestoreCheckpoint(tableCheckpoint);
+            _tables[pair.Key] = replacement;
+        }
+    }
+}
+
+/// <summary>An immutable point-in-time copy of an entire transaction's mutation overlay for SAVEPOINT support.</summary>
+internal sealed record TransactionMutationOverlayCheckpoint(
+    IReadOnlyDictionary<string, TransactionTableOverlayCheckpoint> Tables);

--- a/src/Ahtola.Tests/CustomCollationIndexTests.cs
+++ b/src/Ahtola.Tests/CustomCollationIndexTests.cs
@@ -1,0 +1,2071 @@
+using AwesomeAssertions;
+using MsData = Microsoft.Data.Sqlite;
+using Ahtola.Core;
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Tests;
+
+/// <summary>
+/// Focused coverage for the custom-collation index phase: registered application-defined
+/// collations (<see cref="EmbeddedDatabase.RegisterCollation"/>) must be usable to create,
+/// maintain, reopen, REINDEX, plan, and directly seek persisted secondary indexes across
+/// autocommit, classic transaction overlays, and MVCC, without ever materializing a durable
+/// index solely because its collation is custom. Every scenario proving direct-seek eligibility
+/// asserts both the zero-materialization contract
+/// (<see cref="VdbeJoinIndexSeekMetrics.DurableCursorPlans"/> greater than zero,
+/// <see cref="VdbeJoinIndexSeekMetrics.IndexRowsMaterialized"/> equal to zero) and an
+/// <c>EXPLAIN QUERY PLAN</c> "SEARCH ... USING INDEX ..." row; every scenario proving an index is
+/// unavailable/dirty asserts the corresponding absence of any "SEARCH " plan row.
+/// </summary>
+public sealed class CustomCollationIndexTests
+{
+    private static Func<string, string, int> ReverseOrdinal
+        => static (left, right) => string.CompareOrdinal(right, left);
+
+    private static Func<string, string, int> CaseInsensitiveCustom
+        => static (left, right) => string.Compare(left, right, StringComparison.OrdinalIgnoreCase);
+
+    [Test]
+    public void CreateUseAndReopenAfterReregistrationSeeksDirectly()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        const string path = "custom-collation-create-reopen.db";
+        using (var database = EmbeddedDatabase.OpenFile(path, fileSystem))
+        using (var connection = database.Connect())
+        {
+            database.RegisterCollation("reverse_text", ReverseOrdinal);
+            Execute(connection, "CREATE TABLE outer_items(k TEXT);");
+            Execute(connection, "CREATE TABLE inner_items(k TEXT COLLATE reverse_text, payload TEXT);");
+            Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k);");
+            Execute(connection, "INSERT INTO outer_items VALUES ('b'), ('c');");
+            Execute(connection, "INSERT INTO inner_items VALUES ('b', 'two'), ('c', 'three');");
+            SeedNoiseRows(connection);
+            Execute(connection, "ANALYZE;");
+
+            AssertDirectSeek(database, connection, JoinSql, "two", "three");
+        }
+
+        // Reopening and re-registering the same callback before touching the index at all must
+        // find it already clean: nothing about durable reopen should force a REINDEX.
+        using var reopened = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        reopened.RegisterCollation("reverse_text", ReverseOrdinal);
+        AssertDirectSeek(reopened, reopenedConnection, JoinSql, "two", "three");
+    }
+
+    [Test]
+    public void ReopenBeforeRegistrationFallsBackThenRegisteringRestoresDirectSeek()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        const string path = "custom-collation-reopen-before-register.db";
+        using (var database = EmbeddedDatabase.OpenFile(path, fileSystem))
+        using (var connection = database.Connect())
+        {
+            database.RegisterCollation("reverse_text", ReverseOrdinal);
+            Execute(connection, "CREATE TABLE outer_items(k TEXT);");
+            Execute(connection, "CREATE TABLE inner_items(k TEXT COLLATE reverse_text, payload TEXT);");
+            Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k);");
+            Execute(connection, "INSERT INTO outer_items VALUES ('b'), ('c');");
+            Execute(connection, "INSERT INTO inner_items VALUES ('b', 'two'), ('c', 'three');");
+            Execute(connection, "ANALYZE;");
+        }
+
+        // A fresh connection that has not registered the callback yet must never seek the index
+        // (that would silently treat it as BINARY-ordered) but a read-only scan must still work.
+        using (var reopened = EmbeddedDatabase.OpenFile(path, fileSystem))
+        using (var reopenedConnection = reopened.Connect())
+        {
+            AssertNoSearch(reopened, reopenedConnection, JoinSql, "two", "three");
+
+            // Registering the callback on this same connection, without any REINDEX, must make
+            // the already-correctly-ordered durable index eligible for direct seeks again.
+            reopened.RegisterCollation("reverse_text", ReverseOrdinal);
+            AssertDirectSeek(reopened, reopenedConnection, JoinSql, "two", "three");
+        }
+    }
+
+    [Test]
+    public void MissingCallbackFailsWritesWithNoSuchCollationSequence()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("custom-collation-missing-write.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE items(id INTEGER PRIMARY KEY, value TEXT);");
+
+        // Never registered on this connection at all: CREATE INDEX must fail closed with the
+        // SQLite-style message, never silently fall back to BINARY, and must not leave a partial
+        // index behind.
+        Action createIndex = () => Execute(
+            connection,
+            "CREATE INDEX items_value ON items(value COLLATE never_registered);");
+        createIndex.Should().Throw<EmbeddedSqlException>()
+            .WithMessage("*no such collation sequence*never_registered*");
+        Query(connection, "PRAGMA index_list(items);").Should().BeEmpty();
+    }
+
+    [Test]
+    public void CallbackReplacementMarksIndexDirtyUntilReindexRestoresDirectSeek()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("custom-collation-replace-reindex.db", fileSystem);
+        using var connection = database.Connect();
+        database.RegisterCollation("swap_text", ReverseOrdinal);
+        Execute(connection, "CREATE TABLE outer_items(k TEXT);");
+        Execute(connection, "CREATE TABLE inner_items(k TEXT COLLATE swap_text, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k);");
+        Execute(connection, "INSERT INTO outer_items VALUES ('b'), ('c');");
+        Execute(connection, "INSERT INTO inner_items VALUES ('b', 'two'), ('c', 'three');");
+        Execute(connection, "ANALYZE;");
+        AssertDirectSeek(database, connection, JoinSql, "two", "three");
+
+        // Replacing the callback with one that produces a genuinely different order for the same
+        // durable bytes must make the index provably stale: it must be declined for planning
+        // until REINDEX rebuilds it, never trusted on the old proof.
+        database.RegisterCollation("swap_text", static (left, right) => string.CompareOrdinal(left, right));
+        AssertNoSearch(database, connection, JoinSql, "two", "three");
+
+        Execute(connection, "REINDEX inner_items_k;");
+        AssertDirectSeek(database, connection, JoinSql, "two", "three");
+    }
+
+    [Test]
+    public void ReindexByTableAndByCollationNameBothRestoreDirectSeek()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("custom-collation-reindex-targets.db", fileSystem);
+        using var connection = database.Connect();
+        database.RegisterCollation("swap_text", ReverseOrdinal);
+        Execute(connection, "CREATE TABLE outer_items(k TEXT);");
+        Execute(connection, "CREATE TABLE inner_items(k TEXT COLLATE swap_text, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k);");
+        Execute(connection, "INSERT INTO outer_items VALUES ('b'), ('c');");
+        Execute(connection, "INSERT INTO inner_items VALUES ('b', 'two'), ('c', 'three');");
+        Execute(connection, "ANALYZE;");
+
+        database.RegisterCollation("swap_text", static (left, right) => string.CompareOrdinal(left, right));
+        AssertNoSearch(database, connection, JoinSql, "two", "three");
+        Execute(connection, "REINDEX inner_items;");
+        AssertDirectSeek(database, connection, JoinSql, "two", "three");
+
+        database.RegisterCollation("swap_text", ReverseOrdinal);
+        AssertNoSearch(database, connection, JoinSql, "two", "three");
+        Execute(connection, "REINDEX swap_text;");
+        AssertDirectSeek(database, connection, JoinSql, "two", "three");
+    }
+
+    [Test]
+    public void UnregisterCollationFallsBackUntilReRegistered()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("custom-collation-unregister.db", fileSystem);
+        using var connection = database.Connect();
+        database.RegisterCollation("reverse_text", ReverseOrdinal);
+        Execute(connection, "CREATE TABLE outer_items(k TEXT);");
+        Execute(connection, "CREATE TABLE inner_items(k TEXT COLLATE reverse_text, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k);");
+        Execute(connection, "INSERT INTO outer_items VALUES ('b'), ('c');");
+        Execute(connection, "INSERT INTO inner_items VALUES ('b', 'two'), ('c', 'three');");
+        Execute(connection, "ANALYZE;");
+        AssertDirectSeek(database, connection, JoinSql, "two", "three");
+
+        database.UnregisterCollation("reverse_text").Should().BeTrue();
+        AssertNoSearch(database, connection, JoinSql, "two", "three");
+
+        database.RegisterCollation("reverse_text", ReverseOrdinal);
+        AssertDirectSeek(database, connection, JoinSql, "two", "three");
+    }
+
+    [Test]
+    public void OverridingABuiltInCollationDoesNotAffectAnUnrelatedBinaryIndex()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("custom-collation-override-safety.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE outer_items(k TEXT, nc TEXT);");
+        Execute(connection, "CREATE TABLE inner_items(k TEXT, nc TEXT COLLATE NOCASE, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k);");
+        Execute(connection, "CREATE INDEX inner_items_nc ON inner_items(nc);");
+        Execute(connection, "INSERT INTO outer_items VALUES ('b', 'B'), ('c', 'C');");
+        Execute(connection, "INSERT INTO inner_items VALUES ('b', 'B', 'two'), ('c', 'C', 'three');");
+        Execute(connection, "ANALYZE;");
+
+        const string binarySql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_k ON outer_items.k = inner_items.k
+            ORDER BY outer_items.k;
+            """;
+        const string nocaseSql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_nc ON outer_items.nc = inner_items.nc
+            ORDER BY outer_items.nc;
+            """;
+
+        // Before any override is registered, both are plain built-in-collation indexes.
+        AssertDirectSeek(database, connection, binarySql, "two", "three");
+        AssertDirectSeek(database, connection, nocaseSql, "two", "three");
+
+        // Overriding NOCASE with a callback that disagrees with the durable order (NOCASE's
+        // physical order here happens to already match ordinal-ignore-case, so instead register a
+        // callback with genuinely different semantics to prove staleness) must never affect the
+        // unrelated BINARY index, which needs no callback and no revalidation at all.
+        database.RegisterCollation("NOCASE", static (left, right) => -string.Compare(left, right, StringComparison.OrdinalIgnoreCase));
+        AssertDirectSeek(database, connection, binarySql, "two", "three");
+        AssertNoSearch(database, connection, nocaseSql, "two", "three");
+
+        Execute(connection, "REINDEX inner_items_nc;");
+        AssertDirectSeek(database, connection, nocaseSql, "two", "three");
+        // The BINARY index was never touched by any of this and remains clean throughout.
+        AssertDirectSeek(database, connection, binarySql, "two", "three");
+    }
+
+    [Test]
+    public void PartialIndexWithCustomCollationSeeksDirectly()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("custom-collation-partial.db", fileSystem);
+        using var connection = database.Connect();
+        database.RegisterCollation("reverse_text", ReverseOrdinal);
+        Execute(connection, "CREATE TABLE outer_items(k TEXT);");
+        Execute(
+            connection,
+            "CREATE TABLE inner_items(k TEXT COLLATE reverse_text, payload TEXT, active INTEGER);");
+        Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k) WHERE active = 1;");
+        Execute(connection, "INSERT INTO outer_items VALUES ('b'), ('c');");
+        Execute(
+            connection,
+            "INSERT INTO inner_items VALUES ('b', 'two', 1), ('c', 'excluded', 0), ('c', 'three', 1);");
+        Execute(connection, "ANALYZE;");
+
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_k
+                ON outer_items.k = inner_items.k AND inner_items.active = 1
+            ORDER BY outer_items.k;
+            """;
+        AssertDirectSeek(database, connection, sql, "two", "three");
+    }
+
+    [Test]
+    public void ExpressionIndexWithCustomCollationSeeksDirectly()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("custom-collation-expression.db", fileSystem);
+        using var connection = database.Connect();
+        database.RegisterCollation("reverse_text", ReverseOrdinal);
+        Execute(connection, "CREATE TABLE outer_items(k TEXT);");
+        Execute(connection, "CREATE TABLE inner_items(k TEXT, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_items_expr ON inner_items((k || '') COLLATE reverse_text);");
+        Execute(connection, "INSERT INTO outer_items VALUES ('b'), ('c');");
+        // A custom-collation equality is never hashable (requirement 6), so the only way to avoid
+        // an O(n*m) nested loop is the index seek. With just two rows a side, the cost-based
+        // planner's page-rounded scan cost is cheaper than any seek (same as an ordinary index on
+        // a tiny table -- see DurableReopenUsesPagerSeekForProvenExpressionIndex), so this adds
+        // enough noise rows that the seek is genuinely cheaper, matching that existing convention
+        // for unforced (no INDEXED BY) cost-based index-seek tests.
+        Execute(
+            connection,
+            "INSERT INTO inner_items VALUES ('b', 'two'), ('c', 'three'), "
+                + string.Join(
+                    ", ",
+                    Enumerable.Range(1, 500).Select(value => $"('noise{value}', 'n{value}')"))
+                + ";");
+        Execute(connection, "ANALYZE;");
+
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items
+                ON outer_items.k = (inner_items.k || '') COLLATE reverse_text
+            ORDER BY outer_items.k;
+            """;
+        AssertDirectSeek(database, connection, sql, "two", "three");
+    }
+
+    [Test]
+    public void PartialIndexPredicateWithCustomCollateComparisonBuildsWritesAndReopensCorrectly()
+    {
+        // Distinct from PartialIndexWithCustomCollationSeeksDirectly above: there the WHERE
+        // predicate (`active = 1`) never touches collation at all, and the COLLATE clause lives
+        // on the indexed column's own declared type. Here the partial index's WHERE predicate
+        // itself performs a COLLATE comparison, which only the private index-expression evaluator
+        // (EmbeddedFileStore._indexExpressionEvaluator) resolves while qualifying rows -- both
+        // while building the index and while maintaining it incrementally on INSERT -- so it must
+        // route "ci_text" through the owning connection's registered callback rather than fail
+        // closed with "no such collation sequence" regardless of registration.
+        var fileSystem = new InMemoryFileSystem();
+        const string path = "custom-collation-partial-predicate-collate.db";
+        using (var database = EmbeddedDatabase.OpenFile(path, fileSystem))
+        using (var connection = database.Connect())
+        {
+            database.RegisterCollation("ci_text", CaseInsensitiveCustom);
+            Execute(connection, "CREATE TABLE outer_items(k TEXT);");
+            Execute(connection, "CREATE TABLE inner_items(k TEXT, payload TEXT, tag TEXT);");
+            Execute(
+                connection,
+                "CREATE INDEX inner_items_k ON inner_items(k) WHERE tag COLLATE ci_text = 'KEEP';");
+            Execute(connection, "INSERT INTO outer_items VALUES ('b'), ('c');");
+            Execute(
+                connection,
+                "INSERT INTO inner_items VALUES ('b', 'two', 'keep'), ('c', 'excluded', 'drop'), "
+                    + "('c', 'three', 'Keep');");
+            Execute(connection, "ANALYZE;");
+
+            const string sql =
+                """
+                SELECT inner_items.payload
+                FROM outer_items
+                JOIN inner_items INDEXED BY inner_items_k
+                    ON outer_items.k = inner_items.k AND inner_items.tag COLLATE ci_text = 'KEEP'
+                ORDER BY outer_items.k;
+                """;
+            AssertDirectSeek(database, connection, sql, "two", "three");
+
+            // Incremental maintenance: a row that newly qualifies for the predicate on INSERT
+            // must also have its predicate evaluated through the same resolved callback.
+            Execute(connection, "INSERT INTO inner_items VALUES ('b', 'four', 'KEEP');");
+            const string sqlAfterInsert =
+                """
+                SELECT inner_items.payload
+                FROM outer_items
+                JOIN inner_items INDEXED BY inner_items_k
+                    ON outer_items.k = inner_items.k AND inner_items.tag COLLATE ci_text = 'KEEP'
+                ORDER BY outer_items.k, inner_items.payload;
+                """;
+            AssertDirectSeek(database, connection, sqlAfterInsert, "four", "two", "three");
+        }
+
+        using var reopened = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        reopened.RegisterCollation("ci_text", CaseInsensitiveCustom);
+        const string sqlAfterReopen =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_k
+                ON outer_items.k = inner_items.k AND inner_items.tag COLLATE ci_text = 'KEEP'
+            ORDER BY outer_items.k, inner_items.payload;
+            """;
+        AssertDirectSeek(reopened, reopenedConnection, sqlAfterReopen, "four", "two", "three");
+    }
+
+    [Test]
+    public void ExpressionIndexKeyComputationWithInternalCustomCollateComparisonBuildsWritesAndReopensCorrectly()
+    {
+        // Distinct from ExpressionIndexWithCustomCollationSeeksDirectly above: there the COLLATE
+        // clause is a trailing modifier on the whole indexed expression, extracted as the index
+        // column's own declared collation (IndexExpressionSemantics.GetCollationName) and never
+        // exercises the private evaluator's comparison path at all -- computing `k || ''` needs no
+        // collation lookup. Here the stored key itself is the *result* of a COLLATE comparison, so
+        // computing it (both while building the index and while maintaining it incrementally on
+        // INSERT) must route "ci_text" through the private index-expression evaluator
+        // (EmbeddedFileStore._indexExpressionEvaluator) against the owning connection's registered
+        // callback.
+        //
+        // The outer probe deliberately uses a BLOB-affinity column (no declared type): per finding
+        // #2, an arbitrary (non-provably-typed) expression index seek is only eligible against a
+        // no-affinity/BLOB outer operand, since a boolean-comparison expression like
+        // `tag COLLATE ci_text = 'KEEP'` produces INTEGER 0/1 -- not statically provable TEXT --
+        // and a NUMERIC- or TEXT-affinity outer probe must still decline the seek.
+        //
+        // The CREATE INDEX statement adds a second, trailing "COLLATE ci_text" wrapping the whole
+        // indexed expression, distinct from the one embedded inside it. GetExplicitCollation
+        // (EmbeddedDatabase.cs) recurses into a comparison's operands when resolving the ON
+        // clause's own collation, so it discovers the embedded "ci_text" and threads it into the
+        // join term as EqualitySeekCollation -- CanBindIndexColumn only binds a seek once that
+        // matches the candidate index column's own declared collation
+        // (IndexExpressionSemantics.GetCollationName), which is read from the trailing modifier,
+        // not the embedded one. Without the trailing wrapper the declared collation defaults to
+        // BINARY, mismatches the discovered "ci_text", and the seek is correctly declined (falling
+        // back to the safe evaluator). The trailing wrapper does not change which rows qualify --
+        // the stored key is still the same INTEGER 0/1 comparison result -- it only lets the two
+        // independently-resolved collation strings agree so the seek path is exercised here too.
+        var fileSystem = new InMemoryFileSystem();
+        const string path = "custom-collation-expression-internal-collate.db";
+        using (var database = EmbeddedDatabase.OpenFile(path, fileSystem))
+        using (var connection = database.Connect())
+        {
+            database.RegisterCollation("ci_text", CaseInsensitiveCustom);
+            Execute(connection, "CREATE TABLE outer_items(flag BLOB);");
+            Execute(connection, "CREATE TABLE inner_items(tag TEXT, payload TEXT);");
+            Execute(
+                connection,
+                "CREATE INDEX inner_items_expr ON inner_items((tag COLLATE ci_text = 'KEEP') COLLATE ci_text);");
+            Execute(connection, "INSERT INTO outer_items VALUES (1);");
+            // Noise rows so the cost-based planner genuinely prefers the seek, matching the
+            // unforced (no INDEXED BY) convention used by ExpressionIndexWithCustomCollationSeeksDirectly.
+            Execute(
+                connection,
+                "INSERT INTO inner_items VALUES ('keep', 'two'), ('drop', 'excluded'), "
+                    + "('Keep', 'three'), "
+                    + string.Join(
+                        ", ",
+                        Enumerable.Range(1, 500).Select(value => $"('noise{value}', 'n{value}')"))
+                    + ";");
+            Execute(connection, "ANALYZE;");
+
+            // The outer equality's own collation is plain BINARY (comparing a BLOB against the
+            // expression's INTEGER 0/1 result) -- unlike ExpressionIndexWithCustomCollationSeeksDirectly
+            // above, COLLATE does not wrap the whole comparison here, so the cost-based planner
+            // correctly treats this join as hashable and prefers a hash-equijoin over the seek on
+            // 500+ noise rows. INDEXED BY forces the seek the same way
+            // PartialIndexPredicateWithCustomCollateComparisonBuildsWritesAndReopensCorrectly does,
+            // without changing which plan is *correct* -- both still route the expression's
+            // internal COLLATE through the private evaluator.
+            const string sql =
+                """
+                SELECT inner_items.payload
+                FROM outer_items
+                JOIN inner_items INDEXED BY inner_items_expr
+                    ON outer_items.flag = (inner_items.tag COLLATE ci_text = 'KEEP')
+                ORDER BY inner_items.payload;
+                """;
+            AssertDirectSeek(database, connection, sql, "three", "two");
+        }
+
+        using var reopened = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        reopened.RegisterCollation("ci_text", CaseInsensitiveCustom);
+        const string sqlAfterReopen =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_expr
+                ON outer_items.flag = (inner_items.tag COLLATE ci_text = 'KEEP')
+            ORDER BY inner_items.payload;
+            """;
+        AssertDirectSeek(reopened, reopenedConnection, sqlAfterReopen, "three", "two");
+    }
+
+    [Test]
+    public void PartialIndexPredicateWithOverriddenBinaryCollationBuildsWritesAndAgreesWithScan()
+    {
+        // Finding #1 regression: the private index-expression/partial-predicate evaluator
+        // (EmbeddedFileStore._indexExpressionEvaluator) must consult the active external
+        // collation resolver (see _externalCollationResolver / BuildCollationResolver) BEFORE the
+        // hard-coded BINARY/NOCASE/RTRIM fallback, because an application override of a *built-in*
+        // name is otherwise unreachable there -- unlike a custom name such as "ci_text" above,
+        // which never matches the hard-coded checks anyway and so could not have exposed this
+        // ordering bug. Overriding BINARY with a case-insensitive comparator -- the opposite of
+        // BINARY's real ordinal semantics -- makes 'keep'/'Keep' newly qualify against 'KEEP', an
+        // outcome only the fix can produce.
+        //
+        // The index is built (BuildIndexTree) over an already-populated table, forcing the
+        // private evaluator to decide every existing row's membership; a further INSERT
+        // afterward exercises the same evaluator's incremental-maintenance path. Both the direct
+        // seek (INDEXED BY, trusting the pre-built index's own membership decision) and a plain
+        // NOT INDEXED scan (re-evaluating the predicate row-by-row through ordinary ...
+        // EmbeddedDatabase.Compare, which already correctly consults the override via its own
+        // per-connection _collations registry) must agree: before the fix, the seek path would
+        // silently disagree with the scan path because it was built using the real, ordinal
+        // BINARY instead of the override.
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile(
+            "custom-collation-partial-predicate-overridden-binary.db", fileSystem);
+        using var connection = database.Connect();
+        database.RegisterCollation(
+            "BINARY",
+            static (left, right) => string.Compare(left, right, StringComparison.OrdinalIgnoreCase));
+
+        Execute(connection, "CREATE TABLE outer_items(k TEXT);");
+        Execute(connection, "CREATE TABLE inner_items(k TEXT, payload TEXT, tag TEXT);");
+        Execute(connection, "INSERT INTO outer_items VALUES ('b'), ('c');");
+        Execute(
+            connection,
+            "INSERT INTO inner_items VALUES ('b', 'two', 'keep'), ('c', 'excluded', 'drop'), "
+                + "('c', 'three', 'Keep');");
+        Execute(
+            connection,
+            "CREATE INDEX inner_items_k ON inner_items(k) WHERE tag COLLATE BINARY = 'KEEP';");
+        Execute(connection, "ANALYZE;");
+
+        const string seekSql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_k
+                ON outer_items.k = inner_items.k AND inner_items.tag COLLATE BINARY = 'KEEP'
+            ORDER BY outer_items.k, inner_items.payload;
+            """;
+        const string scanSql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items NOT INDEXED
+                ON outer_items.k = inner_items.k AND inner_items.tag COLLATE BINARY = 'KEEP'
+            ORDER BY outer_items.k, inner_items.payload;
+            """;
+        AssertDirectSeek(database, connection, seekSql, "two", "three");
+        ReadRows(connection, scanSql).Select(row => row[0].AsText()).Should().Equal("two", "three");
+
+        // Incremental maintenance (a write): a row that newly qualifies for the predicate on
+        // INSERT must also have its predicate evaluated through the overridden callback, not the
+        // hard-coded ordinal fallback -- and must still agree with the plain scan.
+        Execute(connection, "INSERT INTO inner_items VALUES ('b', 'four', 'KEEP');");
+        AssertDirectSeek(database, connection, seekSql, "four", "two", "three");
+        ReadRows(connection, scanSql).Select(row => row[0].AsText())
+            .Should().Equal("four", "two", "three");
+    }
+
+    [Test]
+    public void ExpressionIndexKeyComputationWithOverriddenNocaseCollationBuildsWritesAndAgreesWithScan()
+    {
+        // Finding #1 regression, expression-index-key variant of the BINARY test above: the
+        // private index-expression evaluator must also consult the external resolver before the
+        // hard-coded NOCASE fallback when computing a stored expression-index key. Overriding
+        // NOCASE with a case-*sensitive* (ordinal) comparator -- the opposite of NOCASE's real
+        // semantics -- makes 'keep' newly disqualify against 'KEEP' while the exact-case 'KEEP'
+        // row still qualifies, an outcome only the fix can produce. As above, the index is built
+        // over an already-populated table (exercising BuildIndexTree), a further INSERT exercises
+        // incremental maintenance, and both the direct seek and a NOT INDEXED scan must agree.
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile(
+            "custom-collation-expression-overridden-nocase.db", fileSystem);
+        using var connection = database.Connect();
+        database.RegisterCollation("NOCASE", static (left, right) => string.CompareOrdinal(left, right));
+
+        Execute(connection, "CREATE TABLE outer_items(flag BLOB);");
+        Execute(connection, "CREATE TABLE inner_items(tag TEXT, payload TEXT);");
+        Execute(connection, "INSERT INTO outer_items VALUES (1);");
+        // Noise rows so the cost-based planner genuinely prefers the seek, matching the unforced
+        // (no INDEXED BY) convention used elsewhere in this file.
+        Execute(
+            connection,
+            "INSERT INTO inner_items VALUES ('keep', 'two'), ('drop', 'excluded'), "
+                + "('KEEP', 'three'), "
+                + string.Join(
+                    ", ",
+                    Enumerable.Range(1, 500).Select(value => $"('noise{value}', 'n{value}')"))
+                + ";");
+        Execute(
+            connection,
+            "CREATE INDEX inner_items_expr ON inner_items((tag COLLATE NOCASE = 'KEEP') COLLATE NOCASE);");
+        Execute(connection, "ANALYZE;");
+
+        const string seekSql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_expr
+                ON outer_items.flag = (inner_items.tag COLLATE NOCASE = 'KEEP')
+            ORDER BY inner_items.payload;
+            """;
+        const string scanSql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items NOT INDEXED
+                ON outer_items.flag = (inner_items.tag COLLATE NOCASE = 'KEEP')
+            ORDER BY inner_items.payload;
+            """;
+        // Under the overridden (case-sensitive) NOCASE, only the exact-case 'KEEP' row qualifies;
+        // the real, un-overridden NOCASE would also match 'keep', which would wrongly surface
+        // "two" here if either evaluation path missed the override.
+        AssertDirectSeek(database, connection, seekSql, "three");
+        ReadRows(connection, scanSql).Select(row => row[0].AsText()).Should().Equal("three");
+
+        // Incremental maintenance (a write): a newly-inserted row's expression-index key must
+        // also be computed through the overridden callback, and must still agree with the scan.
+        Execute(connection, "INSERT INTO inner_items VALUES ('KEEP', 'four');");
+        AssertDirectSeek(database, connection, seekSql, "four", "three");
+        ReadRows(connection, scanSql).Select(row => row[0].AsText()).Should().Equal("four", "three");
+    }
+
+    [Test]
+    public void PartialIndexPredicateCallbackReplacementMarksIndexDirtyUntilReindexRestoresDirectSeek()
+    {
+        // Distinct from CallbackReplacementMarksIndexDirtyUntilReindexRestoresDirectSeek above:
+        // there the replaced collation qualifies the indexed column itself
+        // (IndexExpressionSemantics.GetCollationName). Here it is embedded only inside the
+        // partial index's WHERE predicate
+        // (IndexExpressionSemantics.CollectEmbeddedCollationNames) -- finding #2 requires
+        // IsCustomCollationIndexPlanReady to track that dependency too, since replacing the
+        // callback can change which rows the predicate actually admits (membership), not merely
+        // reorder an already-fixed row set the way a column-level replacement would. Before the
+        // fix, IsCustomCollationIndexPlanReady only ever inspected index.Columns (all plain
+        // BINARY here), so it would have kept trusting this index's stale membership proof and
+        // offered it for SEARCH with the wrong row set instead of falling back until REINDEX.
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile(
+            "custom-collation-partial-predicate-replace-reindex.db", fileSystem);
+        using var connection = database.Connect();
+        database.RegisterCollation("ci_text", CaseInsensitiveCustom);
+        Execute(connection, "CREATE TABLE outer_items(k TEXT);");
+        Execute(connection, "CREATE TABLE inner_items(k TEXT, payload TEXT, tag TEXT);");
+        Execute(
+            connection,
+            "CREATE INDEX inner_items_k ON inner_items(k) WHERE tag COLLATE ci_text = 'KEEP';");
+        Execute(connection, "INSERT INTO outer_items VALUES ('b'), ('c'), ('d');");
+        Execute(
+            connection,
+            "INSERT INTO inner_items VALUES ('b', 'two', 'keep'), ('c', 'excluded', 'drop'), "
+                + "('c', 'three', 'Keep'), ('d', 'four', 'KEEP');");
+        Execute(connection, "ANALYZE;");
+
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_k
+                ON outer_items.k = inner_items.k AND inner_items.tag COLLATE ci_text = 'KEEP'
+            ORDER BY outer_items.k;
+            """;
+        // Under case-insensitive ci_text, 'keep'/'Keep'/'KEEP' all satisfy the predicate.
+        AssertDirectSeek(database, connection, sql, "two", "three", "four");
+
+        // Replace ci_text with a genuinely different (case-sensitive) comparison: only the exact
+        // 'KEEP' row now satisfies the predicate, so the index's membership proof from before the
+        // replacement is provably stale. It must be declined for planning until REINDEX rebuilds
+        // it, never trusted just because every indexed-term (column-level) collation is still
+        // plain BINARY and unaffected by this replacement.
+        database.RegisterCollation("ci_text", static (left, right) => string.CompareOrdinal(left, right));
+        AssertNoSearch(database, connection, sql, "four");
+
+        Execute(connection, "REINDEX inner_items_k;");
+        AssertDirectSeek(database, connection, sql, "four");
+    }
+
+    [Test]
+    public void ExpressionIndexKeyCallbackReplacementMarksIndexDirtyUntilReindexRestoresDirectSeek()
+    {
+        // Distinct from CallbackReplacementMarksIndexDirtyUntilReindexRestoresDirectSeek above:
+        // there the replaced collation is the index column's own trailing declared collation
+        // (IndexExpressionSemantics.GetCollationName), so the pre-existing column-level
+        // (GetCollationName) loop in IsCustomCollationIndexPlanReady already catches it on its own
+        // -- that does not prove the embedded-name loop
+        // (IndexExpressionSemantics.CollectEmbeddedCollationNames) is load-bearing. A naive
+        // "AND-compound" variant with two *custom* collation names doesn't prove it either: for a
+        // join-seek to bind at all, GetExplicitCollation's single discovered name (here, the AND's
+        // left operand, since BinaryExpression is `Left ?? Right` short-circuiting) must equal the
+        // index column's declared (trailing) collation for CanBindIndexColumn to accept the seek --
+        // and EvaluateCollationNameReadinessLocked classifies *any* name with an active custom
+        // callback as NeedsValidation unconditionally, so merely having a *registered custom*
+        // trailing collation already forces the column-level loop to demand the full
+        // RevalidateIndexOrderAndContent proof, which independently (and correctly) re-derives
+        // every key against whatever callbacks are *currently* active -- catching staleness in the
+        // right AND operand regardless of whether the embedded-name loop ever ran.
+        //
+        // To isolate the embedded loop, the discovered/declared collation must stay classified
+        // Skip (never a registered custom callback) while a *different*, genuinely custom name is
+        // buried where GetExplicitCollation's short-circuit can never reach it. "BINARY" is a
+        // built-in name this test never registers a callback for, so EvaluateCollationNameReadinessLocked("BINARY")
+        // is always Skip. The stored key is `(tag COLLATE BINARY = 'KEEP') AND (other_col COLLATE
+        // flag_collation = 'YES')`, trailed by `COLLATE BINARY` (so the ON clause's discovered
+        // collation -- "BINARY", found from the AND's left operand -- matches the index column's
+        // declared collation and the seek can bind). The column-level (GetCollationName) loop only
+        // ever inspects "BINARY" (Skip); it never even learns "flag_collation" exists, because that
+        // name is not the column's own declared collation and is never discoverable via
+        // GetExplicitCollation's short-circuit. CollectEmbeddedCollationNames, by contrast, walks
+        // BinaryExpression.Left *and* .Right unconditionally, so it is the *only* mechanism able to
+        // find "flag_collation" at all -- without it, IsCustomCollationIndexPlanReady would return
+        // true (Skip only) and never even attempt RevalidateIndexOrderAndContent, trusting a stale
+        // AND result for rows whose left operand is already true.
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile(
+            "custom-collation-expression-and-embedded-replace-reindex.db", fileSystem);
+        using var connection = database.Connect();
+        database.RegisterCollation("flag_collation", CaseInsensitiveCustom);
+        Execute(connection, "CREATE TABLE outer_items(flag BLOB);");
+        Execute(connection, "CREATE TABLE inner_items(tag TEXT, other_col TEXT, payload TEXT);");
+        Execute(
+            connection,
+            "CREATE INDEX inner_items_expr ON inner_items("
+                + "((tag COLLATE BINARY = 'KEEP') AND (other_col COLLATE flag_collation = 'YES')) "
+                + "COLLATE BINARY);");
+        Execute(connection, "INSERT INTO outer_items VALUES (1);");
+        Execute(
+            connection,
+            "INSERT INTO inner_items VALUES "
+                + "('KEEP', 'YES', 'exact'), ('KEEP', 'yes', 'lower'), ('KEEP', 'Yes', 'mixed'), "
+                + "('drop', 'YES', 'excluded'), "
+                + string.Join(
+                    ", ",
+                    Enumerable.Range(1, 500)
+                        .Select(value => $"('noise{value}', 'noise{value}', 'n{value}')"))
+                + ";");
+        Execute(connection, "ANALYZE;");
+
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_expr
+                ON outer_items.flag = (
+                    (inner_items.tag COLLATE BINARY = 'KEEP')
+                    AND (inner_items.other_col COLLATE flag_collation = 'YES'))
+            ORDER BY inner_items.payload;
+            """;
+        // Under case-insensitive flag_collation, 'YES'/'yes'/'Yes' all satisfy the right operand.
+        AssertDirectSeek(database, connection, sql, "exact", "lower", "mixed");
+
+        // Replace flag_collation with a genuinely different (case-sensitive) comparison: only the
+        // exact 'YES' row still satisfies the right AND operand, so the stored keys computed
+        // under the old callback are provably stale. The index must be declined for planning
+        // until REINDEX recomputes every key, never trusted on the old key proof -- even though
+        // no join-seek-matching code path ever discovers "flag_collation" from this ON clause, and
+        // the index's own declared collation ("BINARY") never needed revalidation.
+        database.RegisterCollation("flag_collation", static (left, right) => string.CompareOrdinal(left, right));
+        AssertNoSearch(database, connection, sql, "exact");
+
+        Execute(connection, "REINDEX inner_items_expr;");
+        AssertDirectSeek(database, connection, sql, "exact");
+    }
+
+    [Test]
+    public void PartialIndexPredicateMissingCollateCallbackFailsClosedOnlyWhenARowIsEvaluated()
+    {
+        // Proves the fail-closed contract is genuinely lazy for predicate/expression-embedded
+        // COLLATE clauses (unlike the eager, column-level MissingCallbackFailsWritesWithNoSuchCollationSequence
+        // case above): creating the index over an empty table must succeed even though the
+        // collation was never registered on this connection, since nothing has evaluated the
+        // predicate yet. The first INSERT of a row that requires evaluating it must then fail
+        // closed with the SQLite-style message, never silently fall back to BINARY, and must not
+        // leave a partial row behind.
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile(
+            "custom-collation-partial-predicate-missing.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE inner_items(k TEXT, tag TEXT);");
+        Execute(
+            connection,
+            "CREATE INDEX inner_items_k ON inner_items(k) WHERE tag COLLATE never_registered = 'KEEP';");
+
+        Action insert = () => Execute(connection, "INSERT INTO inner_items VALUES ('a', 'KEEP');");
+        insert.Should().Throw<EmbeddedSqlException>()
+            .WithMessage("*no such collation sequence*never_registered*");
+        Query(connection, "SELECT k FROM inner_items;").Should().BeEmpty();
+    }
+
+    [Test]
+    public void WithoutRowidSecondaryIndexWithCustomCollationSeeksDirectly()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("custom-collation-without-rowid-secondary.db", fileSystem);
+        using var connection = database.Connect();
+        database.RegisterCollation("reverse_text", ReverseOrdinal);
+        Execute(connection, "CREATE TABLE outer_items(k TEXT);");
+        Execute(
+            connection,
+            "CREATE TABLE inner_items(id TEXT PRIMARY KEY, k TEXT COLLATE reverse_text, payload TEXT) WITHOUT ROWID;");
+        Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k);");
+        Execute(connection, "INSERT INTO outer_items VALUES ('b'), ('c');");
+        Execute(connection, "INSERT INTO inner_items VALUES ('id-1', 'b', 'two'), ('id-2', 'c', 'three');");
+        Execute(connection, "ANALYZE;");
+
+        AssertDirectSeek(database, connection, JoinSql, "two", "three");
+    }
+
+    [Test]
+    public void WithoutRowidPrimaryKeyCustomCollationIsRejectedExplicitly()
+    {
+        // Retained boundary: a WITHOUT ROWID table's own primary key must stay built-in-collation
+        // only, because catalog loading fundamentally needs its comparator before any callback
+        // can possibly be registered. This must fail closed with an explicit, distinct message
+        // rather than silently degrading to BINARY or succeeding structurally and misbehaving.
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("custom-collation-without-rowid-pk.db", fileSystem);
+        using var connection = database.Connect();
+        database.RegisterCollation("reverse_text", ReverseOrdinal);
+
+        Action createTable = () => Execute(
+            connection,
+            "CREATE TABLE entry(id TEXT COLLATE reverse_text PRIMARY KEY, payload TEXT) WITHOUT ROWID;");
+        createTable.Should().Throw<EmbeddedSqlException>();
+        Query(connection, "SELECT name FROM sqlite_master WHERE name = 'entry';").Should().BeEmpty();
+    }
+
+    [Test]
+    public void ClassicTransactionOverlayHonorsCustomCollationIndexSeek()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("custom-collation-transaction-overlay.db", fileSystem);
+        using var connection = database.Connect();
+        database.RegisterCollation("reverse_text", ReverseOrdinal);
+        Execute(connection, "CREATE TABLE outer_items(k TEXT);");
+        Execute(connection, "CREATE TABLE inner_items(k TEXT COLLATE reverse_text, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k);");
+        Execute(connection, "INSERT INTO outer_items VALUES ('a'), ('b');");
+        Execute(connection, "INSERT INTO inner_items VALUES ('a', 'one');");
+        SeedNoiseRows(connection);
+        Execute(connection, "ANALYZE;");
+
+        Execute(connection, "BEGIN;");
+        Execute(connection, "INSERT INTO inner_items VALUES ('b', 'two-local');");
+
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, JoinSql).Select(row => row[0].AsText())
+            .Should().Equal("one", "two-local");
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().Be(1);
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+
+        Execute(connection, "ROLLBACK;");
+    }
+
+    [Test]
+    public void MvccTransactionHonorsCustomCollationIndexSeek()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("custom-collation-mvcc.db", fileSystem);
+        using var connection = database.Connect();
+        database.RegisterCollation("reverse_text", ReverseOrdinal);
+        Execute(connection, "CREATE TABLE outer_items(k TEXT);");
+        Execute(connection, "CREATE TABLE inner_items(k TEXT COLLATE reverse_text, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k);");
+        Execute(connection, "INSERT INTO outer_items VALUES ('a'), ('b');");
+        Execute(connection, "INSERT INTO inner_items VALUES ('a', 'one');");
+        SeedNoiseRows(connection);
+        ExecutePragma(connection, "PRAGMA journal_mode=mvcc;");
+        Execute(connection, "ANALYZE;");
+
+        Execute(connection, "BEGIN CONCURRENT;");
+        Execute(connection, "INSERT INTO inner_items VALUES ('b', 'two-local');");
+
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, JoinSql).Select(row => row[0].AsText())
+            .Should().Equal("one", "two-local");
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().BeGreaterThan(0);
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+
+        Execute(connection, "COMMIT;");
+    }
+
+    [Test]
+    public void DuplicateEquivalenceClassRowsArePreservedAndAllReturnedByCustomCollationSeek()
+    {
+        // A custom collation that folds several distinct byte sequences to the same ordering
+        // class (case-insensitive here) must never cause the durable secondary index to drop or
+        // merge duplicates: every row that compares equal under the collation must still be
+        // stored and returned.
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("custom-collation-duplicates.db", fileSystem);
+        using var connection = database.Connect();
+        database.RegisterCollation(
+            "fold_case",
+            static (left, right) => string.Compare(left, right, StringComparison.OrdinalIgnoreCase));
+        Execute(connection, "CREATE TABLE outer_items(k TEXT);");
+        Execute(connection, "CREATE TABLE inner_items(k TEXT COLLATE fold_case, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k);");
+        Execute(connection, "INSERT INTO outer_items VALUES ('KEY');");
+        Execute(
+            connection,
+            "INSERT INTO inner_items VALUES ('key', 'p1'), ('KEY', 'p2'), ('Key', 'p3');");
+        Execute(connection, "ANALYZE;");
+
+        // The equality's collating function follows SQLite's real precedence rule (datatype3.html
+        // §7.1 rule 2): when both operands are columns, the LEFT operand's column collation wins.
+        // outer_items.k has no declared COLLATE (defaults to BINARY), so putting it on the left
+        // would force a byte-exact BINARY comparison and defeat the point of this test; naming
+        // inner_items.k (COLLATE fold_case) first makes its collation govern the comparison, which
+        // is also what makes the durable index's own fold_case ordering the correct seek strategy.
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, "SELECT inner_items.payload FROM outer_items "
+                + "JOIN inner_items INDEXED BY inner_items_k ON inner_items.k = outer_items.k "
+                + "ORDER BY inner_items.payload;")
+            .Select(row => row[0].AsText())
+            .Should().Equal("p1", "p2", "p3");
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().BeGreaterThan(0);
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+    }
+
+    [Test]
+    public void CallbackExceptionPropagatesThroughIndexSeek()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("custom-collation-callback-exception.db", fileSystem);
+        using var connection = database.Connect();
+        database.RegisterCollation(
+            "explosive",
+            (_, _) => throw new InvalidOperationException("boom"));
+        Execute(connection, "CREATE TABLE outer_items(k TEXT);");
+        Execute(connection, "CREATE TABLE inner_items(k TEXT COLLATE explosive, payload TEXT);");
+        Execute(connection, "INSERT INTO outer_items VALUES ('a'), ('b');");
+        Execute(connection, "INSERT INTO inner_items VALUES ('a', 'one'), ('b', 'two');");
+
+        Action createIndex = () => Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k);");
+        createIndex.Should().Throw<InvalidOperationException>().WithMessage("boom");
+    }
+
+    [Test]
+    public void DirectSeekMatchesMicrosoftDataSqliteForCustomCollation()
+    {
+        string[] setup =
+        [
+            "CREATE TABLE outer_items(k TEXT);",
+            "CREATE TABLE inner_items(k TEXT COLLATE reverse_text, payload TEXT);",
+            "CREATE INDEX inner_items_k ON inner_items(k);",
+            "INSERT INTO outer_items VALUES ('a'), ('b'), ('c');",
+            "INSERT INTO inner_items VALUES ('a', 'one'), ('b', 'two'), ('c', 'three');",
+            "ANALYZE;",
+        ];
+
+        using var sqlite = new MsData.SqliteConnection("Data Source=:memory:");
+        sqlite.Open();
+        sqlite.CreateCollation("reverse_text", (left, right) => string.CompareOrdinal(right, left));
+        foreach (var statement in setup)
+        {
+            using var command = sqlite.CreateCommand();
+            command.CommandText = statement;
+            command.ExecuteNonQuery();
+        }
+
+        using var query = sqlite.CreateCommand();
+        query.CommandText = JoinSql;
+        using var reader = query.ExecuteReader();
+        var sqliteRows = new List<string?>();
+        while (reader.Read())
+            sqliteRows.Add(reader.IsDBNull(0) ? null : reader.GetString(0));
+
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("custom-collation-differential.db", fileSystem);
+        using var connection = database.Connect();
+        database.RegisterCollation("reverse_text", ReverseOrdinal);
+        foreach (var statement in setup)
+            Execute(connection, statement);
+
+        var managedRows = ReadRows(connection, JoinSql).Select(row => row[0].AsText()).ToList();
+        managedRows.Should().Equal(sqliteRows);
+    }
+
+    [Test]
+    public void UnregisteringAnAgreeingNocaseOverrideKeepsUniqueIndexValidWithoutReindex()
+    {
+        // Complements CallbackReplacementMarksIndexDirtyUntilReindexRestoresDirectSeek's "genuinely
+        // different order -> REINDEX required" branch: here the override's semantics happen to
+        // AGREE with the built-in NOCASE it replaces (both fold 'a'/'A' together, in the same
+        // order), so revalidating against the restored built-in on unregister must find the
+        // durable index still valid without ever requiring a REINDEX.
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("custom-collation-nocase-agree-unregister.db", fileSystem);
+        using var connection = database.Connect();
+        database.RegisterCollation(
+            "NOCASE",
+            static (left, right) => string.Compare(left, right, StringComparison.OrdinalIgnoreCase));
+        Execute(connection, "CREATE TABLE outer_items(k TEXT);");
+        Execute(connection, "CREATE TABLE inner_items(k TEXT COLLATE NOCASE, payload TEXT);");
+        Execute(connection, "CREATE UNIQUE INDEX inner_items_k ON inner_items(k);");
+        Execute(connection, "INSERT INTO outer_items VALUES ('b'), ('c');");
+        Execute(connection, "INSERT INTO inner_items VALUES ('b', 'two'), ('c', 'three');");
+        SeedNoiseRows(connection);
+        Execute(connection, "ANALYZE;");
+        AssertDirectSeek(database, connection, JoinSql, "two", "three");
+
+        // The UNIQUE constraint must reject a case-fold duplicate while the override is active.
+        Action insertDuplicateWhileOverridden = () =>
+            Execute(connection, "INSERT INTO inner_items VALUES ('B', 'dup');");
+        insertDuplicateWhileOverridden.Should().Throw<EmbeddedSqlException>()
+            .WithMessage("*UNIQUE constraint failed*");
+
+        // Unregistering restores the real built-in NOCASE. Because it agrees with the override on
+        // both order and equivalence classes, the index must revalidate clean immediately -- no
+        // REINDEX required in between -- and stay directly seekable.
+        database.UnregisterCollation("NOCASE").Should().BeTrue();
+        AssertDirectSeek(database, connection, JoinSql, "two", "three");
+
+        // The UNIQUE constraint must still correctly reject the same duplicate under the restored
+        // built-in semantics.
+        Action insertDuplicateAfterUnregister = () =>
+            Execute(connection, "INSERT INTO inner_items VALUES ('B', 'dup');");
+        insertDuplicateAfterUnregister.Should().Throw<EmbeddedSqlException>()
+            .WithMessage("*UNIQUE constraint failed*");
+    }
+
+    [Test]
+    public void PartiallyRegisteredCollationsIsolateUnavailableIndexPerIndexNotGlobally()
+    {
+        // Deferred custom-collation validation must be scoped per index/table, never gated on
+        // whether *any* collation resolver exists at all: with two custom collations A and B only
+        // A registered on this connection, writes to unrelated tables and direct use of A must
+        // both work normally while B stays unavailable and is never binary-compared.
+        var fileSystem = new InMemoryFileSystem();
+        const string path = "custom-collation-partial-registration.db";
+        using (var database = EmbeddedDatabase.OpenFile(path, fileSystem))
+        using (var connection = database.Connect())
+        {
+            database.RegisterCollation("collation_a", ReverseOrdinal);
+            database.RegisterCollation(
+                "collation_b",
+                static (left, right) => string.Compare(left, right, StringComparison.OrdinalIgnoreCase));
+
+            Execute(connection, "CREATE TABLE outer_a(k TEXT);");
+            Execute(connection, "CREATE TABLE inner_a(k TEXT COLLATE collation_a, payload TEXT);");
+            Execute(connection, "CREATE INDEX inner_a_k ON inner_a(k);");
+            Execute(connection, "CREATE TABLE outer_b(k TEXT);");
+            Execute(connection, "CREATE TABLE inner_b(k TEXT COLLATE collation_b, payload TEXT);");
+            Execute(connection, "CREATE INDEX inner_b_k ON inner_b(k);");
+            Execute(connection, "CREATE TABLE plain(id INTEGER PRIMARY KEY, value TEXT);");
+
+            Execute(connection, "INSERT INTO outer_a VALUES ('b'), ('c');");
+            Execute(connection, "INSERT INTO inner_a VALUES ('b', 'two'), ('c', 'three');");
+            Execute(connection, "INSERT INTO outer_b VALUES ('b'), ('c');");
+            Execute(connection, "INSERT INTO inner_b VALUES ('b', 'BEE'), ('c', 'CEE');");
+            Execute(connection, "INSERT INTO plain VALUES (1, 'x');");
+            Execute(connection, "ANALYZE;");
+        }
+
+        // Reopen with only collation_a registered: collation_b is never registered on this
+        // connection at all.
+        using var reopened = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        reopened.RegisterCollation("collation_a", ReverseOrdinal);
+
+        // Writes to a table wholly unrelated to either custom collation must succeed.
+        Execute(reopenedConnection, "INSERT INTO plain VALUES (2, 'y');");
+        Query(reopenedConnection, "SELECT value FROM plain ORDER BY id;")
+            .Select(row => row[0].AsText())
+            .Should().Equal("x", "y");
+
+        // Direct use of the registered collation A still works: writes to its own table and a
+        // direct index seek both succeed exactly as if B did not exist in the same catalog.
+        const string joinA =
+            """
+            SELECT inner_a.payload
+            FROM outer_a
+            JOIN inner_a INDEXED BY inner_a_k ON outer_a.k = inner_a.k
+            ORDER BY outer_a.k;
+            """;
+        Execute(reopenedConnection, "INSERT INTO outer_a VALUES ('d');");
+        Execute(reopenedConnection, "INSERT INTO inner_a VALUES ('d', 'four');");
+        AssertDirectSeek(reopened, reopenedConnection, joinA, "two", "three", "four");
+
+        // B stays unavailable for planning: its join must never be offered a direct seek, but the
+        // full-scan fallback must still return correct rows.
+        const string joinB =
+            """
+            SELECT inner_b.payload
+            FROM outer_b
+            JOIN inner_b INDEXED BY inner_b_k ON outer_b.k = inner_b.k
+            ORDER BY outer_b.k;
+            """;
+        AssertNoSearch(reopened, reopenedConnection, joinB, "BEE", "CEE");
+
+        // B's own callback must never be assumed or substituted with a binary comparison: any
+        // operation that would actually need to reorder or physically touch B's durable index --
+        // writing a new row into its table, or a REINDEX targeting it -- must fail closed with the
+        // real "no such collation sequence" error rather than silently using byte order.
+        Action insertIntoB = () => Execute(reopenedConnection, "INSERT INTO inner_b VALUES ('a', 'AYE');");
+        insertIntoB.Should().Throw<EmbeddedSqlException>()
+            .WithMessage("*no such collation sequence*collation_b*");
+        Action reindexB = () => Execute(reopenedConnection, "REINDEX inner_b_k;");
+        reindexB.Should().Throw<EmbeddedSqlException>()
+            .WithMessage("*no such collation sequence*collation_b*");
+
+        // The failed write must not have partially applied: B's table is exactly as it was.
+        Query(reopenedConnection, "SELECT payload FROM inner_b ORDER BY rowid;")
+            .Select(row => row[0].AsText())
+            .Should().Equal("BEE", "CEE");
+    }
+
+    [Test]
+    public void TargetedReindexOfOneIndexNeverRequiresAnUnrelatedCollationsCallback()
+    {
+        // A targeted REINDEX of index_a must rebuild only index_a's tree, in one pager/WAL
+        // transaction, without ever requiring collation_b's callback and without falling back to
+        // ForceFullCatalogRewrite -- leaving index_b's tree byte-for-byte untouched.
+        var fileSystem = new InMemoryFileSystem();
+        const string path = "custom-collation-targeted-reindex-ab.db";
+        using (var database = EmbeddedDatabase.OpenFile(path, fileSystem))
+        using (var connection = database.Connect())
+        {
+            database.RegisterCollation("collation_a", ReverseOrdinal);
+            database.RegisterCollation(
+                "collation_b",
+                static (left, right) => string.Compare(left, right, StringComparison.OrdinalIgnoreCase));
+
+            Execute(connection, "CREATE TABLE outer_a(k TEXT);");
+            Execute(connection, "CREATE TABLE inner_a(k TEXT COLLATE collation_a, payload TEXT);");
+            Execute(connection, "CREATE INDEX inner_a_k ON inner_a(k);");
+            Execute(connection, "CREATE TABLE outer_b(k TEXT);");
+            Execute(connection, "CREATE TABLE inner_b(k TEXT COLLATE collation_b, payload TEXT);");
+            Execute(connection, "CREATE INDEX inner_b_k ON inner_b(k);");
+
+            Execute(connection, "INSERT INTO outer_a VALUES ('b'), ('c');");
+            Execute(connection, "INSERT INTO inner_a VALUES ('b', 'two'), ('c', 'three');");
+            Execute(connection, "INSERT INTO outer_b VALUES ('b'), ('c');");
+            Execute(connection, "INSERT INTO inner_b VALUES ('b', 'BEE'), ('c', 'CEE');");
+            Execute(connection, "ANALYZE;");
+        }
+
+        // Replace collation_a with a genuinely different order so index_a is provably stale and
+        // needs REINDEX; collation_b is never registered on this connection at all.
+        using var reopened = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        reopened.RegisterCollation("collation_a", static (left, right) => string.CompareOrdinal(left, right));
+
+        const string joinA =
+            """
+            SELECT inner_a.payload
+            FROM outer_a
+            JOIN inner_a INDEXED BY inner_a_k ON outer_a.k = inner_a.k
+            ORDER BY outer_a.k;
+            """;
+        const string joinB =
+            """
+            SELECT inner_b.payload
+            FROM outer_b
+            JOIN inner_b INDEXED BY inner_b_k ON outer_b.k = inner_b.k
+            ORDER BY outer_b.k;
+            """;
+
+        AssertNoSearch(reopened, reopenedConnection, joinA, "two", "three");
+        AssertNoSearch(reopened, reopenedConnection, joinB, "BEE", "CEE");
+
+        // A targeted REINDEX naming index_a only must rebuild its tree and succeed without ever
+        // requiring collation_b's callback.
+        Execute(reopenedConnection, "REINDEX inner_a_k;");
+        AssertDirectSeek(reopened, reopenedConnection, joinA, "two", "three");
+
+        // ...and must leave B's tree completely untouched: still unavailable for direct seek (no
+        // callback registered) and its rows still intact.
+        AssertNoSearch(reopened, reopenedConnection, joinB, "BEE", "CEE");
+
+        // Structural proof that B's durable tree was never rewritten by the targeted REINDEX of A:
+        // simply registering B's original callback (no REINDEX, no full rewrite) must immediately
+        // find its physical order still valid.
+        reopened.RegisterCollation(
+            "collation_b",
+            static (left, right) => string.Compare(left, right, StringComparison.OrdinalIgnoreCase));
+        AssertDirectSeek(reopened, reopenedConnection, joinB, "BEE", "CEE");
+    }
+
+    [Test]
+    public void OverriddenBinaryCollationTargetedReindexNeverComparesOldOrderAndLeavesUnavailableSiblingUntouched()
+    {
+        // forceDeferCustomCollation's structural traversal (used to free a targeted REINDEX's old
+        // pages) must disable ordering validation for EVERY leading term -- including a plain,
+        // unspecified-collation column -- because a built-in name can itself be overridden via
+        // RegisterCollation("BINARY", ...) (see RegisterCollation's remark on
+        // _everOverriddenBuiltInCollations) and no longer agree with the tree's existing physical
+        // order. Deferring only genuinely custom-named terms would let this pass invoke the
+        // newly-overridden BINARY delegate against the OLD (still really-ascending) tree during
+        // what must be a decode/validate-structure-only walk, misreporting a merely-stale tree as
+        // corrupt. An unrelated table indexed under a genuinely unavailable custom collation must
+        // also never be required or touched by any of this.
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile(
+            "custom-collation-overridden-binary-targeted-reindex.db", fileSystem);
+        using var connection = database.Connect();
+        database.RegisterCollation("collation_b", ReverseOrdinal);
+
+        Execute(connection, "CREATE TABLE outer_a(k TEXT);");
+        Execute(connection, "CREATE TABLE inner_a(k TEXT, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_a_k ON inner_a(k);");
+        Execute(connection, "CREATE TABLE outer_b(k TEXT);");
+        Execute(connection, "CREATE TABLE inner_b(k TEXT COLLATE collation_b, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_b_k ON inner_b(k);");
+
+        Execute(connection, "INSERT INTO outer_a VALUES ('b'), ('c');");
+        Execute(connection, "INSERT INTO inner_a VALUES ('b', 'two'), ('c', 'three');");
+        Execute(connection, "INSERT INTO outer_b VALUES ('b'), ('c');");
+        Execute(connection, "INSERT INTO inner_b VALUES ('b', 'BEE'), ('c', 'CEE');");
+        Execute(connection, "ANALYZE;");
+
+        // ORDER BY rowid rather than k: once BINARY itself is overridden below, sorting by the
+        // default-collation column would flip along with it, which is irrelevant noise for this
+        // regression -- only the seek-eligibility and join-correctness of inner_a_k matter here.
+        const string joinA =
+            """
+            SELECT inner_a.payload
+            FROM outer_a
+            JOIN inner_a INDEXED BY inner_a_k ON outer_a.k = inner_a.k
+            ORDER BY outer_a.rowid;
+            """;
+        const string joinB =
+            """
+            SELECT inner_b.payload
+            FROM outer_b
+            JOIN inner_b INDEXED BY inner_b_k ON outer_b.k = inner_b.k
+            ORDER BY outer_b.rowid;
+            """;
+
+        AssertDirectSeek(database, connection, joinA, "two", "three");
+        AssertDirectSeek(database, connection, joinB, "BEE", "CEE");
+
+        // Override the built-in BINARY collation with a genuinely different order: inner_a_k's
+        // durable tree, built under the real BINARY order, is now provably stale -- and unrelated
+        // collation_b is made unavailable at the same time (unregistered, so its own durable
+        // index is intact but nothing has bound its callback right now).
+        database.RegisterCollation("BINARY", ReverseOrdinal);
+        database.UnregisterCollation("collation_b").Should().BeTrue();
+        AssertNoSearch(database, connection, joinA, "two", "three");
+        AssertNoSearch(database, connection, joinB, "BEE", "CEE");
+
+        // A targeted REINDEX of inner_a_k must succeed -- decoding/freeing its old tree's pages
+        // structurally only, never comparing the old physical order under the overridden BINARY
+        // delegate -- and must never require collation_b's callback.
+        Execute(connection, "REINDEX inner_a_k;");
+        AssertDirectSeek(database, connection, joinA, "two", "three");
+
+        // inner_b's tree must remain completely untouched by any of this: still unavailable for
+        // direct seek, still intact, and immediately seekable again once collation_b is
+        // re-registered, with no REINDEX of its own.
+        AssertNoSearch(database, connection, joinB, "BEE", "CEE");
+        database.RegisterCollation("collation_b", ReverseOrdinal);
+        AssertDirectSeek(database, connection, joinB, "BEE", "CEE");
+    }
+
+    [Test]
+    public void ExplicitTransactionPreservesTargetedReindexOfOneIndexWithUnavailableSiblingCollation()
+    {
+        // TargetedIndexRebuild must survive an explicit multi-statement transaction:
+        // BEGIN; REINDEX inner_a_k; COMMIT; must still resolve and apply the targeted rebuild at
+        // actual commit time (TransactionDatabaseState.TargetedIndexRebuildNames /
+        // CommitTransaction's ResolveTargetedIndexRebuild), never requiring collation_b's
+        // callback and never touching inner_b_k's durable tree.
+        var fileSystem = new InMemoryFileSystem();
+        const string path = "custom-collation-explicit-transaction-targeted-reindex.db";
+        using (var database = EmbeddedDatabase.OpenFile(path, fileSystem))
+        using (var connection = database.Connect())
+        {
+            database.RegisterCollation("collation_a", ReverseOrdinal);
+            database.RegisterCollation(
+                "collation_b",
+                static (left, right) => string.Compare(left, right, StringComparison.OrdinalIgnoreCase));
+
+            Execute(connection, "CREATE TABLE outer_a(k TEXT);");
+            Execute(connection, "CREATE TABLE inner_a(k TEXT COLLATE collation_a, payload TEXT);");
+            Execute(connection, "CREATE INDEX inner_a_k ON inner_a(k);");
+            Execute(connection, "CREATE TABLE outer_b(k TEXT);");
+            Execute(connection, "CREATE TABLE inner_b(k TEXT COLLATE collation_b, payload TEXT);");
+            Execute(connection, "CREATE INDEX inner_b_k ON inner_b(k);");
+
+            Execute(connection, "INSERT INTO outer_a VALUES ('b'), ('c');");
+            Execute(connection, "INSERT INTO inner_a VALUES ('b', 'two'), ('c', 'three');");
+            Execute(connection, "INSERT INTO outer_b VALUES ('b'), ('c');");
+            Execute(connection, "INSERT INTO inner_b VALUES ('b', 'BEE'), ('c', 'CEE');");
+            Execute(connection, "ANALYZE;");
+        }
+
+        // Replace collation_a with a genuinely different order so inner_a_k is provably stale;
+        // collation_b is never registered on this connection at all.
+        using var reopened = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        reopened.RegisterCollation("collation_a", static (left, right) => string.CompareOrdinal(left, right));
+
+        const string joinA =
+            """
+            SELECT inner_a.payload
+            FROM outer_a
+            JOIN inner_a INDEXED BY inner_a_k ON outer_a.k = inner_a.k
+            ORDER BY outer_a.k;
+            """;
+        const string joinB =
+            """
+            SELECT inner_b.payload
+            FROM outer_b
+            JOIN inner_b INDEXED BY inner_b_k ON outer_b.k = inner_b.k
+            ORDER BY outer_b.k;
+            """;
+
+        AssertNoSearch(reopened, reopenedConnection, joinA, "two", "three");
+        AssertNoSearch(reopened, reopenedConnection, joinB, "BEE", "CEE");
+
+        Execute(reopenedConnection, "BEGIN;");
+        Execute(reopenedConnection, "REINDEX inner_a_k;");
+        Execute(reopenedConnection, "COMMIT;");
+
+        AssertDirectSeek(reopened, reopenedConnection, joinA, "two", "three");
+        // ...and must leave B's tree completely untouched by the transaction's commit.
+        AssertNoSearch(reopened, reopenedConnection, joinB, "BEE", "CEE");
+
+        reopened.RegisterCollation(
+            "collation_b",
+            static (left, right) => string.Compare(left, right, StringComparison.OrdinalIgnoreCase));
+        AssertDirectSeek(reopened, reopenedConnection, joinB, "BEE", "CEE");
+    }
+
+    [Test]
+    public void SavepointRollbackToRestoresTargetedReindexTrackingThenFreshReindexStillCommitsCorrectly()
+    {
+        // ROLLBACK TO must restore the transaction's tracked targeted-rebuild index names to
+        // exactly the savepoint's snapshot rather than leaving stale entries behind: a REINDEX
+        // issued inside a savepoint, undone via ROLLBACK TO, then reissued and actually committed
+        // must still resolve and apply cleanly, and an unrelated unavailable sibling collation
+        // must never be required by any of it.
+        var fileSystem = new InMemoryFileSystem();
+        const string path = "custom-collation-savepoint-rollback-targeted-reindex.db";
+        using (var database = EmbeddedDatabase.OpenFile(path, fileSystem))
+        using (var connection = database.Connect())
+        {
+            database.RegisterCollation("collation_a", ReverseOrdinal);
+            database.RegisterCollation(
+                "collation_b",
+                static (left, right) => string.Compare(left, right, StringComparison.OrdinalIgnoreCase));
+
+            Execute(connection, "CREATE TABLE outer_a(k TEXT);");
+            Execute(connection, "CREATE TABLE inner_a(k TEXT COLLATE collation_a, payload TEXT);");
+            Execute(connection, "CREATE INDEX inner_a_k ON inner_a(k);");
+            Execute(connection, "CREATE TABLE outer_b(k TEXT);");
+            Execute(connection, "CREATE TABLE inner_b(k TEXT COLLATE collation_b, payload TEXT);");
+            Execute(connection, "CREATE INDEX inner_b_k ON inner_b(k);");
+
+            Execute(connection, "INSERT INTO outer_a VALUES ('b'), ('c');");
+            Execute(connection, "INSERT INTO inner_a VALUES ('b', 'two'), ('c', 'three');");
+            Execute(connection, "INSERT INTO outer_b VALUES ('b'), ('c');");
+            Execute(connection, "INSERT INTO inner_b VALUES ('b', 'BEE'), ('c', 'CEE');");
+            Execute(connection, "ANALYZE;");
+        }
+
+        using var reopened = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        reopened.RegisterCollation("collation_a", static (left, right) => string.CompareOrdinal(left, right));
+
+        const string joinA =
+            """
+            SELECT inner_a.payload
+            FROM outer_a
+            JOIN inner_a INDEXED BY inner_a_k ON outer_a.k = inner_a.k
+            ORDER BY outer_a.k;
+            """;
+        const string joinB =
+            """
+            SELECT inner_b.payload
+            FROM outer_b
+            JOIN inner_b INDEXED BY inner_b_k ON outer_b.k = inner_b.k
+            ORDER BY outer_b.k;
+            """;
+
+        AssertNoSearch(reopened, reopenedConnection, joinA, "two", "three");
+
+        Execute(reopenedConnection, "BEGIN;");
+        Execute(reopenedConnection, "SAVEPOINT sp;");
+        Execute(reopenedConnection, "REINDEX inner_a_k;");
+        Execute(reopenedConnection, "ROLLBACK TO sp;");
+        Execute(reopenedConnection, "REINDEX inner_a_k;");
+        Execute(reopenedConnection, "COMMIT;");
+
+        AssertDirectSeek(reopened, reopenedConnection, joinA, "two", "three");
+        AssertNoSearch(reopened, reopenedConnection, joinB, "BEE", "CEE");
+
+        reopened.RegisterCollation(
+            "collation_b",
+            static (left, right) => string.Compare(left, right, StringComparison.OrdinalIgnoreCase));
+        AssertDirectSeek(reopened, reopenedConnection, joinB, "BEE", "CEE");
+    }
+
+    [Test]
+    public void ExplicitTransactionUnionsMultipleTargetedReindexStatementsAndLeavesUnavailableSiblingUntouched()
+    {
+        // A single explicit transaction that issues REINDEX for two different indexes must union
+        // both into the eventual commit's targeted-rebuild set (TransactionDatabaseState
+        // .TargetedIndexRebuildNames accumulates across every statement in the transaction), so
+        // both end up correctly rebuilt in the same commit -- while a third, wholly unrelated
+        // index whose collation is never registered on this connection stays untouched.
+        var fileSystem = new InMemoryFileSystem();
+        const string path = "custom-collation-transaction-union-targeted-reindex.db";
+        using (var database = EmbeddedDatabase.OpenFile(path, fileSystem))
+        using (var connection = database.Connect())
+        {
+            database.RegisterCollation("collation_a", ReverseOrdinal);
+            database.RegisterCollation("collation_c", ReverseOrdinal);
+            database.RegisterCollation(
+                "collation_b",
+                static (left, right) => string.Compare(left, right, StringComparison.OrdinalIgnoreCase));
+
+            Execute(connection, "CREATE TABLE outer_a(k TEXT);");
+            Execute(connection, "CREATE TABLE inner_a(k TEXT COLLATE collation_a, payload TEXT);");
+            Execute(connection, "CREATE INDEX inner_a_k ON inner_a(k);");
+            Execute(connection, "CREATE TABLE outer_c(k TEXT);");
+            Execute(connection, "CREATE TABLE inner_c(k TEXT COLLATE collation_c, payload TEXT);");
+            Execute(connection, "CREATE INDEX inner_c_k ON inner_c(k);");
+            Execute(connection, "CREATE TABLE outer_b(k TEXT);");
+            Execute(connection, "CREATE TABLE inner_b(k TEXT COLLATE collation_b, payload TEXT);");
+            Execute(connection, "CREATE INDEX inner_b_k ON inner_b(k);");
+
+            Execute(connection, "INSERT INTO outer_a VALUES ('b'), ('c');");
+            Execute(connection, "INSERT INTO inner_a VALUES ('b', 'two'), ('c', 'three');");
+            Execute(connection, "INSERT INTO outer_c VALUES ('b'), ('c');");
+            Execute(connection, "INSERT INTO inner_c VALUES ('b', 'twoC'), ('c', 'threeC');");
+            Execute(connection, "INSERT INTO outer_b VALUES ('b'), ('c');");
+            Execute(connection, "INSERT INTO inner_b VALUES ('b', 'BEE'), ('c', 'CEE');");
+            Execute(connection, "ANALYZE;");
+        }
+
+        using var reopened = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        // Replace both a and c with genuinely different orders; b is never registered on this
+        // connection at all.
+        reopened.RegisterCollation("collation_a", static (left, right) => string.CompareOrdinal(left, right));
+        reopened.RegisterCollation("collation_c", static (left, right) => string.CompareOrdinal(left, right));
+
+        const string joinA =
+            """
+            SELECT inner_a.payload
+            FROM outer_a
+            JOIN inner_a INDEXED BY inner_a_k ON outer_a.k = inner_a.k
+            ORDER BY outer_a.k;
+            """;
+        const string joinC =
+            """
+            SELECT inner_c.payload
+            FROM outer_c
+            JOIN inner_c INDEXED BY inner_c_k ON outer_c.k = inner_c.k
+            ORDER BY outer_c.k;
+            """;
+        const string joinB =
+            """
+            SELECT inner_b.payload
+            FROM outer_b
+            JOIN inner_b INDEXED BY inner_b_k ON outer_b.k = inner_b.k
+            ORDER BY outer_b.k;
+            """;
+
+        AssertNoSearch(reopened, reopenedConnection, joinA, "two", "three");
+        AssertNoSearch(reopened, reopenedConnection, joinC, "twoC", "threeC");
+        AssertNoSearch(reopened, reopenedConnection, joinB, "BEE", "CEE");
+
+        Execute(reopenedConnection, "BEGIN;");
+        Execute(reopenedConnection, "REINDEX inner_a_k;");
+        Execute(reopenedConnection, "REINDEX inner_c_k;");
+        Execute(reopenedConnection, "COMMIT;");
+
+        AssertDirectSeek(reopened, reopenedConnection, joinA, "two", "three");
+        AssertDirectSeek(reopened, reopenedConnection, joinC, "twoC", "threeC");
+        AssertNoSearch(reopened, reopenedConnection, joinB, "BEE", "CEE");
+
+        reopened.RegisterCollation(
+            "collation_b",
+            static (left, right) => string.Compare(left, right, StringComparison.OrdinalIgnoreCase));
+        AssertDirectSeek(reopened, reopenedConnection, joinB, "BEE", "CEE");
+    }
+
+    [Test]
+    public void UnavailableCustomCollationIndexNeverBlocksUnrelatedCreateTableOrSiblingCreateIndex()
+    {
+        // Generalized full-rewrite persistence must preserve an unavailable custom-collation
+        // index's root page and page subtree byte-for-byte rather than requiring BuildIndexTree
+        // (which needs a live comparator) for it: a wholly unrelated CREATE TABLE, and a sibling
+        // CREATE INDEX on an entirely separate table, must both succeed while inner_b_k's own
+        // collation is unavailable -- neither touches inner_b's table, so its collation must
+        // never be resolved by any full catalog rewrite either statement triggers.
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile(
+            "custom-collation-unavailable-does-not-block-ddl.db", fileSystem);
+        using var connection = database.Connect();
+        database.RegisterCollation("collation_b", ReverseOrdinal);
+
+        Execute(connection, "CREATE TABLE outer_b(k TEXT);");
+        Execute(connection, "CREATE TABLE inner_b(k TEXT COLLATE collation_b, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_b_k ON inner_b(k);");
+        Execute(connection, "INSERT INTO outer_b VALUES ('b'), ('c');");
+        Execute(connection, "INSERT INTO inner_b VALUES ('b', 'BEE'), ('c', 'CEE');");
+        Execute(connection, "ANALYZE;");
+
+        const string joinB =
+            """
+            SELECT inner_b.payload
+            FROM outer_b
+            JOIN inner_b INDEXED BY inner_b_k ON outer_b.k = inner_b.k
+            ORDER BY outer_b.k;
+            """;
+        AssertDirectSeek(database, connection, joinB, "BEE", "CEE");
+
+        // Make collation_b unavailable on this connection: inner_b_k becomes dirty/unavailable
+        // but its durable tree remains fully intact.
+        database.UnregisterCollation("collation_b").Should().BeTrue();
+        AssertNoSearch(database, connection, joinB, "BEE", "CEE");
+
+        // A wholly unrelated CREATE TABLE, and a sibling CREATE INDEX (ia) on an entirely
+        // separate table, must both succeed even though inner_b_k (ib) is unavailable right now.
+        Execute(connection, "CREATE TABLE unrelated(id INTEGER PRIMARY KEY, value TEXT);");
+        Execute(connection, "INSERT INTO unrelated VALUES (1, 'x');");
+        Execute(connection, "CREATE TABLE sibling(k TEXT, payload TEXT);");
+        Execute(connection, "CREATE INDEX ia ON sibling(k);");
+        Execute(connection, "INSERT INTO sibling VALUES ('m', 'ehm');");
+
+        Query(connection, "SELECT value FROM unrelated;")
+            .Select(row => row[0].AsText()).Should().Equal("x");
+        Query(connection, "SELECT payload FROM sibling WHERE k = 'm';")
+            .Select(row => row[0].AsText()).Should().Equal("ehm");
+
+        // inner_b's tree must have been preserved byte-for-byte through however many full catalog
+        // rewrites the DDL above triggered: still unavailable for direct seek, still intact, and
+        // immediately seekable again the moment collation_b is re-registered -- with no REINDEX.
+        AssertNoSearch(database, connection, joinB, "BEE", "CEE");
+        database.RegisterCollation("collation_b", ReverseOrdinal);
+        AssertDirectSeek(database, connection, joinB, "BEE", "CEE");
+    }
+
+    [Test]
+    public void UnavailableEmbeddedPartialPredicateCollationIndexNeverBlocksUnrelatedCreateTableOrSiblingCreateIndex()
+    {
+        // Distinct from UnavailableCustomCollationIndexNeverBlocksUnrelatedCreateTableOrSiblingCreateIndex
+        // above: there the unavailable collation qualifies the indexed column itself
+        // (CreateIndexComparer / GetIndexCollation), which TryPreserveUnavailableIndexTrees already
+        // detected directly even before finding #3's fix. Here the collation is embedded only
+        // inside the partial index's WHERE predicate (IndexExpressionSemantics.
+        // CollectEmbeddedCollationNames / EmbeddedFileStore.TryFindUnresolvedEmbeddedIndexCollation),
+        // invisible to CreateIndexComparer, so preservation must be driven by the embedded-collation
+        // probe instead: without it, an unrelated full-catalog rewrite would fall through to
+        // BuildIndexTree for this index, which evaluates the predicate through the (missing)
+        // callback and throws "no such collation sequence" instead of leaving this index's durable
+        // tree alone.
+        var fileSystem = new InMemoryFileSystem();
+        const string path = "custom-collation-unavailable-embedded-predicate-does-not-block-ddl.db";
+        using (var database = EmbeddedDatabase.OpenFile(path, fileSystem))
+        using (var connection = database.Connect())
+        {
+            database.RegisterCollation("ci_text", CaseInsensitiveCustom);
+            Execute(connection, "CREATE TABLE outer_items(k TEXT);");
+            Execute(connection, "CREATE TABLE inner_items(k TEXT, payload TEXT, tag TEXT);");
+            Execute(
+                connection,
+                "CREATE INDEX inner_items_k ON inner_items(k) WHERE tag COLLATE ci_text = 'KEEP';");
+            Execute(connection, "INSERT INTO outer_items VALUES ('b'), ('c');");
+            Execute(
+                connection,
+                "INSERT INTO inner_items VALUES ('b', 'two', 'keep'), ('c', 'excluded', 'drop'), "
+                    + "('c', 'three', 'Keep');");
+            Execute(connection, "ANALYZE;");
+
+            const string sqlBeforeReopen =
+                """
+                SELECT inner_items.payload
+                FROM outer_items
+                JOIN inner_items INDEXED BY inner_items_k
+                    ON outer_items.k = inner_items.k AND inner_items.tag COLLATE ci_text = 'KEEP'
+                ORDER BY outer_items.k;
+                """;
+            AssertDirectSeek(database, connection, sqlBeforeReopen, "two", "three");
+        }
+
+        // Reopen with ci_text never registered on this connection at all: inner_items_k becomes
+        // fully unavailable/dirty (structural validation must defer, per
+        // ValidateStoredIndex/TryFindUnresolvedEmbeddedIndexCollation), but its durable tree
+        // remains fully intact. Note that -- unlike the column-level collation_b case above --
+        // actually *evaluating* this predicate (even via a plan-only scan fallback) also requires
+        // ci_text to be resolvable, since the predicate itself, not merely the index, embeds the
+        // COLLATE reference: PartialIndexPredicateMissingCollateCallbackFailsClosedOnlyWhenARowIsEvaluated
+        // already covers that fail-closed evaluation behavior. This test only checks the query
+        // *plan* (which never evaluates row data) and reads that avoid the predicate entirely, so
+        // it stays isolated to finding #3's actual concern: durable-tree preservation across
+        // unrelated full-catalog rewrites.
+        using var reopened = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var reopenedConnection = reopened.Connect();
+
+        const string joinSql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_k
+                ON outer_items.k = inner_items.k AND inner_items.tag COLLATE ci_text = 'KEEP'
+            ORDER BY outer_items.k;
+            """;
+        const string collationSafeSql = "SELECT k, payload, tag FROM inner_items ORDER BY k, payload;";
+        var originalRows = new[] { "b|two|keep", "c|excluded|drop", "c|three|Keep" };
+
+        AssertPlanHasNoSearch(reopenedConnection, joinSql);
+        Query(reopenedConnection, collationSafeSql)
+            .Select(row => $"{row[0].AsText()}|{row[1].AsText()}|{row[2].AsText()}")
+            .Should().Equal(originalRows);
+
+        // A wholly unrelated CREATE TABLE, and a sibling CREATE INDEX (ia) on an entirely separate
+        // table, must both succeed even though inner_items_k's embedded predicate collation is
+        // unavailable right now: neither touches inner_items' table, so ci_text must never be
+        // resolved by any full catalog rewrite either statement triggers.
+        Execute(reopenedConnection, "CREATE TABLE unrelated(id INTEGER PRIMARY KEY, value TEXT);");
+        Execute(reopenedConnection, "INSERT INTO unrelated VALUES (1, 'x');");
+        Execute(reopenedConnection, "CREATE TABLE sibling(k TEXT, payload TEXT);");
+        Execute(reopenedConnection, "CREATE INDEX ia ON sibling(k);");
+        Execute(reopenedConnection, "INSERT INTO sibling VALUES ('m', 'ehm');");
+
+        Query(reopenedConnection, "SELECT value FROM unrelated;")
+            .Select(row => row[0].AsText()).Should().Equal("x");
+        Query(reopenedConnection, "SELECT payload FROM sibling WHERE k = 'm';")
+            .Select(row => row[0].AsText()).Should().Equal("ehm");
+
+        // inner_items_k's tree must have been preserved byte-for-byte through however many full
+        // catalog rewrites the DDL above triggered: still unavailable for direct seek, its rows
+        // still intact, and immediately seekable again the moment ci_text is registered -- with
+        // no REINDEX.
+        AssertPlanHasNoSearch(reopenedConnection, joinSql);
+        Query(reopenedConnection, collationSafeSql)
+            .Select(row => $"{row[0].AsText()}|{row[1].AsText()}|{row[2].AsText()}")
+            .Should().Equal(originalRows);
+        reopened.RegisterCollation("ci_text", CaseInsensitiveCustom);
+        AssertDirectSeek(reopened, reopenedConnection, joinSql, "two", "three");
+    }
+
+    [Test]
+    public void UnavailableCustomCollationIndexSurvivesNewSiblingIndexOnItsOwnTable()
+    {
+        // Finding #2 regression: unavailable-custom-index preservation must be decided per index
+        // (row/tree storage unchanged for the owning table, plus this specific EmbeddedIndex
+        // instance unchanged), never by requiring the whole table's index *list count* to match
+        // the previous commit. CREATE INDEX new_binary here only appends a new EmbeddedIndex
+        // instance to inner_b.Indexes -- it never touches inner_b's own RowStore -- so
+        // inner_b_k's own preservation must not be defeated merely because inner_b grows a
+        // sibling index of its own, unlike UnavailableCustomCollationIndexNeverBlocksUnrelated-
+        // CreateTableOrSiblingCreateIndex above, whose sibling CREATE INDEX targets an entirely
+        // different table.
+        var fileSystem = new InMemoryFileSystem();
+        const string path = "custom-collation-unavailable-survives-same-table-sibling-index.db";
+        using (var database = EmbeddedDatabase.OpenFile(path, fileSystem))
+        using (var connection = database.Connect())
+        {
+            database.RegisterCollation("collation_b", ReverseOrdinal);
+            Execute(connection, "CREATE TABLE outer_b(k TEXT);");
+            Execute(connection, "CREATE TABLE inner_b(k TEXT COLLATE collation_b, payload TEXT);");
+            Execute(connection, "CREATE INDEX inner_b_k ON inner_b(k);");
+            Execute(connection, "INSERT INTO outer_b VALUES ('b'), ('c');");
+            Execute(connection, "INSERT INTO inner_b VALUES ('b', 'BEE'), ('c', 'CEE');");
+            // Noise rows seeded now, while collation_b is still registered, so inner_b already has
+            // enough rows for the cost-based planner to prefer a seek (matching the SeedNoiseRows
+            // convention) once collation_b becomes unavailable below: nothing further is ever
+            // inserted into inner_b after this point, so its row storage stays provably unchanged
+            // and inner_b_k remains eligible for byte-for-byte preservation throughout the test.
+            Execute(
+                connection,
+                "INSERT INTO inner_b VALUES "
+                    + string.Join(
+                        ", ",
+                        Enumerable.Range(1, 500).Select(value => $"('noise{value:0000}', 'n{value}')"))
+                    + ";");
+            Execute(connection, "ANALYZE;");
+        }
+
+        // Reopen with collation_b never registered on this connection at all: inner_b_k becomes
+        // fully unavailable/dirty, but its durable tree remains fully intact.
+        using var reopened = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var reopenedConnection = reopened.Connect();
+
+        const string joinB =
+            """
+            SELECT inner_b.payload
+            FROM outer_b
+            JOIN inner_b INDEXED BY inner_b_k ON outer_b.k = inner_b.k
+            ORDER BY outer_b.k;
+            """;
+        AssertNoSearch(reopened, reopenedConnection, joinB, "BEE", "CEE");
+
+        // CREATE INDEX new_binary is a sibling of inner_b_k on THE SAME table (inner_b), not on a
+        // separate table. Before the fix, preservation of an unavailable index was (wrongly)
+        // gated on the *table's* whole index-list count matching the previous commit; adding
+        // new_binary changes that count, so inner_b_k -- despite being completely unrelated to
+        // and untouched by this statement -- would be routed through BuildIndexTree, which needs
+        // the missing collation_b callback and throws "no such collation sequence" instead of
+        // leaving inner_b_k's durable tree alone.
+        Execute(reopenedConnection, "CREATE INDEX new_binary ON inner_b(payload);");
+
+        // inner_b_k's tree must have been preserved byte-for-byte across the same-table sibling
+        // CREATE INDEX above: still unavailable for direct seek, its rows still intact, and
+        // immediately seekable again the moment collation_b is re-registered -- with no REINDEX.
+        AssertNoSearch(reopened, reopenedConnection, joinB, "BEE", "CEE");
+
+        // new_binary itself, meanwhile, must already be a fully-built, directly-seekable index:
+        // it never depended on collation_b at all, so it must work immediately, before
+        // collation_b is ever re-registered. A plain single-table forced access path is used
+        // here rather than AssertDirectSeek's JOIN-reordering proof, since that rewrite
+        // additionally requires ANALYZE statistics that cannot be gathered while collation_b
+        // remains unregistered (ANALYZE sorts statistic keys for every index on the connection,
+        // including the still-unavailable inner_b_k); a single-table INDEXED BY access path is
+        // not subject to that join-order cost decision at all.
+        AssertSingleTableSearch(
+            reopenedConnection,
+            "SELECT k FROM inner_b INDEXED BY new_binary WHERE payload = 'BEE';",
+            "new_binary",
+            "b");
+        AssertSingleTableSearch(
+            reopenedConnection,
+            "SELECT k FROM inner_b INDEXED BY new_binary WHERE payload = 'CEE';",
+            "new_binary",
+            "c");
+
+        // Reopen a second time: both indexes must persist correctly through a full close/reopen
+        // cycle. new_binary must still be directly seekable with no dependency on collation_b;
+        // inner_b_k must still be unavailable-but-intact until collation_b is registered again,
+        // at which point it becomes directly seekable too -- with no REINDEX ever required for
+        // either index.
+        using var reopenedAgain = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var reopenedAgainConnection = reopenedAgain.Connect();
+
+        const string payloadLookupBee =
+            "SELECT k FROM inner_b INDEXED BY new_binary WHERE payload = 'BEE';";
+        const string payloadLookupCee =
+            "SELECT k FROM inner_b INDEXED BY new_binary WHERE payload = 'CEE';";
+        AssertSingleTableSearch(reopenedAgainConnection, payloadLookupBee, "new_binary", "b");
+        AssertSingleTableSearch(reopenedAgainConnection, payloadLookupCee, "new_binary", "c");
+        AssertNoSearch(reopenedAgain, reopenedAgainConnection, joinB, "BEE", "CEE");
+
+        reopenedAgain.RegisterCollation("collation_b", ReverseOrdinal);
+        AssertDirectSeek(reopenedAgain, reopenedAgainConnection, joinB, "BEE", "CEE");
+        AssertSingleTableSearch(reopenedAgainConnection, payloadLookupBee, "new_binary", "b");
+        AssertSingleTableSearch(reopenedAgainConnection, payloadLookupCee, "new_binary", "c");
+    }
+
+    [Test]
+    public void AlterColumnRebuildWithCollidingRevisionAndIndexReferencesFailsClosedInsteadOfPreservingStaleTree()
+    {
+        // EmbeddedTable.CreateWithAlteredColumn (used for ALTER TABLE ... ALTER COLUMN) builds a
+        // brand-new RowStore and re-adds every existing row into it one-by-one, and also carries
+        // the table's existing EmbeddedIndex instances forward by reference. With exactly two pure
+        // INSERTs and no prior UPDATE/DELETE on either table, the rebuilt table's Rows.Revision
+        // (== row count) trivially collides with the pre-ALTER table's Revision, and items_tag is
+        // still the identical index-object reference -- the two proofs a naive "this table is
+        // unchanged since the last durable commit" check would rely on to cheaply preserve an
+        // unavailable index's durable tree byte-for-byte instead of revalidating it. Rows.Revision
+        // and index-reference equality alone are not collision-resistant enough to detect this:
+        // only a distinct RowStore.LineageId (assigned fresh on every genuinely new RowStore, and
+        // carried forward only by Clone()'s same-statement working-copy path) proves the table
+        // was *not* actually rebuilt. Retyping tag to NUMERIC (dropping its COLLATE clause, which
+        // is legal even with swap_text unavailable) re-coerces the existing '10'/'20' TEXT values
+        // into integers, so items_tag's durable tree -- still keyed on the old TEXT bytes -- would
+        // silently go stale if it were preserved as-is instead of being revalidated and, since
+        // swap_text truly cannot be resolved on this connection, failing closed.
+        var fileSystem = new InMemoryFileSystem();
+        const string path = "custom-collation-alter-column-lineage.db";
+        using (var database = EmbeddedDatabase.OpenFile(path, fileSystem))
+        using (var connection = database.Connect())
+        {
+            database.RegisterCollation("swap_text", ReverseOrdinal);
+            Execute(connection, "CREATE TABLE items(tag TEXT COLLATE swap_text, payload TEXT);");
+            Execute(connection, "CREATE INDEX items_tag ON items(tag);");
+            Execute(connection, "INSERT INTO items VALUES ('10', 'one'), ('20', 'two');");
+            Execute(connection, "ANALYZE;");
+        }
+
+        // Reopen with swap_text never registered on this connection at all (items_tag is fully
+        // unavailable), but register an unrelated collation so the store's resolver is non-null:
+        // deferred validation is scoped per-index, never gated on whether *any* resolver exists
+        // (see PartiallyRegisteredCollationsIsolateUnavailableIndexPerIndexNotGlobally).
+        using var reopened = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        reopened.RegisterCollation("unrelated_collation", ReverseOrdinal);
+
+        // The ALTER must run inside an explicit transaction: EmbeddedDatabase.CommitTransaction
+        // threads a non-null PragmaHeaderMetadata through EmbeddedFileStore.Persist whenever the
+        // transaction contains schema changes, which is what routes this commit into the
+        // full-catalog-rewrite path (PersistCore's own GetIndexDefinitions/TryPreserveUnavailableIndexTrees
+        // call, correctly threading the real previousTables) instead of the bounded-table-leaf-mutation
+        // fast path -- whose own first HasCurrentSchemaShape probe never receives previousTables at all
+        // and so would fail closed unconditionally the moment any resolver is registered, independent of
+        // this test's actual LineageId regression. Statement execution inside an explicit transaction
+        // only rewrites the in-memory working catalog, so the ALTER itself must not throw -- the
+        // durable-persistence attempt (and the expected failure) happens at COMMIT.
+        Execute(reopenedConnection, "BEGIN;");
+        Execute(reopenedConnection, "ALTER TABLE items ALTER COLUMN tag TO tag NUMERIC;");
+        Action commit = () => Execute(reopenedConnection, "COMMIT;");
+        commit.Should().Throw<EmbeddedSqlException>()
+            .WithMessage("*no such collation sequence*swap_text*");
+        Execute(reopenedConnection, "ROLLBACK;");
+
+        // The failed ALTER must not have partially applied, and must never have persisted a
+        // rebuilt table with items_tag's stale pre-ALTER tree copied forward: reopening with
+        // swap_text registered again must find items exactly as originally written, with its
+        // original TEXT values, original schema, and an intact, still directly-seekable index.
+        using var reopenedAgain = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var reopenedAgainConnection = reopenedAgain.Connect();
+        reopenedAgain.RegisterCollation("swap_text", ReverseOrdinal);
+
+        Query(reopenedAgainConnection, "SELECT sql FROM sqlite_schema WHERE name = 'items';")
+            .Select(row => row[0].AsText())
+            .Should().Equal("CREATE TABLE items(tag TEXT COLLATE swap_text, payload TEXT)");
+        Query(reopenedAgainConnection, "SELECT tag, payload FROM items ORDER BY rowid;")
+            .Select(row => $"{row[0].AsText()}|{row[1].AsText()}")
+            .Should().Equal("10|one", "20|two");
+        Query(reopenedAgainConnection, "SELECT payload FROM items INDEXED BY items_tag WHERE tag = '10';")
+            .Select(row => row[0].AsText())
+            .Should().Equal("one");
+    }
+
+    [Test]
+    public void ConcurrentRegisterCollationDuringQueriesNeverObservesANewComparatorWithAnOldCleanProof()
+    {
+        // RegisterCollation must publish the callback-dictionary write, the registry-version
+        // bump, the file-store resolver rebind, and the _customCollationIndexClean invalidation
+        // as one atomic unit under _gate: a concurrently running query must never observe a mix
+        // where the dictionary already holds a new comparator while the clean-cache/registry
+        // version still describe the previous one (which would let a stale "clean" proof stand
+        // in for the new comparator's real semantics). Stress this under real concurrent load,
+        // alternating between two genuinely different orderings, so any torn publish would
+        // surface as either an exception or an incorrect/incomplete join result.
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("custom-collation-register-atomicity.db", fileSystem);
+        using (var setupConnection = database.Connect())
+        {
+            database.RegisterCollation("swap_text", ReverseOrdinal);
+            Execute(setupConnection, "CREATE TABLE outer_items(k TEXT);");
+            Execute(setupConnection, "CREATE TABLE inner_items(k TEXT COLLATE swap_text, payload TEXT);");
+            Execute(setupConnection, "CREATE INDEX inner_items_k ON inner_items(k);");
+            Execute(setupConnection, "INSERT INTO outer_items VALUES ('b'), ('c');");
+            Execute(setupConnection, "INSERT INTO inner_items VALUES ('b', 'two'), ('c', 'three');");
+        }
+
+        var forward = (Func<string, string, int>)(static (left, right) => string.CompareOrdinal(left, right));
+        var reverse = ReverseOrdinal;
+
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_k ON outer_items.k = inner_items.k;
+            """;
+
+        const int iterations = 2_000;
+        var registrar = Task.Run(() =>
+        {
+            for (var i = 0; i < iterations; i++)
+                database.RegisterCollation("swap_text", i % 2 == 0 ? forward : reverse);
+        });
+
+        var reader = Task.Run(() =>
+        {
+            using var connection = database.Connect();
+            for (var i = 0; i < iterations; i++)
+            {
+                // Equality is unaffected by which of the two orderings is bound (both report 0
+                // exactly for equal values), so the correct answer is always these two rows in
+                // some order -- never a torn mix such as a duplicate, a missing row, or a value
+                // that belongs to neither collation's valid answer.
+                var payloads = ReadRows(connection, sql).Select(row => row[0].AsText()).ToList();
+                payloads.Should().BeEquivalentTo(new[] { "two", "three" });
+            }
+        });
+
+        Task.WaitAll(registrar, reader);
+    }
+
+    [Test]
+    public void ReentrantCollationReplacementDuringValidationForcesFreshRevalidation()
+    {
+        // The collation-registry version is monotonic: registration/replacement/unregister all
+        // increment it, and IsCustomCollationIndexPlanReady must capture the committed generation
+        // and registry version *before* revalidating and only publish its cache if both are still
+        // unchanged *after*. A collation callback that reentrantly replaces its own registration
+        // mid-comparison -- which is legal, since an ordinary comparator invocation carries no
+        // recursive-trigger-callback guard -- must therefore force a discard-and-retry rather than
+        // publish a cache entry keyed to a registry version that no longer matches reality.
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("custom-collation-reentrant-replace.db", fileSystem);
+        using var connection = database.Connect();
+
+        var reentrantArmed = false;
+        var reenteredDuringValidation = false;
+        Func<string, string, int> comparer = null!;
+        comparer = (left, right) =>
+        {
+            if (reentrantArmed && !reenteredDuringValidation)
+            {
+                reenteredDuringValidation = true;
+                // Re-registering the same callback mid-comparison bumps the registry version
+                // while this very validation pass is still in flight: the "before" version this
+                // pass captured can no longer match the "after" version it rechecks, so the
+                // otherwise-clean answer it was about to cache must be discarded and retried.
+                database.RegisterCollation("reentrant_text", comparer);
+            }
+
+            return string.CompareOrdinal(right, left);
+        };
+
+        database.RegisterCollation("reentrant_text", comparer);
+        Execute(connection, "CREATE TABLE outer_items(k TEXT);");
+        Execute(connection, "CREATE TABLE inner_items(k TEXT COLLATE reentrant_text, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k);");
+        Execute(connection, "INSERT INTO outer_items VALUES ('b'), ('c');");
+        Execute(connection, "INSERT INTO inner_items VALUES ('b', 'two'), ('c', 'three');");
+        SeedNoiseRows(connection);
+        Execute(connection, "ANALYZE;");
+        AssertDirectSeek(database, connection, JoinSql, "two", "three");
+
+        // Force a genuinely fresh validation pass: re-registering the same callback bumps the
+        // registry version and invalidates any already-cached "clean" answer, so the next seek's
+        // validation must actually re-run the comparator from scratch, where the reentrant
+        // replacement is armed to fire on its very first invocation.
+        database.RegisterCollation("reentrant_text", comparer);
+        reentrantArmed = true;
+        AssertDirectSeek(database, connection, JoinSql, "two", "three");
+
+        reenteredDuringValidation.Should().BeTrue(
+            "the reentrant replacement must actually have fired during validation for this regression to be meaningful");
+    }
+
+    [Test]
+    public void ExplicitCollateOnBothOperandsUsesLeftOperandPrecedenceNotTheIndexedSide()
+    {
+        // SQLite's real precedence rule (datatype3.html section 7.1, rule 1 in this engine's
+        // terms): when both operands of an equality carry an explicit COLLATE, the LEFT operand's
+        // always wins -- regardless of which operand an expression index happens to be built over.
+        // Two collations with genuinely different equality semantics on the same byte pairs make a
+        // wrong ("whichever operand is indexed wins") resolution observably flip which rows match.
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("custom-collation-explicit-precedence.db", fileSystem);
+        using var connection = database.Connect();
+        database.RegisterCollation(
+            "case_sensitive_exact",
+            static (left, right) => string.CompareOrdinal(left, right));
+        database.RegisterCollation(
+            "fold_case",
+            static (left, right) => string.Compare(left, right, StringComparison.OrdinalIgnoreCase));
+
+        Execute(connection, "CREATE TABLE outer_items(k TEXT);");
+        Execute(connection, "CREATE TABLE inner_items(k TEXT, payload TEXT);");
+        // The expression index is built under fold_case -- the RIGHT-hand operand's explicit
+        // collation in the join predicate below -- so a buggy "whichever operand is indexed wins"
+        // resolution would pick fold_case; the correct, SQLite-compatible resolution must instead
+        // use the LEFT operand's explicit case_sensitive_exact.
+        Execute(connection, "CREATE INDEX inner_items_expr ON inner_items((k || '') COLLATE fold_case);");
+        Execute(connection, "INSERT INTO outer_items VALUES ('A'), ('B'), ('c');");
+        Execute(
+            connection,
+            "INSERT INTO inner_items VALUES ('a', 'wrong-if-fold-wins'), ('B', 'exact-match'), "
+                + "('C', 'wrong-if-fold-wins-2'), "
+                + string.Join(
+                    ", ",
+                    Enumerable.Range(1, 500).Select(value => $"('noise{value:0000}', 'n{value}')"))
+                + ";");
+        Execute(connection, "ANALYZE;");
+
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items
+                ON outer_items.k COLLATE case_sensitive_exact = (inner_items.k || '') COLLATE fold_case
+            ORDER BY outer_items.k;
+            """;
+
+        // Under the correct left-operand precedence (case_sensitive_exact), 'A' <> 'a' and
+        // 'c' <> 'C': only the exact-case pair ('B', 'B') matches. A buggy resolution of the
+        // indexed (right) operand's fold_case instead would incorrectly match both mismatched-case
+        // pairs too, and could do so via a wrong seek rather than the correct fallback comparison.
+        ReadRows(connection, sql).Select(row => row[0].AsText())
+            .Should().Equal("exact-match");
+    }
+
+    private const string JoinSql =
+        """
+        SELECT inner_items.payload
+        FROM outer_items
+        JOIN inner_items INDEXED BY inner_items_k ON outer_items.k = inner_items.k
+        ORDER BY outer_items.k;
+        """;
+
+    private static void AssertDirectSeek(
+        EmbeddedDatabase database,
+        EmbeddedConnection connection,
+        string sql,
+        params string[] expectedPayloads)
+    {
+        ReadRows(connection, "EXPLAIN QUERY PLAN " + sql)
+            .Select(row => row[3].AsText())
+            .Should().Contain(value => value.StartsWith("SEARCH ", StringComparison.Ordinal));
+
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, sql).Select(row => row[0].AsText()).Should().Equal(expectedPayloads);
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().BeGreaterThan(0);
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+    }
+
+    /// <summary>
+    /// Like <see cref="AssertDirectSeek"/>, but for a plain single-table access path (an
+    /// <c>INDEXED BY</c> forced index with no join partner) rather than a durable-pager-seek join
+    /// rewrite. Single-table index selection is not subject to the cost-based join-order
+    /// decision that backs <see cref="AssertDirectSeek"/>'s <see
+    /// cref="VdbeJoinIndexSeekMetrics"/> assertions, so it needs neither <c>ANALYZE</c> statistics
+    /// nor <see cref="SeedNoiseRows"/>-sized tables to be honored: an <c>INDEXED BY</c> hint on a
+    /// single table always compiles to a "SEARCH ... USING INDEX ..." plan naming that index.
+    /// </summary>
+    private static void AssertSingleTableSearch(
+        EmbeddedConnection connection,
+        string sql,
+        string indexName,
+        params string[] expectedResults)
+    {
+        ReadRows(connection, "EXPLAIN QUERY PLAN " + sql)
+            .Select(row => row[3].AsText())
+            .Should()
+            .Contain(value =>
+                value.StartsWith($"SEARCH ", StringComparison.Ordinal)
+                && value.Contains($"USING INDEX {indexName}", StringComparison.Ordinal));
+
+        ReadRows(connection, sql).Select(row => row[0].AsText()).Should().Equal(expectedResults);
+    }
+
+    private static void AssertNoSearch(
+        EmbeddedDatabase database,
+        EmbeddedConnection connection,
+        string sql,
+        params string[] expectedPayloads)
+    {
+        ReadRows(connection, "EXPLAIN QUERY PLAN " + sql)
+            .Select(row => row[3].AsText())
+            .Should().NotContain(value => value.StartsWith("SEARCH ", StringComparison.Ordinal));
+
+        // The rows must still be correct via whatever scan-based plan was chosen instead: falling
+        // back away from a direct seek must never change query results.
+        ReadRows(connection, sql).Select(row => row[0].AsText()).Should().Equal(expectedPayloads);
+    }
+
+    /// <summary>
+    /// Like <see cref="AssertNoSearch"/>, but checks only the query plan, never executing <paramref
+    /// name="sql"/> itself. Use this when <paramref name="sql"/>'s predicate embeds a COLLATE
+    /// reference to a collation that is not currently resolvable on <paramref name="connection"/>:
+    /// evaluating the predicate at all (even via a scan-based fallback plan) would then throw
+    /// "no such collation sequence", independent of whether the index built over it is available
+    /// for planning.
+    /// </summary>
+    private static void AssertPlanHasNoSearch(EmbeddedConnection connection, string sql)
+    {
+        ReadRows(connection, "EXPLAIN QUERY PLAN " + sql)
+            .Select(row => row[3].AsText())
+            .Should().NotContain(value => value.StartsWith("SEARCH ", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Fills <c>inner_items</c> with enough rows that the cost-based join-order planner sees a
+    /// real benefit to an index seek over a full scan, matching the row-count convention used by
+    /// the direct-seek proofs in <c>IndexSeekJoinDirectAccessTests</c>. A 2-row table is too small
+    /// for the planner to bother rewriting the join order at all, which would otherwise make the
+    /// whole statement decline compilation (an unrelated, pre-existing size heuristic, not a
+    /// custom-collation limitation).
+    /// </summary>
+    private static void SeedNoiseRows(EmbeddedConnection connection)
+    {
+        var noise = string.Join(
+            ", ",
+            Enumerable.Range(1, 500).Select(value => $"('noise{value:0000}', 'n{value}')"));
+        Execute(connection, $"INSERT INTO inner_items VALUES {noise};");
+    }
+
+    private static void Execute(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        statement.Step().Should().Be(StatementStepResult.Done);
+    }
+
+    /// <summary>
+    /// Like <see cref="Execute"/>, but for pragmas such as <c>PRAGMA journal_mode=mvcc;</c> that --
+    /// like real SQLite -- report their (possibly newly set) value as a single result row before
+    /// completing, rather than going straight to <see cref="StatementStepResult.Done"/>.
+    /// </summary>
+    private static void ExecutePragma(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        while (statement.Step() == StatementStepResult.Row)
+        {
+        }
+    }
+
+    private static List<SqlValue[]> Query(EmbeddedConnection connection, string sql)
+        => ReadRows(connection, sql);
+
+    private static List<SqlValue[]> ReadRows(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        var rows = new List<SqlValue[]>();
+        while (statement.Step() == StatementStepResult.Row)
+        {
+            var values = new SqlValue[statement.GetColumnCount()];
+            for (var ordinal = 0; ordinal < values.Length; ordinal++)
+                values[ordinal] = statement.GetValue(ordinal);
+            rows.Add(values);
+        }
+
+        return rows;
+    }
+}

--- a/src/Ahtola.Tests/DurableIndexSemanticsTests.cs
+++ b/src/Ahtola.Tests/DurableIndexSemanticsTests.cs
@@ -1300,17 +1300,20 @@ public sealed class DurableIndexSemanticsTests
     }
 
     [Test]
-    public void CustomCollationRejectsBeforePublicationAndRichOrderCorruptionFailsReopen()
+    public void FunctionBasedIndexDefinitionsRejectBeforePublicationAndRichOrderCorruptionFailsReopen()
     {
+        // This test used to also assert that CREATE INDEX ... COLLATE reverse_text was rejected
+        // purely because the collation name was non-built-in. Under the custom-collation index
+        // phase that is no longer the contract: a *registered* custom collation is fully
+        // supported for secondary indexes (see CustomCollationIndexTests), so that sub-case moved
+        // out. Only the function-based rejections below (non-deterministic function, UDF-in-index
+        // expression, function-based built-in-collation override) remain unconditional.
         const string rejectedPath = "custom-index-reject.db";
         var faults = new DeterministicFaultInjector();
         var rejectedFileSystem = new InMemoryFileSystem(faults);
         using (var database = EmbeddedDatabase.OpenFile(rejectedPath, rejectedFileSystem))
         using (var connection = database.Connect())
         {
-            database.RegisterCollation(
-                "reverse_text",
-                (left, right) => string.CompareOrdinal(right, left));
             database.RegisterScalarFunction("managed_index_value", 1, values => values[0]);
             database.RegisterScalarFunction("lower", 1, values => values[0]);
             Execute(connection, "CREATE TABLE retained(id INTEGER PRIMARY KEY, value TEXT);");
@@ -1333,11 +1336,6 @@ public sealed class DurableIndexSemanticsTests
                 "CREATE INDEX rejected_override ON retained(lower(value));");
             overrideBuiltin.Should().Throw<EmbeddedSqlException>()
                 .WithMessage("*application-defined functions are prohibited*");
-            Action create = () => Execute(
-                connection,
-                "CREATE INDEX rejected_custom ON retained(value COLLATE reverse_text);");
-            create.Should().Throw<EmbeddedSqlException>()
-                .WithMessage("*not a supported SQLite built-in collation*");
             faults.GetOperationCount(FileSystemOperation.Write).Should().Be(writesBeforeReject);
             Query(connection, "PRAGMA index_list(retained);").Should().BeEmpty();
             faults.ClearScheduled();

--- a/src/Ahtola.Tests/EmbeddedEngineTests.cs
+++ b/src/Ahtola.Tests/EmbeddedEngineTests.cs
@@ -1875,8 +1875,16 @@ public class EmbeddedEngineTests
             Assert.Throws<EmbeddedSqlException>(() => parameterIndex.Step())!
                 .Message.Should().Contain("parameters are prohibited");
         }
-        Assert.Throws<EmbeddedSqlException>(() => Execute(connection, "CREATE INDEX collated_idx ON t(a + b COLLATE custom);"))!
-            .Message.Should().Contain("not a supported SQLite built-in collation");
+        // "custom" is a valid application-defined collation name syntactically, but nothing has
+        // registered a callback for it on this connection, so CREATE INDEX must fail closed with
+        // the SQLite-style "no such collation sequence" message rather than silently falling back
+        // to BINARY ordering or leaving an unusable index behind (see CustomCollationIndexTests).
+        // COLLATE binds tighter than binary operators (SQLite grammar), so it must wrap the whole
+        // "(a + b)" expression here to become the index term's own collating sequence; without the
+        // parens "a + b COLLATE custom" would parse as "a + (b COLLATE custom)", whose sum discards
+        // the nested collation and never actually needs "custom" registered.
+        Assert.Throws<EmbeddedSqlException>(() => Execute(connection, "CREATE INDEX collated_idx ON t((a + b) COLLATE custom);"))!
+            .Message.Should().Contain("no such collation sequence: custom");
 
         using var list = connection.Prepare("PRAGMA index_list(t);");
         list.Step().Should().Be(StatementStepResult.Done);

--- a/src/Ahtola.Tests/IndexSeekJoinDirectAccessTests.cs
+++ b/src/Ahtola.Tests/IndexSeekJoinDirectAccessTests.cs
@@ -1,0 +1,368 @@
+using AwesomeAssertions;
+using MsData = Microsoft.Data.Sqlite;
+using Ahtola.Core;
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Tests;
+
+/// <summary>
+/// Focused coverage for the first direct-access phase: autocommit, committed file-backed
+/// rowid-table joins that drive a safe partial index or expression index must use the durable
+/// pager b-tree cursor (<see cref="VdbeJoinIndexSeekMetrics.DurableCursorPlans"/>, zero
+/// <see cref="VdbeJoinIndexSeekMetrics.IndexRowsMaterialized"/>) instead of the materialized-index
+/// fallback, but only when eligibility is actually proven.
+/// </summary>
+public sealed class IndexSeekJoinDirectAccessTests
+{
+    [Test]
+    public void DurableReopenUsesPagerSeekForProvenPartialIndex()
+    {
+        string[] setup =
+        [
+            "CREATE TABLE outer_items(k INTEGER);",
+            "CREATE TABLE inner_items(k INTEGER, gate INTEGER, payload TEXT);",
+            "CREATE INDEX inner_items_partial ON inner_items(k) WHERE gate > 0;",
+            "INSERT INTO outer_items VALUES (2), (40);",
+            "INSERT INTO inner_items VALUES "
+                + string.Join(", ", Enumerable.Range(1, 500).Select(value => $"({value}, 1, 'p{value}')"))
+                + ";",
+            "ANALYZE;",
+        ];
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items JOIN inner_items INDEXED BY inner_items_partial
+            ON outer_items.k = inner_items.k AND inner_items.gate > 0
+            ORDER BY outer_items.k;
+            """;
+
+        AssertMatchesSqlite(setup, sql);
+
+        var fileSystem = new InMemoryFileSystem();
+        using (var database = EmbeddedDatabase.OpenFile("partial-index-join.db", fileSystem))
+        using (var connection = database.Connect())
+        {
+            foreach (var statement in setup)
+                Execute(connection, statement);
+        }
+
+        using var reopened = EmbeddedDatabase.OpenFile("partial-index-join.db", fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        ReadRows(reopenedConnection, "EXPLAIN QUERY PLAN " + sql).Single()[3].AsText()
+            .Should().Be("SEARCH inner_items USING INDEX inner_items_partial (k=?)");
+
+        reopened.ResetJoinOrderDiagnostics();
+        ReadRows(reopenedConnection, sql).Select(row => row[0].AsText()).Should().Equal("p2", "p40");
+        reopened.JoinIndexSeekMetrics.DurableCursorPlans.Should().BeGreaterThan(0);
+        reopened.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+    }
+
+    [Test]
+    public void UnprovenPartialIndexPredicateDeclinesAndKeepsRowsResidual()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("partial-index-unsafe.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE outer_items(k INTEGER);");
+        Execute(connection, "CREATE TABLE inner_items(k INTEGER, gate INTEGER, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_items_partial ON inner_items(k) WHERE gate > 0;");
+        Execute(connection, "INSERT INTO outer_items VALUES (2);");
+        Execute(connection, "INSERT INTO inner_items VALUES (2, 1, 'kept'), (2, -1, 'dropped');");
+        Execute(connection, "ANALYZE;");
+
+        // Nothing in the ON/WHERE clause proves inner_items.gate > 0, so the partial index must
+        // stay an ineligible candidate: the join-order planner (unforced) must decline it rather
+        // than ever seeking inner_items_partial, and every row -- including the one that fails
+        // the index's own "gate > 0" predicate -- must still surface as residual output.
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items JOIN inner_items
+            ON outer_items.k = inner_items.k
+            ORDER BY inner_items.payload;
+            """;
+        ReadRows(connection, "EXPLAIN QUERY PLAN " + sql).Single()[3].AsText()
+            .Should().NotContain("inner_items_partial");
+
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, sql).Select(row => row[0].AsText()).Should().Equal("dropped", "kept");
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().Be(0);
+    }
+
+    [Test]
+    public void DurableReopenUsesPagerSeekForProvenExpressionIndex()
+    {
+        string[] setup =
+        [
+            "CREATE TABLE outer_items(k);",
+            "CREATE TABLE inner_items(k TEXT, payload TEXT);",
+            "CREATE INDEX inner_items_lower_k ON inner_items(lower(k));",
+            "INSERT INTO outer_items VALUES ('b'), ('zz');",
+            "INSERT INTO inner_items VALUES ('B', 'p-B'), ('ZZ', 'p-ZZ'), "
+                + string.Join(
+                    ", ",
+                    Enumerable.Range(1, 500).Select(value => $"('noise{value}', 'n{value}')"))
+                + ";",
+            "ANALYZE;",
+        ];
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items JOIN inner_items INDEXED BY inner_items_lower_k
+            ON outer_items.k = lower(inner_items.k)
+            ORDER BY outer_items.k;
+            """;
+
+        AssertMatchesSqlite(setup, sql);
+
+        var fileSystem = new InMemoryFileSystem();
+        using (var database = EmbeddedDatabase.OpenFile("expression-index-join.db", fileSystem))
+        using (var connection = database.Connect())
+        {
+            foreach (var statement in setup)
+                Execute(connection, statement);
+        }
+
+        using var reopened = EmbeddedDatabase.OpenFile("expression-index-join.db", fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        ReadRows(reopenedConnection, "EXPLAIN QUERY PLAN " + sql).Single()[3].AsText()
+            .Should().Contain("inner_items_lower_k");
+
+        reopened.ResetJoinOrderDiagnostics();
+        ReadRows(reopenedConnection, sql).Select(row => row[0].AsText()).Should().Equal("p-B", "p-ZZ");
+        reopened.JoinIndexSeekMetrics.DurableCursorPlans.Should().BeGreaterThan(0);
+        reopened.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+    }
+
+    [TestCase(
+        "CREATE INDEX inner_items_expr ON inner_items(lower(a));",
+        "outer_items.a = upper(inner_items.a)",
+        "X",
+        TestName = "MismatchedIndexedExpressionDeclines")]
+    [TestCase(
+        "CREATE INDEX inner_items_expr ON inner_items(lower(a) COLLATE NOCASE);",
+        "outer_items.a = lower(inner_items.a)",
+        "x",
+        TestName = "MismatchedExpressionIndexCollationDeclines")]
+    public void MismatchedExpressionIndexJoinNeverAdvertisesSearch(string createIndex, string condition, string outerValue)
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE outer_items(a TEXT, b INTEGER);");
+        Execute(connection, "CREATE TABLE inner_items(a TEXT, b INTEGER);");
+        Execute(connection, createIndex);
+        Execute(connection, $"INSERT INTO outer_items VALUES ('{outerValue}', 1);");
+        Execute(connection, "INSERT INTO inner_items VALUES ('x', 1), ('y', 2), ('z', 3);");
+        Execute(connection, "ANALYZE;");
+
+        var detail = ReadRows(
+            connection,
+            $"EXPLAIN QUERY PLAN SELECT outer_items.a FROM outer_items JOIN inner_items ON {condition};");
+        detail.Select(row => row[3].AsText())
+            .Should().NotContain(value => value.StartsWith("SEARCH ", StringComparison.Ordinal));
+
+        ReadRows(
+                connection,
+                $"SELECT outer_items.a FROM outer_items JOIN inner_items ON {condition};")
+            .Should().ContainSingle();
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().Be(0);
+    }
+
+    [Test]
+    public void ExpressionIndexSeekDeclinesWhenComparisonAffinityWouldTransformTheStoredExpression()
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE outer_items(k INTEGER);");
+        Execute(connection, "CREATE TABLE inner_items(k TEXT, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_items_lower_k ON inner_items(lower(k));");
+        Execute(connection, "INSERT INTO outer_items VALUES (1);");
+        Execute(connection, "INSERT INTO inner_items VALUES ('1', 'hit');");
+        Execute(connection, "ANALYZE;");
+
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items JOIN inner_items ON outer_items.k = lower(inner_items.k);
+            """;
+        ReadRows(connection, "EXPLAIN QUERY PLAN " + sql)
+            .Select(row => row[3].AsText())
+            .Should().NotContain(value => value.StartsWith("SEARCH ", StringComparison.Ordinal));
+        ReadRows(connection, sql).Single()[0].AsText().Should().Be("hit");
+    }
+
+    [Test]
+    public void ExpressionIndexSeekDeclinesTextAffinityOuterProbeAgainstNumericExpression()
+    {
+        // The indexed expression "x + 0" always produces a NUMERIC-ish storage class (its
+        // arithmetic result), but nothing declares that statically for an arbitrary expression
+        // index, so the outer probe's own affinity is all that is known. A TEXT-affinity outer
+        // probe ('1') is exactly SQLite's rule-2 case (datatype3.html §7.1): TEXT affinity would
+        // need to be applied to the *indexed* side before comparing, which a seek keyed on the
+        // raw probe value cannot honor (the b-tree stores '1 + 0' as INTEGER 1, sorted with
+        // typed comparison, so a raw TEXT '1' seek key would search the wrong region and miss
+        // the match entirely). The join must decline the index for this shape and fall back to a
+        // residual scan, which evaluates the predicate row-by-row with the correct affinity
+        // rules and matches real SQLite's result.
+        string[] setup =
+        [
+            "CREATE TABLE outer_items(t TEXT);",
+            "CREATE TABLE inner_items(x INTEGER, payload TEXT);",
+            "CREATE INDEX inner_items_x_plus_zero ON inner_items(x + 0);",
+            "INSERT INTO outer_items VALUES ('1');",
+            "INSERT INTO inner_items VALUES (1, 'hit'), (2, 'miss');",
+            "ANALYZE;",
+        ];
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items JOIN inner_items ON outer_items.t = inner_items.x + 0;
+            """;
+
+        AssertMatchesSqlite(setup, sql);
+
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        foreach (var statement in setup)
+            Execute(connection, statement);
+
+        ReadRows(connection, "EXPLAIN QUERY PLAN " + sql)
+            .Select(row => row[3].AsText())
+            .Should().NotContain(value => value.StartsWith("SEARCH ", StringComparison.Ordinal));
+        ReadRows(connection, sql).Single()[0].AsText().Should().Be("hit");
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().Be(0);
+    }
+
+    [Test]
+    public void RegisteredFunctionOverrideCannotDriveAStaleExpressionIndex()
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE outer_items(k);");
+        Execute(connection, "CREATE TABLE inner_items(k TEXT, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_items_lower_k ON inner_items(lower(k));");
+        Execute(connection, "INSERT INTO outer_items VALUES ('ABC');");
+        Execute(connection, "INSERT INTO inner_items VALUES ('ABC', 'hit');");
+        Execute(connection, "ANALYZE;");
+        database.RegisterScalarFunction("lower", 1, static values => values[0]);
+
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items JOIN inner_items ON outer_items.k = lower(inner_items.k);
+            """;
+        ReadRows(connection, "EXPLAIN QUERY PLAN " + sql)
+            .Select(row => row[3].AsText())
+            .Should().NotContain(value => value.StartsWith("SEARCH ", StringComparison.Ordinal));
+        ReadRows(connection, sql).Single()[0].AsText().Should().Be("hit");
+    }
+
+    [Test]
+    public void ExpressionIndexSeekDeclinesWhenAnIndexedCastInheritsAnIncompatibleCollation()
+    {
+        using var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE outer_items(k BLOB);");
+        Execute(connection, "CREATE TABLE inner_items(k TEXT COLLATE NOCASE, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_cast ON inner_items(CAST(k AS TEXT) COLLATE BINARY);");
+        Execute(connection, "INSERT INTO outer_items VALUES ('a');");
+        Execute(connection, "INSERT INTO inner_items VALUES ('A', 'hit');");
+        Execute(connection, "ANALYZE;");
+
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items JOIN inner_items ON CAST(inner_items.k AS TEXT) = outer_items.k;
+            """;
+        ReadRows(connection, "EXPLAIN QUERY PLAN " + sql)
+            .Select(row => row[3].AsText())
+            .Should().NotContain(value => value.StartsWith("SEARCH ", StringComparison.Ordinal));
+        ReadRows(connection, sql).Single()[0].AsText().Should().Be("hit");
+    }
+
+    private static void AssertMatchesSqlite(IReadOnlyList<string> setup, string sql)
+    {
+        using var managed = OpenManaged(setup);
+        var managedRows = ReadRows(managed, sql);
+        using var sqlite = new MsData.SqliteConnection("Data Source=:memory:");
+        sqlite.Open();
+        foreach (var statement in setup)
+        {
+            using var command = sqlite.CreateCommand();
+            command.CommandText = statement;
+            command.ExecuteNonQuery();
+        }
+
+        using var query = sqlite.CreateCommand();
+        query.CommandText = sql;
+        using var reader = query.ExecuteReader();
+        var sqliteRows = new List<object?[]>();
+        while (reader.Read())
+        {
+            var row = new object?[reader.FieldCount];
+            for (var index = 0; index < row.Length; index++)
+                row[index] = reader.IsDBNull(index) ? null : reader.GetValue(index);
+            sqliteRows.Add(row);
+        }
+
+        managedRows.Should().HaveCount(sqliteRows.Count);
+        for (var row = 0; row < sqliteRows.Count; row++)
+        {
+            for (var column = 0; column < sqliteRows[row].Length; column++)
+                CellShouldMatch(managedRows[row][column], sqliteRows[row][column], row, column);
+        }
+    }
+
+    private static EmbeddedConnection OpenManaged(IReadOnlyList<string> setup)
+    {
+        var connection = new EmbeddedDatabase().Connect();
+        foreach (var statement in setup)
+            Execute(connection, statement);
+        return connection;
+    }
+
+    private static void CellShouldMatch(SqlValue managed, object? sqlite, int row, int column)
+    {
+        switch (sqlite)
+        {
+            case null:
+                managed.Should().Be(SqlValue.Null, $"at row {row}, column {column}");
+                break;
+            case long integer:
+                managed.Should().Be(SqlValue.Integer(integer), $"at row {row}, column {column}");
+                break;
+            case double real:
+                managed.Should().Be(SqlValue.Real(real), $"at row {row}, column {column}");
+                break;
+            case string text:
+                managed.Should().Be(SqlValue.Text(text), $"at row {row}, column {column}");
+                break;
+            case byte[] blob:
+                managed.AsBlob().ToArray().Should().Equal(blob);
+                break;
+            default:
+                throw new InvalidOperationException($"Unsupported SQLite value type {sqlite.GetType()}.");
+        }
+    }
+
+    private static void Execute(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        statement.Step().Should().Be(StatementStepResult.Done);
+    }
+
+    private static List<SqlValue[]> ReadRows(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        var rows = new List<SqlValue[]>();
+        while (statement.Step() == StatementStepResult.Row)
+        {
+            var values = new SqlValue[statement.GetColumnCount()];
+            for (var ordinal = 0; ordinal < values.Length; ordinal++)
+                values[ordinal] = statement.GetValue(ordinal);
+            rows.Add(values);
+        }
+
+        return rows;
+    }
+}

--- a/src/Ahtola.Tests/JoinOrderOptimizerTests.cs
+++ b/src/Ahtola.Tests/JoinOrderOptimizerTests.cs
@@ -74,15 +74,15 @@ public sealed class JoinOrderOptimizerTests
     }
 
     [Test]
-    public void EightTableSegmentUsesTheSubsetDynamicProgram()
+    public void TwelveTableSegmentUsesTheSubsetDynamicProgram()
     {
         using var database = new EmbeddedDatabase();
         using var connection = database.Connect();
-        Execute(connection, ChainScript(8, descendingSizes: true));
+        Execute(connection, ChainScript(12, descendingSizes: true));
         Execute(connection, "ANALYZE;");
 
-        var query = ChainSelect(8);
-        JoinDescription(connection, "EXPLAIN " + query).Should().Contain("scan order: t8,");
+        var query = ChainSelect(12);
+        JoinDescription(connection, "EXPLAIN " + query).Should().Contain("scan order: t12,");
         database.JoinOrderDiagnostics.DynamicProgrammingPlans.Should().Be(1);
         database.JoinOrderDiagnostics.GreedyPlans.Should().Be(0);
         Rows(connection, query).Should().HaveCount(6);
@@ -91,20 +91,20 @@ public sealed class JoinOrderOptimizerTests
     [Test]
     public void SegmentAboveTheDynamicProgrammingCapFallsBackToGreedy()
     {
-        JoinOrderEnumerator.DynamicProgrammingMemberCap.Should().Be(8);
+        JoinOrderEnumerator.DynamicProgrammingMemberCap.Should().Be(12);
 
         using var database = new EmbeddedDatabase();
         using var connection = database.Connect();
-        Execute(connection, ChainScript(9, descendingSizes: true));
+        Execute(connection, ChainScript(13, descendingSizes: true));
         Execute(connection, "ANALYZE;");
 
-        var query = ChainSelect(9);
+        var query = ChainSelect(13);
         var description = JoinDescription(connection, "EXPLAIN " + query);
         database.JoinOrderDiagnostics.GreedyPlans.Should().Be(1);
         database.JoinOrderDiagnostics.DynamicProgrammingPlans.Should().Be(0);
 
         // Greedy still produces a genuine reorder, not a decline back to FROM order.
-        description.Should().Contain("scan order: t9,");
+        description.Should().Contain("scan order: t13,");
         Rows(connection, query).Should().HaveCount(6);
     }
 
@@ -712,7 +712,7 @@ public sealed class JoinOrderOptimizerTests
     public void GreedyFallbackProducesAValidOrderNoWorseThanTheFromOrder()
     {
         var random = new Random(4711);
-        for (var members = 9; members <= 12; members++)
+        for (var members = 13; members <= 16; members++)
         {
             var segment = RandomSegment(random, members);
             var plan = JoinOrderEnumerator.Compute(segment);
@@ -835,7 +835,8 @@ public sealed class JoinOrderOptimizerTests
                 Selectivity: JoinCostParams.SelectivityEqualityIndexed,
                 EqualityLeftColumnOrdinal: 0,
                 EqualityRightColumnOrdinal: 0,
-                EqualityCollation: "BINARY"),
+                EqualityCollation: "BINARY",
+                EqualitySeekCollation: "BINARY"),
         ]);
 
         var plan = JoinOrderEnumerator.EvaluateOrder(segment, [0, 1]);
@@ -907,7 +908,8 @@ public sealed class JoinOrderOptimizerTests
                 JoinCostParams.SelectivityEqualityIndexed,
                 EqualityLeftColumnOrdinal: 0,
                 EqualityRightColumnOrdinal: 0,
-                EqualityCollation: "BINARY"),
+                EqualityCollation: "BINARY",
+                EqualitySeekCollation: "BINARY"),
             new JoinPredicateTerm(
                 0b110,
                 true,
@@ -918,7 +920,8 @@ public sealed class JoinOrderOptimizerTests
                 JoinCostParams.SelectivityEqualityIndexed,
                 EqualityLeftColumnOrdinal: 0,
                 EqualityRightColumnOrdinal: 1,
-                EqualityCollation: "BINARY"),
+                EqualityCollation: "BINARY",
+                EqualitySeekCollation: "BINARY"),
         ]);
 
         var plan = JoinOrderEnumerator.Compute(segment);

--- a/src/Ahtola.Tests/ManagedMaintenanceStatementTests.cs
+++ b/src/Ahtola.Tests/ManagedMaintenanceStatementTests.cs
@@ -289,6 +289,152 @@ public sealed class ManagedMaintenanceStatementTests
         ReadInteger(reopenedConnection, "PRAGMA schema_version;").Should().Be(schemaVersion + 1);
     }
 
+    public enum ReindexCoexistingDml
+    {
+        Insert,
+        Update,
+        Delete,
+    }
+
+    /// <summary>
+    /// A targeted, in-place REINDEX (<c>EmbeddedFileStore.TryPersistTargetedIndexRebuild</c>)
+    /// only ever rewrites the selected index's own b-tree; it never re-derives or rewrites any
+    /// table's row storage. If it were persisted as the sole durable mutation whenever it shared
+    /// a transaction with row-level DML, the DML would apply correctly to the in-memory catalog
+    /// but never reach disk, so it would silently vanish the moment the store is reopened even
+    /// though the rebuilt index still (correctly) reflects the in-memory row. Commit must widen
+    /// to the full-catalog rewrite whenever anything besides the targeted rebuild changed.
+    /// </summary>
+    [TestCase(ReindexCoexistingDml.Insert)]
+    [TestCase(ReindexCoexistingDml.Update)]
+    [TestCase(ReindexCoexistingDml.Delete)]
+    public void TargetedReindexPersistsCoexistingDmlInTheSameTransactionAtomically(ReindexCoexistingDml dml)
+    {
+        var fileSystem = new InMemoryFileSystem();
+        var path = $"reindex-with-{dml.ToString().ToLowerInvariant()}.db";
+        using (var database = EmbeddedDatabase.OpenFile(path, fileSystem))
+        using (var connection = database.Connect())
+        {
+            Execute(
+                connection,
+                """
+                CREATE TABLE data(id INTEGER PRIMARY KEY, value TEXT);
+                CREATE INDEX data_value ON data(value);
+                INSERT INTO data VALUES (1, 'one'), (2, 'two'), (3, 'three');
+                """);
+
+            Execute(connection, "BEGIN;");
+            switch (dml)
+            {
+                case ReindexCoexistingDml.Insert:
+                    Execute(connection, "INSERT INTO data VALUES (4, 'four');");
+                    break;
+                case ReindexCoexistingDml.Update:
+                    Execute(connection, "UPDATE data SET value = 'deux' WHERE id = 2;");
+                    break;
+                case ReindexCoexistingDml.Delete:
+                    Execute(connection, "DELETE FROM data WHERE id = 3;");
+                    break;
+            }
+            Execute(connection, "REINDEX data_value;");
+            Execute(connection, "COMMIT;");
+
+            AssertReindexCoexistingDmlApplied(connection, dml);
+        }
+
+        using var reopened = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        AssertReindexCoexistingDmlApplied(reopenedConnection, dml);
+        ReadText(reopenedConnection, "PRAGMA integrity_check;").Should().Be("ok");
+    }
+
+    private static void AssertReindexCoexistingDmlApplied(EmbeddedConnection connection, ReindexCoexistingDml dml)
+    {
+        switch (dml)
+        {
+            case ReindexCoexistingDml.Insert:
+                ReadInteger(connection, "SELECT COUNT(*) FROM data;").Should().Be(4);
+                ReadText(connection, "SELECT value FROM data WHERE id = 4;").Should().Be("four");
+                // Index-driven lookup: proves the rebuilt data_value tree agrees with the
+                // inserted row rather than only the in-memory table.
+                ReadInteger(connection, "SELECT id FROM data WHERE value = 'four';").Should().Be(4);
+                break;
+            case ReindexCoexistingDml.Update:
+                ReadInteger(connection, "SELECT COUNT(*) FROM data;").Should().Be(3);
+                ReadText(connection, "SELECT value FROM data WHERE id = 2;").Should().Be("deux");
+                ReadInteger(connection, "SELECT id FROM data WHERE value = 'deux';").Should().Be(2);
+                ReadInteger(connection, "SELECT COUNT(*) FROM data WHERE value = 'two';").Should().Be(0);
+                break;
+            case ReindexCoexistingDml.Delete:
+                ReadInteger(connection, "SELECT COUNT(*) FROM data;").Should().Be(2);
+                ReadInteger(connection, "SELECT COUNT(*) FROM data WHERE id = 3;").Should().Be(0);
+                ReadInteger(connection, "SELECT COUNT(*) FROM data WHERE value = 'three';").Should().Be(0);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Distinct from <see cref="TargetedReindexPersistsCoexistingDmlInTheSameTransactionAtomically"/>
+    /// above: that test proves the statement's normal-completion path
+    /// (<c>transactionState.HasNonTargetedIndexRebuildChange</c> set right after
+    /// <c>HasChanges = true</c> when a statement changed something other than a pure targeted
+    /// index rebuild) widens commit off the targeted-rebuild-only persistence path. This test
+    /// proves the same for an *exception* path that still preserves a statement's partial row
+    /// changes: <c>EmbeddedConflictFailException</c> (ON CONFLICT FAIL). SQLite's OR FAIL
+    /// semantics abort only the current statement, not the whole transaction, and do not roll
+    /// back rows the statement already inserted before it hit the conflict -- so a multi-row
+    /// <c>INSERT OR FAIL</c> that inserts row 2 before conflicting on row 3 still leaves row 2
+    /// committed to this transaction. That preserved prefix is table DML, never a targeted index
+    /// rebuild. If the catch handler only set <c>HasChanges</c> without also setting
+    /// <c>HasNonTargetedIndexRebuildChange</c>, an earlier targeted <c>REINDEX</c> in the same
+    /// transaction would leave commit believing the sole durable mutation was the targeted
+    /// rebuild (<c>TargetedIndexRebuildNames</c> stays the only non-empty signal), so the
+    /// preserved partial INSERT would be visible in-memory before commit but silently vanish the
+    /// moment the store is reopened, because a targeted rebuild never rewrites table row storage.
+    /// </summary>
+    [Test]
+    public void TargetedReindexPersistsConflictFailPreservedPrefixInTheSameTransactionAtomically()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        const string path = "reindex-with-conflict-fail-prefix.db";
+        using (var database = EmbeddedDatabase.OpenFile(path, fileSystem))
+        using (var connection = database.Connect())
+        {
+            Execute(
+                connection,
+                """
+                CREATE TABLE data(id INTEGER PRIMARY KEY, value TEXT UNIQUE);
+                CREATE INDEX data_scratch ON data(id);
+                INSERT INTO data VALUES (1, 'one');
+                """);
+
+            Execute(connection, "BEGIN;");
+            Execute(connection, "REINDEX data_scratch;");
+            Assert.Throws<EmbeddedSqlException>(
+                () => Execute(
+                    connection,
+                    "INSERT OR FAIL INTO data VALUES (2, 'two'), (3, 'one');"));
+            Execute(connection, "COMMIT;");
+
+            // The failed statement's already-inserted row (id 2) is visible in-memory before
+            // reopen -- this much would already pass even with the bug, since the bug only drops
+            // the durable write on disk, not the in-memory catalog.
+            ReadInteger(connection, "SELECT COUNT(*) FROM data;").Should().Be(2);
+            ReadText(connection, "SELECT value FROM data WHERE id = 2;").Should().Be("two");
+        }
+
+        using var reopened = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        // Without HasNonTargetedIndexRebuildChange on the EmbeddedConflictFailException path,
+        // this reopen would only show the original seed row: the preserved partial INSERT
+        // vanished because commit (incorrectly) took the targeted-index-rebuild-only persistence
+        // path, which never rewrites table row storage.
+        ReadInteger(reopenedConnection, "SELECT COUNT(*) FROM data;").Should().Be(2);
+        ReadText(reopenedConnection, "SELECT value FROM data WHERE id = 2;").Should().Be("two");
+        ReadInteger(reopenedConnection, "SELECT id FROM data WHERE id = 2;").Should().Be(2);
+        ReadText(reopenedConnection, "PRAGMA integrity_check;").Should().Be("ok");
+    }
+
     [TestCase(false)]
     [TestCase(true)]
     public void ReindexWriteFailureRecoversWithoutPublishingAPartialTree(bool deleteJournal)

--- a/src/Ahtola.Tests/MvccCheckpointStateMachineTests.cs
+++ b/src/Ahtola.Tests/MvccCheckpointStateMachineTests.cs
@@ -243,11 +243,16 @@ public sealed class MvccCheckpointStateMachineTests
         Execute(writer, "INSERT INTO t VALUES (91);");
         Execute(writer, "COMMIT;");
 
-        var logLength = ReadFileLength(fileSystem, path + "-log");
+        // The reader's BEGIN CONCURRENT now pins a real durable pager read snapshot (the
+        // page-native EmbeddedFileReadSnapshot base cursor added for MVCC index joins/scans), not
+        // just an MvStore version-chain view. TRUNCATE needs zero active pager readers before it
+        // may reset the WAL file, so it correctly reports Busy while this reader's snapshot is
+        // still open — exactly as it would for a classic (non-MVCC) reader transaction. This is
+        // the same trade-off SQLite's own WAL checkpointing makes: TRUNCATE never discards frames
+        // a live reader still needs, it just declines to make progress until the reader closes.
         var checkpoint = database.RunMvccCheckpoint("TRUNCATE");
-        checkpoint.Busy.Should().BeFalse();
-        checkpoint.CompletedThrough.Should().Be(MvccCheckpointPhase.Complete);
-        ReadFileLength(fileSystem, path + "-log").Should().BeLessThan(logLength);
+        checkpoint.Busy.Should().BeTrue();
+        checkpoint.CompletedThrough.Should().Be(MvccCheckpointPhase.PersistPageWal);
         ReadScalar(reader, "SELECT COUNT(*) FROM t WHERE v = 91;").Should().Be(0);
         database.MvStore!.VersionCount.Should().BeGreaterThan(0);
 

--- a/src/Ahtola.Tests/MvccDirectIndexAccessTests.cs
+++ b/src/Ahtola.Tests/MvccDirectIndexAccessTests.cs
@@ -1,0 +1,514 @@
+using AwesomeAssertions;
+using Ahtola.Core;
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Tests;
+
+/// <summary>
+/// Focused coverage for the MVCC (BEGIN CONCURRENT) page-native direct-index phase: an eligible
+/// join index seek or single-table index scan must serve rows directly from the transaction's own
+/// pinned durable b-tree snapshot (<see cref="QueryContext.TransactionPinnedSnapshot"/>, captured at
+/// BEGIN CONCURRENT), merged lazily with this transaction's visible <c>MvStore</c> effects via the
+/// same two-peek primitive the classic (non-MVCC) transaction overlay uses (<see
+/// cref="MvccDualCursor"/>), so every scenario below asserts both correctness (read your own
+/// writes, suppress base rows shadowed by a visible overlay effect, respect snapshot isolation
+/// against peers) and the zero-materialization contract (<see
+/// cref="VdbeJoinIndexSeekMetrics.DurableCursorPlans"/> greater than zero, <see
+/// cref="VdbeJoinIndexSeekMetrics.IndexRowsMaterialized"/> equal to zero).
+/// </summary>
+public sealed class MvccDirectIndexAccessTests
+{
+    [Test]
+    public void OrdinaryIndexJoinUsesTheDurableSnapshotWithoutMaterializingTheBaseIndex()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("mvcc-ordinary-index-join.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE outer_items(k INTEGER);");
+        Execute(connection, "CREATE TABLE inner_items(k INTEGER, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k);");
+        Execute(connection, "INSERT INTO outer_items VALUES (1), (2);");
+        Execute(connection, "INSERT INTO inner_items VALUES (1, 'one'), (2, 'two');");
+        Execute(connection, "PRAGMA journal_mode=mvcc;");
+        Execute(connection, "ANALYZE;");
+
+        Execute(connection, "BEGIN CONCURRENT;");
+
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_k ON outer_items.k = inner_items.k
+            ORDER BY outer_items.k;
+            """;
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, sql).Select(row => row[0].AsText()).Should().Equal("one", "two");
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().BeGreaterThan(0);
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+
+        Execute(connection, "COMMIT;");
+    }
+
+    [Test]
+    public void LocalInsertUpdateDeleteAndKeyMoveAreVisibleThroughTheMvccMerge()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("mvcc-local-mutations.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE outer_items(k INTEGER);");
+        Execute(connection, "CREATE TABLE inner_items(id INTEGER PRIMARY KEY, k INTEGER, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k);");
+        Execute(connection, "INSERT INTO outer_items VALUES (1), (2), (3), (4), (5);");
+        Execute(
+            connection,
+            "INSERT INTO inner_items VALUES "
+                + "(1, 1, 'stays'), (2, 2, 'will-update'), (3, 3, 'will-delete'), (4, 40, 'will-move');");
+        Execute(connection, "PRAGMA journal_mode=mvcc;");
+        Execute(connection, "ANALYZE;");
+
+        Execute(connection, "BEGIN CONCURRENT;");
+        // Local insert: a brand new row this transaction alone can see.
+        Execute(connection, "INSERT INTO inner_items VALUES (5, 5, 'new-in-txn');");
+        // Local update of a non-indexed column: the old key stays valid, payload changes.
+        Execute(connection, "UPDATE inner_items SET payload = 'updated' WHERE id = 2;");
+        // Local delete: must be suppressed from the merged stream.
+        Execute(connection, "DELETE FROM inner_items WHERE id = 3;");
+        // Local key-changing update: the old key (40) must vanish, the new key (4) must appear.
+        Execute(connection, "UPDATE inner_items SET k = 4 WHERE id = 4;");
+
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_k ON outer_items.k = inner_items.k
+            ORDER BY outer_items.k;
+            """;
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, sql).Select(row => row[0].AsText())
+            .Should().Equal("stays", "updated", "will-move", "new-in-txn");
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().BeGreaterThan(0);
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+
+        Execute(connection, "ROLLBACK;");
+    }
+
+    [Test]
+    public void PartialIndexMembershipChangesAreReflectedThroughTheMvccMerge()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("mvcc-partial-membership.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE outer_items(k INTEGER);");
+        Execute(connection, "CREATE TABLE inner_items(id INTEGER PRIMARY KEY, k INTEGER, gate INTEGER, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_items_partial ON inner_items(k) WHERE gate > 0;");
+        Execute(connection, "INSERT INTO outer_items VALUES (1), (2);");
+        // id=1 starts outside the partial predicate (gate <= 0); id=2 starts inside it.
+        Execute(connection, "INSERT INTO inner_items VALUES (1, 1, -1, 'joins-in-txn');");
+        Execute(connection, "INSERT INTO inner_items VALUES (2, 2, 1, 'leaves-in-txn');");
+        Execute(connection, "PRAGMA journal_mode=mvcc;");
+        Execute(connection, "ANALYZE;");
+
+        Execute(connection, "BEGIN CONCURRENT;");
+        Execute(connection, "UPDATE inner_items SET gate = 1 WHERE id = 1;");
+        Execute(connection, "UPDATE inner_items SET gate = -1 WHERE id = 2;");
+
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_partial
+            ON outer_items.k = inner_items.k AND inner_items.gate > 0
+            ORDER BY outer_items.k;
+            """;
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, sql).Select(row => row[0].AsText()).Should().Equal("joins-in-txn");
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().BeGreaterThan(0);
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+
+        Execute(connection, "ROLLBACK;");
+    }
+
+    [Test]
+    public void ExpressionIndexKeyChangesAreReflectedThroughTheMvccMerge()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("mvcc-expression-key.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE outer_items(k);");
+        Execute(connection, "CREATE TABLE inner_items(id INTEGER PRIMARY KEY, k TEXT, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_items_lower_k ON inner_items(lower(k));");
+        Execute(connection, "INSERT INTO outer_items VALUES ('old'), ('new');");
+        Execute(connection, "INSERT INTO inner_items VALUES (1, 'OLD', 'p-old');");
+        Execute(connection, "PRAGMA journal_mode=mvcc;");
+        Execute(connection, "ANALYZE;");
+
+        Execute(connection, "BEGIN CONCURRENT;");
+        Execute(connection, "UPDATE inner_items SET k = 'NEW' WHERE id = 1;");
+
+        const string sql =
+            """
+            SELECT outer_items.k, inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_lower_k ON outer_items.k = lower(inner_items.k)
+            ORDER BY outer_items.k;
+            """;
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, sql).Select(row => (row[0].AsText(), row[1].AsText()))
+            .Should().Equal(("new", "p-old"));
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().BeGreaterThan(0);
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+
+        Execute(connection, "ROLLBACK;");
+    }
+
+    [Test]
+    public void WithoutRowidPrimaryKeyAndSecondaryIndexSeeksReflectMvccMutations()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("mvcc-without-rowid.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE outer_codes(code TEXT);");
+        Execute(connection, "CREATE TABLE outer_tags(tag TEXT);");
+        Execute(connection, "CREATE TABLE entry(code TEXT PRIMARY KEY, tag TEXT) WITHOUT ROWID;");
+        Execute(connection, "CREATE INDEX entry_tag ON entry(tag);");
+        Execute(connection, "INSERT INTO outer_codes VALUES ('k1'), ('k2');");
+        Execute(connection, "INSERT INTO outer_tags VALUES ('t1'), ('t9');");
+        Execute(connection, "INSERT INTO entry VALUES ('k1', 't1');");
+        Execute(connection, "PRAGMA journal_mode=mvcc;");
+        Execute(connection, "ANALYZE;");
+
+        Execute(connection, "BEGIN CONCURRENT;");
+        Execute(connection, "INSERT INTO entry VALUES ('k2', 't2');");
+        Execute(connection, "UPDATE entry SET tag = 't9' WHERE code = 'k1';");
+
+        const string primaryKeySql =
+            """
+            SELECT entry.code, entry.tag
+            FROM outer_codes
+            JOIN entry ON outer_codes.code = entry.code
+            ORDER BY outer_codes.code;
+            """;
+        const string secondaryIndexSql =
+            """
+            SELECT entry.code
+            FROM outer_tags
+            JOIN entry INDEXED BY entry_tag ON outer_tags.tag = entry.tag
+            ORDER BY outer_tags.tag;
+            """;
+
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, primaryKeySql).Select(row => (row[0].AsText(), row[1].AsText()))
+            .Should().Equal(("k1", "t9"), ("k2", "t2"));
+        ReadRows(connection, secondaryIndexSql).Select(row => row[0].AsText())
+            .Should().Equal("k1");
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+
+        Execute(connection, "ROLLBACK;");
+    }
+
+    [Test]
+    public void DuplicateIndexKeysAcrossBaseAndOverlayAreAllEmittedExactlyOnce()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("mvcc-duplicate-prefix.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE outer_items(k INTEGER);");
+        Execute(connection, "CREATE TABLE inner_items(id INTEGER PRIMARY KEY, k INTEGER, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k);");
+        Execute(connection, "INSERT INTO outer_items VALUES (7);");
+        // Two base rows already share the duplicate key.
+        Execute(connection, "INSERT INTO inner_items VALUES (1, 7, 'base-a'), (2, 7, 'base-b');");
+        Execute(connection, "PRAGMA journal_mode=mvcc;");
+        Execute(connection, "ANALYZE;");
+
+        Execute(connection, "BEGIN CONCURRENT;");
+        // A third row joins the same duplicate key purely through this transaction's overlay.
+        Execute(connection, "INSERT INTO inner_items VALUES (3, 7, 'overlay-c');");
+
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_k ON outer_items.k = inner_items.k
+            ORDER BY inner_items.payload;
+            """;
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, sql).Select(row => row[0].AsText())
+            .Should().Equal("base-a", "base-b", "overlay-c");
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().BeGreaterThan(0);
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+
+        Execute(connection, "ROLLBACK;");
+    }
+
+    [Test]
+    public void LimitShortCircuitsTheMergedDurableStreamWithoutMaterializingTheWholeIndex()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("mvcc-limit.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE items(id INTEGER PRIMARY KEY, k INTEGER, payload TEXT);");
+        Execute(connection, "CREATE INDEX items_k ON items(k);");
+        Execute(
+            connection,
+            "INSERT INTO items VALUES "
+                + string.Join(", ", Enumerable.Range(1, 500).Select(value => $"({value}, {value}, 'p{value}')"))
+                + ";");
+        Execute(connection, "PRAGMA journal_mode=mvcc;");
+        Execute(connection, "ANALYZE;");
+
+        Execute(connection, "BEGIN CONCURRENT;");
+        Execute(connection, "INSERT INTO items VALUES (501, 0, 'overlay-first');");
+
+        const string sql =
+            """
+            SELECT items.payload
+            FROM items INDEXED BY items_k
+            WHERE items.k >= 0
+            ORDER BY items.k
+            LIMIT 2;
+            """;
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, sql).Select(row => row[0].AsText()).Should().Equal("overlay-first", "p1");
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+
+        Execute(connection, "ROLLBACK;");
+    }
+
+    [Test]
+    public void SavepointRollbackRestoresTheMvccMergeToItsCheckpointedState()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("mvcc-savepoint-rollback.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE outer_items(k INTEGER);");
+        Execute(connection, "CREATE TABLE inner_items(k INTEGER, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k);");
+        Execute(connection, "INSERT INTO outer_items VALUES (10), (11);");
+        Execute(connection, "PRAGMA journal_mode=mvcc;");
+        Execute(connection, "ANALYZE;");
+
+        const string sql =
+            """
+            SELECT outer_items.k, inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_k ON outer_items.k = inner_items.k
+            ORDER BY outer_items.k;
+            """;
+
+        Execute(connection, "BEGIN CONCURRENT;");
+        Execute(connection, "INSERT INTO inner_items VALUES (10, 'ten');");
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, sql).Select(row => (row[0].AsInteger(), row[1].AsText()))
+            .Should().Equal((10L, "ten"));
+
+        Execute(connection, "SAVEPOINT sp1;");
+        Execute(connection, "INSERT INTO inner_items VALUES (11, 'eleven');");
+        Execute(connection, "DELETE FROM inner_items WHERE k = 10;");
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, sql).Select(row => (row[0].AsInteger(), row[1].AsText()))
+            .Should().Equal((11L, "eleven"));
+
+        Execute(connection, "ROLLBACK TO sp1;");
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, sql).Select(row => (row[0].AsInteger(), row[1].AsText()))
+            .Should().Equal((10L, "ten"));
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+
+        Execute(connection, "ROLLBACK;");
+    }
+
+    [Test]
+    public void PeerCommitAfterBeginConcurrentStaysInvisibleUntilANewTransactionBegins()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("mvcc-peer-commit.db", fileSystem);
+        using var writer = database.Connect();
+        using var reader = database.Connect();
+        Execute(writer, "CREATE TABLE outer_items(k INTEGER);");
+        Execute(writer, "CREATE TABLE inner_items(k INTEGER, payload TEXT);");
+        Execute(writer, "CREATE INDEX inner_items_k ON inner_items(k);");
+        Execute(writer, "INSERT INTO outer_items VALUES (2), (3);");
+        Execute(writer, "INSERT INTO inner_items VALUES (2, 'two');");
+        Execute(writer, "PRAGMA journal_mode=mvcc;");
+        Execute(writer, "ANALYZE;");
+
+        Execute(reader, "BEGIN CONCURRENT;");
+
+        Execute(writer, "BEGIN CONCURRENT;");
+        Execute(writer, "INSERT INTO inner_items VALUES (3, 'three-peer');");
+        Execute(writer, "COMMIT;");
+
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_k ON outer_items.k = inner_items.k
+            ORDER BY outer_items.k;
+            """;
+        database.ResetJoinOrderDiagnostics();
+        // Snapshot isolation: the peer's post-BEGIN commit must stay invisible for the whole
+        // reader transaction.
+        ReadRows(reader, sql).Select(row => row[0].AsText()).Should().Equal("two");
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().BeGreaterThan(0);
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+        Execute(reader, "ROLLBACK;");
+
+        // A fresh transaction re-pins its own snapshot and now sees the peer's committed row.
+        Execute(reader, "BEGIN CONCURRENT;");
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(reader, sql).Select(row => row[0].AsText()).Should().Equal("two", "three-peer");
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+        Execute(reader, "ROLLBACK;");
+    }
+
+    [Test]
+    public void CheckpointAndReopenPreserveTheDurableMvccIndexJoinPath()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        const string path = "mvcc-checkpoint-reopen.db";
+        using (var database = EmbeddedDatabase.OpenFile(path, fileSystem))
+        using (var connection = database.Connect())
+        {
+            Execute(connection, "CREATE TABLE outer_items(k INTEGER);");
+            Execute(connection, "CREATE TABLE inner_items(id INTEGER PRIMARY KEY, k INTEGER, payload TEXT);");
+            Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k);");
+            Execute(connection, "INSERT INTO outer_items VALUES (1), (2), (3), (4);");
+            Execute(connection, "INSERT INTO inner_items VALUES (1, 1, 'stays'), (2, 2, 'will-move'), (3, 3, 'will-delete');");
+            Execute(connection, "PRAGMA journal_mode=mvcc;");
+            Execute(connection, "ANALYZE;");
+
+            Execute(connection, "BEGIN CONCURRENT;");
+            Execute(connection, "UPDATE inner_items SET k = 4 WHERE id = 2;");
+            Execute(connection, "DELETE FROM inner_items WHERE id = 3;");
+            Execute(connection, "INSERT INTO inner_items VALUES (4, 4, 'new-in-txn');");
+            Execute(connection, "COMMIT;");
+
+            database.RunMvccCheckpoint("TRUNCATE");
+        }
+
+        using var reopened = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        Execute(reopenedConnection, "BEGIN CONCURRENT;");
+
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_k ON outer_items.k = inner_items.k
+            ORDER BY inner_items.payload;
+            """;
+        reopened.ResetJoinOrderDiagnostics();
+        ReadRows(reopenedConnection, sql).Select(row => row[0].AsText())
+            .Should().Equal("new-in-txn", "stays", "will-move");
+        reopened.JoinIndexSeekMetrics.DurableCursorPlans.Should().BeGreaterThan(0);
+        reopened.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+
+        Execute(reopenedConnection, "ROLLBACK;");
+    }
+
+    [Test]
+    public void OldestReaderKeepsItsSnapshotConsistentAcrossACheckpointWhileUsingTheDurableIndexJoin()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        const string path = "mvcc-oldest-reader-index-join.db";
+        using var database = EmbeddedDatabase.OpenFile(path, fileSystem);
+        using var writer = database.Connect();
+        using var reader = database.Connect();
+        Execute(writer, "CREATE TABLE outer_items(k INTEGER);");
+        Execute(writer, "CREATE TABLE inner_items(id INTEGER PRIMARY KEY, k INTEGER, payload TEXT);");
+        Execute(writer, "CREATE INDEX inner_items_k ON inner_items(k);");
+        Execute(writer, "INSERT INTO outer_items VALUES (9), (91);");
+        Execute(writer, "INSERT INTO inner_items VALUES (1, 9, 'base');");
+        Execute(writer, "PRAGMA journal_mode=mvcc;");
+        Execute(writer, "ANALYZE;");
+
+        // The reader pins its snapshot (and version-store floor) before the writer's later commit.
+        Execute(reader, "BEGIN CONCURRENT;");
+
+        Execute(writer, "BEGIN CONCURRENT;");
+        Execute(writer, "INSERT INTO inner_items VALUES (2, 91, 'from-writer');");
+        Execute(writer, "COMMIT;");
+
+        // The reader's still-open BEGIN CONCURRENT pins a real durable pager read snapshot (the
+        // page-native base cursor this phase adds), so TRUNCATE correctly declines to reset the
+        // WAL while that reader might still need pre-checkpoint frames — exactly like a classic
+        // reader transaction. The reader's row visibility and the zero-materialization join
+        // metrics below are what this test actually verifies.
+        var checkpoint = database.RunMvccCheckpoint("TRUNCATE");
+        checkpoint.Busy.Should().BeTrue();
+
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_k ON outer_items.k = inner_items.k
+            ORDER BY outer_items.k;
+            """;
+        database.ResetJoinOrderDiagnostics();
+        // The oldest reader's snapshot must stay consistent across the checkpoint: it still sees
+        // only what was visible when it began, even though the writer's row has since been
+        // materialized into the durable catalog and the version chain garbage-collected up to the
+        // reader's floor.
+        ReadRows(reader, sql).Select(row => row[0].AsText()).Should().Equal("base");
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().BeGreaterThan(0);
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+        Execute(reader, "ROLLBACK;");
+
+        // Once the reader closes, a fresh transaction sees both rows through the same durable
+        // index-join path.
+        Execute(reader, "BEGIN CONCURRENT;");
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(reader, sql).Select(row => row[0].AsText()).Should().Equal("base", "from-writer");
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+        Execute(reader, "ROLLBACK;");
+    }
+
+    [Test]
+    public void SingleTableMvccIndexScanUsesTheDurableFullScanAccessorWithoutMaterialization()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("mvcc-single-table-scan.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE items(id INTEGER PRIMARY KEY, k INTEGER, payload TEXT);");
+        Execute(connection, "CREATE INDEX items_k ON items(k);");
+        Execute(connection, "INSERT INTO items VALUES (1, 3, 'c'), (2, 1, 'a'), (3, 2, 'b');");
+        Execute(connection, "PRAGMA journal_mode=mvcc;");
+        Execute(connection, "ANALYZE;");
+
+        Execute(connection, "BEGIN CONCURRENT;");
+        Execute(connection, "INSERT INTO items VALUES (4, 4, 'd');");
+        Execute(connection, "DELETE FROM items WHERE id = 2;");
+
+        const string sql =
+            """
+            SELECT items.payload FROM items INDEXED BY items_k ORDER BY items.k;
+            """;
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, sql).Select(row => row[0].AsText()).Should().Equal("b", "c", "d");
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+
+        Execute(connection, "ROLLBACK;");
+    }
+
+    private static void Execute(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        _ = statement.Step();
+    }
+
+    private static List<SqlValue[]> ReadRows(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        var rows = new List<SqlValue[]>();
+        while (statement.Step() == StatementStepResult.Row)
+        {
+            var values = new SqlValue[statement.GetColumnCount()];
+            for (var ordinal = 0; ordinal < values.Length; ordinal++)
+                values[ordinal] = statement.GetValue(ordinal);
+            rows.Add(values);
+        }
+
+        return rows;
+    }
+}

--- a/src/Ahtola.Tests/MvccSelectDualCursorRoutingTests.cs
+++ b/src/Ahtola.Tests/MvccSelectDualCursorRoutingTests.cs
@@ -845,9 +845,27 @@ public sealed class MvccSelectDualCursorRoutingTests
         var smallAllocation = MeasureConcurrentIndexLimitOneAllocation(rowCount: 10);
         var largeAllocation = MeasureConcurrentIndexLimitOneAllocation(largeRowCount);
 
+        // The authoritative "no full base-index materialization" proof is the join-index-seek
+        // metrics (asserted inside MeasureConcurrentIndexLimitOneAllocation): a warmed index
+        // LIMIT 1 scan drives its rows through a durable page-native cursor plan and never
+        // materializes the base index into a row list, regardless of the catalog size.
+        //
+        // The raw byte-delta below is a secondary sanity check. It is intentionally *not*
+        // required to stay flat as rowCount grows: parsing a b-tree leaf page validates every
+        // record on that page in strictly increasing key order (SqliteIndexLeafPageView /
+        // SqliteIndexInteriorPage.ReadAndValidateRecords), and the touched leaf page is far
+        // fuller once the catalog holds 10,000 sequentially-inserted rows than once it holds
+        // 10. That per-page validation cost is bounded by a single page's cell capacity
+        // (~a few hundred cells for small integer keys), not by the total row count, so it
+        // does not grow further past this point -- unlike a true full-materialization
+        // regression, which scales linearly with rowCount and would blow through this budget
+        // by orders of magnitude (as it did before the fixes to SqliteIndexLeafPageView /
+        // SqliteIndexInteriorPage / SqliteTableLeafPageView / SqliteTableInteriorPage that
+        // motivated this test).
         largeAllocation.Should().BeLessThan(
-            smallAllocation + 256 * 1024,
-            "a warmed index LIMIT 1 scan should not rebuild a materialized MVCC overlay");
+            smallAllocation + 512 * 1024,
+            "a warmed index LIMIT 1 scan should not rebuild a materialized MVCC overlay, " +
+            "beyond the bounded per-page record-order validation cost of the single touched leaf page");
     }
 
     private static object? Scalar(SqliteConnection connection, string sql)
@@ -948,6 +966,12 @@ public sealed class MvccSelectDualCursorRoutingTests
         var before = GC.GetAllocatedBytesForCurrentThread();
         ExecuteIndexLimitOne(connection);
         var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        // Authoritative proof that the index LIMIT 1 scan drove its rows through the durable
+        // page-native MVCC cursor plan and never materialized the base index, regardless of
+        // how many rows the base catalog holds.
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().BeGreaterThan(0);
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
 
         Execute(connection, "ROLLBACK;");
         return allocated;

--- a/src/Ahtola.Tests/PlannerAccessPathDepthTests.cs
+++ b/src/Ahtola.Tests/PlannerAccessPathDepthTests.cs
@@ -390,7 +390,7 @@ public sealed class PlannerAccessPathDepthTests
     }
 
     [Test]
-    public void TransactionLocalRowsUseMaterializedIndexFallback()
+    public void TransactionLocalRowsUseDurablePagerAccessorWithOverlay()
     {
         var fileSystem = new InMemoryFileSystem();
         using var database = EmbeddedDatabase.OpenFile("planner-depth-transaction.db", fileSystem);
@@ -415,8 +415,10 @@ public sealed class PlannerAccessPathDepthTests
                 """)
             .Select(row => row[0].AsText())
             .Should().Equal("two", "two-local");
-        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().Be(0);
-        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(3);
+        // The pinned durable pager snapshot plus this transaction's mutation overlay serves the
+        // seek directly: no full-index materialization is needed to see the transaction-local row.
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().Be(1);
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
         Execute(connection, "ROLLBACK;");
     }
 

--- a/src/Ahtola.Tests/TransactionDirectIndexOverlayTests.cs
+++ b/src/Ahtola.Tests/TransactionDirectIndexOverlayTests.cs
@@ -1,0 +1,1311 @@
+using AwesomeAssertions;
+using Ahtola.Core;
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Tests;
+
+/// <summary>
+/// Focused coverage for the classic (non-MVCC) transaction direct-index-overlay phase: a
+/// file-backed explicit transaction must serve eligible join index seeks directly from the pinned
+/// durable pager snapshot taken at BEGIN, merged with this transaction's own
+/// <c>TransactionMutationOverlay</c>, so every scenario below asserts both correctness (read your
+/// own writes, suppress stale base entries, respect snapshot isolation against peers) and the
+/// zero-materialization contract (<see cref="VdbeJoinIndexSeekMetrics.DurableCursorPlans"/> greater
+/// than zero, <see cref="VdbeJoinIndexSeekMetrics.IndexRowsMaterialized"/> equal to zero).
+/// </summary>
+public sealed class TransactionDirectIndexOverlayTests
+{
+    [Test]
+    public void PinnedSnapshotSurvivesALaterPeerCommitWhileTheOverlaySeesItsOwnWrites()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using (var setupDatabase = EmbeddedDatabase.OpenFile("overlay-peer-snapshot.db", fileSystem))
+        using (var setupConnection = setupDatabase.Connect())
+        {
+            Execute(setupConnection, "CREATE TABLE outer_items(k INTEGER);");
+            Execute(setupConnection, "CREATE TABLE inner_items(k INTEGER, payload TEXT);");
+            Execute(setupConnection, "CREATE INDEX inner_items_k ON inner_items(k);");
+            Execute(setupConnection, "INSERT INTO outer_items VALUES (2), (3);");
+            Execute(setupConnection, "INSERT INTO inner_items VALUES (2, 'two');");
+            Execute(setupConnection, "ANALYZE;");
+        }
+
+        using var databaseA = EmbeddedDatabase.OpenFile("overlay-peer-snapshot.db", fileSystem);
+        using var connectionA = databaseA.Connect();
+        // BEGIN pins the durable snapshot before this transaction takes any write lock, so a peer
+        // can still commit its own write in between.
+        Execute(connectionA, "BEGIN;");
+
+        // A peer connection commits an unrelated row after A pinned its snapshot at BEGIN, while A
+        // still holds no write lock of its own.
+        using (var databaseB = EmbeddedDatabase.OpenFile("overlay-peer-snapshot.db", fileSystem))
+        using (var connectionB = databaseB.Connect())
+        {
+            Execute(connectionB, "INSERT INTO inner_items VALUES (3, 'three-peer');");
+        }
+
+        // This transaction's own uncommitted write must be visible through the overlay, even
+        // though the peer's commit above has already advanced the durable catalog underneath it.
+        Execute(connectionA, "INSERT INTO inner_items VALUES (2, 'two-local');");
+
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_k ON outer_items.k = inner_items.k
+            ORDER BY outer_items.k, inner_items.payload;
+            """;
+
+        databaseA.ResetJoinOrderDiagnostics();
+        // Snapshot isolation: the peer's post-BEGIN commit (k=3) must stay invisible for the whole
+        // transaction, while this transaction's own overlay row (k=2, 'two-local') is visible
+        // alongside the row that was already committed when the snapshot was pinned.
+        ReadRows(connectionA, sql).Select(row => row[0].AsText()).Should().Equal("two", "two-local");
+        databaseA.JoinIndexSeekMetrics.DurableCursorPlans.Should().Be(1);
+        databaseA.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+
+        // This phase is classic (non-MVCC): a write transaction whose pinned snapshot has since
+        // been superseded by a peer's commit cannot land its own write, so it must roll back
+        // rather than silently rebase onto the newer snapshot.
+        Execute(connectionA, "ROLLBACK;");
+
+        using var connectionC = databaseA.Connect();
+        ReadRows(connectionC, sql).Select(row => row[0].AsText())
+            .Should().Equal("two", "three-peer");
+    }
+
+    [Test]
+    public void UpdatedIndexedColumnSuppressesTheStaleKeyAndExposesTheNewKeyThroughTheOverlay()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("overlay-update-key.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE outer_items(k INTEGER);");
+        Execute(connection, "CREATE TABLE inner_items(id INTEGER PRIMARY KEY, k INTEGER, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k);");
+        Execute(connection, "INSERT INTO outer_items VALUES (1), (2);");
+        Execute(connection, "INSERT INTO inner_items VALUES (1, 1, 'a');");
+        Execute(connection, "ANALYZE;");
+
+        Execute(connection, "BEGIN;");
+        Execute(connection, "UPDATE inner_items SET k = 2 WHERE id = 1;");
+
+        const string sql =
+            """
+            SELECT outer_items.k, inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_k ON outer_items.k = inner_items.k
+            ORDER BY outer_items.k;
+            """;
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, sql).Select(row => (row[0].AsInteger(), row[1].AsText()))
+            .Should().Equal((2L, "a"));
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().Be(1);
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+
+        Execute(connection, "ROLLBACK;");
+    }
+
+    [Test]
+    public void DeletedRowIsSuppressedFromTheDurableIndexSeekThroughTheOverlay()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("overlay-delete.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE outer_items(k INTEGER);");
+        Execute(connection, "CREATE TABLE inner_items(id INTEGER PRIMARY KEY, k INTEGER, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k);");
+        Execute(connection, "INSERT INTO outer_items VALUES (1);");
+        Execute(connection, "INSERT INTO inner_items VALUES (1, 1, 'a');");
+        Execute(connection, "ANALYZE;");
+
+        Execute(connection, "BEGIN;");
+        Execute(connection, "DELETE FROM inner_items WHERE id = 1;");
+
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_k ON outer_items.k = inner_items.k;
+            """;
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, sql).Should().BeEmpty();
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().Be(1);
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+
+        Execute(connection, "ROLLBACK;");
+    }
+
+    [Test]
+    public void RowidMoveIsVisibleThroughTheOverlayAndSuppressesTheOldIdentity()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("overlay-rowid-move.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE outer_items(k INTEGER);");
+        Execute(connection, "CREATE TABLE inner_items(id INTEGER PRIMARY KEY, k INTEGER, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k);");
+        Execute(connection, "INSERT INTO outer_items VALUES (7);");
+        Execute(connection, "INSERT INTO inner_items VALUES (1, 7, 'a');");
+        Execute(connection, "ANALYZE;");
+
+        Execute(connection, "BEGIN;");
+        // Changing the INTEGER PRIMARY KEY rowid alias moves the row's identity while its indexed
+        // column (k) stays put -- the overlay must key the replacement by the *new* rowid.
+        Execute(connection, "UPDATE inner_items SET id = 999 WHERE id = 1;");
+
+        const string sql =
+            """
+            SELECT inner_items.id, inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_k ON outer_items.k = inner_items.k;
+            """;
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, sql).Select(row => (row[0].AsInteger(), row[1].AsText()))
+            .Should().Equal((999L, "a"));
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().Be(1);
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+
+        Execute(connection, "ROLLBACK;");
+    }
+
+    [Test]
+    public void PartialIndexMembershipChangesAreReflectedThroughTheOverlay()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("overlay-partial-membership.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE outer_items(k INTEGER);");
+        Execute(connection, "CREATE TABLE inner_items(id INTEGER PRIMARY KEY, k INTEGER, gate INTEGER, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_items_partial ON inner_items(k) WHERE gate > 0;");
+        Execute(connection, "INSERT INTO outer_items VALUES (1), (2);");
+        // id=1 starts outside the partial predicate (gate <= 0); id=2 starts inside it.
+        Execute(connection, "INSERT INTO inner_items VALUES (1, 1, -1, 'joins-in-txn');");
+        Execute(connection, "INSERT INTO inner_items VALUES (2, 2, 1, 'leaves-in-txn');");
+        Execute(connection, "ANALYZE;");
+
+        Execute(connection, "BEGIN;");
+        Execute(connection, "UPDATE inner_items SET gate = 1 WHERE id = 1;");
+        Execute(connection, "UPDATE inner_items SET gate = -1 WHERE id = 2;");
+
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_partial
+            ON outer_items.k = inner_items.k AND inner_items.gate > 0
+            ORDER BY outer_items.k;
+            """;
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, sql).Select(row => row[0].AsText()).Should().Equal("joins-in-txn");
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().Be(1);
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+
+        Execute(connection, "ROLLBACK;");
+    }
+
+    [Test]
+    public void ExpressionIndexKeyChangesAreReflectedThroughTheOverlay()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("overlay-expression-key.db", fileSystem);
+        using var connection = database.Connect();
+        // The outer join column must stay untyped (no declared affinity) so the compiled
+        // expression-index plan does not decline the seek for a possible affinity coercion --
+        // see IndexSeekJoinDirectAccessTests.DurableReopenUsesPagerSeekForProvenExpressionIndex.
+        Execute(connection, "CREATE TABLE outer_items(k);");
+        Execute(connection, "CREATE TABLE inner_items(id INTEGER PRIMARY KEY, k TEXT, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_items_lower_k ON inner_items(lower(k));");
+        Execute(connection, "INSERT INTO outer_items VALUES ('old'), ('new');");
+        Execute(connection, "INSERT INTO inner_items VALUES (1, 'OLD', 'p-old');");
+        Execute(
+            connection,
+            "INSERT INTO inner_items VALUES "
+                + string.Join(", ", Enumerable.Range(2, 500).Select(value => $"({value}, 'noise{value}', 'n{value}')"))
+                + ";");
+        Execute(connection, "ANALYZE;");
+
+        Execute(connection, "BEGIN;");
+        Execute(connection, "UPDATE inner_items SET k = 'NEW' WHERE id = 1;");
+
+        const string sql =
+            """
+            SELECT outer_items.k, inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_lower_k ON outer_items.k = lower(inner_items.k)
+            ORDER BY outer_items.k;
+            """;
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, sql).Select(row => (row[0].AsText(), row[1].AsText()))
+            .Should().Equal(("new", "p-old"));
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().Be(1);
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+
+        Execute(connection, "ROLLBACK;");
+    }
+
+    [Test]
+    public void WithoutRowidPrimaryKeyAndSecondaryIndexSeeksReflectOverlayMutations()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("overlay-without-rowid.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE outer_codes(code TEXT);");
+        Execute(connection, "CREATE TABLE outer_tags(tag TEXT);");
+        Execute(connection, "CREATE TABLE entry(code TEXT PRIMARY KEY, tag TEXT) WITHOUT ROWID;");
+        Execute(connection, "CREATE INDEX entry_tag ON entry(tag);");
+        Execute(connection, "INSERT INTO outer_codes VALUES ('k1'), ('k2');");
+        Execute(connection, "INSERT INTO outer_tags VALUES ('t1'), ('t9');");
+        Execute(connection, "INSERT INTO entry VALUES ('k1', 't1');");
+        // The planner only prefers the durable PK/secondary index seek over a small-table
+        // automatic-covering-index materialization once the table has enough baseline rows for
+        // ANALYZE to make that estimate; these noise rows never match outer_codes/outer_tags.
+        Execute(
+            connection,
+            "INSERT INTO entry VALUES "
+                + string.Join(", ", Enumerable.Range(1, 500).Select(value => $"('noise-{value:D5}', 'noise-tag-{value:D5}')"))
+                + ";");
+        Execute(connection, "ANALYZE;");
+
+        Execute(connection, "BEGIN;");
+        Execute(connection, "INSERT INTO entry VALUES ('k2', 't2');");
+        Execute(connection, "UPDATE entry SET tag = 't9' WHERE code = 'k1';");
+
+        const string primaryKeySql =
+            """
+            SELECT entry.code, entry.tag
+            FROM outer_codes
+            JOIN entry ON outer_codes.code = entry.code
+            ORDER BY outer_codes.code;
+            """;
+        const string secondaryIndexSql =
+            """
+            SELECT entry.code
+            FROM outer_tags
+            JOIN entry INDEXED BY entry_tag ON outer_tags.tag = entry.tag
+            ORDER BY outer_tags.tag;
+            """;
+
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, primaryKeySql).Select(row => (row[0].AsText(), row[1].AsText()))
+            .Should().Equal(("k1", "t9"), ("k2", "t2"));
+        ReadRows(connection, secondaryIndexSql).Select(row => row[0].AsText())
+            .Should().Equal("k1");
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().Be(2);
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+
+        Execute(connection, "ROLLBACK;");
+    }
+
+    [Test]
+    public void RollbackToSavepointRestoresTheOverlayToItsCheckpointedState()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("overlay-savepoint-rollback.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE outer_items(k INTEGER);");
+        Execute(connection, "CREATE TABLE inner_items(k INTEGER, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k);");
+        Execute(connection, "INSERT INTO outer_items VALUES (10), (11);");
+        // A non-empty baseline table is required for the planner to choose a compiled index-seek
+        // plan instead of an empty-table scan shortcut; this row never matches outer_items.k.
+        Execute(connection, "INSERT INTO inner_items VALUES (999, 'noise');");
+        Execute(connection, "ANALYZE;");
+
+        const string sql =
+            """
+            SELECT outer_items.k, inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_k ON outer_items.k = inner_items.k
+            ORDER BY outer_items.k;
+            """;
+
+        Execute(connection, "BEGIN;");
+        Execute(connection, "INSERT INTO inner_items VALUES (10, 'ten');");
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, sql).Select(row => (row[0].AsInteger(), row[1].AsText()))
+            .Should().Equal((10L, "ten"));
+
+        Execute(connection, "SAVEPOINT sp1;");
+        Execute(connection, "INSERT INTO inner_items VALUES (11, 'eleven');");
+        Execute(connection, "DELETE FROM inner_items WHERE k = 10;");
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, sql).Select(row => (row[0].AsInteger(), row[1].AsText()))
+            .Should().Equal((11L, "eleven"));
+
+        Execute(connection, "ROLLBACK TO sp1;");
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, sql).Select(row => (row[0].AsInteger(), row[1].AsText()))
+            .Should().Equal((10L, "ten"));
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().Be(1);
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+
+        Execute(connection, "ROLLBACK;");
+    }
+
+    [Test]
+    public void ReleasedSavepointKeepsItsOverlayMutationsVisibleThroughTheDurableSeek()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("overlay-savepoint-release.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE outer_items(k INTEGER);");
+        Execute(connection, "CREATE TABLE inner_items(k INTEGER, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k);");
+        Execute(connection, "INSERT INTO outer_items VALUES (20);");
+        // A non-empty baseline table is required for the planner to choose a compiled index-seek
+        // plan instead of an empty-table scan shortcut; this row never matches outer_items.k.
+        Execute(connection, "INSERT INTO inner_items VALUES (999, 'noise');");
+        Execute(connection, "ANALYZE;");
+
+        Execute(connection, "BEGIN;");
+        Execute(connection, "SAVEPOINT sp1;");
+        Execute(connection, "INSERT INTO inner_items VALUES (20, 'twenty');");
+        Execute(connection, "RELEASE sp1;");
+
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_k ON outer_items.k = inner_items.k;
+            """;
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, sql).Select(row => row[0].AsText()).Should().Equal("twenty");
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().Be(1);
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+
+        Execute(connection, "COMMIT;");
+
+        using var reopened = EmbeddedDatabase.OpenFile("overlay-savepoint-release.db", fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        ReadRows(reopenedConnection, sql).Select(row => row[0].AsText()).Should().Equal("twenty");
+    }
+
+    [Test]
+    public void TriggerCascadedInsertIsVisibleThroughTheOverlayWithoutMaterializingTheIndex()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("overlay-trigger-cascade.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE outer_items(k INTEGER);");
+        Execute(connection, "CREATE TABLE orders(id INTEGER PRIMARY KEY, k INTEGER);");
+        Execute(connection, "CREATE TABLE order_log(k INTEGER, note TEXT);");
+        Execute(connection, "CREATE INDEX order_log_k ON order_log(k);");
+        Execute(
+            connection,
+            "CREATE TRIGGER orders_log AFTER INSERT ON orders "
+                + "BEGIN INSERT INTO order_log VALUES (NEW.k, 'logged'); END;");
+        Execute(connection, "INSERT INTO outer_items VALUES (77);");
+        // A non-empty baseline table is required for the planner to choose a compiled index-seek
+        // plan instead of an empty-table scan shortcut; this row never matches outer_items.k.
+        Execute(connection, "INSERT INTO order_log VALUES (999, 'noise');");
+        Execute(connection, "ANALYZE;");
+
+        Execute(connection, "BEGIN;");
+        Execute(connection, "INSERT INTO orders VALUES (1, 77);");
+
+        const string sql =
+            """
+            SELECT order_log.note
+            FROM outer_items
+            JOIN order_log INDEXED BY order_log_k ON outer_items.k = order_log.k;
+            """;
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, sql).Select(row => row[0].AsText()).Should().Equal("logged");
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().Be(1);
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+
+        Execute(connection, "ROLLBACK;");
+    }
+
+    [Test]
+    public void ForeignKeyCascadeDeleteSuppressesDependentRowsThroughTheOverlay()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("overlay-fk-cascade.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "PRAGMA foreign_keys = ON;");
+        Execute(connection, "CREATE TABLE outer_items(k INTEGER);");
+        Execute(connection, "CREATE TABLE parent(id INTEGER PRIMARY KEY);");
+        Execute(
+            connection,
+            "CREATE TABLE child(id INTEGER PRIMARY KEY, "
+                + "parent_id INTEGER REFERENCES parent(id) ON DELETE CASCADE, tag INTEGER);");
+        Execute(connection, "CREATE INDEX child_tag ON child(tag);");
+        Execute(connection, "INSERT INTO outer_items VALUES (55);");
+        Execute(connection, "INSERT INTO parent VALUES (1);");
+        Execute(connection, "INSERT INTO child VALUES (1, 1, 55);");
+        Execute(connection, "ANALYZE;");
+
+        Execute(connection, "BEGIN;");
+        Execute(connection, "DELETE FROM parent WHERE id = 1;");
+
+        const string sql =
+            """
+            SELECT child.id
+            FROM outer_items
+            JOIN child INDEXED BY child_tag ON outer_items.k = child.tag;
+            """;
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, sql).Should().BeEmpty();
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().Be(1);
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+
+        Execute(connection, "ROLLBACK;");
+    }
+
+    [Test]
+    public void RollbackDiscardsTheOverlaySoALaterTransactionOnTheSameConnectionStartsClean()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("overlay-rollback-cleanup.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE outer_items(k INTEGER);");
+        Execute(connection, "CREATE TABLE inner_items(k INTEGER, payload TEXT);");
+        Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k);");
+        Execute(connection, "INSERT INTO outer_items VALUES (30);");
+        // A non-empty baseline table is required for the planner to choose a compiled index-seek
+        // plan instead of an empty-table scan shortcut; this row never matches outer_items.k and
+        // survives the ROLLBACK below since it was committed before BEGIN.
+        Execute(connection, "INSERT INTO inner_items VALUES (999, 'noise');");
+        Execute(connection, "ANALYZE;");
+
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_k ON outer_items.k = inner_items.k;
+            """;
+
+        Execute(connection, "BEGIN;");
+        Execute(connection, "INSERT INTO inner_items VALUES (30, 'thirty');");
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, sql).Select(row => row[0].AsText()).Should().Equal("thirty");
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().Be(1);
+        Execute(connection, "ROLLBACK;");
+
+        // A fresh explicit transaction on the very same connection must re-pin its own snapshot
+        // and start with an empty overlay: no leaked state from the rolled-back transaction.
+        Execute(connection, "BEGIN;");
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, sql).Should().BeEmpty();
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().Be(1);
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+        Execute(connection, "COMMIT;");
+    }
+
+    [Test]
+    public void ConnectionDisposalDuringAnOpenTransactionReleasesThePinnedSnapshotWithoutCorruptingTheFile()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using (var database = EmbeddedDatabase.OpenFile("overlay-connection-disposal.db", fileSystem))
+        {
+            using (var connection = database.Connect())
+            {
+                Execute(connection, "CREATE TABLE items(id INTEGER PRIMARY KEY, payload TEXT);");
+                Execute(connection, "INSERT INTO items VALUES (1, 'committed');");
+                Execute(connection, "BEGIN;");
+                Execute(connection, "INSERT INTO items VALUES (2, 'uncommitted');");
+                // Disposing the connection mid-transaction must dispose the pinned snapshot rather
+                // than leak a reader that would wedge a later peer's checkpoint.
+            }
+
+            using var freshConnection = database.Connect();
+            ReadRows(freshConnection, "SELECT payload FROM items ORDER BY id;")
+                .Select(row => row[0].AsText())
+                .Should().Equal("committed");
+        }
+
+        using var reopened = EmbeddedDatabase.OpenFile("overlay-connection-disposal.db", fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        ReadRows(reopenedConnection, "SELECT payload FROM items ORDER BY id;")
+            .Select(row => row[0].AsText())
+            .Should().Equal("committed");
+    }
+
+    [Test]
+    public void DurableReopenAfterCommitSeesEveryOverlayMutationWithoutMaterialization()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using (var database = EmbeddedDatabase.OpenFile("overlay-durable-reopen.db", fileSystem))
+        using (var connection = database.Connect())
+        {
+            Execute(connection, "CREATE TABLE outer_items(k INTEGER);");
+            Execute(connection, "CREATE TABLE inner_items(id INTEGER PRIMARY KEY, k INTEGER, payload TEXT);");
+            Execute(connection, "CREATE INDEX inner_items_k ON inner_items(k);");
+            Execute(connection, "INSERT INTO outer_items VALUES (1), (2), (3);");
+            Execute(connection, "INSERT INTO inner_items VALUES (1, 1, 'stays'), (2, 2, 'will-move'), (3, 3, 'will-delete');");
+            Execute(connection, "ANALYZE;");
+
+            Execute(connection, "BEGIN;");
+            Execute(connection, "UPDATE inner_items SET k = 4 WHERE id = 2;");
+            Execute(connection, "DELETE FROM inner_items WHERE id = 3;");
+            Execute(connection, "INSERT INTO inner_items VALUES (4, 4, 'new-in-txn');");
+            Execute(connection, "COMMIT;");
+        }
+
+        using var reopened = EmbeddedDatabase.OpenFile("overlay-durable-reopen.db", fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_k ON outer_items.k = inner_items.k
+            ORDER BY inner_items.payload;
+            """;
+        reopened.ResetJoinOrderDiagnostics();
+        ReadRows(reopenedConnection, sql).Select(row => row[0].AsText()).Should().Equal("stays");
+
+        const string movedSql =
+            """
+            SELECT inner_items.payload
+            FROM inner_items INDEXED BY inner_items_k
+            WHERE inner_items.k = 4
+            ORDER BY inner_items.payload;
+            """;
+        ReadRows(reopenedConnection, movedSql).Select(row => row[0].AsText())
+            .Should().Equal("new-in-txn", "will-move");
+        reopened.JoinIndexSeekMetrics.DurableCursorPlans.Should().Be(1);
+        reopened.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+    }
+
+    // --- Finding #1: a failed AFTER-trigger statement must restore the overlay, not just the ---
+    // --- statement's cloned catalog, so trigger-cascaded phantom rows never leak into a later ---
+    // --- read on the still-open transaction. ---
+    [Test]
+    public void FailedAfterTriggerStatementRestoresTheOverlayAndSuppressesPhantomTriggerRowsButKeepsTheTransactionOpen()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("overlay-failed-after-trigger.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE outer_items(k INTEGER);");
+        Execute(connection, "CREATE TABLE source(id INTEGER PRIMARY KEY, k INTEGER, mode TEXT);");
+        Execute(connection, "CREATE TABLE mirror(k INTEGER, note TEXT);");
+        Execute(connection, "CREATE INDEX mirror_k ON mirror(k);");
+        Execute(connection, "CREATE TABLE guard(id INTEGER PRIMARY KEY, k INTEGER, tag INTEGER);");
+        Execute(connection, "CREATE INDEX guard_tag ON guard(tag);");
+        Execute(
+            connection,
+            """
+            CREATE TRIGGER source_after_insert AFTER INSERT ON source BEGIN
+                INSERT INTO mirror VALUES (NEW.k, 'mirrored-' || NEW.id);
+                DELETE FROM guard WHERE tag = NEW.k;
+                SELECT CASE WHEN NEW.mode = 'abort' THEN RAISE(ABORT, 'guard tripped') END;
+            END;
+            """);
+        Execute(connection, "INSERT INTO outer_items VALUES (77);");
+        // A non-empty baseline table is required for the planner to choose a compiled index-seek
+        // plan instead of an empty-table scan shortcut; these rows never match outer_items.k.
+        Execute(connection, "INSERT INTO mirror VALUES (999, 'noise');");
+        Execute(connection, "INSERT INTO guard VALUES (999, 999, 999);");
+        Execute(connection, "ANALYZE;");
+
+        const string mirrorSql =
+            """
+            SELECT mirror.note
+            FROM outer_items
+            JOIN mirror INDEXED BY mirror_k ON outer_items.k = mirror.k
+            ORDER BY mirror.note;
+            """;
+        const string guardSql =
+            """
+            SELECT guard.id
+            FROM outer_items
+            JOIN guard INDEXED BY guard_tag ON outer_items.k = guard.tag;
+            """;
+
+        Execute(connection, "BEGIN;");
+        Execute(connection, "INSERT INTO source VALUES (1, 77, 'ok');");
+        Execute(connection, "INSERT INTO guard VALUES (2, 77, 77);");
+
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, mirrorSql).Select(row => row[0].AsText()).Should().Equal("mirrored-1");
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().Be(1);
+        ReadRows(connection, guardSql).Select(row => row[0].AsInteger()).Should().Equal(2L);
+
+        var abortedInsert = () => Execute(connection, "INSERT INTO source VALUES (2, 77, 'abort');");
+        abortedInsert.Should().Throw<EmbeddedSqlException>().WithMessage("*guard tripped*");
+
+        // The failed AFTER-trigger statement must restore the overlay to exactly what it was
+        // before this statement ran: the trigger's phantom mirror insert must vanish and the
+        // trigger's phantom guard delete must be undone, even though both mutations came from a
+        // trigger body rather than the top-level statement.
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, mirrorSql).Select(row => row[0].AsText()).Should().Equal("mirrored-1");
+        database.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+        ReadRows(connection, guardSql).Select(row => row[0].AsInteger()).Should().Equal(2L);
+
+        // The transaction itself must still be open and usable after the failed statement: a
+        // subsequent successful statement must see only its own effect layered on the restored
+        // overlay, proving the restore did not discard unrelated prior mutations either.
+        Execute(connection, "INSERT INTO source VALUES (3, 77, 'ok');");
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, mirrorSql).Select(row => row[0].AsText()).Should().Equal("mirrored-1", "mirrored-3");
+        ReadRows(connection, guardSql).Should().BeEmpty();
+
+        Execute(connection, "COMMIT;");
+    }
+
+    // --- Finding #2: the per-file catalog/version lock must be held across the catalog refresh, ---
+    // --- clone, and pager snapshot pin, so a peer's commit cannot land in that window and pin a ---
+    // --- snapshot generation that no longer matches the cloned catalog. ---
+    [Test]
+    public void PeerCommitBlocksOnTheSharedFileCatalogLockUntilTheSnapshotIsFullyClonedAndPinned()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using (var setupDatabase = EmbeddedDatabase.OpenFile("overlay-peer-race.db", fileSystem))
+        using (var setupConnection = setupDatabase.Connect())
+        {
+            Execute(setupConnection, "CREATE TABLE outer_items(k INTEGER);");
+            Execute(setupConnection, "CREATE TABLE inner_items(k INTEGER, payload TEXT);");
+            Execute(setupConnection, "CREATE INDEX inner_items_k ON inner_items(k);");
+            Execute(setupConnection, "INSERT INTO outer_items VALUES (5);");
+            // A non-empty baseline table is required for the planner to choose a compiled
+            // index-seek plan instead of an empty-table scan shortcut; this row never matches.
+            Execute(setupConnection, "INSERT INTO inner_items VALUES (999, 'noise');");
+            Execute(setupConnection, "ANALYZE;");
+        }
+
+        using var databaseA = EmbeddedDatabase.OpenFile("overlay-peer-race.db", fileSystem);
+        using var connectionA = databaseA.Connect();
+        using var databaseB = EmbeddedDatabase.OpenFile("overlay-peer-race.db", fileSystem);
+        using var connectionB = databaseB.Connect();
+
+        using var peerStarted = new ManualResetEventSlim(false);
+        var peerCommitted = false;
+        Task? peerTask = null;
+
+        EmbeddedDatabase.BeforePinningTransactionSnapshotForTesting = () =>
+        {
+            peerTask = Task.Run(() =>
+            {
+                peerStarted.Set();
+                Execute(connectionB, "INSERT INTO inner_items VALUES (5, 'five-peer');");
+                Volatile.Write(ref peerCommitted, true);
+            });
+
+            peerStarted.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue(
+                "the peer task must start running while this hook still holds the shared file catalog lock");
+            Thread.Sleep(100);
+            Volatile.Read(ref peerCommitted).Should().BeFalse(
+                "the peer's commit must stay blocked on the shared file-catalog lock for as long as this " +
+                "hook — which runs between the catalog clone and the pager snapshot pin — has not returned");
+        };
+        try
+        {
+            Execute(connectionA, "BEGIN;");
+        }
+        finally
+        {
+            EmbeddedDatabase.BeforePinningTransactionSnapshotForTesting = null;
+        }
+
+        peerTask.Should().NotBeNull();
+        peerTask!.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue("the peer task must finish once the lock is released");
+
+        // The pinned snapshot taken for connectionA's BEGIN must be exactly what the catalog
+        // clone observed while still holding the lock: the peer's now-committed row must never
+        // appear for the rest of this transaction, proving the clone and the pin observed the
+        // same generation.
+        const string sql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_k ON outer_items.k = inner_items.k;
+            """;
+        databaseA.ResetJoinOrderDiagnostics();
+        ReadRows(connectionA, sql).Should().BeEmpty();
+        databaseA.JoinIndexSeekMetrics.DurableCursorPlans.Should().Be(1);
+        Execute(connectionA, "COMMIT;");
+
+        using var verifyConnection = databaseA.Connect();
+        ReadRows(verifyConnection, sql).Select(row => row[0].AsText()).Should().Equal("five-peer");
+    }
+
+    // --- Review fix: TryOpenIndexAccessor/TryOpenPrimaryKeyIndexAccessor must resolve table and ---
+    // --- index root pages from the pinned snapshot's own immutable mapping, never from the file ---
+    // --- store's live _tableRootPages/_indexRootPages, so a peer's drop/recreate (which reuses ---
+    // --- the same name with a brand-new root page, possibly reusing a page number the old ---
+    // --- object used to occupy) cannot redirect an already-pinned transaction's reads. ---
+    [Test]
+    public void PinnedTransactionResolvesIndexAndPrimaryKeyRootsFromItsOwnSnapshotDespitePeerDropRecreate()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using (var setupDatabase = EmbeddedDatabase.OpenFile("overlay-pinned-root-pages.db", fileSystem))
+        using (var setupConnection = setupDatabase.Connect())
+        {
+            Execute(setupConnection, "CREATE TABLE outer_items(k INTEGER);");
+            Execute(setupConnection, "CREATE TABLE inner_items(k INTEGER, payload TEXT);");
+            Execute(setupConnection, "CREATE INDEX inner_items_k ON inner_items(k);");
+            Execute(setupConnection, "CREATE TABLE pk_items(k INTEGER PRIMARY KEY, payload TEXT) WITHOUT ROWID;");
+            Execute(setupConnection, "INSERT INTO outer_items VALUES (5);");
+            Execute(setupConnection, "INSERT INTO inner_items VALUES (5, 'orig-index');");
+            // pk_items needs enough rows that the planner's cost model prefers a genuine seek
+            // through the table's own primary-key b-tree over building a one-shot in-memory
+            // automatic index (which a single-row table would make artificially cheap and would
+            // never exercise TryOpenTransactionIndexAccessor's pinned-snapshot resolution at all).
+            Execute(
+                setupConnection,
+                "INSERT INTO pk_items VALUES "
+                    + string.Join(
+                        ", ",
+                        Enumerable.Range(1, 500)
+                            .Select(value => value == 5 ? "(5, 'orig-pk')" : $"({value}, 'row-{value}')"))
+                    + ";");
+            Execute(setupConnection, "ANALYZE;");
+        }
+
+        using var databaseA = EmbeddedDatabase.OpenFile("overlay-pinned-root-pages.db", fileSystem);
+        using var connectionA = databaseA.Connect();
+        using var databaseB = EmbeddedDatabase.OpenFile("overlay-pinned-root-pages.db", fileSystem);
+        using var connectionB = databaseB.Connect();
+
+        // BEGIN pins connectionA's durable snapshot — including its table/index root-page
+        // mapping — before it makes any schema change of its own, so the pinned-snapshot direct
+        // index accessor path stays eligible for the whole transaction below.
+        Execute(connectionA, "BEGIN;");
+
+        const string indexSql =
+            """
+            SELECT inner_items.payload
+            FROM outer_items
+            JOIN inner_items INDEXED BY inner_items_k ON outer_items.k = inner_items.k;
+            """;
+        const string pkSql =
+            """
+            SELECT pk_items.payload
+            FROM outer_items
+            JOIN pk_items ON outer_items.k = pk_items.k;
+            """;
+
+        databaseA.ResetJoinOrderDiagnostics();
+        ReadRows(connectionA, indexSql).Select(row => row[0].AsText()).Should().Equal("orig-index");
+        ReadRows(connectionA, pkSql).Select(row => row[0].AsText()).Should().Equal("orig-pk");
+        databaseA.JoinIndexSeekMetrics.DurableCursorPlans.Should().BeGreaterThan(0);
+        databaseA.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+
+        // A peer drops and recreates both tables (and the secondary index), reallocating fresh
+        // root pages that may reuse the very page numbers connectionA's pinned snapshot captured
+        // for the old objects, then churns the free list with an unrelated create/drop cycle so
+        // the allocator has additional opportunities to reissue those pages before A reads again.
+        Execute(connectionB, "DROP TABLE inner_items;");
+        Execute(connectionB, "CREATE TABLE inner_items(k INTEGER, payload TEXT);");
+        Execute(connectionB, "CREATE INDEX inner_items_k ON inner_items(k);");
+        Execute(connectionB, "INSERT INTO inner_items VALUES (5, 'new-index');");
+        Execute(connectionB, "DROP TABLE pk_items;");
+        Execute(connectionB, "CREATE TABLE pk_items(k INTEGER PRIMARY KEY, payload TEXT) WITHOUT ROWID;");
+        Execute(connectionB, "INSERT INTO pk_items VALUES (5, 'new-pk');");
+        Execute(connectionB, "CREATE TABLE churn(v INTEGER);");
+        Execute(connectionB, "DROP TABLE churn;");
+        Execute(connectionB, "ANALYZE;");
+
+        // connectionA's still-open transaction must keep resolving inner_items/pk_items (and the
+        // secondary index) to the root pages its own pinned snapshot captured at BEGIN, not
+        // whatever object the peer's drop/recreate now owns those same page numbers under: no
+        // exception, and the transaction's original rows, never the peer's new ones.
+        databaseA.ResetJoinOrderDiagnostics();
+        ReadRows(connectionA, indexSql).Select(row => row[0].AsText()).Should().Equal("orig-index");
+        ReadRows(connectionA, pkSql).Select(row => row[0].AsText()).Should().Equal("orig-pk");
+        databaseA.JoinIndexSeekMetrics.DurableCursorPlans.Should().BeGreaterThan(0);
+        databaseA.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+
+        Execute(connectionA, "COMMIT;");
+
+        // After commit, a fresh read must see the peer's committed data, proving A's isolation
+        // was scoped to its own transaction rather than a permanent staleness bug.
+        databaseA.ResetJoinOrderDiagnostics();
+        ReadRows(connectionA, indexSql).Select(row => row[0].AsText()).Should().Equal("new-index");
+        ReadRows(connectionA, pkSql).Select(row => row[0].AsText()).Should().Equal("new-pk");
+    }
+
+    // --- Finding #3: if the pager snapshot pin fails after the catalog clone and active- ---
+    // --- transaction registration, BeginTransaction must clean up the currently-failing ---
+    // --- database's cloned virtual tables and active-transaction count too, not just the ---
+    // --- other databases already recorded in `states`. ---
+    [Test]
+    public void FailedSnapshotPinDuringBeginCleansUpSoTheConnectionStaysFullyUsableAfterward()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("overlay-begin-pin-failure.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE t(v INTEGER);");
+        Execute(connection, "INSERT INTO t VALUES (1);");
+
+        EmbeddedDatabase.BeforePinningTransactionSnapshotForTesting =
+            () => throw new IOException("simulated pager snapshot-open failure");
+        try
+        {
+            var beginWithInjectedFailure = () => Execute(connection, "BEGIN;");
+            beginWithInjectedFailure.Should().Throw<IOException>()
+                .WithMessage("*simulated pager snapshot-open failure*");
+        }
+        finally
+        {
+            EmbeddedDatabase.BeforePinningTransactionSnapshotForTesting = null;
+        }
+
+        // A failed pin must have cleaned up the cloned virtual tables and decremented the
+        // active-transaction count for this database, and BeginTransaction's own cleanup must
+        // have covered the currently-failing database too: a fresh explicit transaction on the
+        // same connection must now work exactly as if the failed BEGIN had never happened.
+        Execute(connection, "BEGIN;");
+        ReadRows(connection, "SELECT v FROM t;").Select(row => row[0].AsInteger()).Should().Equal(1L);
+        Execute(connection, "INSERT INTO t VALUES (2);");
+        Execute(connection, "COMMIT;");
+        ReadRows(connection, "SELECT v FROM t ORDER BY v;")
+            .Select(row => row[0].AsInteger()).Should().Equal(1L, 2L);
+
+        // VACUUM's own dispatch throws if the active-transaction count was left nonzero, so a
+        // clean VACUUM here independently proves the failed BEGIN did not leak the
+        // active-transaction bump that CloneTransactionSnapshotLocked applied before the
+        // injected pin failure.
+        Execute(connection, "VACUUM;");
+    }
+
+    // BeginConcurrentTransactionSnapshotLocked's own failure-cleanup catch block used to only
+    // dispose a partially-opened pinned pager snapshot and roll back the MvStore transaction it
+    // had just begun -- it never disconnected the catalog CloneTransactionSnapshotLocked had
+    // already cloned, nor called EndTransaction to undo the active-transaction count that same
+    // clone had already bumped, whenever the durable pager snapshot pin failed *after* the
+    // clone succeeded. That left a stale active-transaction registration (and, for a database
+    // with virtual tables, orphaned cloned virtual-table instances) behind every failed BEGIN
+    // CONCURRENT pin, even though the MvStore transaction itself was already correctly rolled
+    // back. This must never happen: a failed pin must unwind exactly as completely as a failed
+    // pin on the classic (non-MVCC) BEGIN path above.
+    [Test]
+    public void FailedSnapshotPinDuringBeginConcurrentCleansUpSoTheConnectionStaysFullyUsableAfterward()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("overlay-begin-concurrent-pin-failure.db", fileSystem);
+        using var connection = database.Connect();
+        ReadRows(connection, "PRAGMA journal_mode=mvcc;");
+        Execute(connection, "CREATE TABLE t(v INTEGER);");
+        Execute(connection, "INSERT INTO t VALUES (1);");
+
+        EmbeddedDatabase.BeforePinningTransactionSnapshotForTesting =
+            () => throw new IOException("simulated pager snapshot-open failure");
+        try
+        {
+            var beginConcurrentWithInjectedFailure = () => Execute(connection, "BEGIN CONCURRENT;");
+            beginConcurrentWithInjectedFailure.Should().Throw<IOException>()
+                .WithMessage("*simulated pager snapshot-open failure*");
+        }
+        finally
+        {
+            EmbeddedDatabase.BeforePinningTransactionSnapshotForTesting = null;
+        }
+
+        // A failed pin must have rolled back the MvStore transaction
+        // BeginConcurrentTransactionSnapshotLocked had already begun, disconnected the cloned
+        // virtual tables, and decremented the active-transaction count: a fresh BEGIN CONCURRENT
+        // on the same connection must now work exactly as if the failed one had never happened.
+        Execute(connection, "BEGIN CONCURRENT;");
+        ReadRows(connection, "SELECT v FROM t;").Select(row => row[0].AsInteger()).Should().Equal(1L);
+        Execute(connection, "INSERT INTO t VALUES (2);");
+        Execute(connection, "COMMIT;");
+        ReadRows(connection, "SELECT v FROM t ORDER BY v;")
+            .Select(row => row[0].AsInteger()).Should().Equal(1L, 2L);
+
+        // VACUUM's own dispatch throws if the active-transaction count was left nonzero, so a
+        // clean VACUUM here independently proves the failed BEGIN CONCURRENT did not leak the
+        // active-transaction bump CloneTransactionSnapshotLocked applied, and the fresh
+        // BEGIN CONCURRENT/COMMIT round-trip above independently proves the rolled-back MvStore
+        // transaction left no dangling read mark or version-chain registration behind either.
+        Execute(connection, "VACUUM;");
+    }
+
+    // --- Review fix: CreateTransactionSnapshotWithPin's cleanup must attempt every step (virtual ---
+    // --- table disconnect, then EndTransaction) even when an earlier step also throws, and ---
+    // --- SchemaCatalog.DisconnectOwnedVirtualTables must itself attempt every owned instance ---
+    // --- instead of stopping at the first one whose Disconnect() callback throws. This combines ---
+    // --- both: two virtual table instances are cloned into the failing pin's snapshot catalog, ---
+    // --- only the first (by name) throws on Disconnect(), and the pin itself is also made to ---
+    // --- fail, so BeginTransaction must surface both failures while still disconnecting the ---
+    // --- second instance and unconditionally running EndTransaction. ---
+    [Test]
+    public void FailedSnapshotPinWithAThrowingVirtualTableDisconnectStillDisconnectsEveryInstanceAndEndsTheTransaction()
+    {
+        _ = MultiDisconnectModule.Instance;
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("overlay-multi-disconnect-pin-failure.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE t(v INTEGER);");
+        Execute(connection, "INSERT INTO t VALUES (1);");
+        Execute(connection, $"CREATE VIRTUAL TABLE v1 USING {MultiDisconnectModule.ModuleName}();");
+        Execute(connection, $"CREATE VIRTUAL TABLE v2 USING {MultiDisconnectModule.ModuleName}();");
+
+        MultiDisconnectTable.DisconnectedNames = [];
+        MultiDisconnectTable.ThrowOnDisconnectForName = "v1";
+        EmbeddedDatabase.BeforePinningTransactionSnapshotForTesting =
+            () => throw new IOException("simulated pager snapshot-open failure");
+        try
+        {
+            var beginWithInjectedFailure = () => Execute(connection, "BEGIN;");
+            // Both the primary pin failure and v1's cleanup-time disconnect failure must be
+            // preserved, not silently dropped in favor of one or the other.
+            beginWithInjectedFailure.Should().Throw<AggregateException>()
+                .Where(aggregate =>
+                    aggregate.InnerExceptions.Any(inner => inner is IOException)
+                    && aggregate.InnerExceptions.Any(inner => inner is InvalidOperationException));
+        }
+        finally
+        {
+            EmbeddedDatabase.BeforePinningTransactionSnapshotForTesting = null;
+            MultiDisconnectTable.ThrowOnDisconnectForName = null;
+        }
+
+        // Every virtual table instance owned by the failed transaction's cloned catalog must
+        // have gotten a disconnect attempt, not just the ones enumerated before v1's throwing
+        // callback: a single misbehaving instance must never leak every later one in the same
+        // catalog's disconnect loop.
+        MultiDisconnectTable.DisconnectedNames.Should().Contain(["v1", "v2"]);
+        MultiDisconnectTable.DisconnectedNames = null;
+
+        // EndTransaction must still have run despite the disconnect failure: a fresh explicit
+        // transaction on the same connection now works exactly as if the failed BEGIN had never
+        // happened, and VACUUM (which throws if the active-transaction count was left nonzero)
+        // independently proves the active-transaction count and any write reservation/lock this
+        // method had already taken were not leaked.
+        Execute(connection, "BEGIN;");
+        ReadRows(connection, "SELECT v FROM t;").Select(row => row[0].AsInteger()).Should().Equal(1L);
+        Execute(connection, "INSERT INTO t VALUES (2);");
+        Execute(connection, "COMMIT;");
+        ReadRows(connection, "SELECT v FROM t ORDER BY v;")
+            .Select(row => row[0].AsInteger()).Should().Equal(1L, 2L);
+        Execute(connection, "VACUUM;");
+    }
+
+    // --- Finding #4: TransactionMutationOverlay.RestoreCheckpoint must remove overlays for ---
+    // --- tables absent from the checkpoint and rebuild an overlay under the checkpoint's own ---
+    // --- shape when a table's rowid-vs-WITHOUT-ROWID identity changed since the checkpoint was ---
+    // --- taken (dropped and recreated across a savepoint rollback). These are white-box tests ---
+    // --- against the overlay types directly; they never call the buggy-by-design ---
+    // --- TransactionMutationOverlay.GetOrCreate(database, table, tableName) (which looks up by ---
+    // --- name only and cannot see a shape change), and instead populate `_tables` exclusively ---
+    // --- through RestoreCheckpoint's own "no live entry / shape mismatch" branch. ---
+    [Test]
+    public void RestoreCheckpointRemovesOverlayEntriesForTablesAbsentFromTheCheckpoint()
+    {
+        var overlay = new TransactionMutationOverlay();
+        var seedCheckpoint = new TransactionMutationOverlayCheckpoint(
+            new Dictionary<string, TransactionTableOverlayCheckpoint>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["ghost"] = new TransactionTableOverlayCheckpoint(
+                    true,
+                    new Dictionary<long, SqlValue[]?> { [1] = [SqlValue.Integer(1)] },
+                    null),
+            });
+        overlay.RestoreCheckpoint(seedCheckpoint);
+        overlay.TryGet("ghost", out var seeded).Should().BeTrue();
+        seeded.TryGetByRowId(1, out var seededRow).Should().BeTrue();
+        seededRow.Should().Equal(SqlValue.Integer(1));
+
+        // Restoring a checkpoint predating "ghost"'s first touch (an empty checkpoint) must
+        // remove the overlay outright, not merely clear it: leaving a stale-but-cleared entry
+        // around would keep the table's overlay identity alive under the wrong assumption that
+        // it had already been touched at checkpoint time.
+        var emptyCheckpoint = new TransactionMutationOverlayCheckpoint(
+            new Dictionary<string, TransactionTableOverlayCheckpoint>(StringComparer.OrdinalIgnoreCase));
+        overlay.RestoreCheckpoint(emptyCheckpoint);
+
+        overlay.TryGet("ghost", out _).Should().BeFalse(
+            "a table overlay absent from the checkpoint must be removed outright");
+    }
+
+    [Test]
+    public void RestoreCheckpointReconstructsAMismatchedShapeOverlayFromTheCheckpointRowidData()
+    {
+        var overlay = new TransactionMutationOverlay();
+
+        // Seed "shifted" as a WITHOUT ROWID overlay: the shape in effect before the simulated
+        // DROP/CREATE across the savepoint.
+        var withoutRowidCheckpoint = new TransactionMutationOverlayCheckpoint(
+            new Dictionary<string, TransactionTableOverlayCheckpoint>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["shifted"] = new TransactionTableOverlayCheckpoint(
+                    false,
+                    null,
+                    [([SqlValue.Integer(9)], [SqlValue.Integer(9), SqlValue.Text("stale-shape")])]),
+            });
+        overlay.RestoreCheckpoint(withoutRowidCheckpoint, _ => new SqliteIndexRecordComparer());
+        overlay.TryGet("shifted", out var seeded).Should().BeTrue();
+        seeded.HasRowid.Should().BeFalse();
+
+        // Now restore a checkpoint that describes "shifted" as a ROWID table — as if it had been
+        // dropped and recreated with a different shape after the checkpoint was taken but before
+        // this ROLLBACK TO. No resolver is supplied: a ROWID checkpoint target must never need
+        // one, since only a WITHOUT ROWID replacement overlay needs a primary-key comparer.
+        var rowidCheckpoint = new TransactionMutationOverlayCheckpoint(
+            new Dictionary<string, TransactionTableOverlayCheckpoint>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["shifted"] = new TransactionTableOverlayCheckpoint(
+                    true,
+                    new Dictionary<long, SqlValue[]?> { [5] = [SqlValue.Text("recreated")] },
+                    null),
+            });
+        overlay.RestoreCheckpoint(rowidCheckpoint);
+
+        overlay.TryGet("shifted", out var reconstructed).Should().BeTrue();
+        reconstructed.HasRowid.Should().BeTrue(
+            "a shape mismatch between the live overlay and the checkpoint must replace the overlay " +
+            "with a freshly shaped one rather than force mismatched data into the wrong storage");
+        reconstructed.TryGetByRowId(5, out var recreatedRow).Should().BeTrue();
+        recreatedRow.Should().Equal(SqlValue.Text("recreated"));
+        // The old WITHOUT ROWID data is gone by construction: TryGetByPrimaryKey always returns
+        // false on a ROWID-shaped overlay.
+        reconstructed.TryGetByPrimaryKey([SqlValue.Integer(9)], out _).Should().BeFalse();
+    }
+
+    [Test]
+    public void RestoreCheckpointThrowsWhenAWithoutRowidReconstructionNeedsAComparerButNoneWasSupplied()
+    {
+        var overlay = new TransactionMutationOverlay();
+        var checkpoint = new TransactionMutationOverlayCheckpoint(
+            new Dictionary<string, TransactionTableOverlayCheckpoint>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["wr"] = new TransactionTableOverlayCheckpoint(
+                    false,
+                    null,
+                    [([SqlValue.Integer(1)], [SqlValue.Integer(1)])]),
+            });
+
+        var restoreWithoutResolver = () => overlay.RestoreCheckpoint(checkpoint);
+
+        restoreWithoutResolver.Should().Throw<InvalidOperationException>()
+            .WithMessage("*primary-key comparer*");
+    }
+
+    [Test]
+    public void DropAndRecreateWithDifferentRowIdentityDoesNotReuseAnIncompatibleOverlay()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("overlay-recreate-shape.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT);");
+
+        Execute(connection, "BEGIN;");
+        Execute(connection, "INSERT INTO t VALUES (1, 'rowid');");
+        Execute(connection, "DROP TABLE t;");
+        Execute(connection, "CREATE TABLE t(id TEXT PRIMARY KEY, payload TEXT) WITHOUT ROWID;");
+        Execute(connection, "INSERT INTO t VALUES ('key', 'without-rowid');");
+        ReadRows(connection, "SELECT payload FROM t;").Single()[0].AsText()
+            .Should().Be("without-rowid");
+        Execute(connection, "ROLLBACK;");
+
+        ReadRows(connection, "SELECT count(*) FROM t;").Single()[0].AsInteger().Should().Be(0);
+    }
+
+    // --- Finding #5: ResetTransactionState must complete every cleanup step — catalog ---
+    // --- disconnect, pinned-snapshot dispose, savepoint/overlay clearing, write-reservation ---
+    // --- release, and EndTransaction — even when a virtual table's Rollback() callback throws, ---
+    // --- surfacing that callback's exception only after all cleanup has run. ---
+    [Test]
+    public void ResetTransactionStateCompletesAllCleanupEvenWhenAVirtualTableRollbackCallbackThrows()
+    {
+        _ = RollbackFailureModule.Instance;
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("overlay-vtab-rollback-throws.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE t(v INTEGER);");
+        Execute(connection, "INSERT INTO t VALUES (1);");
+        Execute(connection, $"CREATE VIRTUAL TABLE side USING {RollbackFailureModule.ModuleName}();");
+
+        Execute(connection, "BEGIN;");
+        Execute(connection, "INSERT INTO t VALUES (2);");
+        // Only a write against the virtual table registers it as a participant in this
+        // transaction's ManagedVirtualTableTransaction, which is what makes ResetTransactionState
+        // actually invoke its Rollback() callback below.
+        Execute(connection, "INSERT INTO side VALUES (1);");
+
+        RollbackFailureTable.ThrowOnRollback = true;
+        var rollbackWithThrowingVirtualTable = () => Execute(connection, "ROLLBACK;");
+        rollbackWithThrowingVirtualTable.Should().Throw<InvalidOperationException>()
+            .WithMessage("*simulated virtual-table rollback failure*");
+
+        // Despite the virtual table's Rollback() callback throwing, ResetTransactionState must
+        // still have discarded the transaction (t.v = 2 never committed), disposed the pinned
+        // snapshot, released the write reservation, and ended the transaction: a fresh
+        // BEGIN/read/write/COMMIT on the very same connection must work exactly as if the failed
+        // rollback callback had never happened, proving no leaked read mark or lock.
+        Execute(connection, "BEGIN;");
+        ReadRows(connection, "SELECT v FROM t;").Select(row => row[0].AsInteger()).Should().Equal(1L);
+        Execute(connection, "INSERT INTO t VALUES (3);");
+        Execute(connection, "COMMIT;");
+        ReadRows(connection, "SELECT v FROM t ORDER BY v;")
+            .Select(row => row[0].AsInteger()).Should().Equal(1L, 3L);
+
+        // VACUUM's own dispatch throws if the active-transaction count was left nonzero, so a
+        // clean VACUUM here independently proves EndTransaction() ran for this database despite
+        // the earlier throwing rollback callback.
+        Execute(connection, "VACUUM;");
+    }
+
+    private static void Execute(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        statement.Step().Should().Be(StatementStepResult.Done);
+    }
+
+    private static List<SqlValue[]> ReadRows(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        var rows = new List<SqlValue[]>();
+        while (statement.Step() == StatementStepResult.Row)
+        {
+            var values = new SqlValue[statement.GetColumnCount()];
+            for (var ordinal = 0; ordinal < values.Length; ordinal++)
+                values[ordinal] = statement.GetValue(ordinal);
+            rows.Add(values);
+        }
+
+        return rows;
+    }
+
+    /// <summary>Minimal writable virtual-table module whose table simulates a throwing Rollback().</summary>
+    private sealed class RollbackFailureModule : ManagedVirtualTableModule
+    {
+        public const string ModuleName = "overlay_rollback_failure_test";
+
+        public static readonly RollbackFailureModule Instance = Register();
+
+        public override string Name => ModuleName;
+
+        public override ManagedVirtualTable Create(ManagedVirtualTableCreateContext context) => new RollbackFailureTable();
+
+        public override ManagedVirtualTable Create(
+            ManagedVirtualTableCreateContext context,
+            ManagedVirtualTablePersistencePayload payload)
+            => new RollbackFailureTable();
+
+        private static RollbackFailureModule Register()
+        {
+            var module = new RollbackFailureModule();
+            ManagedVirtualTableModuleRegistry.Register(module);
+            return module;
+        }
+    }
+
+    private sealed class RollbackFailureTable : ManagedVirtualTable
+    {
+        private static readonly ManagedVirtualTableSchema TableSchema =
+            new([new ManagedVirtualTableColumn("v", ManagedVirtualTableAffinity.Integer)]);
+
+        [ThreadStatic]
+        public static bool ThrowOnRollback;
+
+        public override ManagedVirtualTableSchema Schema => TableSchema;
+
+        public override ManagedVirtualTablePlan BestIndex(
+            IReadOnlyList<ManagedVirtualTableConstraint> constraints,
+            IReadOnlyList<ManagedVirtualTableOrderBy> orderBy)
+            => new(constraints.Select(static _ => ManagedVirtualTableConstraintUsage.Unused).ToArray());
+
+        public override ManagedVirtualTableCursor Open() => new RollbackFailureCursor();
+
+        public override ManagedVirtualTablePersistencePayload GetPersistencePayload() => new(1, []);
+
+        public override long? Update(IReadOnlyList<SqlValue> arguments) => 1L;
+
+        public override void Rollback()
+        {
+            if (!ThrowOnRollback)
+                return;
+            ThrowOnRollback = false;
+            throw new InvalidOperationException("simulated virtual-table rollback failure");
+        }
+
+        private sealed class RollbackFailureCursor : ManagedVirtualTableCursor
+        {
+            public override bool Filter(ManagedVirtualTablePlan plan, IReadOnlyList<SqlValue> arguments) => true;
+
+            public override void Next()
+            {
+            }
+
+            public override bool Eof => true;
+
+            public override SqlValue Column(int columnIndex)
+                => throw new InvalidOperationException("this test-double virtual table never has rows");
+
+            public override long RowId
+                => throw new InvalidOperationException("this test-double virtual table never has rows");
+        }
+    }
+
+    /// <summary>
+    /// Minimal virtual-table module whose instances record every Disconnect() call by the name
+    /// they were created with, and can be told to throw for one specific name — used to prove a
+    /// catalog owning several instances attempts every instance's disconnect even when one of
+    /// them fails.
+    /// </summary>
+    private sealed class MultiDisconnectModule : ManagedVirtualTableModule
+    {
+        public const string ModuleName = "overlay_multi_disconnect_test";
+
+        public static readonly MultiDisconnectModule Instance = Register();
+
+        public override string Name => ModuleName;
+
+        public override ManagedVirtualTable Create(ManagedVirtualTableCreateContext context)
+            => new MultiDisconnectTable(context.TableName);
+
+        public override ManagedVirtualTable Create(
+            ManagedVirtualTableCreateContext context,
+            ManagedVirtualTablePersistencePayload payload)
+            => new MultiDisconnectTable(context.TableName);
+
+        private static MultiDisconnectModule Register()
+        {
+            var module = new MultiDisconnectModule();
+            ManagedVirtualTableModuleRegistry.Register(module);
+            return module;
+        }
+    }
+
+    private sealed class MultiDisconnectTable(string name) : ManagedVirtualTable
+    {
+        private static readonly ManagedVirtualTableSchema TableSchema =
+            new([new ManagedVirtualTableColumn("v", ManagedVirtualTableAffinity.Integer)]);
+
+        [ThreadStatic]
+        public static string? ThrowOnDisconnectForName;
+
+        [ThreadStatic]
+        public static List<string>? DisconnectedNames;
+
+        public override ManagedVirtualTableSchema Schema => TableSchema;
+
+        public override ManagedVirtualTablePlan BestIndex(
+            IReadOnlyList<ManagedVirtualTableConstraint> constraints,
+            IReadOnlyList<ManagedVirtualTableOrderBy> orderBy)
+            => new(constraints.Select(static _ => ManagedVirtualTableConstraintUsage.Unused).ToArray());
+
+        public override ManagedVirtualTableCursor Open() => new MultiDisconnectCursor();
+
+        public override ManagedVirtualTablePersistencePayload GetPersistencePayload() => new(1, []);
+
+        public override void Disconnect()
+        {
+            DisconnectedNames?.Add(name);
+            if (string.Equals(ThrowOnDisconnectForName, name, StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException($"simulated disconnect failure for '{name}'");
+        }
+
+        private sealed class MultiDisconnectCursor : ManagedVirtualTableCursor
+        {
+            public override bool Filter(ManagedVirtualTablePlan plan, IReadOnlyList<SqlValue> arguments) => true;
+
+            public override void Next()
+            {
+            }
+
+            public override bool Eof => true;
+
+            public override SqlValue Column(int columnIndex)
+                => throw new InvalidOperationException("this test-double virtual table never has rows");
+
+            public override long RowId
+                => throw new InvalidOperationException("this test-double virtual table never has rows");
+        }
+    }
+}

--- a/src/Ahtola.Tests/WithoutRowidIndexSeekJoinTests.cs
+++ b/src/Ahtola.Tests/WithoutRowidIndexSeekJoinTests.cs
@@ -1,0 +1,491 @@
+using AwesomeAssertions;
+using MsData = Microsoft.Data.Sqlite;
+using Ahtola.Core;
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Tests;
+
+/// <summary>
+/// Focused coverage for the WITHOUT ROWID leg of durable join index seeks: committed,
+/// autocommit, file-backed WITHOUT ROWID tables must join through the pager b-tree cursor
+/// (<see cref="VdbeJoinIndexSeekMetrics.DurableCursorPlans"/>, zero
+/// <see cref="VdbeJoinIndexSeekMetrics.IndexRowsMaterialized"/>) for both an equality seek on
+/// the table's own primary-key b-tree and a seek through one of its secondary indexes,
+/// instead of ever materializing an in-memory index view.
+/// </summary>
+public sealed class WithoutRowidIndexSeekJoinTests
+{
+    [Test]
+    public void DurableReopenUsesPagerSeekForPrimaryKeyJoin()
+    {
+        string[] setup =
+        [
+            "CREATE TABLE outer_items(code TEXT);",
+            "CREATE TABLE entry(code TEXT PRIMARY KEY, payload TEXT) WITHOUT ROWID;",
+            "INSERT INTO outer_items VALUES ('key-00002'), ('key-00300');",
+            "INSERT INTO entry VALUES "
+                + string.Join(", ", Enumerable.Range(1, 500).Select(value => $"('key-{value:D5}', 'p{value}')"))
+                + ";",
+            "ANALYZE;",
+        ];
+        const string sql =
+            """
+            SELECT entry.payload
+            FROM outer_items JOIN entry
+            ON outer_items.code = entry.code
+            ORDER BY outer_items.code;
+            """;
+
+        AssertMatchesSqlite(setup, sql);
+
+        var fileSystem = new InMemoryFileSystem();
+        using (var database = EmbeddedDatabase.OpenFile("without-rowid-pk-join.db", fileSystem))
+        using (var connection = database.Connect())
+        {
+            foreach (var statement in setup)
+                Execute(connection, statement);
+        }
+
+        using var reopened = EmbeddedDatabase.OpenFile("without-rowid-pk-join.db", fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        ReadRows(reopenedConnection, "EXPLAIN QUERY PLAN " + sql).Single()[3].AsText()
+            .Should().Be("SEARCH entry USING COVERING INDEX sqlite_autoindex_entry_1 (code=?)");
+
+        reopened.ResetJoinOrderDiagnostics();
+        ReadRows(reopenedConnection, sql).Select(row => row[0].AsText()).Should().Equal("p2", "p300");
+        reopened.JoinIndexSeekMetrics.DurableCursorPlans.Should().BeGreaterThan(0);
+        reopened.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+    }
+
+    [Test]
+    public void DurableReopenUsesPagerSeekForSecondaryIndexJoin()
+    {
+        string[] setup =
+        [
+            "CREATE TABLE outer_items(tag TEXT);",
+            "CREATE TABLE entry(code TEXT PRIMARY KEY, tag TEXT) WITHOUT ROWID;",
+            "CREATE INDEX entry_tag ON entry(tag);",
+            "INSERT INTO outer_items VALUES ('t-00002'), ('t-00300');",
+            "INSERT INTO entry VALUES "
+                + string.Join(
+                    ", ",
+                    Enumerable.Range(1, 500).Select(value => $"('key-{value:D5}', 't-{value:D5}')"))
+                + ";",
+            "ANALYZE;",
+        ];
+        // entry_tag's storage columns (its own column + the appended PK suffix) are tag and code,
+        // which is every column the table has -- so this candidate is fully covering.
+        const string sql =
+            """
+            SELECT entry.code
+            FROM outer_items JOIN entry INDEXED BY entry_tag
+            ON outer_items.tag = entry.tag
+            ORDER BY outer_items.tag;
+            """;
+
+        AssertMatchesSqlite(setup, sql);
+
+        var fileSystem = new InMemoryFileSystem();
+        using (var database = EmbeddedDatabase.OpenFile("without-rowid-secondary-join.db", fileSystem))
+        using (var connection = database.Connect())
+        {
+            foreach (var statement in setup)
+                Execute(connection, statement);
+        }
+
+        using var reopened = EmbeddedDatabase.OpenFile("without-rowid-secondary-join.db", fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        ReadRows(reopenedConnection, "EXPLAIN QUERY PLAN " + sql).Single()[3].AsText()
+            .Should().Be("SEARCH entry USING COVERING INDEX entry_tag (tag=?)");
+
+        reopened.ResetJoinOrderDiagnostics();
+        ReadRows(reopenedConnection, sql).Select(row => row[0].AsText()).Should().Equal("key-00002", "key-00300");
+        reopened.JoinIndexSeekMetrics.DurableCursorPlans.Should().BeGreaterThan(0);
+        reopened.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+    }
+
+    [Test]
+    public void DurableReopenUsesPagerSeekForNonCoveringSecondaryIndexJoin()
+    {
+        string[] setup =
+        [
+            "CREATE TABLE outer_items(tag TEXT);",
+            "CREATE TABLE entry(code TEXT PRIMARY KEY, tag TEXT, payload TEXT, extra TEXT) WITHOUT ROWID;",
+            "CREATE INDEX entry_tag ON entry(tag);",
+            "INSERT INTO outer_items VALUES ('t-00002'), ('t-00300');",
+            "INSERT INTO entry VALUES "
+                + string.Join(
+                    ", ",
+                    Enumerable.Range(1, 500)
+                        .Select(value => $"('key-{value:D5}', 't-{value:D5}', 'p{value}', 'x{value}')"))
+                + ";",
+            "ANALYZE;",
+        ];
+        // entry.extra is not part of entry_tag's storage columns (index columns + PK suffix), so
+        // this join must stay non-covering and still fetch the table root row.
+        const string sql =
+            """
+            SELECT entry.payload, entry.extra
+            FROM outer_items JOIN entry INDEXED BY entry_tag
+            ON outer_items.tag = entry.tag
+            ORDER BY outer_items.tag;
+            """;
+
+        AssertMatchesSqlite(setup, sql);
+
+        var fileSystem = new InMemoryFileSystem();
+        using (var database = EmbeddedDatabase.OpenFile("without-rowid-noncovering-join.db", fileSystem))
+        using (var connection = database.Connect())
+        {
+            foreach (var statement in setup)
+                Execute(connection, statement);
+        }
+
+        using var reopened = EmbeddedDatabase.OpenFile("without-rowid-noncovering-join.db", fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        ReadRows(reopenedConnection, "EXPLAIN QUERY PLAN " + sql).Single()[3].AsText()
+            .Should().Be("SEARCH entry USING INDEX entry_tag (tag=?)");
+
+        reopened.ResetJoinOrderDiagnostics();
+        ReadRows(reopenedConnection, sql).Select(row => (row[0].AsText(), row[1].AsText()))
+            .Should().Equal(("p2", "x2"), ("p300", "x300"));
+        reopened.JoinIndexSeekMetrics.DurableCursorPlans.Should().BeGreaterThan(0);
+        reopened.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+    }
+
+    [Test]
+    public void DurableReopenUsesPagerSeekForCompositePrimaryKeySuffixLookup()
+    {
+        string[] setup =
+        [
+            "CREATE TABLE outer_items(part TEXT);",
+            "CREATE TABLE entry(part TEXT, seq INTEGER, payload TEXT, PRIMARY KEY(part, seq)) WITHOUT ROWID;",
+            "INSERT INTO outer_items VALUES ('a'), ('c');",
+            "INSERT INTO entry VALUES "
+                + string.Join(
+                    ", ",
+                    new[] { "a", "b", "c" }.SelectMany(part =>
+                        Enumerable.Range(1, 100).Select(seq => $"('{part}', {seq}, 'p-{part}-{seq}')")))
+                + ";",
+            "ANALYZE;",
+        ];
+        // Only the leading PK term (part) is bound by the join predicate; seq is unconstrained,
+        // so the durable seek must use a one-column prefix of the composite two-column PK.
+        const string sql =
+            """
+            SELECT entry.seq, entry.payload
+            FROM outer_items JOIN entry
+            ON outer_items.part = entry.part
+            ORDER BY outer_items.part, entry.seq;
+            """;
+
+        AssertMatchesSqlite(setup, sql);
+
+        var fileSystem = new InMemoryFileSystem();
+        using (var database = EmbeddedDatabase.OpenFile("without-rowid-composite-pk-join.db", fileSystem))
+        using (var connection = database.Connect())
+        {
+            foreach (var statement in setup)
+                Execute(connection, statement);
+        }
+
+        using var reopened = EmbeddedDatabase.OpenFile("without-rowid-composite-pk-join.db", fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        ReadRows(reopenedConnection, "EXPLAIN QUERY PLAN " + sql).Single()[3].AsText()
+            .Should().Be("SEARCH entry USING COVERING INDEX sqlite_autoindex_entry_1 (part=?)");
+
+        reopened.ResetJoinOrderDiagnostics();
+        var rows = ReadRows(reopenedConnection, sql);
+        rows.Should().HaveCount(200);
+        rows.Select(row => row[1].AsText()).Take(3).Should().Equal("p-a-1", "p-a-2", "p-a-3");
+        reopened.JoinIndexSeekMetrics.DurableCursorPlans.Should().BeGreaterThan(0);
+        reopened.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+    }
+
+    [Test]
+    public void DurableReopenUsesPagerSeekWhenSecondaryIndexHasDuplicateValues()
+    {
+        string[] setup =
+        [
+            "CREATE TABLE outer_items(tag TEXT);",
+            "CREATE TABLE entry(code TEXT PRIMARY KEY, tag TEXT, payload TEXT) WITHOUT ROWID;",
+            "CREATE INDEX entry_tag ON entry(tag);",
+            "INSERT INTO outer_items VALUES ('shared');",
+            // Every row shares the same secondary-index key: the pager seek must land on every
+            // matching leaf entry and disambiguate by the PK suffix carried in the index record.
+            "INSERT INTO entry VALUES "
+                + string.Join(
+                    ", ",
+                    Enumerable.Range(1, 300).Select(value => $"('key-{value:D5}', 'shared', 'p{value}')"))
+                + ";",
+            "ANALYZE;",
+        ];
+        const string sql =
+            """
+            SELECT entry.payload
+            FROM outer_items JOIN entry INDEXED BY entry_tag
+            ON outer_items.tag = entry.tag
+            ORDER BY entry.payload;
+            """;
+
+        AssertMatchesSqlite(setup, sql);
+
+        var fileSystem = new InMemoryFileSystem();
+        using (var database = EmbeddedDatabase.OpenFile("without-rowid-duplicate-secondary.db", fileSystem))
+        using (var connection = database.Connect())
+        {
+            foreach (var statement in setup)
+                Execute(connection, statement);
+        }
+
+        using var reopened = EmbeddedDatabase.OpenFile("without-rowid-duplicate-secondary.db", fileSystem);
+        using var reopenedConnection = reopened.Connect();
+        ReadRows(reopenedConnection, "EXPLAIN QUERY PLAN " + sql).Single()[3].AsText()
+            .Should().Be("SEARCH entry USING INDEX entry_tag (tag=?)");
+
+        reopened.ResetJoinOrderDiagnostics();
+        var expected = Enumerable.Range(1, 300).Select(value => $"p{value}")
+            .OrderBy(value => value, StringComparer.Ordinal)
+            .ToArray();
+        ReadRows(reopenedConnection, sql).Select(row => row[0].AsText()).Should().Equal(expected);
+        reopened.JoinIndexSeekMetrics.DurableCursorPlans.Should().BeGreaterThan(0);
+        reopened.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+    }
+
+    [Test]
+    public void PrimaryKeyJoinDeclinesWhenIndexedByNamesADifferentIndex()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("without-rowid-indexed-by-guard.db", fileSystem);
+        using var connection = database.Connect();
+        Execute(connection, "CREATE TABLE outer_items(code TEXT, tag TEXT);");
+        Execute(connection, "CREATE TABLE entry(code TEXT PRIMARY KEY, tag TEXT, payload TEXT) WITHOUT ROWID;");
+        Execute(connection, "CREATE INDEX entry_tag ON entry(tag);");
+        Execute(connection, "INSERT INTO outer_items VALUES ('key-1', 't1'), ('key-2', 't2');");
+        Execute(connection, "INSERT INTO entry VALUES ('key-1', 't1', 'p1'), ('key-2', 't2', 'p2');");
+        Execute(connection, "ANALYZE;");
+
+        // INDEXED BY names entry_tag explicitly, so the implicit primary-key candidate must be
+        // suppressed even though outer_items.code = entry.code would otherwise be eligible.
+        const string sql =
+            """
+            SELECT entry.payload
+            FROM outer_items JOIN entry INDEXED BY entry_tag
+            ON outer_items.code = entry.code AND outer_items.tag = entry.tag
+            ORDER BY entry.payload;
+            """;
+        ReadRows(connection, "EXPLAIN QUERY PLAN " + sql).Single()[3].AsText()
+            .Should().NotContain("sqlite_autoindex_entry_1");
+        ReadRows(connection, sql).Select(row => row[0].AsText()).Should().Equal("p1", "p2");
+    }
+
+    [Test]
+    public void PrimaryKeyJoinWithoutOrderByStillUsesTheCostedPagerSeek()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using (var database = EmbeddedDatabase.OpenFile("without-rowid-pk-no-order.db", fileSystem))
+        using (var setupConnection = database.Connect())
+        {
+            Execute(setupConnection, "CREATE TABLE outer_items(code TEXT);");
+            Execute(setupConnection, "CREATE TABLE entry(code TEXT PRIMARY KEY, payload TEXT) WITHOUT ROWID;");
+            Execute(setupConnection, "INSERT INTO outer_items VALUES ('key-2');");
+            Execute(setupConnection, "INSERT INTO entry VALUES ('key-1','p1'),('key-2','p2');");
+            Execute(setupConnection, "ANALYZE;");
+            ReadRows(setupConnection, "SELECT idx FROM sqlite_stat1 WHERE tbl='entry';")
+                .Single()[0].AsText().Should().Be("entry");
+        }
+
+        using var reopened = EmbeddedDatabase.OpenFile("without-rowid-pk-no-order.db", fileSystem);
+        using var connection = reopened.Connect();
+        const string sql =
+            "SELECT entry.payload FROM outer_items JOIN entry ON outer_items.code=entry.code;";
+        ReadRows(connection, "EXPLAIN QUERY PLAN " + sql).Single()[3].AsText()
+            .Should().Contain("sqlite_autoindex_entry_1");
+        reopened.ResetJoinOrderDiagnostics();
+        ReadRows(connection, sql).Single()[0].AsText().Should().Be("p2");
+        reopened.JoinIndexSeekMetrics.DurableCursorPlans.Should().BeGreaterThan(0);
+        reopened.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+    }
+
+    [Test]
+    public void IndexedByMayNameTheWithoutRowidPrimaryKey()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        using (var database = EmbeddedDatabase.OpenFile("without-rowid-pk-indexed-by.db", fileSystem))
+        using (var setupConnection = database.Connect())
+        {
+            Execute(setupConnection, "CREATE TABLE outer_items(code TEXT);");
+            Execute(setupConnection, "CREATE TABLE entry(code TEXT PRIMARY KEY, payload TEXT) WITHOUT ROWID;");
+            Execute(setupConnection, "INSERT INTO outer_items VALUES ('key-2');");
+            Execute(setupConnection, "INSERT INTO entry VALUES ('key-1','p1'),('key-2','p2');");
+            Execute(setupConnection, "ANALYZE;");
+        }
+
+        using var reopened = EmbeddedDatabase.OpenFile("without-rowid-pk-indexed-by.db", fileSystem);
+        using var connection = reopened.Connect();
+        const string sql =
+            """
+            SELECT entry.payload
+            FROM outer_items JOIN entry INDEXED BY sqlite_autoindex_entry_1
+            ON outer_items.code=entry.code;
+            """;
+        ReadRows(connection, sql).Single()[0].AsText().Should().Be("p2");
+        reopened.JoinIndexSeekMetrics.DurableCursorPlans.Should().BeGreaterThan(0);
+        reopened.JoinIndexSeekMetrics.IndexRowsMaterialized.Should().Be(0);
+    }
+
+    [Test]
+    public void PrimaryKeyJoinDeclinesSearchWhenBinaryCollationIsOverridden()
+    {
+        // Finding #3 regression: entry's own root page is a WITHOUT ROWID primary-key b-tree, but
+        // CreatePrimaryKeyComparer (EmbeddedFileStore) never binds a live collation-resolver
+        // override to a primary-key term -- unlike GetIndexCollation for a secondary index -- so
+        // the durable b-tree's physical order always stays plain BINARY, permanently. Once an
+        // application overrides BINARY, the live evaluator (EmbeddedDatabase.Compare, per the
+        // Finding #1 fix) computes "equal"/"less than" using the override, while this table's own
+        // root page is still ordered by the untouched built-in comparison -- a seek that assumed
+        // the two agreed could silently miss matching rows or return the wrong ones. The implicit
+        // primary-key candidate must therefore be withdrawn entirely while any override is active,
+        // for both the planner's own automatic choice and an explicit INDEXED BY/NOT INDEXED
+        // comparison, and the query must still return correct rows via whatever plan replaces it.
+        var fileSystem = new InMemoryFileSystem();
+        using var database = EmbeddedDatabase.OpenFile("without-rowid-pk-overridden-binary.db", fileSystem);
+        using var connection = database.Connect();
+
+        Execute(connection, "CREATE TABLE outer_items(code TEXT);");
+        Execute(connection, "CREATE TABLE entry(code TEXT PRIMARY KEY, payload TEXT) WITHOUT ROWID;");
+        Execute(connection, "INSERT INTO outer_items VALUES ('key-00002'), ('key-00300');");
+        Execute(
+            connection,
+            "INSERT INTO entry VALUES "
+                + string.Join(", ", Enumerable.Range(1, 500).Select(value => $"('key-{value:D5}', 'p{value}')"))
+                + ";");
+        Execute(connection, "ANALYZE;");
+
+        const string defaultSql =
+            """
+            SELECT entry.payload
+            FROM outer_items JOIN entry
+            ON outer_items.code = entry.code
+            ORDER BY outer_items.code;
+            """;
+        const string notIndexedSql =
+            """
+            SELECT entry.payload
+            FROM outer_items JOIN entry NOT INDEXED
+            ON outer_items.code = entry.code
+            ORDER BY outer_items.code;
+            """;
+
+        // Baseline, no override yet: the implicit primary-key candidate is offered and used, so
+        // the freely-planned query genuinely searches while the NOT INDEXED one does not.
+        ReadRows(connection, "EXPLAIN QUERY PLAN " + defaultSql).Single()[3].AsText()
+            .Should().Be("SEARCH entry USING COVERING INDEX sqlite_autoindex_entry_1 (code=?)");
+        database.ResetJoinOrderDiagnostics();
+        ReadRows(connection, defaultSql).Select(row => row[0].AsText()).Should().Equal("p2", "p300");
+        database.JoinIndexSeekMetrics.DurableCursorPlans.Should().BeGreaterThan(0);
+
+        database.RegisterCollation(
+            "BINARY",
+            static (left, right) => string.Compare(left, right, StringComparison.OrdinalIgnoreCase));
+
+        // With BINARY overridden, neither the planner's own automatic choice nor an explicit NOT
+        // INDEXED scan may ever show a SEARCH plan against entry's primary-key b-tree, and the two
+        // must agree on results -- proving the withdrawal, not just a coincidentally-matching
+        // fallback plan shape.
+        ReadRows(connection, "EXPLAIN QUERY PLAN " + defaultSql)
+            .Select(row => row[3].AsText())
+            .Should().NotContain(value => value.StartsWith("SEARCH ", StringComparison.Ordinal));
+        ReadRows(connection, "EXPLAIN QUERY PLAN " + notIndexedSql)
+            .Select(row => row[3].AsText())
+            .Should().NotContain(value => value.StartsWith("SEARCH ", StringComparison.Ordinal));
+        ReadRows(connection, defaultSql).Select(row => row[0].AsText()).Should().Equal("p2", "p300");
+        ReadRows(connection, notIndexedSql).Select(row => row[0].AsText()).Should().Equal("p2", "p300");
+    }
+
+    private static void AssertMatchesSqlite(IReadOnlyList<string> setup, string sql)
+    {
+        using var managed = OpenManaged(setup);
+        var managedRows = ReadRows(managed, sql);
+        using var sqlite = new MsData.SqliteConnection("Data Source=:memory:");
+        sqlite.Open();
+        foreach (var statement in setup)
+        {
+            using var command = sqlite.CreateCommand();
+            command.CommandText = statement;
+            command.ExecuteNonQuery();
+        }
+
+        using var query = sqlite.CreateCommand();
+        query.CommandText = sql;
+        using var reader = query.ExecuteReader();
+        var sqliteRows = new List<object?[]>();
+        while (reader.Read())
+        {
+            var row = new object?[reader.FieldCount];
+            for (var index = 0; index < row.Length; index++)
+                row[index] = reader.IsDBNull(index) ? null : reader.GetValue(index);
+            sqliteRows.Add(row);
+        }
+
+        managedRows.Should().HaveCount(sqliteRows.Count);
+        for (var row = 0; row < sqliteRows.Count; row++)
+        {
+            for (var column = 0; column < sqliteRows[row].Length; column++)
+                CellShouldMatch(managedRows[row][column], sqliteRows[row][column], row, column);
+        }
+    }
+
+    private static EmbeddedConnection OpenManaged(IReadOnlyList<string> setup)
+    {
+        var connection = new EmbeddedDatabase().Connect();
+        foreach (var statement in setup)
+            Execute(connection, statement);
+        return connection;
+    }
+
+    private static void CellShouldMatch(SqlValue managed, object? sqlite, int row, int column)
+    {
+        switch (sqlite)
+        {
+            case null:
+                managed.Should().Be(SqlValue.Null, $"at row {row}, column {column}");
+                break;
+            case long integer:
+                managed.Should().Be(SqlValue.Integer(integer), $"at row {row}, column {column}");
+                break;
+            case double real:
+                managed.Should().Be(SqlValue.Real(real), $"at row {row}, column {column}");
+                break;
+            case string text:
+                managed.Should().Be(SqlValue.Text(text), $"at row {row}, column {column}");
+                break;
+            case byte[] blob:
+                managed.AsBlob().ToArray().Should().Equal(blob);
+                break;
+            default:
+                throw new InvalidOperationException($"Unsupported SQLite value type {sqlite.GetType()}.");
+        }
+    }
+
+    private static void Execute(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        statement.Step().Should().Be(StatementStepResult.Done);
+    }
+
+    private static List<SqlValue[]> ReadRows(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        var rows = new List<SqlValue[]>();
+        while (statement.Step() == StatementStepResult.Row)
+        {
+            var values = new SqlValue[statement.GetColumnCount()];
+            for (var ordinal = 0; ordinal < values.Length; ordinal++)
+                values[ordinal] = statement.GetValue(ordinal);
+            rows.Add(values);
+        }
+
+        return rows;
+    }
+}

--- a/src/Ahtola.Tests/WithoutRowidIndexTablePersistenceSliceTests.cs
+++ b/src/Ahtola.Tests/WithoutRowidIndexTablePersistenceSliceTests.cs
@@ -133,8 +133,12 @@ public sealed class WithoutRowidIndexTablePersistenceSliceTests
             connection,
             "CREATE INDEX entry_value ON entry(value COLLATE custom_collation);");
 
+        // "custom_collation" is a valid application-defined collation name, but nothing has
+        // registered a callback for it on this connection, so CREATE INDEX must fail closed with
+        // the SQLite-style "no such collation sequence" message instead of the old unconditional
+        // "application-defined collations are rejected" wording (see CustomCollationIndexTests).
         rejected.Should().Throw<EmbeddedSqlException>()
-            .WithMessage("*application-defined collation 'CUSTOM_COLLATION'*");
+            .WithMessage("*no such collation sequence*custom_collation*");
         faults.GetOperationCount(FileSystemOperation.Write).Should().Be(writesBeforeReject);
         faults.ClearScheduled();
         Scalar(connection, "SELECT value FROM entry WHERE code = 'saved';").AsText().Should().Be("durable");


### PR DESCRIPTION
## Summary

- align System-R subset planning with Turso's 12-member threshold and retain deterministic greedy planning through SQLite's 64-table limit
- add direct pager seeks for partial/expression indexes and `WITHOUT ROWID` primary/secondary indexes
- merge pinned pager snapshots with savepoint-aware classic transaction overlays and MVCC version streams instead of rebuilding complete indexes
- support validated connection-bound custom-collation secondary indexes, including targeted `REINDEX` and preservation of unavailable unchanged trees
- harden snapshot, callback, root-page, WAL/freelist, statement-failure, and transaction/savepoint lifecycle paths
- update planner and MVCC parity documentation

## Validation

- `./build.ps1 test`: 7,000 passed, 0 failed
- `./build.ps1 build`: all target frameworks, 0 warnings and 0 errors
- focused planner/direct-index regression suites: 149 passed

## Remaining boundaries

- custom-collated `WITHOUT ROWID` primary keys remain fail-closed
- unsupported range shapes retain deterministic fallback
- OUTER/NATURAL/USING reorder barriers remain correctness-preserving