### PR TITLE
Close first half of VDBE gaps vs Turso: opcodes 146–165

### DIFF
--- a/src/Ahtola.Core/Compilation/CompoundProgramBuilder.cs
+++ b/src/Ahtola.Core/Compilation/CompoundProgramBuilder.cs
@@ -146,6 +146,7 @@ public static class CompoundProgramBuilder
         var distinctBase = new int[count];
         var instructionBase = new int[count];
         var parameterSlotBase = new int[count];
+        var hashTableBase = new int[count];
 
         var totalRegisters = 0;
         var totalCursors = 0;
@@ -154,6 +155,7 @@ public static class CompoundProgramBuilder
         var totalDistinctSets = 0;
         var totalInstructions = 0;
         var totalParameterSlots = 0;
+        var totalHashTables = 0;
         for (var i = 0; i < count; i++)
         {
             var program = terms[i].Program;
@@ -164,6 +166,7 @@ public static class CompoundProgramBuilder
             distinctBase[i] = totalDistinctSets;
             instructionBase[i] = totalInstructions;
             parameterSlotBase[i] = totalParameterSlots;
+            hashTableBase[i] = totalHashTables;
 
             totalRegisters += program.RegisterCount;
             totalCursors += program.CursorCount;
@@ -173,6 +176,7 @@ public static class CompoundProgramBuilder
             totalInstructions += KeptInstructionCount(program, isLast: i == count - 1)
                 + (i == count - 1 ? 0 : program.AccumulatorCount);
             totalParameterSlots += program.ParameterSlotCount;
+            totalHashTables += program.HashTableCount;
         }
 
         // The outer distinct set (for BuildUnionDistinct) is allocated after every term's own sets; the
@@ -198,6 +202,7 @@ public static class CompoundProgramBuilder
                     distinctBase[i],
                     instructionBase[i],
                     parameterSlotBase[i],
+                    hashTableBase[i],
                     distinctEquality,
                     outerDistinctSet));
             }
@@ -220,7 +225,8 @@ public static class CompoundProgramBuilder
             totalSorters,
             totalAccumulators,
             combinedDistinctSets,
-            totalParameterSlots);
+            totalParameterSlots,
+            hashTableCount: totalHashTables);
         return new CompoundTerm(combined, cursorSources);
     }
 
@@ -271,6 +277,7 @@ public static class CompoundProgramBuilder
         var distinctBase = new int[count];
         var instructionBase = new int[count];
         var parameterSlotBase = new int[count];
+        var hashTableBase = new int[count];
 
         var totalRegisters = 0;
         var totalCursors = 0;
@@ -279,6 +286,7 @@ public static class CompoundProgramBuilder
         var totalDistinctSets = 0;
         var totalInstructions = 0;
         var totalParameterSlots = 0;
+        var totalHashTables = 0;
         for (var termIndex = 0; termIndex < count; termIndex++)
         {
             var program = terms[termIndex].Program;
@@ -289,6 +297,7 @@ public static class CompoundProgramBuilder
             distinctBase[termIndex] = totalDistinctSets;
             instructionBase[termIndex] = totalInstructions;
             parameterSlotBase[termIndex] = totalParameterSlots;
+            hashTableBase[termIndex] = totalHashTables;
 
             totalRegisters += program.RegisterCount;
             totalCursors += program.CursorCount;
@@ -298,6 +307,7 @@ public static class CompoundProgramBuilder
             totalInstructions += KeptInstructionCount(program, isLast: false)
                 + program.AccumulatorCount;
             totalParameterSlots += program.ParameterSlotCount;
+            totalHashTables += program.HashTableCount;
         }
 
         var capturesSingleSet = mode is null;
@@ -331,6 +341,7 @@ public static class CompoundProgramBuilder
                     distinctBase[termIndex],
                     instructionBase[termIndex],
                     parameterSlotBase[termIndex],
+                    hashTableBase[termIndex],
                     rowEquality,
                     captureSets[termIndex]));
             }
@@ -370,7 +381,8 @@ public static class CompoundProgramBuilder
             totalSorters,
             totalAccumulators,
             combinedDistinctSets,
-            totalParameterSlots);
+            totalParameterSlots,
+            hashTableCount: totalHashTables);
         return new CompoundTerm(combinedSetOp, cursorSources);
     }
 
@@ -425,6 +437,7 @@ public static class CompoundProgramBuilder
         int distinctBase,
         int instructionBase,
         int parameterSlotBase,
+        int hashTableBase,
         VdbeRowEquality? distinctEquality,
         int outerDistinctSet)
     {
@@ -436,7 +449,8 @@ public static class CompoundProgramBuilder
                 accumulatorBase,
                 distinctBase,
                 instructionBase,
-                parameterSlotBase)
+                parameterSlotBase,
+                hashTableBase)
             is { } structural)
         {
             return structural;
@@ -520,6 +534,7 @@ public static class CompoundProgramBuilder
         int distinctBase,
         int instructionBase,
         int parameterSlotBase,
+        int hashTableBase,
         VdbeRowEquality equality,
         int captureSet)
     {
@@ -531,7 +546,8 @@ public static class CompoundProgramBuilder
                 accumulatorBase,
                 distinctBase,
                 instructionBase,
-                parameterSlotBase)
+                parameterSlotBase,
+                hashTableBase)
             is { } structural)
         {
             return structural;
@@ -593,7 +609,8 @@ public static class CompoundProgramBuilder
         int accumulatorBase,
         int distinctBase,
         int instructionBase,
-        int parameterSlotBase)
+        int parameterSlotBase,
+        int hashTableBase)
     {
         Register Reg(Register register) => new(register.Index + registerBase);
         Cursor Cur(Cursor cursor) => new(cursor.Index + cursorBase);
@@ -636,6 +653,7 @@ public static class CompoundProgramBuilder
             AggStepInstruction x => new AggStepInstruction(Acc(x.Accumulator), x.Aggregate, Range(x.Arguments)),
             AggInverseInstruction x => new AggInverseInstruction(Acc(x.Accumulator), x.Aggregate, Range(x.Arguments)),
             AggFinalizeInstruction x => new AggFinalizeInstruction(Acc(x.Accumulator), x.Aggregate, Reg(x.Destination)),
+            AggValueInstruction x => new AggValueInstruction(Acc(x.Accumulator), x.Aggregate, Reg(x.Destination)),
             SameGroupInstruction x => new SameGroupInstruction(Range(x.CurrentKey), Range(x.SavedKey), x.Comparer, Pc(x.SameGroupTarget)),
             RowSetInsertInstruction x => new RowSetInsertInstruction(
                 Range(x.Values),
@@ -658,6 +676,53 @@ public static class CompoundProgramBuilder
                         destination.Equality,
                         destination.RowSetIndex + distinctBase)),
             RewindCursorInstruction x => new RewindCursorInstruction(Cur(x.Cursor), Pc(x.EmptyTarget)),
+            OpenAutoindexInstruction x => new OpenAutoindexInstruction(Cur(x.Cursor), x.ColumnCount),
+            OpenDupInstruction x => new OpenDupInstruction(Cur(x.NewCursor), Cur(x.OriginalCursor)),
+            ResetSorterInstruction x => new ResetSorterInstruction(Cur(x.Cursor)),
+            ColumnHasFieldInstruction x => new ColumnHasFieldInstruction(Cur(x.Cursor), x.Column, Pc(x.Target)),
+            DeferredSeekInstruction x => new DeferredSeekInstruction(Cur(x.IndexCursor), Cur(x.TableCursor)),
+            SeekEndInstruction x => new SeekEndInstruction(Cur(x.Cursor)),
+            BloomFilterInstruction x => new BloomFilterInstruction(Cur(x.Cursor), Range(x.Key), Pc(x.NotPresentTarget)),
+            BloomFilterAddInstruction x => new BloomFilterAddInstruction(Cur(x.Cursor), Range(x.Key)),
+            HashBuildInstruction x => new HashBuildInstruction(
+                Cur(x.Cursor),
+                Range(x.Key),
+                x.HashTableId + hashTableBase,
+                x.MemoryBudget,
+                x.Collations,
+                x.Payload is { } payload ? Range(payload) : null,
+                x.TrackMatched),
+            HashDistinctInstruction x => new HashDistinctInstruction(
+                Range(x.Key),
+                x.Collations,
+                x.HashTableId + hashTableBase,
+                Pc(x.DuplicateTarget)),
+            HashBuildFinalizeInstruction x => new HashBuildFinalizeInstruction(x.HashTableId + hashTableBase),
+            HashProbeInstruction x => new HashProbeInstruction(
+                x.HashTableId + hashTableBase,
+                Range(x.Key),
+                Reg(x.Destination),
+                x.PayloadDestination is { } payloadDest ? Range(payloadDest) : null,
+                Pc(x.NotFoundTarget)),
+            HashNextInstruction x => new HashNextInstruction(
+                x.HashTableId + hashTableBase,
+                Reg(x.Destination),
+                x.PayloadDestination is { } payloadDest ? Range(payloadDest) : null,
+                Pc(x.ExhaustedTarget)),
+            HashCloseInstruction x => new HashCloseInstruction(x.HashTableId + hashTableBase),
+            HashClearInstruction x => new HashClearInstruction(x.HashTableId + hashTableBase),
+            HashMarkMatchedInstruction x => new HashMarkMatchedInstruction(x.HashTableId + hashTableBase),
+            HashResetMatchedInstruction x => new HashResetMatchedInstruction(x.HashTableId + hashTableBase),
+            HashScanUnmatchedInstruction x => new HashScanUnmatchedInstruction(
+                x.HashTableId + hashTableBase,
+                Reg(x.Destination),
+                x.PayloadDestination is { } payloadDest ? Range(payloadDest) : null,
+                Pc(x.ExhaustedTarget)),
+            HashNextUnmatchedInstruction x => new HashNextUnmatchedInstruction(
+                x.HashTableId + hashTableBase,
+                Reg(x.Destination),
+                x.PayloadDestination is { } payloadDest ? Range(payloadDest) : null,
+                Pc(x.ExhaustedTarget)),
             ColumnInstruction x => new ColumnInstruction(Cur(x.Cursor), x.ColumnIndex, Reg(x.Destination)),
             RowIdInstruction x => new RowIdInstruction(Cur(x.Cursor), Reg(x.Destination)),
             DeleteInstruction x => new DeleteInstruction(Cur(x.Cursor)),

--- a/src/Ahtola.Core/Execution/ResumableStatement.cs
+++ b/src/Ahtola.Core/Execution/ResumableStatement.cs
@@ -38,6 +38,7 @@ public sealed class ResumableStatement : IDisposable
     private readonly VdbeRecordValue?[] _recordRegisters;
     private readonly bool[] _openCursors;
     private readonly int[] _cursorPositions;
+    private readonly (int IndexCursor, int TableCursor)?[] _deferredSeeks;
     private readonly bool[] _skipLastInsertRowId;
     private readonly SqlValue[]?[] _materializedRows;
     private readonly long[] _materializedRowIds;
@@ -50,6 +51,8 @@ public sealed class ResumableStatement : IDisposable
     private readonly List<SqlValue[]>?[] _groupKeys;
     private readonly Dictionary<SqlValue[], int>?[] _groupIndexes;
     private readonly Dictionary<int, IntegerRowSet> _integerRowSets = [];
+    private readonly Dictionary<int, VdbeBloomFilter> _bloomFilters = [];
+    private readonly Dictionary<int, VdbeHashTable> _hashTables = [];
     private readonly Dictionary<int, ResumableStatement> _subprogramStatements = [];
     private readonly WorkTableRuntime?[] _workTables;
     private readonly WindowBufferRuntime?[] _windowBuffers;
@@ -156,6 +159,7 @@ public sealed class ResumableStatement : IDisposable
         _recordRegisters = _registers.Records;
         _openCursors = new bool[program.CursorCount];
         _cursorPositions = new int[program.CursorCount];
+        _deferredSeeks = new (int IndexCursor, int TableCursor)?[program.CursorCount];
         _skipLastInsertRowId = new bool[program.CursorCount];
         _materializedRows = new SqlValue[program.CursorCount][];
         _materializedRowIds = new long[program.CursorCount];
@@ -420,6 +424,251 @@ public sealed class ResumableStatement : IDisposable
                     _materializedRows[openEphemeral.Cursor.Index] = null;
                     AdvanceInstructionPointer();
                     break;
+                case OpenAutoindexInstruction openAutoindex:
+                    // Turso's OpenAutoindex is OpenEphemeral with is_table=false; the managed
+                    // ephemeral runtime has no separate index shape, so both share one path.
+                    OpenCursor(openAutoindex.Cursor);
+                    _ephemeralTables[openAutoindex.Cursor.Index] = new EphemeralTableRuntime(
+                        openAutoindex.ColumnCount,
+                        _memory);
+                    _cursorPositions[openAutoindex.Cursor.Index] = -1;
+                    _materializedRows[openAutoindex.Cursor.Index] = null;
+                    AdvanceInstructionPointer();
+                    break;
+                case OpenDupInstruction openDup:
+                    {
+                        // Turso's OpenDup opens a fresh cursor over the same underlying data.
+                        // Both cursors share one runtime, so closing either disposes it for both.
+                        var original = RequireEphemeralTable(openDup.OriginalCursor);
+                        OpenCursor(openDup.NewCursor);
+                        _ephemeralTables[openDup.NewCursor.Index] = original;
+                        _cursorPositions[openDup.NewCursor.Index] = -1;
+                        _materializedRows[openDup.NewCursor.Index] = null;
+                        AdvanceInstructionPointer();
+                        break;
+                    }
+                case ResetSorterInstruction resetSorter:
+                    {
+                        // Turso clears the ephemeral b-tree; callers ensure this only targets
+                        // ephemeral tables (window partition boundaries).
+                        var table = RequireEphemeralTable(resetSorter.Cursor);
+                        table.Clear();
+                        _cursorPositions[resetSorter.Cursor.Index] = -1;
+                        _materializedRows[resetSorter.Cursor.Index] = null;
+                        AdvanceInstructionPointer();
+                        break;
+                    }
+                case DeferredSeekInstruction deferredSeek:
+                    // Mirrors Turso's op_deferred_seek: record the (index, table) pairing and let
+                    // the next Column/RowId read on the table cursor perform the actual seek.
+                    _deferredSeeks[deferredSeek.TableCursor.Index] =
+                        (deferredSeek.IndexCursor.Index, deferredSeek.TableCursor.Index);
+                    AdvanceInstructionPointer();
+                    break;
+                case SeekEndInstruction seekEnd:
+                    // Mirrors Turso's op_seek_end: position past the last row so Prev walks the
+                    // rows backwards while Next exits immediately.
+                    _materializedRows[seekEnd.Cursor.Index] = null;
+                    _cursorPositions[seekEnd.Cursor.Index] = CursorRowCount(seekEnd.Cursor);
+                    AdvanceInstructionPointer();
+                    break;
+                case BloomFilterAddInstruction bloomAdd:
+                    {
+                        // Mirrors Turso's op_filter_add: register the key (or composite key) in
+                        // the bloom filter attached to the cursor's hash table / ephemeral index.
+                        if (!_bloomFilters.TryGetValue(bloomAdd.Cursor.Index, out var filter))
+                        {
+                            filter = new VdbeBloomFilter();
+                            _bloomFilters[bloomAdd.Cursor.Index] = filter;
+                        }
+
+                        if (bloomAdd.Key.Count == 1)
+                        {
+                            filter.InsertValue(_registers[bloomAdd.Key.Start.Index]);
+                        }
+                        else
+                        {
+                            filter.InsertValues(ReadRegisters(bloomAdd.Key));
+                        }
+
+                        AdvanceInstructionPointer();
+                        break;
+                    }
+                case BloomFilterInstruction bloomFilter:
+                    {
+                        // Mirrors Turso's op_filter: jump when the key is definitely absent. A
+                        // cursor that never built a filter can't exclude anything, so fall through.
+                        if (_bloomFilters.TryGetValue(bloomFilter.Cursor.Index, out var filter))
+                        {
+                            var mightContain = bloomFilter.Key.Count == 1
+                                ? filter.ContainsValue(_registers[bloomFilter.Key.Start.Index])
+                                : filter.ContainsValues(ReadRegisters(bloomFilter.Key));
+                            if (!mightContain)
+                            {
+                                _instructionPointer = bloomFilter.NotPresentTarget;
+                                break;
+                            }
+                        }
+
+                        AdvanceInstructionPointer();
+                        break;
+                    }
+                case HashBuildInstruction hashBuild:
+                    {
+                        // Mirrors Turso's op_hash_build: append the current cursor row (key +
+                        // rowid + optional payload) to the build-side hash table, creating it
+                        // on first use. NULL-keyed rows are dropped by the table itself
+                        // unless matched-tracking (anti-join) retains them for the unmatched scan.
+                        var table = GetOrBuildHashTable(hashBuild.HashTableId, hashBuild.Collations, hashBuild.Key.Count, hashBuild.TrackMatched, hashBuild.MemoryBudget);
+                        ResolveDeferredSeekForRowIdRead(hashBuild.Cursor);
+                        var keys = ReadRegisters(hashBuild.Key);
+                        var payload = hashBuild.Payload is { } payloadRange ? ReadRegisters(payloadRange) : [];
+                        table.InsertPending(keys, CurrentCursorRowId(hashBuild.Cursor), payload);
+                        AdvanceInstructionPointer();
+                        break;
+                    }
+                case HashDistinctInstruction hashDistinct:
+                    {
+                        // Mirrors Turso's op_hash_distinct: insert the key when it is new,
+                        // jumping over the duplicate otherwise. NULL compares equal to NULL.
+                        var table = GetOrBuildHashTable(hashDistinct.HashTableId, hashDistinct.Collations, hashDistinct.Key.Count, trackMatched: false, memoryBudget: 0);
+                        if (!table.InsertDistinct(ReadRegisters(hashDistinct.Key)))
+                        {
+                            _instructionPointer = hashDistinct.DuplicateTarget;
+                            break;
+                        }
+
+                        AdvanceInstructionPointer();
+                        break;
+                    }
+                case HashBuildFinalizeInstruction hashFinalize:
+                    {
+                        // Mirrors Turso's op_hash_build_finalize: flip the table to probing.
+                        // A never-built table is simply absent.
+                        if (_hashTables.TryGetValue(hashFinalize.HashTableId, out var table))
+                            table.FinalizeBuild();
+                        AdvanceInstructionPointer();
+                        break;
+                    }
+                case HashProbeInstruction hashProbe:
+                    {
+                        // Mirrors Turso's op_hash_probe: a missing table is a miss.
+                        if (!_hashTables.TryGetValue(hashProbe.HashTableId, out var table))
+                        {
+                            _instructionPointer = hashProbe.NotFoundTarget;
+                            break;
+                        }
+
+                        var entry = table.Probe(ReadRegisters(hashProbe.Key));
+                        if (entry is null)
+                        {
+                            _instructionPointer = hashProbe.NotFoundTarget;
+                            break;
+                        }
+
+                        _registers[hashProbe.Destination.Index] = SqlValue.Integer(entry.RowId);
+                        WriteHashPayload(hashProbe.PayloadDestination, entry.Payload);
+                        AdvanceInstructionPointer();
+                        break;
+                    }
+                case HashNextInstruction hashNext:
+                    {
+                        // Mirrors Turso's op_hash_next: continues the probe chain started by
+                        // HashProbe. Without a table the program is malformed.
+                        if (!_hashTables.TryGetValue(hashNext.HashTableId, out var table))
+                        {
+                            throw new InvalidOperationException($"Hash table not found with ID: {hashNext.HashTableId}");
+                        }
+
+                        var entry = table.NextMatch();
+                        if (entry is null)
+                        {
+                            _instructionPointer = hashNext.ExhaustedTarget;
+                            break;
+                        }
+
+                        _registers[hashNext.Destination.Index] = SqlValue.Integer(entry.RowId);
+                        WriteHashPayload(hashNext.PayloadDestination, entry.Payload);
+                        AdvanceInstructionPointer();
+                        break;
+                    }
+                case HashCloseInstruction hashClose:
+                    {
+                        // Mirrors Turso's op_hash_close: drop the table from the statement registry.
+                        if (_hashTables.Remove(hashClose.HashTableId, out var table))
+                            table.Close();
+                        AdvanceInstructionPointer();
+                        break;
+                    }
+                case HashClearInstruction hashClear:
+                    {
+                        // Mirrors Turso's op_hash_clear: empty the table for a correlated rebuild.
+                        if (_hashTables.TryGetValue(hashClear.HashTableId, out var table))
+                            table.Clear();
+                        AdvanceInstructionPointer();
+                        break;
+                    }
+                case HashMarkMatchedInstruction hashMarkMatched:
+                    {
+                        // Mirrors Turso's op_hash_mark_matched: no-op for tables that don't
+                        // track matches (or that never materialized).
+                        if (_hashTables.TryGetValue(hashMarkMatched.HashTableId, out var table))
+                            table.MarkCurrentMatched();
+                        AdvanceInstructionPointer();
+                        break;
+                    }
+                case HashResetMatchedInstruction hashResetMatched:
+                    {
+                        // Mirrors Turso's op_hash_reset_matched: clear the matched bits so an
+                        // anti-join loop can restart the unmatched scan.
+                        if (_hashTables.TryGetValue(hashResetMatched.HashTableId, out var table))
+                            table.ResetMatchedBits();
+                        AdvanceInstructionPointer();
+                        break;
+                    }
+                case HashScanUnmatchedInstruction hashScanUnmatched:
+                    {
+                        // Mirrors Turso's op_hash_scan_unmatched: a missing table is already exhausted.
+                        if (!_hashTables.TryGetValue(hashScanUnmatched.HashTableId, out var table))
+                        {
+                            _instructionPointer = hashScanUnmatched.ExhaustedTarget;
+                            break;
+                        }
+
+                        table.BeginUnmatchedScan();
+                        var entry = table.NextUnmatched();
+                        if (entry is null)
+                        {
+                            _instructionPointer = hashScanUnmatched.ExhaustedTarget;
+                            break;
+                        }
+
+                        _registers[hashScanUnmatched.Destination.Index] = SqlValue.Integer(entry.RowId);
+                        WriteHashPayload(hashScanUnmatched.PayloadDestination, entry.Payload);
+                        AdvanceInstructionPointer();
+                        break;
+                    }
+                case HashNextUnmatchedInstruction hashNextUnmatched:
+                    {
+                        // Mirrors Turso's op_hash_next_unmatched: continues the scan started by
+                        // HashScanUnmatched. Without a table the program is malformed.
+                        if (!_hashTables.TryGetValue(hashNextUnmatched.HashTableId, out var table))
+                        {
+                            throw new InvalidOperationException($"Hash table not found with ID: {hashNextUnmatched.HashTableId}");
+                        }
+
+                        var entry = table.NextUnmatched();
+                        if (entry is null)
+                        {
+                            _instructionPointer = hashNextUnmatched.ExhaustedTarget;
+                            break;
+                        }
+
+                        _registers[hashNextUnmatched.Destination.Index] = SqlValue.Integer(entry.RowId);
+                        WriteHashPayload(hashNextUnmatched.PayloadDestination, entry.Payload);
+                        AdvanceInstructionPointer();
+                        break;
+                    }
                 case OpenPseudoInstruction openPseudo:
                     OpenCursor(openPseudo.Cursor);
                     _pseudoCursors[openPseudo.Cursor.Index] = openPseudo.Content;
@@ -459,6 +708,9 @@ public sealed class ResumableStatement : IDisposable
                     }
                 case RewindCursorInstruction rewind:
                     {
+                        // Turso clears the cursor's bloom filter unconditionally on rewind, before
+                        // deciding whether the cursor is empty.
+                        _bloomFilters.Remove(rewind.Cursor.Index);
                         _materializedRows[rewind.Cursor.Index] = null;
                         if (_pseudoCursors[rewind.Cursor.Index] is { } pseudo)
                         {
@@ -526,6 +778,8 @@ public sealed class ResumableStatement : IDisposable
                     }
                 case ColumnInstruction column:
                     {
+                        if (!ResolveDeferredSeekForColumnRead(column))
+                            break;
                         var row = CurrentCursorRow(column.Cursor);
                         _registers[column.Destination.Index] = row[column.ColumnIndex];
                         AdvanceInstructionPointer();
@@ -547,6 +801,7 @@ public sealed class ResumableStatement : IDisposable
                     }
                 case RowIdInstruction rowId:
                     {
+                        ResolveDeferredSeekForRowIdRead(rowId.Cursor);
                         _registers[rowId.Destination.Index] = SqlValue.Integer(CurrentCursorRowId(rowId.Cursor));
                         AdvanceInstructionPointer();
                         break;
@@ -713,6 +968,18 @@ public sealed class ResumableStatement : IDisposable
                             AdvanceInstructionPointer();
                         else
                             _instructionPointer = noConflict.NoConflictTarget;
+                        break;
+                    }
+                case ColumnHasFieldInstruction columnHasField:
+                    {
+                        // Turso: jump when the current record carries the column. A cursor with no
+                        // current record behaves like Turso's missing-record case and falls through.
+                        var hasField = TryCurrentCursorRow(columnHasField.Cursor, out var row)
+                            && row.Length > columnHasField.Column;
+                        if (hasField)
+                            _instructionPointer = columnHasField.Target;
+                        else
+                            AdvanceInstructionPointer();
                         break;
                     }
                 case FkCounterInstruction fkCounter:
@@ -1405,6 +1672,28 @@ public sealed class ResumableStatement : IDisposable
 
                         break;
                     }
+                case AggValueInstruction aggValue:
+                    {
+                        try
+                        {
+                            var index = aggValue.Accumulator.Index;
+                            // Turso's AggValue shares op_agg_final but leaves the accumulator
+                            // untouched, so the aggregate can still be stepped afterwards.
+                            var context = _accumulatorInitialized[index]
+                                ? _accumulatorContexts[index]
+                                : aggValue.Aggregate.CreateContext();
+                            _registers[aggValue.Destination.Index] =
+                                aggValue.Aggregate.Finalize(context);
+                            AdvanceInstructionPointer();
+                        }
+                        catch
+                        {
+                            State = ResumableStatementState.Faulted;
+                            throw;
+                        }
+
+                        break;
+                    }
                 case SameGroupInstruction sameGroup:
                     {
                         var current = ReadRegisters(sameGroup.CurrentKey);
@@ -2015,6 +2304,9 @@ public sealed class ResumableStatement : IDisposable
                         Array.Clear(_windowBuffers);
                         Array.Clear(_ephemeralTables);
                         Array.Clear(_pseudoCursors);
+                        Array.Clear(_deferredSeeks);
+                        _bloomFilters.Clear();
+                        _hashTables.Clear();
                         if (halt.ErrorCode != 0)
                             throw CreateHaltException(halt);
 
@@ -2039,6 +2331,9 @@ public sealed class ResumableStatement : IDisposable
                             Array.Clear(_windowBuffers);
                             Array.Clear(_ephemeralTables);
                             Array.Clear(_pseudoCursors);
+                            Array.Clear(_deferredSeeks);
+                            _bloomFilters.Clear();
+                            _hashTables.Clear();
                             throw CreateHaltIfNullException(haltIfNull);
                         }
 
@@ -2070,6 +2365,7 @@ public sealed class ResumableStatement : IDisposable
         _registers.Clear();
         Array.Clear(_openCursors);
         Array.Clear(_cursorPositions);
+        Array.Clear(_deferredSeeks);
         Array.Clear(_skipLastInsertRowId);
         Array.Clear(_materializedRows);
         Array.Clear(_materializedRowIds);
@@ -2081,6 +2377,8 @@ public sealed class ResumableStatement : IDisposable
         Array.Clear(_groupKeys);
         Array.Clear(_groupIndexes);
         _integerRowSets.Clear();
+        _bloomFilters.Clear();
+        _hashTables.Clear();
         foreach (var subprogram in _subprogramStatements.Values)
             subprogram.Reset();
         Array.Clear(_workTables);
@@ -2321,6 +2619,8 @@ public sealed class ResumableStatement : IDisposable
         Array.Clear(_groupKeys);
         Array.Clear(_groupIndexes);
         _integerRowSets.Clear();
+        _bloomFilters.Clear();
+        _hashTables.Clear();
         foreach (var subprogram in _subprogramStatements.Values)
             subprogram.Dispose();
         _subprogramStatements.Clear();
@@ -2328,6 +2628,7 @@ public sealed class ResumableStatement : IDisposable
         Array.Clear(_windowBuffers);
         Array.Clear(_ephemeralTables);
         Array.Clear(_pseudoCursors);
+        Array.Clear(_deferredSeeks);
         _onceVisited.Clear();
         if (_ownsTransaction)
             _transaction.Reset();
@@ -2345,6 +2646,14 @@ public sealed class ResumableStatement : IDisposable
             throw new InvalidOperationException($"Cursor {cursor.Index} is already open.");
 
         _openCursors[cursor.Index] = true;
+        // Mirrors Turso's invalidate_deferred_seeks_for_cursor: (re)opening a cursor drops any
+        // pending deferred seek that references it on either the index or the table side.
+        for (var i = 0; i < _deferredSeeks.Length; i++)
+        {
+            if (_deferredSeeks[i] is { } pending
+                && (pending.IndexCursor == cursor.Index || pending.TableCursor == cursor.Index))
+                _deferredSeeks[i] = null;
+        }
     }
 
     private void CloseCursor(Cursor cursor)
@@ -2353,6 +2662,8 @@ public sealed class ResumableStatement : IDisposable
             throw new InvalidOperationException($"Cursor {cursor.Index} is not open.");
 
         _openCursors[cursor.Index] = false;
+        // Mirrors Turso's op_close: closing a cursor drops its own pending deferred seek.
+        _deferredSeeks[cursor.Index] = null;
         _virtualCursors[cursor.Index]?.Dispose();
         _virtualCursors[cursor.Index] = null;
         _indexMethodCursors[cursor.Index]?.Dispose();
@@ -2925,6 +3236,18 @@ public sealed class ResumableStatement : IDisposable
         if (_virtualCursors[cursor.Index] is { } virtualCursor)
             return virtualCursor.RowId;
 
+        // Ephemeral tables are not bound write targets; their rowids come from the
+        // table's own sequential insertion order, exactly like RequireCursorSource.
+        if (_ephemeralTables[cursor.Index] is { } ephemeral)
+        {
+            var ephemeralPosition = _cursorPositions[cursor.Index];
+            var ephemeralRowIds = ephemeral.AsCursorSource().RowIds
+                ?? throw new InvalidOperationException($"Cursor {cursor.Index} has no rowid source bound.");
+            if (ephemeralPosition < 0 || ephemeralPosition >= ephemeralRowIds.Count)
+                throw new InvalidOperationException($"Cursor {cursor.Index} is not positioned on a row.");
+            return ephemeralRowIds[ephemeralPosition];
+        }
+
         if (_joinCursorStates[cursor.Index] is not null)
         {
             throw new InvalidOperationException(
@@ -2957,6 +3280,32 @@ public sealed class ResumableStatement : IDisposable
         var values = new SqlValue[range.Count];
         _registers.CopyTo(range.Start.Index, values, 0, range.Count);
         return values;
+    }
+
+    private VdbeHashTable GetOrBuildHashTable(
+        int hashTableId,
+        IReadOnlyList<string?> collations,
+        int keyCount,
+        bool trackMatched,
+        long memoryBudget)
+    {
+        if (!_hashTables.TryGetValue(hashTableId, out var table))
+        {
+            table = new VdbeHashTable(keyCount, collations, trackMatched, memoryBudget);
+            _hashTables[hashTableId] = table;
+        }
+
+        return table;
+    }
+
+    private void WriteHashPayload(RegisterRange? payloadDestination, SqlValue[] payload)
+    {
+        if (payloadDestination is not { } range || payload.Length == 0)
+            return;
+
+        var count = Math.Min(range.Count, payload.Length);
+        for (var index = 0; index < count; index++)
+            _registers[range.Start.Index + index] = payload[index];
     }
 
     private bool TryCurrentCursorRow(Cursor cursor, out SqlValue[] row)
@@ -3234,6 +3583,80 @@ public sealed class ResumableStatement : IDisposable
         for (var i = 0; i < rowIds.Count; i++)
         {
             if (rowIds[i] != target)
+                continue;
+
+            _cursorPositions[cursor.Index] = i;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Resolves a pending <see cref="DeferredSeekInstruction"/> before a column read, mirroring
+    /// Turso's op_column slow path. Returns true when the caller should proceed with the ordinary
+    /// column read; returns false when the index cursor had no current record and the destination
+    /// register was already written NULL with the instruction pointer advanced (Turso's
+    /// write_null_regs).
+    /// </summary>
+    private bool ResolveDeferredSeekForColumnRead(ColumnInstruction column)
+    {
+        var pending = _deferredSeeks[column.Cursor.Index];
+        if (pending is null)
+            return true;
+
+        _deferredSeeks[column.Cursor.Index] = null;
+        var indexCursor = new Cursor(pending.Value.IndexCursor);
+        if (!TryCurrentCursorRow(indexCursor, out _))
+        {
+            _registers[column.Destination.Index] = SqlValue.Null;
+            AdvanceInstructionPointer();
+            return false;
+        }
+
+        TryPositionCursorOnRowIdValue(column.Cursor, CurrentCursorRowId(indexCursor));
+        return true;
+    }
+
+    /// <summary>
+    /// Resolves a pending <see cref="DeferredSeekInstruction"/> before a rowid read, mirroring
+    /// Turso's op_row_id slow path. Turso expects the index cursor to hold a record at this
+    /// point; the managed engine surfaces the same contract as an error instead of panicking.
+    /// </summary>
+    private void ResolveDeferredSeekForRowIdRead(Cursor cursor)
+    {
+        var pending = _deferredSeeks[cursor.Index];
+        if (pending is null)
+            return;
+
+        _deferredSeeks[cursor.Index] = null;
+        var indexCursor = new Cursor(pending.Value.IndexCursor);
+        if (!TryCurrentCursorRow(indexCursor, out _))
+        {
+            throw new InvalidOperationException(
+                $"Deferred seek of cursor {cursor.Index} requires index cursor {indexCursor.Index} to be positioned on a record.");
+        }
+
+        TryPositionCursorOnRowIdValue(cursor, CurrentCursorRowId(indexCursor));
+    }
+
+    /// <summary>
+    /// Positions <paramref name="cursor"/> on the row whose rowid equals
+    /// <paramref name="rowId"/>. Returns false when the cursor's source exposes no rowids or the
+    /// rowid is absent; deferred-seek resolution treats such a miss the way the subsequent column
+    /// or rowid read would for an unpositioned cursor.
+    /// </summary>
+    private bool TryPositionCursorOnRowIdValue(Cursor cursor, long rowId)
+    {
+        _materializedRows[cursor.Index] = null;
+        var source = RequireCursorSource(cursor);
+        var rowIds = source.RowIds;
+        if (rowIds is null)
+            return false;
+
+        for (var i = 0; i < rowIds.Count; i++)
+        {
+            if (rowIds[i] != rowId)
                 continue;
 
             _cursorPositions[cursor.Index] = i;
@@ -3638,6 +4061,21 @@ public sealed class ResumableStatement : IDisposable
             _rowIds.RemoveAt(position);
             _sourceView = null;
             return true;
+        }
+
+        // Turso's ResetSorter clears the ephemeral b-tree (clear_btree) at partition boundaries.
+        // The rowid space restarts from 1 to match a freshly opened table.
+        public void Clear()
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_retainedBytes > 0 || _retainedRows > 0)
+                _memory.Release(_retainedBytes, _retainedRows);
+            _rows.Clear();
+            _rowIds.Clear();
+            _sourceView = null;
+            _retainedBytes = 0;
+            _retainedRows = 0;
+            _nextRowId = 1;
         }
 
         public VdbeCursorSource AsCursorSource()

--- a/src/Ahtola.Core/Execution/VdbeBloomFilter.cs
+++ b/src/Ahtola.Core/Execution/VdbeBloomFilter.cs
@@ -1,0 +1,288 @@
+using System.Text;
+
+namespace Ahtola.Core.Execution;
+
+/// <summary>
+/// A pure-managed bloom filter for fast probabilistic set membership testing, mirroring
+/// Turso's <c>vdbe::bloom_filter::BloomFilter</c>. One filter is attached per cursor that
+/// builds a hash table or ephemeral index: the build side adds keys
+/// (<see cref="VdbeOpcode.BloomFilterAdd"/>) and the probe side asks
+/// "is this key definitely absent?" (<see cref="VdbeOpcode.BloomFilter"/>), so a negative
+/// answer is always correct while a positive one permits false positives.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The hash function itself does not need to match Turso's rapidhash: only within-engine
+/// consistency matters. Key equivalence, however, must mirror Turso exactly — numerically
+/// equal values (10 and 10.0, 0.0 and -0.0) hash into the same domain so membership can
+/// never return a false negative for them, while integers too large for exact f64
+/// representation fall back to the integer domain (tag 1) so they cannot collide with
+/// their lossy double image.
+/// </para>
+/// <para>
+/// NULL semantics follow Turso: a single NULL key increments the count but is never hashed
+/// into the bit array, <c>Contains</c> on NULL always returns false, composite keys hash
+/// NULL components as a no-op on insert, and a composite probe containing any NULL
+/// component can never match.
+/// </para>
+/// <para>
+/// Allocation-free on the probe path except for text UTF-8 encoding; no reflection, no
+/// codegen — NativeAOT and trim safe.
+/// </para>
+/// </remarks>
+internal sealed class VdbeBloomFilter
+{
+    /// <summary>Default number of expected items (Turso <c>DEFAULT_EXPECTED_ITEMS</c>).</summary>
+    private const int DefaultExpectedItems = 1024;
+
+    /// <summary>Default false positive rate, 1% (Turso <c>DEFAULT_FALSE_POSITIVE_RATE</c>).</summary>
+    private const double DefaultFalsePositiveRate = 0.01;
+
+    // FNV-1a 64 constants (same precedent as ManagedVectorIndexState.Fingerprint).
+    private const ulong FnvOffsetBasis = 0xCBF29CE484222325UL;
+    private const ulong FnvPrime = 0x100000001B3UL;
+
+    // Value-domain tags, mirroring Turso's hash_value discriminators.
+    private const byte LargeIntegerTag = 1;
+    private const byte NumericTag = 2;
+    private const byte TextTag = 3;
+    private const byte BlobTag = 4;
+
+    private readonly ulong[] _bits;
+    private readonly int _bitMask;
+    private readonly int _probeCount;
+    private int _count;
+
+    public VdbeBloomFilter()
+        : this(DefaultExpectedItems, DefaultFalsePositiveRate)
+    {
+    }
+
+    public VdbeBloomFilter(int expectedItems, double falsePositiveRate)
+    {
+        if (expectedItems < 1)
+        {
+            expectedItems = 1;
+        }
+
+        // Optimal bit-array size m = -(n * ln p) / (ln 2)^2, rounded up to a power of two so
+        // index reduction is a mask. For n = 1024, p = 0.01 this is ~9815 bits -> 16384.
+        var optimalBits = -(expectedItems * Math.Log(falsePositiveRate)) / (Math.Log(2) * Math.Log(2));
+        var bitCount = 64;
+        while (bitCount < optimalBits)
+        {
+            bitCount <<= 1;
+        }
+
+        _bits = new ulong[bitCount / 64];
+        _bitMask = bitCount - 1;
+
+        // Optimal probe count k = (m / n) * ln 2, at least one. For 16384 bits / 1024 items
+        // this is 11.09 -> 11 probes.
+        _probeCount = Math.Max(1, (int)Math.Round((double)bitCount / expectedItems * Math.Log(2)));
+    }
+
+    /// <summary>Number of items inserted into the filter (Turso <c>count</c>).</summary>
+    public int Count => _count;
+
+    /// <summary>Inserts a single key value (Turso <c>insert_value</c>). NULL counts but is not hashed.</summary>
+    public void InsertValue(SqlValue value)
+    {
+        if (value.Kind != SqlValueKind.Null)
+        {
+            var hasher = new FnvHasher();
+            HashValue(ref hasher, value);
+            SetProbes(hasher.Finish());
+        }
+
+        _count++;
+    }
+
+    /// <summary>
+    /// Inserts a composite key (Turso <c>insert_values</c>): all components are folded into a
+    /// single hash. NULL components contribute nothing to the hash but the key still counts.
+    /// </summary>
+    public void InsertValues(IReadOnlyList<SqlValue> values)
+    {
+        var hasher = new FnvHasher();
+        for (var i = 0; i < values.Count; i++)
+        {
+            HashValue(ref hasher, values[i]);
+        }
+
+        SetProbes(hasher.Finish());
+        _count++;
+    }
+
+    /// <summary>Checks membership of a single key (Turso <c>contains_value</c>). NULL never matches.</summary>
+    public bool ContainsValue(SqlValue value)
+    {
+        if (value.Kind == SqlValueKind.Null)
+        {
+            return false;
+        }
+
+        var hasher = new FnvHasher();
+        HashValue(ref hasher, value);
+        return TestProbes(hasher.Finish());
+    }
+
+    /// <summary>
+    /// Checks membership of a composite key (Turso <c>contains_values</c>). If any component
+    /// is NULL the key can never match.
+    /// </summary>
+    public bool ContainsValues(IReadOnlyList<SqlValue> values)
+    {
+        var hasher = new FnvHasher();
+        for (var i = 0; i < values.Count; i++)
+        {
+            var value = values[i];
+            if (value.Kind == SqlValueKind.Null)
+            {
+                return false;
+            }
+
+            HashValue(ref hasher, value);
+        }
+
+        return TestProbes(hasher.Finish());
+    }
+
+    /// <summary>Resets the filter (Turso <c>clear</c>): forgets every inserted key.</summary>
+    public void Clear()
+    {
+        Array.Clear(_bits, 0, _bits.Length);
+        _count = 0;
+    }
+
+    /// <summary>
+    /// Hashes one value into <paramref name="hasher"/> mirroring Turso's <c>hash_value</c>.
+    /// NULL is a no-op so NULL components of composite keys do not perturb the hash of the
+    /// remaining components.
+    /// </summary>
+    private static void HashValue(ref FnvHasher hasher, SqlValue value)
+    {
+        switch (value.Kind)
+        {
+            case SqlValueKind.Null:
+                break;
+            case SqlValueKind.Integer:
+                {
+                    var integer = value.AsInteger();
+                    // Hash integers in the same domain as numerically equivalent REALs so
+                    // membership can never return a false negative for e.g. 10 vs 10.0.
+                    var asReal = (double)integer;
+                    if (double.IsFinite(asReal) && (long)asReal == integer)
+                    {
+                        HashNumeric(ref hasher, asReal);
+                    }
+                    else
+                    {
+                        // Fall back to the integer domain when the float representation would
+                        // lose precision (|i| > 2^53).
+                        hasher.WriteByte(LargeIntegerTag);
+                        hasher.WriteUInt64(unchecked((ulong)integer));
+                    }
+
+                    break;
+                }
+            case SqlValueKind.Real:
+                HashNumeric(ref hasher, value.AsReal());
+                break;
+            case SqlValueKind.Text:
+                hasher.WriteByte(TextTag);
+                hasher.WriteBytes(Encoding.UTF8.GetBytes(value.AsText()));
+                break;
+            case SqlValueKind.Blob:
+                hasher.WriteByte(BlobTag);
+                hasher.WriteBytes(value.AsBlobSpan());
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Hashes INTEGER and REAL values into the same domain (Turso <c>hash_numeric</c>) so
+    /// numerically equal values collide by design (10 == 10.0, -0.0 == 0.0).
+    /// </summary>
+    private static void HashNumeric(ref FnvHasher hasher, double value)
+    {
+        hasher.WriteByte(NumericTag);
+        hasher.WriteUInt64(unchecked((ulong)BitConverter.DoubleToInt64Bits(NormalizeSignedZero(value))));
+    }
+
+    /// <summary>Normalizes signed zero so 0.0 and -0.0 hash the same (Turso <c>normalized_f64_bits</c>).</summary>
+    private static double NormalizeSignedZero(double value)
+        => value == 0.0 ? 0.0 : value;
+
+    private void SetProbes(ulong hash)
+    {
+        ForEachProbe(hash, static (self, bit) => self._bits[bit >> 6] |= 1UL << (bit & 63));
+    }
+
+    private bool TestProbes(ulong hash)
+    {
+        var first = (int)(hash & (ulong)_bitMask);
+        // Force an odd step so the probe sequence is coprime with the power-of-two bit count
+        // and covers the whole table instead of half of it.
+        var step = (int)((hash >> 32) | 1UL);
+        var bit = first;
+        for (var probe = 0; probe < _probeCount; probe++)
+        {
+            var index = bit & _bitMask;
+            if ((_bits[index >> 6] & (1UL << (index & 63))) == 0)
+            {
+                return false;
+            }
+
+            bit += step;
+        }
+
+        return true;
+    }
+
+    private void ForEachProbe(ulong hash, Action<VdbeBloomFilter, int> visit)
+    {
+        var first = (int)(hash & (ulong)_bitMask);
+        var step = (int)((hash >> 32) | 1UL);
+        var bit = first;
+        for (var probe = 0; probe < _probeCount; probe++)
+        {
+            visit(this, bit & _bitMask);
+            bit += step;
+        }
+    }
+
+    /// <summary>Incremental FNV-1a 64-bit hasher; deterministic and endian independent.</summary>
+    private struct FnvHasher
+    {
+        private ulong _hash;
+
+        public FnvHasher()
+        {
+            _hash = FnvOffsetBasis;
+        }
+
+        public void WriteByte(byte value)
+        {
+            _hash ^= value;
+            _hash *= FnvPrime;
+        }
+
+        public void WriteBytes(ReadOnlySpan<byte> bytes)
+        {
+            foreach (var value in bytes)
+            {
+                WriteByte(value);
+            }
+        }
+
+        public void WriteUInt64(ulong value)
+        {
+            Span<byte> buffer = stackalloc byte[8];
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(buffer, value);
+            WriteBytes(buffer);
+        }
+
+        public readonly ulong Finish() => _hash;
+    }
+}

--- a/src/Ahtola.Core/Execution/VdbeExplain.cs
+++ b/src/Ahtola.Core/Execution/VdbeExplain.cs
@@ -409,6 +409,126 @@ public static class VdbeExplain
                 ephemeralInsert.Values.Count,
                 null,
                 $"insert into ephemeral cursor {ephemeralInsert.Cursor.Index} from {FormatRange(ephemeralInsert.Values)}"),
+            OpenAutoindexInstruction openAutoindex => (
+                openAutoindex.Cursor.Index,
+                openAutoindex.ColumnCount,
+                0,
+                null,
+                $"open autoindex cursor {openAutoindex.Cursor.Index} cols={openAutoindex.ColumnCount}"),
+            OpenDupInstruction openDup => (
+                openDup.NewCursor.Index,
+                openDup.OriginalCursor.Index,
+                0,
+                null,
+                $"duplicate ephemeral cursor {openDup.OriginalCursor.Index} to cursor {openDup.NewCursor.Index}"),
+            ResetSorterInstruction resetSorter => (
+                resetSorter.Cursor.Index,
+                0,
+                0,
+                null,
+                $"reset ephemeral cursor {resetSorter.Cursor.Index}"),
+            ColumnHasFieldInstruction columnHasField => (
+                columnHasField.Cursor.Index,
+                columnHasField.Column,
+                columnHasField.Target.Offset,
+                null,
+                $"jump to {columnHasField.Target.Offset} when cursor {columnHasField.Cursor.Index} has column {columnHasField.Column}"),
+            DeferredSeekInstruction deferredSeek => (
+                deferredSeek.IndexCursor.Index,
+                deferredSeek.TableCursor.Index,
+                0,
+                null,
+                $"deferred seek table cursor {deferredSeek.TableCursor.Index} via index cursor {deferredSeek.IndexCursor.Index}"),
+            SeekEndInstruction seekEnd => (
+                seekEnd.Cursor.Index,
+                0,
+                0,
+                null,
+                $"position cursor {seekEnd.Cursor.Index} past its last row for a reverse scan"),
+            BloomFilterInstruction bloomFilter => (
+                bloomFilter.Cursor.Index,
+                bloomFilter.NotPresentTarget.Offset,
+                bloomFilter.Key.Start.Index,
+                FormatRange(bloomFilter.Key),
+                $"if !bloom_filter({FormatRange(bloomFilter.Key)}) goto {bloomFilter.NotPresentTarget.Offset}"),
+            BloomFilterAddInstruction bloomAdd => (
+                bloomAdd.Cursor.Index,
+                0,
+                bloomAdd.Key.Start.Index,
+                FormatRange(bloomAdd.Key),
+                $"bloom_filter_add({FormatRange(bloomAdd.Key)})"),
+            HashBuildInstruction hashBuild => (
+                hashBuild.Cursor.Index,
+                hashBuild.Key.Start.Index,
+                hashBuild.Key.Count,
+                FormatRange(hashBuild.Key),
+                $"hash_build c[{hashBuild.Cursor.Index}] keys {FormatRange(hashBuild.Key)} -> hash_table[{hashBuild.HashTableId}] budget={hashBuild.MemoryBudget}"
+                    + (hashBuild.Payload is { } payload ? $" payload {FormatRange(payload)}" : string.Empty)
+                    + (hashBuild.TrackMatched ? " track_matched" : string.Empty)),
+            HashDistinctInstruction hashDistinct => (
+                hashDistinct.HashTableId,
+                hashDistinct.Key.Start.Index,
+                hashDistinct.Key.Count,
+                FormatRange(hashDistinct.Key),
+                $"hash_distinct {FormatRange(hashDistinct.Key)} jmp={hashDistinct.DuplicateTarget.Offset}"),
+            HashBuildFinalizeInstruction hashFinalize => (
+                hashFinalize.HashTableId,
+                0,
+                0,
+                null,
+                $"hash_build_finalize hash_table[{hashFinalize.HashTableId}]"),
+            HashProbeInstruction hashProbe => (
+                hashProbe.HashTableId,
+                hashProbe.Key.Start.Index,
+                hashProbe.Key.Count,
+                FormatRange(hashProbe.Key),
+                $"r[{hashProbe.Destination.Index}]=hash_probe({FormatRange(hashProbe.Key)}) goto {hashProbe.NotFoundTarget.Offset} if not found"
+                    + (hashProbe.PayloadDestination is { } payloadDest ? $" payload {FormatRange(payloadDest)}" : string.Empty)),
+            HashNextInstruction hashNext => (
+                hashNext.HashTableId,
+                hashNext.Destination.Index,
+                hashNext.ExhaustedTarget.Offset,
+                null,
+                $"r[{hashNext.Destination.Index}]=hash_next goto {hashNext.ExhaustedTarget.Offset} if exhausted"
+                    + (hashNext.PayloadDestination is { } payloadDest ? $" payload {FormatRange(payloadDest)}" : string.Empty)),
+            HashCloseInstruction hashClose => (
+                hashClose.HashTableId,
+                0,
+                0,
+                null,
+                $"hash_close hash_table[{hashClose.HashTableId}]"),
+            HashClearInstruction hashClear => (
+                hashClear.HashTableId,
+                0,
+                0,
+                null,
+                $"hash_clear hash_table[{hashClear.HashTableId}]"),
+            HashMarkMatchedInstruction hashMarkMatched => (
+                hashMarkMatched.HashTableId,
+                0,
+                0,
+                null,
+                $"hash_mark_matched hash_table[{hashMarkMatched.HashTableId}]"),
+            HashResetMatchedInstruction hashResetMatched => (
+                hashResetMatched.HashTableId,
+                0,
+                0,
+                null,
+                $"hash_reset_matched hash_table[{hashResetMatched.HashTableId}]"),
+            HashScanUnmatchedInstruction hashScanUnmatched => (
+                hashScanUnmatched.HashTableId,
+                hashScanUnmatched.Destination.Index,
+                hashScanUnmatched.ExhaustedTarget.Offset,
+                null,
+                $"r[{hashScanUnmatched.Destination.Index}]=hash_scan_unmatched goto {hashScanUnmatched.ExhaustedTarget.Offset} if exhausted"
+                    + (hashScanUnmatched.PayloadDestination is { } payloadDest ? $" payload {FormatRange(payloadDest)}" : string.Empty)),
+            HashNextUnmatchedInstruction hashNextUnmatched => (
+                hashNextUnmatched.HashTableId,
+                hashNextUnmatched.Destination.Index,
+                hashNextUnmatched.ExhaustedTarget.Offset,
+                null,
+                $"r[{hashNextUnmatched.Destination.Index}]=hash_next_unmatched goto {hashNextUnmatched.ExhaustedTarget.Offset} if exhausted"
+                    + (hashNextUnmatched.PayloadDestination is { } payloadDest ? $" payload {FormatRange(payloadDest)}" : string.Empty)),
             NoConflictInstruction noConflict => (
                 noConflict.Cursor.Index,
                 noConflict.NoConflictTarget.Offset,
@@ -638,6 +758,12 @@ public static class VdbeExplain
                 0,
                 aggFinalize.Aggregate.Name,
                 $"r[{aggFinalize.Destination.Index}]={aggFinalize.Aggregate.Name} finalize accumulator {aggFinalize.Accumulator.Index}"),
+            AggValueInstruction aggValue => (
+                aggValue.Accumulator.Index,
+                aggValue.Destination.Index,
+                0,
+                aggValue.Aggregate.Name,
+                $"r[{aggValue.Destination.Index}]={aggValue.Aggregate.Name} value accumulator {aggValue.Accumulator.Index} (no reset)"),
             SameGroupInstruction sameGroup => (
                 sameGroup.CurrentKey.Start.Index,
                 sameGroup.SameGroupTarget.Offset,

--- a/src/Ahtola.Core/Execution/VdbeHashTable.cs
+++ b/src/Ahtola.Core/Execution/VdbeHashTable.cs
@@ -1,0 +1,624 @@
+using System.Text;
+using Ahtola.Core.Storage;
+
+namespace Ahtola.Core.Execution;
+
+/// <summary>
+/// Lifecycle state of a hash-join hash table, mirroring Turso's <c>HashTableState</c>
+/// without the spill states (the managed port is in-memory only).
+/// </summary>
+public enum VdbeHashTableState
+{
+    Building,
+    Probing,
+    Closed,
+}
+
+/// <summary>
+/// A single entry in a <see cref="VdbeHashTable"/>, mirroring Turso's <c>HashEntry</c>:
+/// the precomputed key hash, the key values, the source rowid, and any payload columns.
+/// </summary>
+public sealed class VdbeHashEntry
+{
+    internal VdbeHashEntry(ulong hash, SqlValue[] keys, long rowId, SqlValue[] payload)
+    {
+        Hash = hash;
+        Keys = keys;
+        RowId = rowId;
+        Payload = payload;
+    }
+
+    public ulong Hash { get; }
+
+    public SqlValue[] Keys { get; }
+
+    public long RowId { get; }
+
+    public SqlValue[] Payload { get; }
+}
+
+/// <summary>
+/// A pure-managed hash table for VDBE hash joins, mirroring Turso's
+/// <c>vdbe::hash_table::HashTable</c> for the in-memory (non-spilled) paths. The build side
+/// inserts rows (<see cref="VdbeOpcode.HashBuild"/>), the table is finalized
+/// (<see cref="VdbeOpcode.HashBuildFinalize"/>), and the probe side iterates matches
+/// (<see cref="VdbeOpcode.HashProbe"/>/<see cref="VdbeOpcode.HashNext"/>). Anti-joins
+/// additionally track which entries matched (<see cref="VdbeOpcode.HashMarkMatched"/>) and
+/// scan the unmatched remainder (<see cref="VdbeOpcode.HashScanUnmatched"/>/
+/// <see cref="VdbeOpcode.HashNextUnmatched"/>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The hash function itself does not need to match Turso's rapidhash: only within-engine
+/// consistency matters. Key equivalence, however, must mirror Turso exactly — numerically
+/// equal values (10 and 10.0, 0.0 and -0.0) hash into the same float domain so a probe can
+/// never miss a match, while integers too large for exact f64 representation fall back to
+/// the integer domain (tag 1) so they cannot collide with their lossy double image.
+/// </para>
+/// <para>
+/// Join equality never treats NULL as equal to anything, so <see cref="Probe"/> with a key
+/// containing NULL always reports no match (mirroring Turso's early return). Distinct
+/// insertion (<see cref="InsertDistinct"/>) instead treats NULL as equal to NULL so it
+/// deduplicates. No reflection, no codegen — NativeAOT and trim safe.
+/// </para>
+/// <para>
+/// Turso's grace-hash-join opcodes (<c>HashGraceInit</c>, <c>HashGraceLoadPartition</c>,
+/// <c>HashGraceNextProbe</c>, <c>HashGraceAdvancePartition</c>) are deliberately not ported:
+/// they exist solely to spill oversized build sides to disk partitions and re-probe them,
+/// and the managed port keeps hash joins fully in memory. Port them only if a
+/// memory-budget spill requirement appears.
+/// </para>
+/// </remarks>
+public sealed class VdbeHashTable
+{
+    /// <summary>Default bucket count (Turso <c>DEFAULT_BUCKETS</c>).</summary>
+    public const int DefaultBucketCount = 1024;
+
+    // Value-domain tags, mirroring Turso's hash_join_key discriminators.
+    private const byte NullTag = 0;
+    private const byte IntegerTag = 1;
+    private const byte FloatTag = 2;
+    private const byte TextTag = 3;
+    private const byte BlobTag = 4;
+
+    // FNV-1a 64 constants (same precedent as VdbeBloomFilter).
+    private const ulong FnvOffsetBasis = 0xCBF29CE484222325UL;
+    private const ulong FnvPrime = 0x100000001B3UL;
+
+    private readonly List<VdbeHashEntry>[] _buckets;
+    private readonly List<bool>[]? _matchedBits;
+    private readonly string?[] _collations;
+    private readonly bool _trackMatched;
+
+    private SqlValue[]? _currentProbeKeys;
+    private ulong? _currentProbeHash;
+    private int _probeEntryIndex;
+    private int _probeBucketIndex;
+    private int _unmatchedScanBucket;
+    private int _unmatchedScanEntry;
+    private long _entryCount;
+
+    public VdbeHashTable(
+        int keyCount,
+        IReadOnlyList<string?> collations,
+        bool trackMatched,
+        long memoryBudget)
+    {
+        if (keyCount < 1)
+            throw new ArgumentOutOfRangeException(nameof(keyCount));
+        if (collations is null)
+            throw new ArgumentNullException(nameof(collations));
+        if (collations.Count != keyCount)
+            throw new ArgumentException(
+                $"Hash table expects {keyCount} collations but received {collations.Count}.",
+                nameof(collations));
+
+        var retainedCollations = new string?[keyCount];
+        for (var i = 0; i < keyCount; i++)
+        {
+            if (!SqliteIndexRecordComparer.IsSupportedCollation(collations[i]))
+                throw new ArgumentException($"Hash table does not support collation {collations[i]}.", nameof(collations));
+
+            retainedCollations[i] = collations[i];
+        }
+
+        _collations = retainedCollations;
+        _trackMatched = trackMatched;
+        MemoryBudget = memoryBudget;
+
+        _buckets = new List<VdbeHashEntry>[DefaultBucketCount];
+        for (var i = 0; i < _buckets.Length; i++)
+            _buckets[i] = [];
+
+        if (trackMatched)
+        {
+            _matchedBits = new List<bool>[DefaultBucketCount];
+            for (var i = 0; i < _matchedBits.Length; i++)
+                _matchedBits[i] = [];
+        }
+    }
+
+    public VdbeHashTableState State { get; private set; } = VdbeHashTableState.Building;
+
+    /// <summary>Number of entries inserted into the table (Turso <c>num_entries</c>).</summary>
+    public long EntryCount => _entryCount;
+
+    /// <summary>
+    /// Memory budget accepted from <see cref="VdbeOpcode.HashBuild"/>. The managed port never
+    /// spills, so the budget is retained for parity only.
+    /// </summary>
+    public long MemoryBudget { get; }
+
+    /// <summary>
+    /// Inserts one build-side row (Turso <c>insert_pending</c>). Rows whose key contains NULL
+    /// are silently dropped unless the table tracks matched entries, mirroring Turso's early
+    /// return — an anti-join build must retain them so the unmatched scan can emit them.
+    /// </summary>
+    public void InsertPending(SqlValue[] keys, long rowId, SqlValue[] payload)
+    {
+        if (State != VdbeHashTableState.Building)
+            throw new InvalidOperationException("Hash table can only accept inserts while building.");
+
+        if (HasNullKey(keys) && !_trackMatched)
+            return;
+
+        var hash = HashKeys(keys);
+        var bucketIndex = BucketIndex(hash);
+        _buckets[bucketIndex].Add(new VdbeHashEntry(hash, keys, rowId, payload));
+        _matchedBits?[bucketIndex].Add(false);
+        _entryCount++;
+    }
+
+    /// <summary>
+    /// Inserts one key if it is not already present (Turso <c>insert_distinct</c>), returning
+    /// whether the key was new. NULL compares equal to NULL here, so NULL keys deduplicate.
+    /// </summary>
+    public bool InsertDistinct(SqlValue[] keys)
+    {
+        if (State != VdbeHashTableState.Building)
+            throw new InvalidOperationException("Hash table can only accept inserts while building.");
+
+        var hash = HashKeys(keys);
+        var bucketIndex = BucketIndex(hash);
+        var bucket = _buckets[bucketIndex];
+        for (var i = 0; i < bucket.Count; i++)
+        {
+            var entry = bucket[i];
+            if (entry.Hash == hash && KeysEqualDistinct(entry.Keys, keys))
+                return false;
+        }
+
+        bucket.Add(new VdbeHashEntry(hash, keys, rowId: 0, payload: []));
+        _entryCount++;
+        return true;
+    }
+
+    /// <summary>Completes the build phase (Turso <c>finalize_build</c>): probes become legal.</summary>
+    public void FinalizeBuild()
+    {
+        if (State != VdbeHashTableState.Building)
+            throw new InvalidOperationException("Hash table can only be finalized while building.");
+
+        State = VdbeHashTableState.Probing;
+    }
+
+    /// <summary>
+    /// Looks up the first entry matching <paramref name="keys"/> (Turso <c>probe</c>) and
+    /// positions the match iterator just past it so <see cref="NextMatch"/> continues the
+    /// chain. A key containing NULL never matches: the keys are remembered (with no hash) and
+    /// <see langword="null"/> is returned.
+    /// </summary>
+    public VdbeHashEntry? Probe(SqlValue[] keys)
+    {
+        if (State != VdbeHashTableState.Probing)
+            throw new InvalidOperationException("Hash table must be finalized before probing.");
+
+        if (HasNullKey(keys))
+        {
+            _currentProbeKeys = keys;
+            _currentProbeHash = null;
+            return null;
+        }
+
+        var hash = HashKeys(keys);
+        _currentProbeKeys = keys;
+        _currentProbeHash = hash;
+        _probeEntryIndex = 0;
+        _probeBucketIndex = BucketIndex(hash);
+
+        var bucket = _buckets[_probeBucketIndex];
+        for (var i = 0; i < bucket.Count; i++)
+        {
+            var entry = bucket[i];
+            if (entry.Hash == hash && KeysEqual(entry.Keys, keys))
+            {
+                _probeEntryIndex = i + 1;
+                return entry;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Continues the match chain started by <see cref="Probe"/> (Turso <c>next_match</c>),
+    /// returning the next entry with equal keys or <see langword="null"/> when exhausted.
+    /// </summary>
+    public VdbeHashEntry? NextMatch()
+    {
+        if (State != VdbeHashTableState.Probing)
+            throw new InvalidOperationException("Hash table must be finalized before probing.");
+        if (_currentProbeKeys is null)
+            throw new InvalidOperationException("HashNext requires a preceding HashProbe on the same hash table.");
+
+        var hash = _currentProbeHash ?? HashKeys(_currentProbeKeys);
+        var bucket = _buckets[_probeBucketIndex];
+        for (var i = _probeEntryIndex; i < bucket.Count; i++)
+        {
+            var entry = bucket[i];
+            if (entry.Hash == hash && KeysEqual(entry.Keys, _currentProbeKeys))
+            {
+                _probeEntryIndex = i + 1;
+                return entry;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Marks the entry most recently returned by <see cref="Probe"/>/<see cref="NextMatch"/>
+    /// as matched (Turso <c>mark_current_matched</c>). Tables that do not track matches
+    /// ignore the call.
+    /// </summary>
+    public void MarkCurrentMatched()
+    {
+        if (!_trackMatched)
+            return;
+
+        var entryIndex = _probeEntryIndex - 1;
+        var bits = _matchedBits![_probeBucketIndex];
+        if (entryIndex < 0 || entryIndex >= bits.Count)
+            throw new InvalidOperationException("HashMarkMatched requires a current match from HashProbe or HashNext.");
+
+        bits[entryIndex] = true;
+    }
+
+    /// <summary>Clears every matched bit (Turso <c>reset_matched_bits</c>).</summary>
+    public void ResetMatchedBits()
+    {
+        if (_matchedBits is null)
+            return;
+
+        for (var i = 0; i < _matchedBits.Length; i++)
+        {
+            var bits = _matchedBits[i];
+            for (var j = 0; j < bits.Count; j++)
+                bits[j] = false;
+        }
+    }
+
+    /// <summary>Restarts the unmatched-entry scan (Turso <c>begin_unmatched_scan</c>).</summary>
+    public void BeginUnmatchedScan()
+    {
+        _unmatchedScanBucket = 0;
+        _unmatchedScanEntry = 0;
+    }
+
+    /// <summary>
+    /// Returns the next entry never marked matched (Turso <c>next_unmatched</c> over the main
+    /// buckets), or <see langword="null"/> when the scan is exhausted.
+    /// </summary>
+    public VdbeHashEntry? NextUnmatched()
+    {
+        while (_unmatchedScanBucket < _buckets.Length)
+        {
+            var bucket = _buckets[_unmatchedScanBucket];
+            while (_unmatchedScanEntry < bucket.Count)
+            {
+                var entryIndex = _unmatchedScanEntry;
+                _unmatchedScanEntry++;
+                if (_matchedBits is null || !_matchedBits[_unmatchedScanBucket][entryIndex])
+                    return bucket[entryIndex];
+            }
+
+            _unmatchedScanBucket++;
+            _unmatchedScanEntry = 0;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Empties the table and returns it to the building state (Turso <c>clear</c>) so a
+    /// correlated subquery can rebuild it for the next outer row.
+    /// </summary>
+    public void Clear()
+    {
+        if (_entryCount == 0)
+        {
+            ResetProbeState();
+            State = VdbeHashTableState.Building;
+            return;
+        }
+
+        for (var i = 0; i < _buckets.Length; i++)
+        {
+            _buckets[i].Clear();
+            _matchedBits?[i].Clear();
+        }
+
+        _entryCount = 0;
+        ResetProbeState();
+        State = VdbeHashTableState.Building;
+    }
+
+    /// <summary>Closes the table (Turso <c>close</c>); <see cref="VdbeOpcode.HashClose"/> then drops it.</summary>
+    public void Close()
+        => State = VdbeHashTableState.Closed;
+
+    private void ResetProbeState()
+    {
+        _currentProbeKeys = null;
+        _currentProbeHash = null;
+        _probeEntryIndex = 0;
+        _probeBucketIndex = 0;
+        _unmatchedScanBucket = 0;
+        _unmatchedScanEntry = 0;
+    }
+
+    private int BucketIndex(ulong hash)
+        => (int)(hash % (ulong)_buckets.Length);
+
+    private static bool HasNullKey(SqlValue[] keys)
+    {
+        for (var i = 0; i < keys.Length; i++)
+        {
+            if (keys[i].Kind == SqlValueKind.Null)
+                return true;
+        }
+
+        return false;
+    }
+
+    private ulong HashKeys(SqlValue[] keys)
+    {
+        var hasher = new FnvHasher();
+        for (var i = 0; i < keys.Length; i++)
+            HashJoinKey(ref hasher, keys[i], _collations[i]);
+
+        return hasher.Finish();
+    }
+
+    /// <summary>
+    /// Hashes one key component mirroring Turso's <c>hash_join_key</c>. NULL has its own tag;
+    /// integers exactly representable as f64 hash in the float domain with their numeric
+    /// equivalents; text honours the per-key collation.
+    /// </summary>
+    private static void HashJoinKey(ref FnvHasher hasher, SqlValue value, string? collation)
+    {
+        switch (value.Kind)
+        {
+            case SqlValueKind.Null:
+                hasher.WriteByte(NullTag);
+                break;
+            case SqlValueKind.Integer:
+                {
+                    var integer = value.AsInteger();
+                    var asReal = (double)integer;
+                    if (double.IsFinite(asReal) && (long)asReal == integer)
+                    {
+                        HashReal(ref hasher, asReal);
+                    }
+                    else
+                    {
+                        // Fall back to the integer domain when the float representation would
+                        // lose precision (|i| > 2^53).
+                        hasher.WriteByte(IntegerTag);
+                        hasher.WriteUInt64(unchecked((ulong)integer));
+                    }
+
+                    break;
+                }
+            case SqlValueKind.Real:
+                HashReal(ref hasher, value.AsReal());
+                break;
+            case SqlValueKind.Text:
+                hasher.WriteByte(TextTag);
+                HashText(ref hasher, value.AsText(), collation);
+                break;
+            case SqlValueKind.Blob:
+                hasher.WriteByte(BlobTag);
+                hasher.WriteBytes(value.AsBlobSpan());
+                break;
+        }
+    }
+
+    /// <summary>Hashes REAL values with signed zero normalized (Turso <c>hash_numeric</c>).</summary>
+    private static void HashReal(ref FnvHasher hasher, double value)
+    {
+        hasher.WriteByte(FloatTag);
+        var normalized = value == 0.0 ? 0.0 : value;
+        hasher.WriteUInt64(unchecked((ulong)BitConverter.DoubleToInt64Bits(normalized)));
+    }
+
+    /// <summary>
+    /// Hashes text per collation mirroring Turso's <c>hash_text</c>: NOCASE writes the byte
+    /// length then ASCII-folded bytes, stopping at the first zero byte; RTRIM trims trailing
+    /// spaces; BINARY hashes the raw UTF-8 bytes.
+    /// </summary>
+    private static void HashText(ref FnvHasher hasher, string text, string? collation)
+    {
+        if (IsNoCase(collation))
+        {
+            var bytes = Encoding.UTF8.GetBytes(text);
+            hasher.WriteUInt64((ulong)bytes.Length);
+            foreach (var value in bytes)
+            {
+                if (value == 0)
+                    break;
+
+                hasher.WriteByte(FoldAscii(value));
+            }
+
+            return;
+        }
+
+        if (IsRTrim(collation))
+        {
+            hasher.WriteBytes(Encoding.UTF8.GetBytes(text.TrimEnd(' ')));
+            return;
+        }
+
+        hasher.WriteBytes(Encoding.UTF8.GetBytes(text));
+    }
+
+    /// <summary>
+    /// Join equality for one key component (Turso <c>values_equal</c>): NULL is never equal,
+    /// INTEGER and REAL compare across kinds, text uses the retained collation.
+    /// </summary>
+    private static bool ValuesEqual(SqlValue left, SqlValue right, string? collation)
+    {
+        if (left.Kind == SqlValueKind.Null || right.Kind == SqlValueKind.Null)
+            return false;
+
+        if (left.Kind is SqlValueKind.Integer or SqlValueKind.Real
+            && right.Kind is SqlValueKind.Integer or SqlValueKind.Real)
+            return NumericValuesEqual(left, right);
+
+        if (left.Kind == SqlValueKind.Blob && right.Kind == SqlValueKind.Blob)
+            return left.AsBlobSpan().SequenceEqual(right.AsBlobSpan());
+
+        if (left.Kind == SqlValueKind.Text && right.Kind == SqlValueKind.Text)
+            return TextEquals(left.AsText(), right.AsText(), collation);
+
+        return false;
+    }
+
+    /// <summary>Distinct equality (Turso <c>values_equal_distinct</c>): NULL equals NULL.</summary>
+    private static bool ValuesEqualDistinct(SqlValue left, SqlValue right, string? collation)
+    {
+        if (left.Kind == SqlValueKind.Null && right.Kind == SqlValueKind.Null)
+            return true;
+        if (left.Kind == SqlValueKind.Null || right.Kind == SqlValueKind.Null)
+            return false;
+
+        return ValuesEqual(left, right, collation);
+    }
+
+    private bool KeysEqual(SqlValue[] left, SqlValue[] right)
+    {
+        if (left.Length != right.Length)
+            return false;
+
+        for (var i = 0; i < left.Length; i++)
+        {
+            if (!ValuesEqual(left[i], right[i], _collations[i]))
+                return false;
+        }
+
+        return true;
+    }
+
+    private bool KeysEqualDistinct(SqlValue[] left, SqlValue[] right)
+    {
+        if (left.Length != right.Length)
+            return false;
+
+        for (var i = 0; i < left.Length; i++)
+        {
+            if (!ValuesEqualDistinct(left[i], right[i], _collations[i]))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool NumericValuesEqual(SqlValue left, SqlValue right)
+    {
+        if (left.Kind == SqlValueKind.Integer && right.Kind == SqlValueKind.Integer)
+            return left.AsInteger() == right.AsInteger();
+
+        if (left.Kind == SqlValueKind.Real && right.Kind == SqlValueKind.Real)
+            return left.AsReal() == right.AsReal();
+
+        var integer = left.Kind == SqlValueKind.Integer ? left.AsInteger() : right.AsInteger();
+        var real = left.Kind == SqlValueKind.Real ? left.AsReal() : right.AsReal();
+        return CompareIntegerToReal(integer, real) == 0;
+    }
+
+    private static int CompareIntegerToReal(long integer, double real)
+    {
+        // Same boundaries and truncation logic as SqliteIndexRecordComparer so hash equality
+        // and ordering-based index lookups agree.
+        const double MinimumInt64 = -9_223_372_036_854_775_808d;
+        const double OnePastMaximumInt64 = 9_223_372_036_854_775_808d;
+        if (real < MinimumInt64)
+            return 1;
+        if (real >= OnePastMaximumInt64)
+            return -1;
+
+        var truncated = (long)real;
+        var comparison = integer.CompareTo(truncated);
+        if (comparison != 0 || real == truncated)
+            return comparison;
+
+        return real > 0 ? -1 : 1;
+    }
+
+    private static bool TextEquals(string left, string right, string? collation)
+    {
+        if (IsNoCase(collation))
+            return SqliteIndexRecordComparer.CompareNoCaseText(left, right) == 0;
+
+        if (IsRTrim(collation))
+            return SqliteIndexRecordComparer.CompareRTrimText(left, right) == 0;
+
+        return string.CompareOrdinal(left, right) == 0;
+    }
+
+    private static bool IsNoCase(string? collation)
+        => collation is not null && string.Equals(collation, "NOCASE", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsRTrim(string? collation)
+        => collation is not null && string.Equals(collation, "RTRIM", StringComparison.OrdinalIgnoreCase);
+
+    private static byte FoldAscii(byte value)
+        => value is >= (byte)'A' and <= (byte)'Z'
+            ? (byte)(value + ((byte)'a' - (byte)'A'))
+            : value;
+
+    /// <summary>Incremental FNV-1a 64-bit hasher; deterministic and endian independent.</summary>
+    private struct FnvHasher
+    {
+        private ulong _hash;
+
+        public FnvHasher()
+        {
+            _hash = FnvOffsetBasis;
+        }
+
+        public void WriteByte(byte value)
+        {
+            _hash ^= value;
+            _hash *= FnvPrime;
+        }
+
+        public void WriteBytes(ReadOnlySpan<byte> bytes)
+        {
+            foreach (var value in bytes)
+            {
+                WriteByte(value);
+            }
+        }
+
+        public void WriteUInt64(ulong value)
+        {
+            Span<byte> buffer = stackalloc byte[8];
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(buffer, value);
+            WriteBytes(buffer);
+        }
+
+        public readonly ulong Finish() => _hash;
+    }
+}

--- a/src/Ahtola.Core/Execution/VdbeProgram.cs
+++ b/src/Ahtola.Core/Execution/VdbeProgram.cs
@@ -414,6 +414,121 @@ public enum VdbeOpcode
 
     /// <summary>Store the statement change count into a register (Turso <c>ChangeCount</c>).</summary>
     ChangeCount = 145,
+
+    /// <summary>
+    /// Clear an ephemeral table in place, keeping the cursor open (Turso <c>ResetSorter</c>).
+    /// </summary>
+    ResetSorter = 146,
+
+    /// <summary>
+    /// Materialize an aggregate accumulator into a register without resetting it
+    /// (Turso <c>AggValue</c>).
+    /// </summary>
+    AggValue = 147,
+
+    /// <summary>
+    /// Open a second cursor over the same ephemeral data as an existing cursor
+    /// (Turso <c>OpenDup</c>).
+    /// </summary>
+    OpenDup = 148,
+
+    /// <summary>
+    /// Open an ephemeral index cursor used for automatic indexes (Turso <c>OpenAutoindex</c>).
+    /// </summary>
+    OpenAutoindex = 149,
+
+    /// <summary>
+    /// Jump when the current record of a cursor carries a given column (Turso <c>ColumnHasField</c>).
+    /// </summary>
+    ColumnHasField = 150,
+
+    /// <summary>
+    /// Record a pending lazy seek of a table cursor to the rowid of an index cursor's
+    /// current entry, resolved at the next <c>Column</c>/<c>RowId</c> on the table cursor
+    /// (Turso <c>DeferredSeek</c>).
+    /// </summary>
+    DeferredSeek = 151,
+
+    /// <summary>
+    /// Position a cursor one row past its last row so a following <c>Prev</c> scan walks it
+    /// backwards from the end (Turso <c>SeekEnd</c>).
+    /// </summary>
+    SeekEnd = 152,
+
+    /// <summary>
+    /// Probe the per-cursor bloom filter for a key; jump when the key is definitely not
+    /// present (Turso <c>Filter</c>).
+    /// </summary>
+    BloomFilter = 153,
+
+    /// <summary>
+    /// Insert a key into the per-cursor bloom filter (Turso <c>FilterAdd</c>).
+    /// </summary>
+    BloomFilterAdd = 154,
+
+    /// <summary>
+    /// Insert the current row of a cursor into a hash table keyed on a register range
+    /// (Turso <c>HashBuild</c>).
+    /// </summary>
+    HashBuild = 155,
+
+    /// <summary>
+    /// Insert a key into a hash table if absent, jumping to the duplicate target when the
+    /// key already exists (Turso <c>HashDistinct</c>).
+    /// </summary>
+    HashDistinct = 156,
+
+    /// <summary>
+    /// Finalize a hash table's build phase so probing becomes legal (Turso
+    /// <c>HashBuildFinalize</c>).
+    /// </summary>
+    HashBuildFinalize = 157,
+
+    /// <summary>
+    /// Look up the first entry matching a key in a finalized hash table; jump when no match
+    /// exists (Turso <c>HashProbe</c>).
+    /// </summary>
+    HashProbe = 158,
+
+    /// <summary>
+    /// Continue the match chain started by <see cref="HashProbe"/>; jump when exhausted
+    /// (Turso <c>HashNext</c>).
+    /// </summary>
+    HashNext = 159,
+
+    /// <summary>
+    /// Remove a hash table from the statement registry (Turso <c>HashClose</c>).
+    /// </summary>
+    HashClose = 160,
+
+    /// <summary>
+    /// Empty a hash table and return it to the building state for a rebuild (Turso
+    /// <c>HashClear</c>).
+    /// </summary>
+    HashClear = 161,
+
+    /// <summary>
+    /// Mark the entry most recently matched by <see cref="HashProbe"/>/<see cref="HashNext"/>
+    /// so anti-join scans can skip it (Turso <c>HashMarkMatched</c>).
+    /// </summary>
+    HashMarkMatched = 162,
+
+    /// <summary>
+    /// Clear every matched bit of a hash table (Turso <c>HashResetMatched</c>).
+    /// </summary>
+    HashResetMatched = 163,
+
+    /// <summary>
+    /// Begin scanning the entries of a hash table that were never marked matched, returning
+    /// the first one; jump when none exist (Turso <c>HashScanUnmatched</c>).
+    /// </summary>
+    HashScanUnmatched = 164,
+
+    /// <summary>
+    /// Continue an unmatched-entry scan started by <see cref="HashScanUnmatched"/>; jump when
+    /// exhausted (Turso <c>HashNextUnmatched</c>).
+    /// </summary>
+    HashNextUnmatched = 165,
 }
 
 /// <summary>
@@ -3056,6 +3171,20 @@ public sealed record AggFinalizeInstruction(
     public override VdbeOpcode Opcode => VdbeOpcode.AggFinalize;
 }
 
+/// <summary>Reads the current value of <paramref name="Accumulator"/> with
+/// <paramref name="Aggregate"/> into <paramref name="Destination"/> without resetting it,
+/// so the aggregate can still be stepped afterwards (Turso <c>AggValue</c>, used for
+/// running aggregates and window-function value extraction). Shares the finalize semantics
+/// of <see cref="AggFinalizeInstruction"/>; an accumulator that was reset but never stepped
+/// yields the aggregate's empty-input value.</summary>
+public sealed record AggValueInstruction(
+    Accumulator Accumulator,
+    VdbeAggregate Aggregate,
+    Register Destination) : VdbeInstruction
+{
+    public override VdbeOpcode Opcode => VdbeOpcode.AggValue;
+}
+
 /// <summary>Compares the group-key tuple in <paramref name="CurrentKey"/> against the
 /// saved tuple in <paramref name="SavedKey"/> with <paramref name="Comparer"/> and jumps
 /// to <paramref name="SameGroupTarget"/> when they fall in the same group, falling through
@@ -3689,6 +3818,256 @@ public sealed record EphemeralInsertInstruction(Cursor Cursor, RegisterRange Val
 }
 
 /// <summary>
+/// Opens an ephemeral index cursor on <paramref name="Cursor"/> with
+/// <paramref name="ColumnCount"/> columns, used to hold automatic indexes (Turso
+/// <c>OpenAutoindex</c> — <c>OpenEphemeral</c> with <c>is_table=false</c>). The managed
+/// ephemeral runtime has a single shape, so this shares the
+/// <see cref="OpenEphemeralInstruction"/> open path and scans through the normal
+/// Rewind/Next/Column/Found family.
+/// </summary>
+public sealed record OpenAutoindexInstruction(Cursor Cursor, int ColumnCount) : VdbeInstruction
+{
+    public override VdbeOpcode Opcode => VdbeOpcode.OpenAutoindex;
+}
+
+/// <summary>
+/// Opens <paramref name="NewCursor"/> as a second cursor over the same underlying
+/// ephemeral data as <paramref name="OriginalCursor"/> (Turso <c>OpenDup</c>). Both
+/// cursors share one storage instance: inserting through either is visible to both, and
+/// closing either disposes the shared storage for both — programs must keep their
+/// lifetimes coupled, exactly as in Turso.
+/// </summary>
+public sealed record OpenDupInstruction(Cursor NewCursor, Cursor OriginalCursor) : VdbeInstruction
+{
+    public override VdbeOpcode Opcode => VdbeOpcode.OpenDup;
+}
+
+/// <summary>
+/// Clears all rows from the ephemeral table on <paramref name="Cursor"/> in place,
+/// leaving the cursor open and rewound, with rowids restarting from 1 (Turso
+/// <c>ResetSorter</c>, which clears the ephemeral b-tree). Validated to target only
+/// ephemeral cursors — callers (window partition boundaries) own that guarantee.
+/// </summary>
+public sealed record ResetSorterInstruction(Cursor Cursor) : VdbeInstruction
+{
+    public override VdbeOpcode Opcode => VdbeOpcode.ResetSorter;
+}
+
+/// <summary>
+/// Jumps to <paramref name="Target"/> when the record currently positioned on
+/// <paramref name="Cursor"/> carries <paramref name="Column"/> (that is, has at least
+/// <c>Column + 1</c> columns); otherwise falls through (Turso <c>ColumnHasField</c>,
+/// used to detect short rows before reading a trailing field). A cursor with no current
+/// record falls through.
+/// </summary>
+public sealed record ColumnHasFieldInstruction(
+    Cursor Cursor,
+    int Column,
+    ProgramCounter Target) : VdbeInstruction
+{
+    public override VdbeOpcode Opcode => VdbeOpcode.ColumnHasField;
+}
+
+/// <summary>
+/// Records a pending seek of <paramref name="TableCursor"/> without moving it: the table
+/// cursor will be repositioned onto the rowid of <paramref name="IndexCursor"/>'s current
+/// entry lazily, at the next <c>Column</c> or <c>RowId</c> read of the table cursor (Turso
+/// <c>DeferredSeek</c>). If the index cursor has no current entry when the read resolves,
+/// the pending seek is discarded and the column read observes the table cursor's existing
+/// position. Reopening or closing either cursor invalidates the pending seek.
+/// </summary>
+public sealed record DeferredSeekInstruction(Cursor IndexCursor, Cursor TableCursor) : VdbeInstruction
+{
+    public override VdbeOpcode Opcode => VdbeOpcode.DeferredSeek;
+}
+
+/// <summary>
+/// Positions <paramref name="Cursor"/> one row past its last row (Turso <c>SeekEnd</c>).
+/// The cursor itself reports no current row in this state; a following <c>Prev</c>
+/// instruction lands on the last row, enabling backwards full scans.
+/// </summary>
+public sealed record SeekEndInstruction(Cursor Cursor) : VdbeInstruction
+{
+    public override VdbeOpcode Opcode => VdbeOpcode.SeekEnd;
+}
+
+/// <summary>
+/// Probes the bloom filter attached to <paramref name="Cursor"/> for the key held in
+/// <paramref name="Key"/>. Jumps to <paramref name="NotPresentTarget"/> when the key is
+/// definitely absent (or contains a NULL component); otherwise falls through — a match
+/// is possible but not guaranteed (Turso <c>Filter</c>). A cursor with no filter yet
+/// falls through.
+/// </summary>
+public sealed record BloomFilterInstruction(
+    Cursor Cursor,
+    RegisterRange Key,
+    ProgramCounter NotPresentTarget) : VdbeInstruction
+{
+    public override VdbeOpcode Opcode => VdbeOpcode.BloomFilter;
+}
+
+/// <summary>
+/// Inserts the key held in <paramref name="Key"/> into the bloom filter attached to
+/// <paramref name="Cursor"/>, creating the filter on first use (Turso <c>FilterAdd</c>).
+/// A single NULL key contributes nothing; NULL components of a composite key are hashed
+/// as absent while the remaining components still participate.
+/// </summary>
+public sealed record BloomFilterAddInstruction(Cursor Cursor, RegisterRange Key) : VdbeInstruction
+{
+    public override VdbeOpcode Opcode => VdbeOpcode.BloomFilterAdd;
+}
+
+/// <summary>
+/// Inserts the current row of <paramref name="Cursor"/> into hash table
+/// <paramref name="HashTableId"/>, creating the table on first use (Turso <c>HashBuild</c>).
+/// The key is read from the <paramref name="Key"/> registers, the rowid from the cursor, and
+/// optional payload columns from the <paramref name="Payload"/> registers. Rows whose key
+/// contains NULL are dropped unless <paramref name="TrackMatched"/> is set (anti-joins must
+/// retain them for the unmatched scan).
+/// </summary>
+public sealed record HashBuildInstruction(
+    Cursor Cursor,
+    RegisterRange Key,
+    int HashTableId,
+    long MemoryBudget,
+    IReadOnlyList<string?> Collations,
+    RegisterRange? Payload,
+    bool TrackMatched) : VdbeInstruction
+{
+    public override VdbeOpcode Opcode => VdbeOpcode.HashBuild;
+}
+
+/// <summary>
+/// Inserts the key held in the <paramref name="Key"/> registers into hash table
+/// <paramref name="HashTableId"/> if it is not already present (Turso <c>HashDistinct</c>),
+/// creating the table on first use. Falls through for a new key; jumps to
+/// <paramref name="DuplicateTarget"/> when the key already exists. NULL compares equal to
+/// NULL, so NULL keys deduplicate.
+/// </summary>
+public sealed record HashDistinctInstruction(
+    RegisterRange Key,
+    IReadOnlyList<string?> Collations,
+    int HashTableId,
+    ProgramCounter DuplicateTarget) : VdbeInstruction
+{
+    public override VdbeOpcode Opcode => VdbeOpcode.HashDistinct;
+}
+
+/// <summary>
+/// Finalizes hash table <paramref name="HashTableId"/>, ending the build phase (Turso
+/// <c>HashBuildFinalize</c>). A missing table is a no-op, mirroring Turso.
+/// </summary>
+public sealed record HashBuildFinalizeInstruction(int HashTableId) : VdbeInstruction
+{
+    public override VdbeOpcode Opcode => VdbeOpcode.HashBuildFinalize;
+}
+
+/// <summary>
+/// Looks up the first entry of hash table <paramref name="HashTableId"/> whose keys equal the
+/// <paramref name="Key"/> registers (Turso <c>HashProbe</c>). On a match, writes the entry's
+/// rowid to <paramref name="Destination"/> and any payload columns to
+/// <paramref name="PayloadDestination"/>; otherwise jumps to
+/// <paramref name="NotFoundTarget"/> — also when the table does not exist.
+/// </summary>
+public sealed record HashProbeInstruction(
+    int HashTableId,
+    RegisterRange Key,
+    Register Destination,
+    RegisterRange? PayloadDestination,
+    ProgramCounter NotFoundTarget) : VdbeInstruction
+{
+    public override VdbeOpcode Opcode => VdbeOpcode.HashProbe;
+}
+
+/// <summary>
+/// Continues the match chain started by <see cref="HashProbeInstruction"/> on hash table
+/// <paramref name="HashTableId"/> (Turso <c>HashNext</c>), writing the next matching entry's
+/// rowid to <paramref name="Destination"/> (and payload to
+/// <paramref name="PayloadDestination"/>) or jumping to <paramref name="ExhaustedTarget"/>
+/// when the chain is exhausted. A missing table is an error.
+/// </summary>
+public sealed record HashNextInstruction(
+    int HashTableId,
+    Register Destination,
+    RegisterRange? PayloadDestination,
+    ProgramCounter ExhaustedTarget) : VdbeInstruction
+{
+    public override VdbeOpcode Opcode => VdbeOpcode.HashNext;
+}
+
+/// <summary>
+/// Removes hash table <paramref name="HashTableId"/> from the statement registry and closes
+/// it (Turso <c>HashClose</c>).
+/// </summary>
+public sealed record HashCloseInstruction(int HashTableId) : VdbeInstruction
+{
+    public override VdbeOpcode Opcode => VdbeOpcode.HashClose;
+}
+
+/// <summary>
+/// Empties hash table <paramref name="HashTableId"/> and returns it to the building state
+/// (Turso <c>HashClear</c>) so a correlated subquery can rebuild it for the next outer row.
+/// A missing table is a no-op, mirroring Turso.
+/// </summary>
+public sealed record HashClearInstruction(int HashTableId) : VdbeInstruction
+{
+    public override VdbeOpcode Opcode => VdbeOpcode.HashClear;
+}
+
+/// <summary>
+/// Marks the entry most recently matched by <see cref="HashProbeInstruction"/>/
+/// <see cref="HashNextInstruction"/> on hash table <paramref name="HashTableId"/> as matched
+/// (Turso <c>HashMarkMatched</c>). Tables that do not track matches ignore it, as does a
+/// missing table.
+/// </summary>
+public sealed record HashMarkMatchedInstruction(int HashTableId) : VdbeInstruction
+{
+    public override VdbeOpcode Opcode => VdbeOpcode.HashMarkMatched;
+}
+
+/// <summary>
+/// Clears every matched bit of hash table <paramref name="HashTableId"/> (Turso
+/// <c>HashResetMatched</c>). A missing table is a no-op, mirroring Turso.
+/// </summary>
+public sealed record HashResetMatchedInstruction(int HashTableId) : VdbeInstruction
+{
+    public override VdbeOpcode Opcode => VdbeOpcode.HashResetMatched;
+}
+
+/// <summary>
+/// Starts a scan over the entries of hash table <paramref name="HashTableId"/> that were
+/// never marked matched (Turso <c>HashScanUnmatched</c>), writing the first unmatched entry's
+/// rowid to <paramref name="Destination"/> (and payload to
+/// <paramref name="PayloadDestination"/>) or jumping to <paramref name="ExhaustedTarget"/>
+/// when every entry matched — also when the table does not exist.
+/// </summary>
+public sealed record HashScanUnmatchedInstruction(
+    int HashTableId,
+    Register Destination,
+    RegisterRange? PayloadDestination,
+    ProgramCounter ExhaustedTarget) : VdbeInstruction
+{
+    public override VdbeOpcode Opcode => VdbeOpcode.HashScanUnmatched;
+}
+
+/// <summary>
+/// Continues the unmatched-entry scan started by
+/// <see cref="HashScanUnmatchedInstruction"/> on hash table
+/// <paramref name="HashTableId"/> (Turso <c>HashNextUnmatched</c>), writing the next unmatched
+/// entry's rowid to <paramref name="Destination"/> (and payload to
+/// <paramref name="PayloadDestination"/>) or jumping to <paramref name="ExhaustedTarget"/>
+/// when the scan is exhausted. A missing table is an error.
+/// </summary>
+public sealed record HashNextUnmatchedInstruction(
+    int HashTableId,
+    Register Destination,
+    RegisterRange? PayloadDestination,
+    ProgramCounter ExhaustedTarget) : VdbeInstruction
+{
+    public override VdbeOpcode Opcode => VdbeOpcode.HashNextUnmatched;
+}
+
+/// <summary>
 /// Probes <paramref name="Cursor"/> for a row whose leading columns equal
 /// <paramref name="Key"/>. Jumps to <paramref name="NoConflictTarget"/> when any key
 /// register is NULL or no match exists (Turso/SQLite <c>NoConflict</c> — NULL never
@@ -4123,7 +4502,8 @@ public sealed class VdbeProgram
         int distinctSetCount = 0,
         int parameterSlotCount = 0,
         int workTableCount = 0,
-        int windowBufferCount = 0)
+        int windowBufferCount = 0,
+        int hashTableCount = 0)
     {
         if (registerCount < 0)
             throw new ArgumentOutOfRangeException(nameof(registerCount));
@@ -4141,6 +4521,8 @@ public sealed class VdbeProgram
             throw new ArgumentOutOfRangeException(nameof(workTableCount));
         if (windowBufferCount < 0)
             throw new ArgumentOutOfRangeException(nameof(windowBufferCount));
+        if (hashTableCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(hashTableCount));
         ArgumentNullException.ThrowIfNull(instructions);
 
         RegisterCount = registerCount;
@@ -4151,6 +4533,7 @@ public sealed class VdbeProgram
         ParameterSlotCount = parameterSlotCount;
         WorkTableCount = workTableCount;
         WindowBufferCount = windowBufferCount;
+        HashTableCount = hashTableCount;
         _instructions = Array.AsReadOnly(instructions.ToArray());
         Validate();
     }
@@ -4180,6 +4563,11 @@ public sealed class VdbeProgram
     /// window functions.</summary>
     public int WindowBufferCount { get; }
 
+    /// <summary>The number of in-memory hash tables the program references via the
+    /// <see cref="VdbeOpcode.HashBuild"/> family. Hash tables are created lazily at run time and
+    /// shared across subprogram statements of one resumable statement.</summary>
+    public int HashTableCount { get; }
+
     public IReadOnlyList<VdbeInstruction> Instructions => _instructions;
 
     public void Validate()
@@ -4191,6 +4579,7 @@ public sealed class VdbeProgram
 
         var openCursors = new bool[CursorCount];
         var cursorColumnCounts = new int[CursorCount];
+        var ephemeralCursors = new bool[CursorCount];
         var openSorters = new bool[SorterCount];
         var sorterColumnCounts = new int[SorterCount];
         var openWorkTables = new bool[WorkTableCount];
@@ -4696,7 +5085,76 @@ public sealed class VdbeProgram
                     }
 
                     openCursors[openEphemeral.Cursor.Index] = true;
+                    ephemeralCursors[openEphemeral.Cursor.Index] = true;
                     cursorColumnCounts[openEphemeral.Cursor.Index] = openEphemeral.ColumnCount;
+                    break;
+                case OpenAutoindexInstruction openAutoindex:
+                    ValidateCursor(openAutoindex.Cursor, instructionIndex);
+                    if (openCursors[openAutoindex.Cursor.Index])
+                    {
+                        throw new VdbeProgramValidationException(
+                            $"VDBE instruction {instructionIndex} opens cursor {openAutoindex.Cursor.Index} twice.");
+                    }
+
+                    if (openAutoindex.ColumnCount <= 0)
+                    {
+                        throw new VdbeProgramValidationException(
+                            $"VDBE instruction {instructionIndex} opens autoindex cursor {openAutoindex.Cursor.Index} with a non-positive column count.");
+                    }
+
+                    openCursors[openAutoindex.Cursor.Index] = true;
+                    ephemeralCursors[openAutoindex.Cursor.Index] = true;
+                    cursorColumnCounts[openAutoindex.Cursor.Index] = openAutoindex.ColumnCount;
+                    break;
+                case OpenDupInstruction openDup:
+                    ValidateCursor(openDup.NewCursor, instructionIndex);
+                    ValidateCursor(openDup.OriginalCursor, instructionIndex);
+                    if (openDup.NewCursor.Index == openDup.OriginalCursor.Index)
+                    {
+                        throw new VdbeProgramValidationException(
+                            $"VDBE instruction {instructionIndex} duplicates cursor {openDup.OriginalCursor.Index} onto itself.");
+                    }
+
+                    if (!openCursors[openDup.OriginalCursor.Index])
+                    {
+                        throw new VdbeProgramValidationException(
+                            $"VDBE instruction {instructionIndex} duplicates cursor {openDup.OriginalCursor.Index} before opening it.");
+                    }
+
+                    if (!ephemeralCursors[openDup.OriginalCursor.Index])
+                    {
+                        throw new VdbeProgramValidationException(
+                            $"VDBE instruction {instructionIndex} duplicates cursor {openDup.OriginalCursor.Index}, which is not an ephemeral cursor.");
+                    }
+
+                    if (openCursors[openDup.NewCursor.Index])
+                    {
+                        throw new VdbeProgramValidationException(
+                            $"VDBE instruction {instructionIndex} opens cursor {openDup.NewCursor.Index} twice.");
+                    }
+
+                    openCursors[openDup.NewCursor.Index] = true;
+                    ephemeralCursors[openDup.NewCursor.Index] = true;
+                    cursorColumnCounts[openDup.NewCursor.Index] = cursorColumnCounts[openDup.OriginalCursor.Index];
+                    break;
+                case ResetSorterInstruction resetSorter:
+                    ValidateOpenCursor(resetSorter.Cursor, openCursors, instructionIndex);
+                    if (!ephemeralCursors[resetSorter.Cursor.Index])
+                    {
+                        throw new VdbeProgramValidationException(
+                            $"VDBE instruction {instructionIndex} resets cursor {resetSorter.Cursor.Index}, which is not an ephemeral cursor.");
+                    }
+
+                    break;
+                case ColumnHasFieldInstruction columnHasField:
+                    ValidateOpenCursor(columnHasField.Cursor, openCursors, instructionIndex);
+                    if (columnHasField.Column < 0)
+                    {
+                        throw new VdbeProgramValidationException(
+                            $"VDBE instruction {instructionIndex} checks negative column {columnHasField.Column} on cursor {columnHasField.Cursor.Index}.");
+                    }
+
+                    ValidateJumpTarget(columnHasField.Target, instructionIndex);
                     break;
                 case EphemeralInsertInstruction ephemeralInsert:
                     ValidateOpenCursor(ephemeralInsert.Cursor, openCursors, instructionIndex);
@@ -4815,6 +5273,162 @@ public sealed class VdbeProgram
                     ValidateOpenCursor(seekRowid.Cursor, openCursors, instructionIndex);
                     ValidateRegister(seekRowid.RowIdRegister, instructionIndex);
                     ValidateJumpTarget(seekRowid.NotFoundTarget, instructionIndex);
+                    break;
+                case DeferredSeekInstruction deferredSeek:
+                    ValidateOpenCursor(deferredSeek.IndexCursor, openCursors, instructionIndex);
+                    ValidateOpenCursor(deferredSeek.TableCursor, openCursors, instructionIndex);
+                    if (deferredSeek.IndexCursor.Index == deferredSeek.TableCursor.Index)
+                    {
+                        throw new VdbeProgramValidationException(
+                            $"VDBE instruction {instructionIndex} deferred-seeks cursor {deferredSeek.TableCursor.Index} against itself.");
+                    }
+
+                    break;
+                case SeekEndInstruction seekEnd:
+                    ValidateOpenCursor(seekEnd.Cursor, openCursors, instructionIndex);
+                    break;
+                case BloomFilterInstruction bloomFilter:
+                    ValidateOpenCursor(bloomFilter.Cursor, openCursors, instructionIndex);
+                    ValidateRegisterRange(bloomFilter.Key, instructionIndex);
+                    if (bloomFilter.Key.Count <= 0)
+                    {
+                        throw new VdbeProgramValidationException(
+                            $"VDBE instruction {instructionIndex} BloomFilter requires a positive key width.");
+                    }
+
+                    ValidateJumpTarget(bloomFilter.NotPresentTarget, instructionIndex);
+                    break;
+                case BloomFilterAddInstruction bloomAdd:
+                    ValidateOpenCursor(bloomAdd.Cursor, openCursors, instructionIndex);
+                    ValidateRegisterRange(bloomAdd.Key, instructionIndex);
+                    if (bloomAdd.Key.Count <= 0)
+                    {
+                        throw new VdbeProgramValidationException(
+                            $"VDBE instruction {instructionIndex} BloomFilterAdd requires a positive key width.");
+                    }
+
+                    break;
+                case HashBuildInstruction hashBuild:
+                    ValidateOpenCursor(hashBuild.Cursor, openCursors, instructionIndex);
+                    ValidateRegisterRange(hashBuild.Key, instructionIndex);
+                    if (hashBuild.Key.Count <= 0)
+                    {
+                        throw new VdbeProgramValidationException(
+                            $"VDBE instruction {instructionIndex} HashBuild requires a positive key width.");
+                    }
+
+                    ValidateHashTable(hashBuild.HashTableId, instructionIndex);
+                    if (hashBuild.MemoryBudget < 0)
+                    {
+                        throw new VdbeProgramValidationException(
+                            $"VDBE instruction {instructionIndex} HashBuild has a negative memory budget of {hashBuild.MemoryBudget}.");
+                    }
+
+                    ValidateHashCollations(hashBuild.Collations, hashBuild.Key.Count, instructionIndex, nameof(HashBuildInstruction));
+                    if (hashBuild.Payload is { } buildPayload)
+                    {
+                        ValidateRegisterRange(buildPayload, instructionIndex);
+                        if (buildPayload.Count <= 0)
+                        {
+                            throw new VdbeProgramValidationException(
+                                $"VDBE instruction {instructionIndex} HashBuild payload range must carry at least one register.");
+                        }
+                    }
+
+                    break;
+                case HashDistinctInstruction hashDistinct:
+                    ValidateRegisterRange(hashDistinct.Key, instructionIndex);
+                    if (hashDistinct.Key.Count <= 0)
+                    {
+                        throw new VdbeProgramValidationException(
+                            $"VDBE instruction {instructionIndex} HashDistinct requires a positive key width.");
+                    }
+
+                    ValidateHashCollations(hashDistinct.Collations, hashDistinct.Key.Count, instructionIndex, nameof(HashDistinctInstruction));
+                    ValidateHashTable(hashDistinct.HashTableId, instructionIndex);
+                    ValidateJumpTarget(hashDistinct.DuplicateTarget, instructionIndex);
+                    break;
+                case HashBuildFinalizeInstruction hashFinalize:
+                    ValidateHashTable(hashFinalize.HashTableId, instructionIndex);
+                    break;
+                case HashProbeInstruction hashProbe:
+                    ValidateHashTable(hashProbe.HashTableId, instructionIndex);
+                    ValidateRegisterRange(hashProbe.Key, instructionIndex);
+                    if (hashProbe.Key.Count <= 0)
+                    {
+                        throw new VdbeProgramValidationException(
+                            $"VDBE instruction {instructionIndex} HashProbe requires a positive key width.");
+                    }
+
+                    ValidateRegister(hashProbe.Destination, instructionIndex);
+                    if (hashProbe.PayloadDestination is { } probePayload)
+                    {
+                        ValidateRegisterRange(probePayload, instructionIndex);
+                        if (probePayload.Count <= 0)
+                        {
+                            throw new VdbeProgramValidationException(
+                                $"VDBE instruction {instructionIndex} HashProbe payload range must carry at least one register.");
+                        }
+                    }
+
+                    ValidateJumpTarget(hashProbe.NotFoundTarget, instructionIndex);
+                    break;
+                case HashNextInstruction hashNext:
+                    ValidateHashTable(hashNext.HashTableId, instructionIndex);
+                    ValidateRegister(hashNext.Destination, instructionIndex);
+                    if (hashNext.PayloadDestination is { } nextPayload)
+                    {
+                        ValidateRegisterRange(nextPayload, instructionIndex);
+                        if (nextPayload.Count <= 0)
+                        {
+                            throw new VdbeProgramValidationException(
+                                $"VDBE instruction {instructionIndex} HashNext payload range must carry at least one register.");
+                        }
+                    }
+
+                    ValidateJumpTarget(hashNext.ExhaustedTarget, instructionIndex);
+                    break;
+                case HashCloseInstruction hashClose:
+                    ValidateHashTable(hashClose.HashTableId, instructionIndex);
+                    break;
+                case HashClearInstruction hashClear:
+                    ValidateHashTable(hashClear.HashTableId, instructionIndex);
+                    break;
+                case HashMarkMatchedInstruction hashMarkMatched:
+                    ValidateHashTable(hashMarkMatched.HashTableId, instructionIndex);
+                    break;
+                case HashResetMatchedInstruction hashResetMatched:
+                    ValidateHashTable(hashResetMatched.HashTableId, instructionIndex);
+                    break;
+                case HashScanUnmatchedInstruction hashScanUnmatched:
+                    ValidateHashTable(hashScanUnmatched.HashTableId, instructionIndex);
+                    ValidateRegister(hashScanUnmatched.Destination, instructionIndex);
+                    if (hashScanUnmatched.PayloadDestination is { } scanPayload)
+                    {
+                        ValidateRegisterRange(scanPayload, instructionIndex);
+                        if (scanPayload.Count <= 0)
+                        {
+                            throw new VdbeProgramValidationException(
+                                $"VDBE instruction {instructionIndex} HashScanUnmatched payload range must carry at least one register.");
+                        }
+                    }
+
+                    ValidateJumpTarget(hashScanUnmatched.ExhaustedTarget, instructionIndex);
+                    break;
+                case HashNextUnmatchedInstruction hashNextUnmatched:
+                    ValidateHashTable(hashNextUnmatched.HashTableId, instructionIndex);
+                    ValidateRegister(hashNextUnmatched.Destination, instructionIndex);
+                    if (hashNextUnmatched.PayloadDestination is { } nextUnmatchedPayload)
+                    {
+                        ValidateRegisterRange(nextUnmatchedPayload, instructionIndex);
+                        if (nextUnmatchedPayload.Count <= 0)
+                        {
+                            throw new VdbeProgramValidationException(
+                                $"VDBE instruction {instructionIndex} HashNextUnmatched payload range must carry at least one register.");
+                        }
+                    }
+
+                    ValidateJumpTarget(hashNextUnmatched.ExhaustedTarget, instructionIndex);
                     break;
                 case NotExistsInstruction notExists:
                     ValidateOpenCursor(notExists.Cursor, openCursors, instructionIndex);
@@ -5096,6 +5710,16 @@ public sealed class VdbeProgram
                     }
 
                     ValidateRegister(aggFinalize.Destination, instructionIndex);
+                    break;
+                case AggValueInstruction aggValue:
+                    ValidateAccumulator(aggValue.Accumulator, instructionIndex);
+                    if (aggValue.Aggregate is null)
+                    {
+                        throw new VdbeProgramValidationException(
+                            $"VDBE instruction {instructionIndex} reads accumulator {aggValue.Accumulator.Index} with a null aggregate.");
+                    }
+
+                    ValidateRegister(aggValue.Destination, instructionIndex);
                     break;
                 case SameGroupInstruction sameGroup:
                     if (sameGroup.Comparer is null)
@@ -5817,6 +6441,37 @@ public sealed class VdbeProgram
         {
             throw new VdbeProgramValidationException(
                 $"VDBE instruction {instructionIndex} references parameter slot {slot.Index}, but the program has {ParameterSlotCount} parameter slots.");
+        }
+    }
+
+    private void ValidateHashTable(int hashTableId, int instructionIndex)
+    {
+        if (hashTableId < 0 || hashTableId >= HashTableCount)
+        {
+            throw new VdbeProgramValidationException(
+                $"VDBE instruction {instructionIndex} references hash table {hashTableId}, but the program has {HashTableCount} hash tables.");
+        }
+    }
+
+    private static void ValidateHashCollations(
+        IReadOnlyList<string?> collations,
+        int keyCount,
+        int instructionIndex,
+        string instructionName)
+    {
+        if (collations.Count != keyCount)
+        {
+            throw new VdbeProgramValidationException(
+                $"VDBE instruction {instructionIndex} {instructionName} declares {collations.Count} collations for {keyCount} key columns.");
+        }
+
+        for (int index = 0; index < collations.Count; index++)
+        {
+            if (!SqliteIndexRecordComparer.IsSupportedCollation(collations[index]))
+            {
+                throw new VdbeProgramValidationException(
+                    $"VDBE instruction {instructionIndex} {instructionName} uses unsupported collation '{collations[index]}' for key column {index}.");
+            }
         }
     }
 

--- a/src/Ahtola.Tests/AggregateOpcodeExecutionTests.cs
+++ b/src/Ahtola.Tests/AggregateOpcodeExecutionTests.cs
@@ -82,6 +82,54 @@ public class AggregateOpcodeExecutionTests
     }
 
     [Test]
+    public void AggValueDoesNotResetTheAccumulator()
+    {
+        // AggValue reads the current value without touching the accumulator: a second step
+        // afterwards must fold into the same context, unlike AggFinalize which pairs with a
+        // reset in SQLite's classic flow.
+        VdbeInstruction[] instructions =
+        [
+            new LoadConstantInstruction(new Register(0), SqlValue.Integer(5)),
+            new AggStepInstruction(new Accumulator(0), AggregateTestSupport.Sum(), new RegisterRange(new Register(0), 1)),
+            new AggValueInstruction(new Accumulator(0), AggregateTestSupport.Sum(), new Register(1)),
+            new ResultRowInstruction(new RegisterRange(new Register(1), 1)),
+            new LoadConstantInstruction(new Register(0), SqlValue.Integer(7)),
+            new AggStepInstruction(new Accumulator(0), AggregateTestSupport.Sum(), new RegisterRange(new Register(0), 1)),
+            new AggValueInstruction(new Accumulator(0), AggregateTestSupport.Sum(), new Register(1)),
+            new ResultRowInstruction(new RegisterRange(new Register(1), 1)),
+            new HaltInstruction(),
+        ];
+
+        var program = new VdbeProgram(registerCount: 2, cursorCount: 0, instructions, accumulatorCount: 1);
+
+        var rows = RunToCompletion(program);
+
+        rows.Select(row => row[0].AsInteger()).Should().Equal(5, 12);
+    }
+
+    [Test]
+    public void AggValueOnNeverSteppedAccumulatorYieldsTheEmptyInputValue()
+    {
+        // Reading a never-stepped accumulator must behave like finalizing a fresh context:
+        // SUM yields NULL and COUNT(*) yields 0.
+        VdbeInstruction[] instructions =
+        [
+            new AggValueInstruction(new Accumulator(0), AggregateTestSupport.Sum(), new Register(0)),
+            new AggValueInstruction(new Accumulator(1), AggregateTestSupport.CountStar(), new Register(1)),
+            new ResultRowInstruction(new RegisterRange(new Register(0), 2)),
+            new HaltInstruction(),
+        ];
+
+        var program = new VdbeProgram(registerCount: 2, cursorCount: 0, instructions, accumulatorCount: 2);
+
+        var rows = RunToCompletion(program);
+
+        rows.Should().ContainSingle();
+        rows[0][0].Kind.Should().Be(SqlValueKind.Null);
+        rows[0][1].Should().Be(SqlValue.Integer(0));
+    }
+
+    [Test]
     public void AggResetDiscardsAccumulatedState()
     {
         VdbeInstruction[] instructions =
@@ -394,6 +442,16 @@ public class AggregateOpcodeExecutionTests
             ],
             accumulatorCount: 1));
 
+        // Reading with a null aggregate.
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 1,
+            cursorCount: 0,
+            [
+                new AggValueInstruction(new Accumulator(0), null!, new Register(0)),
+                new HaltInstruction(),
+            ],
+            accumulatorCount: 1));
+
         // Stepping arguments that reach outside the register file.
         Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
             registerCount: 1,
@@ -681,6 +739,26 @@ public class AggregateOpcodeExecutionTests
         ((int)VdbeOpcode.GroupKey).Should().Be(58);
         ((int)VdbeOpcode.DistinctGate).Should().Be(59);
         ((int)VdbeOpcode.AggInverse).Should().Be(136);
+        ((int)VdbeOpcode.ResetSorter).Should().Be(146);
+        ((int)VdbeOpcode.AggValue).Should().Be(147);
+        ((int)VdbeOpcode.OpenDup).Should().Be(148);
+        ((int)VdbeOpcode.OpenAutoindex).Should().Be(149);
+        ((int)VdbeOpcode.ColumnHasField).Should().Be(150);
+        ((int)VdbeOpcode.DeferredSeek).Should().Be(151);
+        ((int)VdbeOpcode.SeekEnd).Should().Be(152);
+        ((int)VdbeOpcode.BloomFilter).Should().Be(153);
+        ((int)VdbeOpcode.BloomFilterAdd).Should().Be(154);
+        ((int)VdbeOpcode.HashBuild).Should().Be(155);
+        ((int)VdbeOpcode.HashDistinct).Should().Be(156);
+        ((int)VdbeOpcode.HashBuildFinalize).Should().Be(157);
+        ((int)VdbeOpcode.HashProbe).Should().Be(158);
+        ((int)VdbeOpcode.HashNext).Should().Be(159);
+        ((int)VdbeOpcode.HashClose).Should().Be(160);
+        ((int)VdbeOpcode.HashClear).Should().Be(161);
+        ((int)VdbeOpcode.HashMarkMatched).Should().Be(162);
+        ((int)VdbeOpcode.HashResetMatched).Should().Be(163);
+        ((int)VdbeOpcode.HashScanUnmatched).Should().Be(164);
+        ((int)VdbeOpcode.HashNextUnmatched).Should().Be(165);
     }
 
     // Loads saved/current keys, compares them with SameGroup, and returns the value the

--- a/src/Ahtola.Tests/VdbeMicroCursorOpcodeTests.cs
+++ b/src/Ahtola.Tests/VdbeMicroCursorOpcodeTests.cs
@@ -1,0 +1,1390 @@
+using AwesomeAssertions;
+using Ahtola.Core;
+using Ahtola.Core.Execution;
+
+namespace Ahtola.Tests;
+
+/// <summary>
+/// Covers the micro-cursor opcodes ported from Turso's same-named <c>Insn</c>s:
+/// <c>ResetSorter</c>, <c>OpenDup</c>, <c>OpenAutoindex</c>, <c>ColumnHasField</c>,
+/// <c>DeferredSeek</c>, <c>SeekEnd</c>, <c>BloomFilter</c>, <c>BloomFilterAdd</c>,
+/// and the hash-join family (<c>HashBuild</c>, <c>HashDistinct</c>, <c>HashBuildFinalize</c>,
+/// <c>HashProbe</c>, <c>HashNext</c>, <c>HashClose</c>, <c>HashClear</c>,
+/// <c>HashMarkMatched</c>, <c>HashResetMatched</c>, <c>HashScanUnmatched</c>,
+/// <c>HashNextUnmatched</c>).
+/// The aggregate half (<c>AggValue</c>) lives in <c>AggregateOpcodeExecutionTests</c>.
+/// </summary>
+public sealed class VdbeMicroCursorOpcodeTests
+{
+    [Test]
+    public void ResetSorterClearsRowsAndRestartsRowIds()
+    {
+        // Insert two rows, then ResetSorter clears them in place: the rewind must see an
+        // empty table, and the next insert must receive rowid 1 again.
+        VdbeInstruction[] instructions =
+        [
+            new OpenEphemeralInstruction(new Cursor(0), ColumnCount: 1),
+            new LoadConstantInstruction(new Register(0), SqlValue.Text("a")),
+            new EphemeralInsertInstruction(new Cursor(0), new RegisterRange(new Register(0), 1)),
+            new LoadConstantInstruction(new Register(0), SqlValue.Text("b")),
+            new EphemeralInsertInstruction(new Cursor(0), new RegisterRange(new Register(0), 1)),
+            new ResetSorterInstruction(new Cursor(0)),
+            new RewindCursorInstruction(new Cursor(0), new ProgramCounter(9)),
+            new LoadConstantInstruction(new Register(1), SqlValue.Text("leak")),
+            new ResultRowInstruction(new RegisterRange(new Register(1), 1)),
+            new LoadConstantInstruction(new Register(1), SqlValue.Text("empty")),
+            new ResultRowInstruction(new RegisterRange(new Register(1), 1)),
+            new LoadConstantInstruction(new Register(0), SqlValue.Text("c")),
+            new EphemeralInsertInstruction(new Cursor(0), new RegisterRange(new Register(0), 1)),
+            new LoadConstantInstruction(new Register(2), SqlValue.Integer(1)),
+            new SeekRowidInstruction(new Cursor(0), new Register(2), new ProgramCounter(17), "seek rowid 1"),
+            new ColumnInstruction(new Cursor(0), ColumnIndex: 0, new Register(1)),
+            new ResultRowInstruction(new RegisterRange(new Register(1), 1)),
+            new HaltInstruction(),
+        ];
+
+        var program = new VdbeProgram(registerCount: 3, cursorCount: 1, instructions);
+        using var statement = new ResumableStatement(program);
+        var values = new List<string>();
+        while (statement.StepResumable() == ResumableStatementStepResult.Row)
+            values.Add(statement.CurrentRow![0].AsText());
+
+        values.Should().Equal("empty", "c");
+    }
+
+    [Test]
+    public void ResetSorterRejectsNonEphemeralCursor()
+    {
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 0,
+            cursorCount: 1,
+            [
+                new OpenReadCursorInstruction(new Cursor(0), "t", ColumnCount: 1),
+                new ResetSorterInstruction(new Cursor(0)),
+                new HaltInstruction(),
+            ]))!.Message.Should().Contain("not an ephemeral cursor");
+    }
+
+    [Test]
+    public void OpenDupSharesRowsAcrossCursors()
+    {
+        // A row inserted through the original cursor must be visible through the duplicate:
+        // both cursors share one ephemeral storage instance. Scanning through the duplicate
+        // also proves it inherited the original's column count.
+        VdbeInstruction[] instructions =
+        [
+            new OpenEphemeralInstruction(new Cursor(0), ColumnCount: 1),
+            new OpenDupInstruction(new Cursor(1), new Cursor(0)),
+            new LoadConstantInstruction(new Register(0), SqlValue.Text("shared")),
+            new EphemeralInsertInstruction(new Cursor(0), new RegisterRange(new Register(0), 1)),
+            new RewindCursorInstruction(new Cursor(1), new ProgramCounter(8)),
+            new ColumnInstruction(new Cursor(1), ColumnIndex: 0, new Register(1)),
+            new ResultRowInstruction(new RegisterRange(new Register(1), 1)),
+            new NextInstruction(new Cursor(1), new ProgramCounter(5)),
+            new HaltInstruction(),
+        ];
+
+        var program = new VdbeProgram(registerCount: 2, cursorCount: 2, instructions);
+        using var statement = new ResumableStatement(program);
+        var values = new List<string>();
+        while (statement.StepResumable() == ResumableStatementStepResult.Row)
+            values.Add(statement.CurrentRow![0].AsText());
+
+        values.Should().ContainSingle().Which.Should().Be("shared");
+    }
+
+    [Test]
+    public void OpenAutoindexInsertsAndScans()
+    {
+        // Autoindex cursors open through the ephemeral path and scan like any ephemeral table.
+        VdbeInstruction[] instructions =
+        [
+            new OpenAutoindexInstruction(new Cursor(0), ColumnCount: 1),
+            new LoadConstantInstruction(new Register(0), SqlValue.Text("x")),
+            new EphemeralInsertInstruction(new Cursor(0), new RegisterRange(new Register(0), 1)),
+            new RewindCursorInstruction(new Cursor(0), new ProgramCounter(7)),
+            new ColumnInstruction(new Cursor(0), ColumnIndex: 0, new Register(1)),
+            new ResultRowInstruction(new RegisterRange(new Register(1), 1)),
+            new NextInstruction(new Cursor(0), new ProgramCounter(4)),
+            new HaltInstruction(),
+        ];
+
+        var program = new VdbeProgram(registerCount: 2, cursorCount: 1, instructions);
+        using var statement = new ResumableStatement(program);
+        var values = new List<string>();
+        while (statement.StepResumable() == ResumableStatementStepResult.Row)
+            values.Add(statement.CurrentRow![0].AsText());
+
+        values.Should().ContainSingle().Which.Should().Be("x");
+    }
+
+    [Test]
+    public void ColumnHasFieldJumpsOnlyWhenCurrentRecordCarriesTheColumn()
+    {
+        // The first record carries column 2 (jump branch); the second is a short record
+        // (fall-through branch).
+        VdbeInstruction[] instructions =
+        [
+            new OpenReadCursorInstruction(new Cursor(0), "t", ColumnCount: 3),
+            new RewindCursorInstruction(new Cursor(0), new ProgramCounter(8)),
+            new ColumnHasFieldInstruction(new Cursor(0), Column: 2, new ProgramCounter(5)),
+            new LoadConstantInstruction(new Register(0), SqlValue.Text("short")),
+            new GotoInstruction(new ProgramCounter(6)),
+            new LoadConstantInstruction(new Register(0), SqlValue.Text("wide")),
+            new ResultRowInstruction(new RegisterRange(new Register(0), 1)),
+            new NextInstruction(new Cursor(0), new ProgramCounter(2)),
+            new HaltInstruction(),
+        ];
+
+        var program = new VdbeProgram(registerCount: 1, cursorCount: 1, instructions);
+        using var statement = new ResumableStatement(
+            program,
+            [new VdbeCursorSource([
+                [SqlValue.Integer(1), SqlValue.Integer(2), SqlValue.Integer(3)],
+                [SqlValue.Integer(1)],
+            ])]);
+        var values = new List<string>();
+        while (statement.StepResumable() == ResumableStatementStepResult.Row)
+            values.Add(statement.CurrentRow![0].AsText());
+
+        values.Should().Equal("wide", "short");
+    }
+
+    [Test]
+    public void ColumnHasFieldFallsThroughWithoutCurrentRecord()
+    {
+        // A cursor that was opened but never advanced has no current record and must fall
+        // through, matching Turso's missing-record behavior.
+        VdbeInstruction[] instructions =
+        [
+            new OpenReadCursorInstruction(new Cursor(0), "t", ColumnCount: 1),
+            new ColumnHasFieldInstruction(new Cursor(0), Column: 0, new ProgramCounter(4)),
+            new LoadConstantInstruction(new Register(0), SqlValue.Text("miss")),
+            new GotoInstruction(new ProgramCounter(5)),
+            new LoadConstantInstruction(new Register(0), SqlValue.Text("hit")),
+            new ResultRowInstruction(new RegisterRange(new Register(0), 1)),
+            new HaltInstruction(),
+        ];
+
+        var program = new VdbeProgram(registerCount: 1, cursorCount: 1, instructions);
+        using var statement = new ResumableStatement(
+            program,
+            [new VdbeCursorSource([[SqlValue.Integer(1)]])]);
+        var values = new List<string>();
+        while (statement.StepResumable() == ResumableStatementStepResult.Row)
+            values.Add(statement.CurrentRow![0].AsText());
+
+        values.Should().ContainSingle().Which.Should().Be("miss");
+    }
+
+    [Test]
+    public void ValidationRejectsMalformedMicroCursorBytecode()
+    {
+        // OpenDup onto a non-ephemeral original.
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 0,
+            cursorCount: 2,
+            [
+                new OpenReadCursorInstruction(new Cursor(0), "t", ColumnCount: 1),
+                new OpenDupInstruction(new Cursor(1), new Cursor(0)),
+                new HaltInstruction(),
+            ]))!.Message.Should().Contain("not an ephemeral cursor");
+
+        // OpenDup onto itself.
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 0,
+            cursorCount: 1,
+            [
+                new OpenEphemeralInstruction(new Cursor(0), ColumnCount: 1),
+                new OpenDupInstruction(new Cursor(0), new Cursor(0)),
+                new HaltInstruction(),
+            ]))!.Message.Should().Contain("onto itself");
+
+        // OpenDup before the original is open.
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 0,
+            cursorCount: 2,
+            [
+                new OpenDupInstruction(new Cursor(1), new Cursor(0)),
+                new HaltInstruction(),
+            ]))!.Message.Should().Contain("before opening it");
+
+        // OpenDup onto a cursor that is already open.
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 0,
+            cursorCount: 2,
+            [
+                new OpenEphemeralInstruction(new Cursor(0), ColumnCount: 1),
+                new OpenEphemeralInstruction(new Cursor(1), ColumnCount: 1),
+                new OpenDupInstruction(new Cursor(1), new Cursor(0)),
+                new HaltInstruction(),
+            ]))!.Message.Should().Contain("opens cursor 1 twice");
+
+        // ColumnHasField with a negative column.
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 0,
+            cursorCount: 1,
+            [
+                new OpenEphemeralInstruction(new Cursor(0), ColumnCount: 1),
+                new ColumnHasFieldInstruction(new Cursor(0), Column: -1, new ProgramCounter(2)),
+                new HaltInstruction(),
+            ]))!.Message.Should().Contain("negative column");
+
+        // OpenAutoindex with a non-positive column count.
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 0,
+            cursorCount: 1,
+            [
+                new OpenAutoindexInstruction(new Cursor(0), ColumnCount: 0),
+                new HaltInstruction(),
+            ]))!.Message.Should().Contain("non-positive column count");
+
+        // OpenAutoindex on an already-open cursor.
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 0,
+            cursorCount: 1,
+            [
+                new OpenEphemeralInstruction(new Cursor(0), ColumnCount: 1),
+                new OpenAutoindexInstruction(new Cursor(0), ColumnCount: 1),
+                new HaltInstruction(),
+            ]))!.Message.Should().Contain("opens cursor 0 twice");
+    }
+
+    [Test]
+    public void ExplainDescribesMicroCursorOpcodes()
+    {
+        var (p1, p2, _, _, autoindexComment) = VdbeExplain.Describe(new OpenAutoindexInstruction(new Cursor(2), ColumnCount: 5));
+        p1.Should().Be(2);
+        p2.Should().Be(5);
+        autoindexComment.Should().Be("open autoindex cursor 2 cols=5");
+
+        var (dupNew, dupOriginal, _, _, dupComment) = VdbeExplain.Describe(new OpenDupInstruction(new Cursor(1), new Cursor(0)));
+        dupNew.Should().Be(1);
+        dupOriginal.Should().Be(0);
+        dupComment.Should().Be("duplicate ephemeral cursor 0 to cursor 1");
+
+        var (resetCursor, _, _, _, resetComment) = VdbeExplain.Describe(new ResetSorterInstruction(new Cursor(3)));
+        resetCursor.Should().Be(3);
+        resetComment.Should().Be("reset ephemeral cursor 3");
+
+        var (hasCursor, hasColumn, hasTarget, _, hasComment) = VdbeExplain.Describe(
+            new ColumnHasFieldInstruction(new Cursor(0), Column: 2, new ProgramCounter(7)));
+        hasCursor.Should().Be(0);
+        hasColumn.Should().Be(2);
+        hasTarget.Should().Be(7);
+        hasComment.Should().Be("jump to 7 when cursor 0 has column 2");
+
+        var aggValue = new AggValueInstruction(new Accumulator(1), AggregateTestSupport.Sum(), new Register(2));
+        var (accIndex, destIndex, _, aggName, aggComment) = VdbeExplain.Describe(aggValue);
+        accIndex.Should().Be(1);
+        destIndex.Should().Be(2);
+        aggName.Should().Be("sum");
+        aggComment.Should().Contain("no reset");
+        aggValue.Opcode.Should().Be(VdbeOpcode.AggValue);
+    }
+
+    [Test]
+    public void DeferredSeekSeeksTableCursorByIndexRowId()
+    {
+        var indexSource = new VdbeCursorSource(
+            [
+                [SqlValue.Integer(10)],
+                [SqlValue.Integer(20)],
+            ],
+            [10, 20]);
+        // Table rows are stored reversed relative to the index rowids so a plain forward
+        // scan would return them in the wrong order; only a real seek yields 210, 220.
+        var tableSource = new VdbeCursorSource(
+            [
+                [SqlValue.Integer(220)],
+                [SqlValue.Integer(210)],
+            ],
+            [20, 10]);
+
+        VdbeInstruction[] instructions =
+        [
+            new OpenReadCursorInstruction(new Cursor(0), "i", ColumnCount: 1),
+            new OpenReadCursorInstruction(new Cursor(1), "t", ColumnCount: 1),
+            new RewindCursorInstruction(new Cursor(0), new ProgramCounter(7)),
+            new DeferredSeekInstruction(new Cursor(0), new Cursor(1)),
+            new ColumnInstruction(new Cursor(1), 0, new Register(0)),
+            new ResultRowInstruction(new RegisterRange(new Register(0), 1)),
+            new NextInstruction(new Cursor(0), new ProgramCounter(3)),
+            new HaltInstruction(),
+        ];
+        var program = new VdbeProgram(registerCount: 1, cursorCount: 2, instructions);
+        using var statement = new ResumableStatement(program, [indexSource, tableSource]);
+
+        var values = new List<long>();
+        while (statement.StepResumable() == ResumableStatementStepResult.Row)
+            values.Add(statement.CurrentRow![0].AsInteger());
+
+        values.Should().Equal(210L, 220L);
+    }
+
+    [Test]
+    public void DeferredSeekWritesNullWhenIndexCursorIsUnpositioned()
+    {
+        var indexSource = new VdbeCursorSource(
+            [
+                [SqlValue.Integer(10)],
+            ],
+            [10]);
+        var tableSource = new VdbeCursorSource(
+            [
+                [SqlValue.Integer(220)],
+            ],
+            [10]);
+
+        VdbeInstruction[] instructions =
+        [
+            new OpenReadCursorInstruction(new Cursor(0), "i", ColumnCount: 1),
+            new OpenReadCursorInstruction(new Cursor(1), "t", ColumnCount: 1),
+            new DeferredSeekInstruction(new Cursor(0), new Cursor(1)),
+            new ColumnInstruction(new Cursor(1), 0, new Register(0)),
+            new ResultRowInstruction(new RegisterRange(new Register(0), 1)),
+            new HaltInstruction(),
+        ];
+        var program = new VdbeProgram(registerCount: 1, cursorCount: 2, instructions);
+        using var statement = new ResumableStatement(program, [indexSource, tableSource]);
+
+        statement.StepResumable().Should().Be(ResumableStatementStepResult.Row);
+        statement.CurrentRow![0].Should().Be(SqlValue.Null);
+    }
+
+    [Test]
+    public void DeferredSeekResolvesRowIdReadThroughIndexCursor()
+    {
+        var indexSource = new VdbeCursorSource(
+            [
+                [SqlValue.Integer(42)],
+            ],
+            [42]);
+        var tableSource = new VdbeCursorSource(
+            [
+                [SqlValue.Integer(1)],
+            ],
+            [42]);
+
+        VdbeInstruction[] instructions =
+        [
+            new OpenReadCursorInstruction(new Cursor(0), "i", ColumnCount: 1),
+            new OpenReadCursorInstruction(new Cursor(1), "t", ColumnCount: 1),
+            new RewindCursorInstruction(new Cursor(0), new ProgramCounter(6)),
+            new DeferredSeekInstruction(new Cursor(0), new Cursor(1)),
+            new RowIdInstruction(new Cursor(1), new Register(0)),
+            new ResultRowInstruction(new RegisterRange(new Register(0), 1)),
+            new HaltInstruction(),
+        ];
+        var program = new VdbeProgram(registerCount: 1, cursorCount: 2, instructions);
+        using var statement = new ResumableStatement(program, [indexSource, tableSource]);
+
+        statement.StepResumable().Should().Be(ResumableStatementStepResult.Row);
+        statement.CurrentRow![0].Should().Be(SqlValue.Integer(42));
+    }
+
+    [Test]
+    public void DeferredSeekRowIdReadThrowsWhenIndexCursorIsUnpositioned()
+    {
+        var indexSource = new VdbeCursorSource(
+            [
+                [SqlValue.Integer(42)],
+            ],
+            [42]);
+        var tableSource = new VdbeCursorSource(
+            [
+                [SqlValue.Integer(1)],
+            ],
+            [42]);
+
+        VdbeInstruction[] instructions =
+        [
+            new OpenReadCursorInstruction(new Cursor(0), "i", ColumnCount: 1),
+            new OpenReadCursorInstruction(new Cursor(1), "t", ColumnCount: 1),
+            new DeferredSeekInstruction(new Cursor(0), new Cursor(1)),
+            new RowIdInstruction(new Cursor(1), new Register(0)),
+            new HaltInstruction(),
+        ];
+        var program = new VdbeProgram(registerCount: 1, cursorCount: 2, instructions);
+        using var statement = new ResumableStatement(program, [indexSource, tableSource]);
+
+        Assert.Throws<InvalidOperationException>(() => statement.StepResumable())!
+            .Message.Should().Contain("positioned on a record");
+    }
+
+    [Test]
+    public void ReopeningTableCursorInvalidatesPendingDeferredSeek()
+    {
+        var indexSource = new VdbeCursorSource(
+            [
+                [SqlValue.Integer(10)],
+            ],
+            [10]);
+        var tableSource = new VdbeCursorSource(
+            [
+                [SqlValue.Integer(220)],
+            ],
+            [10]);
+
+        VdbeInstruction[] instructions =
+        [
+            new OpenReadCursorInstruction(new Cursor(0), "i", ColumnCount: 1),
+            new OpenReadCursorInstruction(new Cursor(1), "t", ColumnCount: 1),
+            new RewindCursorInstruction(new Cursor(0), new ProgramCounter(7)),
+            new DeferredSeekInstruction(new Cursor(0), new Cursor(1)),
+            new CloseCursorInstruction(new Cursor(1)),
+            new OpenReadCursorInstruction(new Cursor(1), "t", ColumnCount: 1),
+            new ColumnInstruction(new Cursor(1), 0, new Register(0)),
+            new HaltInstruction(),
+        ];
+        var program = new VdbeProgram(registerCount: 1, cursorCount: 2, instructions);
+        using var statement = new ResumableStatement(program, [indexSource, tableSource]);
+
+        Assert.Throws<InvalidOperationException>(() => statement.StepResumable())!
+            .Message.Should().Contain("not positioned on a row");
+    }
+
+    [Test]
+    public void SeekEndThenPrevWalksRowsInReverse()
+    {
+        var source = new VdbeCursorSource(
+            [
+                [SqlValue.Integer(1)],
+                [SqlValue.Integer(2)],
+                [SqlValue.Integer(3)],
+            ],
+            [1, 2, 3]);
+
+        VdbeInstruction[] instructions =
+        [
+            new OpenReadCursorInstruction(new Cursor(0), "t", ColumnCount: 1),
+            new SeekEndInstruction(new Cursor(0)),
+            new PrevInstruction(new Cursor(0), new ProgramCounter(4)),
+            new GotoInstruction(new ProgramCounter(7)),
+            new ColumnInstruction(new Cursor(0), 0, new Register(0)),
+            new ResultRowInstruction(new RegisterRange(new Register(0), 1)),
+            new GotoInstruction(new ProgramCounter(2)),
+            new HaltInstruction(),
+        ];
+        var program = new VdbeProgram(registerCount: 1, cursorCount: 1, instructions);
+        using var statement = new ResumableStatement(program, [source]);
+
+        var values = new List<long>();
+        while (statement.StepResumable() == ResumableStatementStepResult.Row)
+            values.Add(statement.CurrentRow![0].AsInteger());
+
+        values.Should().Equal(3L, 2L, 1L);
+    }
+
+    [Test]
+    public void SeekEndThenNextExitsImmediately()
+    {
+        var source = new VdbeCursorSource(
+            [
+                [SqlValue.Integer(1)],
+            ],
+            [1]);
+
+        VdbeInstruction[] instructions =
+        [
+            new OpenReadCursorInstruction(new Cursor(0), "t", ColumnCount: 1),
+            new SeekEndInstruction(new Cursor(0)),
+            new NextInstruction(new Cursor(0), new ProgramCounter(4)),
+            new GotoInstruction(new ProgramCounter(7)),
+            new ColumnInstruction(new Cursor(0), 0, new Register(0)),
+            new ResultRowInstruction(new RegisterRange(new Register(0), 1)),
+            new GotoInstruction(new ProgramCounter(2)),
+            new HaltInstruction(),
+        ];
+        var program = new VdbeProgram(registerCount: 1, cursorCount: 1, instructions);
+        using var statement = new ResumableStatement(program, [source]);
+
+        var values = new List<long>();
+        while (statement.StepResumable() == ResumableStatementStepResult.Row)
+            values.Add(statement.CurrentRow![0].AsInteger());
+
+        values.Should().BeEmpty();
+    }
+
+    [Test]
+    public void ValidationRejectsDeferredSeekOnUnopenedCursors()
+    {
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 0,
+            cursorCount: 2,
+            [
+                new DeferredSeekInstruction(new Cursor(0), new Cursor(1)),
+                new HaltInstruction(),
+            ]))!
+            .Message.Should().Contain("uses cursor 0 before opening it");
+    }
+
+    [Test]
+    public void ValidationRejectsDeferredSeekAgainstSameCursor()
+    {
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 0,
+            cursorCount: 1,
+            [
+                new OpenReadCursorInstruction(new Cursor(0), "t", ColumnCount: 1),
+                new DeferredSeekInstruction(new Cursor(0), new Cursor(0)),
+                new HaltInstruction(),
+            ]))!
+            .Message.Should().Contain("against itself");
+    }
+
+    [Test]
+    public void ValidationRejectsSeekEndOnUnopenedCursor()
+    {
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 0,
+            cursorCount: 1,
+            [
+                new SeekEndInstruction(new Cursor(0)),
+                new HaltInstruction(),
+            ]))!
+            .Message.Should().Contain("uses cursor 0 before opening it");
+    }
+
+    [Test]
+    public void ExplainDescribesDeferredSeekAndSeekEnd()
+    {
+        var deferredSeek = new DeferredSeekInstruction(new Cursor(0), new Cursor(1));
+        var (seekIndexCursor, seekTableCursor, seekP3, seekP4, seekComment) = VdbeExplain.Describe(deferredSeek);
+        seekIndexCursor.Should().Be(0);
+        seekTableCursor.Should().Be(1);
+        seekP3.Should().Be(0);
+        seekP4.Should().BeNull();
+        seekComment.Should().Be("deferred seek table cursor 1 via index cursor 0");
+        deferredSeek.Opcode.Should().Be(VdbeOpcode.DeferredSeek);
+
+        var seekEnd = new SeekEndInstruction(new Cursor(2));
+        var (endCursor, endP2, endP3, endP4, endComment) = VdbeExplain.Describe(seekEnd);
+        endCursor.Should().Be(2);
+        endP2.Should().Be(0);
+        endP3.Should().Be(0);
+        endP4.Should().BeNull();
+        endComment.Should().Be("position cursor 2 past its last row for a reverse scan");
+        seekEnd.Opcode.Should().Be(VdbeOpcode.SeekEnd);
+    }
+
+    private static List<SqlValue> RunBloomProbe(VdbeInstruction[] instructions, int registerCount = 2)
+    {
+        var program = new VdbeProgram(registerCount: registerCount, cursorCount: 1, instructions);
+        using var statement = new ResumableStatement(program);
+
+        var values = new List<SqlValue>();
+        while (statement.StepResumable() == ResumableStatementStepResult.Row)
+        {
+            values.Add(statement.CurrentRow![0]);
+        }
+
+        return values;
+    }
+
+    /// <summary>
+    /// Layout: open an ephemeral cursor (its index keys the per-cursor filter), optionally add a
+    /// key with BloomFilterAdd, probe with BloomFilter, and emit one row only when the probe
+    /// fell through (i.e. the key might be present or no filter exists).
+    /// </summary>
+    private static VdbeInstruction[] BloomProbeLayout(SqlValue insertedKey, SqlValue probeKey, bool insert)
+    {
+        var instructions = new List<VdbeInstruction>
+        {
+            new OpenEphemeralInstruction(new Cursor(0), ColumnCount: 1),
+        };
+        if (insert)
+        {
+            instructions.Add(new LoadConstantInstruction(new Register(0), insertedKey));
+            instructions.Add(new BloomFilterAddInstruction(new Cursor(0), new RegisterRange(new Register(0), 1)));
+        }
+
+        // BloomFilter jump target = instructions.Count + 3 at add time = the terminal Halt.
+        instructions.Add(new LoadConstantInstruction(new Register(1), probeKey));
+        instructions.Add(new BloomFilterInstruction(new Cursor(0), new RegisterRange(new Register(1), 1), new ProgramCounter(instructions.Count + 3)));
+        instructions.Add(new LoadConstantInstruction(new Register(0), SqlValue.Text("hit")));
+        instructions.Add(new ResultRowInstruction(new RegisterRange(new Register(0), 1)));
+        instructions.Add(new HaltInstruction());
+        return instructions.ToArray();
+    }
+
+    [Test]
+    public void BloomFilterFallsThroughWhenKeyMightBePresent()
+    {
+        var rows = RunBloomProbe(BloomProbeLayout(SqlValue.Integer(10), SqlValue.Integer(10), insert: true));
+        rows.Should().ContainSingle();
+        rows[0].AsText().Should().Be("hit");
+    }
+
+    [Test]
+    public void BloomFilterJumpsWhenKeyWasNeverInserted()
+    {
+        var rows = RunBloomProbe(BloomProbeLayout(SqlValue.Integer(10), SqlValue.Integer(20), insert: true));
+        rows.Should().BeEmpty();
+    }
+
+    [Test]
+    public void BloomFilterNeverReportsNullKeys()
+    {
+        var rows = RunBloomProbe(BloomProbeLayout(SqlValue.Null, SqlValue.Null, insert: true));
+        rows.Should().BeEmpty();
+    }
+
+    [Test]
+    public void BloomFilterFallsThroughWhenCursorHasNoFilter()
+    {
+        var rows = RunBloomProbe(BloomProbeLayout(SqlValue.Null, SqlValue.Integer(10), insert: false));
+        rows.Should().ContainSingle();
+        rows[0].AsText().Should().Be("hit");
+    }
+
+    [Test]
+    public void BloomFilterTreatsExactIntegersAndRealsAsTheSameDomain()
+    {
+        var hit = RunBloomProbe(BloomProbeLayout(SqlValue.Integer(10), SqlValue.Real(10.0), insert: true));
+        hit.Should().ContainSingle();
+        hit[0].AsText().Should().Be("hit");
+
+        // 2^53 + 1 cannot be represented exactly as a double, so it stays in the integer domain
+        // and must not collide with its lossy double image 2^53.
+        var miss = RunBloomProbe(BloomProbeLayout(SqlValue.Integer(9007199254740993), SqlValue.Real(9007199254740992.0), insert: true));
+        miss.Should().BeEmpty();
+    }
+
+    [Test]
+    public void BloomFilterTreatsNegativeZeroAsZero()
+    {
+        var rows = RunBloomProbe(BloomProbeLayout(SqlValue.Real(-0.0), SqlValue.Real(0.0), insert: true));
+        rows.Should().ContainSingle();
+        rows[0].AsText().Should().Be("hit");
+    }
+
+    [Test]
+    public void BloomFilterProbesCompositeKeys()
+    {
+        VdbeInstruction[] instructions =
+        [
+            new OpenEphemeralInstruction(new Cursor(0), ColumnCount: 2),
+            new LoadConstantInstruction(new Register(0), SqlValue.Integer(1)),
+            new LoadConstantInstruction(new Register(1), SqlValue.Text("a")),
+            new BloomFilterAddInstruction(new Cursor(0), new RegisterRange(new Register(0), 2)),
+            new LoadConstantInstruction(new Register(0), SqlValue.Integer(1)),
+            new LoadConstantInstruction(new Register(1), SqlValue.Text("a")),
+            new BloomFilterInstruction(new Cursor(0), new RegisterRange(new Register(0), 2), new ProgramCounter(9)),
+            new LoadConstantInstruction(new Register(0), SqlValue.Text("hit")),
+            new ResultRowInstruction(new RegisterRange(new Register(0), 1)),
+            new LoadConstantInstruction(new Register(0), SqlValue.Integer(1)),
+            new LoadConstantInstruction(new Register(1), SqlValue.Text("b")),
+            new BloomFilterInstruction(new Cursor(0), new RegisterRange(new Register(0), 2), new ProgramCounter(14)),
+            new LoadConstantInstruction(new Register(0), SqlValue.Text("miss")),
+            new ResultRowInstruction(new RegisterRange(new Register(0), 1)),
+            new HaltInstruction(),
+        ];
+
+        var rows = RunBloomProbe(instructions);
+        rows.Should().ContainSingle();
+        rows[0].AsText().Should().Be("hit");
+    }
+
+    [Test]
+    public void BloomFilterRejectsCompositeKeysContainingNull()
+    {
+        VdbeInstruction[] instructions =
+        [
+            new OpenEphemeralInstruction(new Cursor(0), ColumnCount: 2),
+            new LoadConstantInstruction(new Register(0), SqlValue.Integer(1)),
+            new LoadConstantInstruction(new Register(1), SqlValue.Text("a")),
+            new BloomFilterAddInstruction(new Cursor(0), new RegisterRange(new Register(0), 2)),
+            new LoadConstantInstruction(new Register(0), SqlValue.Null),
+            new LoadConstantInstruction(new Register(1), SqlValue.Text("a")),
+            new BloomFilterInstruction(new Cursor(0), new RegisterRange(new Register(0), 2), new ProgramCounter(9)),
+            new LoadConstantInstruction(new Register(0), SqlValue.Text("hit")),
+            new ResultRowInstruction(new RegisterRange(new Register(0), 1)),
+            new HaltInstruction(),
+        ];
+
+        RunBloomProbe(instructions).Should().BeEmpty();
+    }
+
+    [Test]
+    public void RewindClearsTheCursorBloomFilter()
+    {
+        // Build a one-row ephemeral cursor and add its key to the filter, then scan the cursor
+        // with Rewind/Next. Rewind removes the filter before the emptiness check, so after the
+        // scan a probe of a never-inserted key at index 9 finds no filter and falls through to
+        // emit "cleared". Had the filter survived, the probe would miss and jump to Halt.
+        VdbeInstruction[] instructions =
+        [
+            new OpenEphemeralInstruction(new Cursor(0), ColumnCount: 1),
+            new LoadConstantInstruction(new Register(0), SqlValue.Integer(10)),
+            new EphemeralInsertInstruction(new Cursor(0), new RegisterRange(new Register(0), 1)),
+            new BloomFilterAddInstruction(new Cursor(0), new RegisterRange(new Register(0), 1)),
+            new RewindCursorInstruction(new Cursor(0), new ProgramCounter(10)),
+            new ColumnInstruction(new Cursor(0), ColumnIndex: 0, new Register(1)),
+            new ResultRowInstruction(new RegisterRange(new Register(1), 1)),
+            new NextInstruction(new Cursor(0), new ProgramCounter(5)),
+            new LoadConstantInstruction(new Register(0), SqlValue.Integer(999)),
+            new BloomFilterInstruction(new Cursor(0), new RegisterRange(new Register(0), 1), new ProgramCounter(12)),
+            new LoadConstantInstruction(new Register(0), SqlValue.Text("cleared")),
+            new ResultRowInstruction(new RegisterRange(new Register(0), 1)),
+            new HaltInstruction(),
+        ];
+
+        var rows = RunBloomProbe(instructions);
+        rows.Should().HaveCount(2);
+        rows[0].Should().Be(SqlValue.Integer(10));
+        rows[1].AsText().Should().Be("cleared");
+    }
+
+    [Test]
+    public void ExplainDescribesBloomFilterOpcodes()
+    {
+        var bloomAdd = new BloomFilterAddInstruction(new Cursor(2), new RegisterRange(new Register(4), 2));
+        var (addCursor, addP2, addP3, addP4, addComment) = VdbeExplain.Describe(bloomAdd);
+        addCursor.Should().Be(2);
+        addP2.Should().Be(0);
+        addP3.Should().Be(4);
+        addP4.Should().Be("r[4..5]");
+        addComment.Should().Be("bloom_filter_add(r[4..5])");
+        bloomAdd.Opcode.Should().Be(VdbeOpcode.BloomFilterAdd);
+
+        var bloomFilter = new BloomFilterInstruction(new Cursor(2), new RegisterRange(new Register(6), 1), new ProgramCounter(9));
+        var (probeCursor, probeP2, probeP3, probeP4, probeComment) = VdbeExplain.Describe(bloomFilter);
+        probeCursor.Should().Be(2);
+        probeP2.Should().Be(9);
+        probeP3.Should().Be(6);
+        probeP4.Should().Be("r[6]");
+        probeComment.Should().Be("if !bloom_filter(r[6]) goto 9");
+        bloomFilter.Opcode.Should().Be(VdbeOpcode.BloomFilter);
+    }
+
+    [Test]
+    public void ValidationRejectsEmptyBloomFilterKeys()
+    {
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 2,
+            cursorCount: 1,
+            [
+                new OpenEphemeralInstruction(new Cursor(0), ColumnCount: 1),
+                new BloomFilterAddInstruction(new Cursor(0), new RegisterRange(new Register(0), 0)),
+                new HaltInstruction(),
+            ]))!
+            .Message.Should().Contain("requires a positive key width");
+
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 2,
+            cursorCount: 1,
+            [
+                new OpenEphemeralInstruction(new Cursor(0), ColumnCount: 1),
+                new BloomFilterInstruction(new Cursor(0), new RegisterRange(new Register(0), 0), new ProgramCounter(2)),
+                new HaltInstruction(),
+            ]))!
+            .Message.Should().Contain("requires a positive key width");
+    }
+
+    [Test]
+    public void HashBuildProbeNextYieldsAllMatchesInInsertionOrder()
+    {
+        // Build side (cursor 0): rows (1,a), (2,b), (1,c) -> rowids 1, 2, 3.
+        // Probe side (cursor 1): a single row with key 1. HashProbe finds the first match,
+        // then HashNext walks the remaining matches in bucket insertion order.
+        VdbeInstruction[] instructions =
+        [
+            new OpenEphemeralInstruction(new Cursor(0), ColumnCount: 2),
+            new LoadConstantInstruction(new Register(0), SqlValue.Integer(1)),
+            new LoadConstantInstruction(new Register(1), SqlValue.Text("a")),
+            new EphemeralInsertInstruction(new Cursor(0), new RegisterRange(new Register(0), 2)),
+            new LoadConstantInstruction(new Register(0), SqlValue.Integer(2)),
+            new LoadConstantInstruction(new Register(1), SqlValue.Text("b")),
+            new EphemeralInsertInstruction(new Cursor(0), new RegisterRange(new Register(0), 2)),
+            new LoadConstantInstruction(new Register(0), SqlValue.Integer(1)),
+            new LoadConstantInstruction(new Register(1), SqlValue.Text("c")),
+            new EphemeralInsertInstruction(new Cursor(0), new RegisterRange(new Register(0), 2)),
+            new RewindCursorInstruction(new Cursor(0), new ProgramCounter(26)),
+            new ColumnInstruction(new Cursor(0), ColumnIndex: 0, new Register(2)),
+            new ColumnInstruction(new Cursor(0), ColumnIndex: 1, new Register(3)),
+            new HashBuildInstruction(new Cursor(0), new RegisterRange(new Register(2), 1), HashTableId: 0, MemoryBudget: 0, Collations: [null], Payload: new RegisterRange(new Register(3), 1), TrackMatched: false),
+            new NextInstruction(new Cursor(0), new ProgramCounter(11)),
+            new HashBuildFinalizeInstruction(HashTableId: 0),
+            new OpenEphemeralInstruction(new Cursor(1), ColumnCount: 1),
+            new LoadConstantInstruction(new Register(0), SqlValue.Integer(1)),
+            new EphemeralInsertInstruction(new Cursor(1), new RegisterRange(new Register(0), 1)),
+            new RewindCursorInstruction(new Cursor(1), new ProgramCounter(26)),
+            new ColumnInstruction(new Cursor(1), ColumnIndex: 0, new Register(2)),
+            new HashProbeInstruction(HashTableId: 0, new RegisterRange(new Register(2), 1), new Register(4), PayloadDestination: new RegisterRange(new Register(5), 1), NotFoundTarget: new ProgramCounter(26)),
+            new ResultRowInstruction(new RegisterRange(new Register(4), 2)),
+            new HashNextInstruction(HashTableId: 0, new Register(4), PayloadDestination: new RegisterRange(new Register(5), 1), ExhaustedTarget: new ProgramCounter(26)),
+            new ResultRowInstruction(new RegisterRange(new Register(4), 2)),
+            new GotoInstruction(new ProgramCounter(23)),
+            new HaltInstruction(),
+        ];
+
+        var rows = RunHashProgram(instructions, registerCount: 6, cursorCount: 2, hashTableCount: 1);
+        rows.Should().HaveCount(4);
+        rows[0].Should().Be(SqlValue.Integer(1));
+        rows[1].Should().Be(SqlValue.Text("a"));
+        rows[2].Should().Be(SqlValue.Integer(3));
+        rows[3].Should().Be(SqlValue.Text("c"));
+    }
+
+    [Test]
+    public void HashProbeJumpsWhenTableIsMissingOrKeyAbsent()
+    {
+        // Table 1 is declared but never created, so HashProbe must jump to Halt without a row.
+        VdbeInstruction[] instructions =
+        [
+            new LoadConstantInstruction(new Register(1), SqlValue.Integer(1)),
+            new HashProbeInstruction(HashTableId: 1, new RegisterRange(new Register(1), 1), new Register(2), PayloadDestination: null, NotFoundTarget: new ProgramCounter(3)),
+            new ResultRowInstruction(new RegisterRange(new Register(1), 1)),
+            new HaltInstruction(),
+        ];
+
+        RunHashProgram(instructions, registerCount: 3, cursorCount: 1, hashTableCount: 2).Should().BeEmpty();
+    }
+
+    [Test]
+    public void HashProbeJumpsWhenKeyIsAbsent()
+    {
+        // Build one row with key 1, finalize, then probe for key 999, which must jump to Halt.
+        VdbeInstruction[] instructions =
+        [
+            new OpenEphemeralInstruction(new Cursor(0), ColumnCount: 1),
+            new LoadConstantInstruction(new Register(0), SqlValue.Integer(1)),
+            new EphemeralInsertInstruction(new Cursor(0), new RegisterRange(new Register(0), 1)),
+            new RewindCursorInstruction(new Cursor(0), new ProgramCounter(9)),
+            new ColumnInstruction(new Cursor(0), ColumnIndex: 0, new Register(1)),
+            new HashBuildInstruction(new Cursor(0), new RegisterRange(new Register(1), 1), HashTableId: 0, MemoryBudget: 0, Collations: [null], Payload: null, TrackMatched: false),
+            new NextInstruction(new Cursor(0), new ProgramCounter(4)),
+            new HashBuildFinalizeInstruction(HashTableId: 0),
+            new LoadConstantInstruction(new Register(0), SqlValue.Integer(999)),
+            new HashProbeInstruction(HashTableId: 0, new RegisterRange(new Register(0), 1), new Register(2), PayloadDestination: null, NotFoundTarget: new ProgramCounter(12)),
+            new LoadConstantInstruction(new Register(0), SqlValue.Text("found")),
+            new ResultRowInstruction(new RegisterRange(new Register(0), 1)),
+            new HaltInstruction(),
+        ];
+
+        RunHashProgram(instructions, registerCount: 3, cursorCount: 1, hashTableCount: 1).Should().BeEmpty();
+    }
+
+    [Test]
+    public void HashProbeRequiresFinalizedTable()
+    {
+        // HashDistinct lazily creates table 0 in the Building state; probing it must throw.
+        VdbeInstruction[] instructions =
+        [
+            new LoadConstantInstruction(new Register(0), SqlValue.Integer(1)),
+            new HashDistinctInstruction(new RegisterRange(new Register(0), 1), Collations: [null], HashTableId: 0, DuplicateTarget: new ProgramCounter(3)),
+            new HashProbeInstruction(HashTableId: 0, new RegisterRange(new Register(0), 1), new Register(1), PayloadDestination: null, NotFoundTarget: new ProgramCounter(3)),
+            new HaltInstruction(),
+        ];
+
+        var program = new VdbeProgram(registerCount: 2, cursorCount: 1, instructions, hashTableCount: 1);
+        using var statement = new ResumableStatement(program);
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            while (statement.StepResumable() == ResumableStatementStepResult.Row)
+            {
+            }
+        })!.Message.Should().Contain("Hash table must be finalized before probing.");
+    }
+
+    [Test]
+    public void HashNextWithoutProbeThrows()
+    {
+        // Lazily create table 0 (HashDistinct), finalize it, then HashNext without a probe.
+        VdbeInstruction[] instructions =
+        [
+            new LoadConstantInstruction(new Register(0), SqlValue.Integer(1)),
+            new HashDistinctInstruction(new RegisterRange(new Register(0), 1), Collations: [null], HashTableId: 0, DuplicateTarget: new ProgramCounter(4)),
+            new HashBuildFinalizeInstruction(HashTableId: 0),
+            new HashNextInstruction(HashTableId: 0, new Register(0), PayloadDestination: null, ExhaustedTarget: new ProgramCounter(4)),
+            new HaltInstruction(),
+        ];
+
+        var program = new VdbeProgram(registerCount: 1, cursorCount: 1, instructions, hashTableCount: 1);
+        using var statement = new ResumableStatement(program);
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            while (statement.StepResumable() == ResumableStatementStepResult.Row)
+            {
+            }
+        })!.Message.Should().Contain("HashNext requires a preceding HashProbe on the same hash table.");
+    }
+
+    [Test]
+    public void HashNextOnMissingTableThrows()
+    {
+        VdbeInstruction[] instructions =
+        [
+            new HashNextInstruction(HashTableId: 0, new Register(0), PayloadDestination: null, ExhaustedTarget: new ProgramCounter(1)),
+            new HaltInstruction(),
+        ];
+
+        var program = new VdbeProgram(registerCount: 1, cursorCount: 1, instructions, hashTableCount: 1);
+        using var statement = new ResumableStatement(program);
+        Assert.Throws<InvalidOperationException>(() => statement.StepResumable())!
+            .Message.Should().Contain("Hash table not found with ID: 0");
+    }
+
+    [Test]
+    public void HashNextUnmatchedOnMissingTableThrows()
+    {
+        VdbeInstruction[] instructions =
+        [
+            new HashNextUnmatchedInstruction(HashTableId: 0, new Register(0), PayloadDestination: null, ExhaustedTarget: new ProgramCounter(1)),
+            new HaltInstruction(),
+        ];
+
+        var program = new VdbeProgram(registerCount: 1, cursorCount: 1, instructions, hashTableCount: 1);
+        using var statement = new ResumableStatement(program);
+        Assert.Throws<InvalidOperationException>(() => statement.StepResumable())!
+            .Message.Should().Contain("Hash table not found with ID: 0");
+    }
+
+    [Test]
+    public void HashBuildRejectsInsertsAfterFinalize()
+    {
+        // HashDistinct lazily creates table 0 in the Building state, finalize flips it to
+        // Probing, and the following HashBuild must reject the insert. The cursor stays
+        // positioned on its single row so HashBuild reaches the state check.
+        VdbeInstruction[] instructions =
+        [
+            new OpenEphemeralInstruction(new Cursor(0), ColumnCount: 1),
+            new LoadConstantInstruction(new Register(0), SqlValue.Integer(1)),
+            new EphemeralInsertInstruction(new Cursor(0), new RegisterRange(new Register(0), 1)),
+            new RewindCursorInstruction(new Cursor(0), new ProgramCounter(7)),
+            new HashDistinctInstruction(new RegisterRange(new Register(0), 1), Collations: [null], HashTableId: 0, DuplicateTarget: new ProgramCounter(7)),
+            new HashBuildFinalizeInstruction(HashTableId: 0),
+            new HashBuildInstruction(new Cursor(0), new RegisterRange(new Register(0), 1), HashTableId: 0, MemoryBudget: 0, Collations: [null], Payload: null, TrackMatched: false),
+            new HaltInstruction(),
+        ];
+
+        var program = new VdbeProgram(registerCount: 1, cursorCount: 1, instructions, hashTableCount: 1);
+        using var statement = new ResumableStatement(program);
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            while (statement.StepResumable() == ResumableStatementStepResult.Row)
+            {
+            }
+        })!.Message.Should().Contain("Hash table can only accept inserts while building.");
+    }
+
+    [Test]
+    public void HashDistinctDeduplicatesKeysIncludingNull()
+    {
+        // Probe rows: 1, 1, NULL, NULL. HashDistinct keeps the first 1 and the first NULL
+        // (NULL == NULL for distinctness) and jumps on each duplicate. Every fall-through emits 10.
+        VdbeInstruction[] instructions =
+        [
+            new OpenEphemeralInstruction(new Cursor(0), ColumnCount: 1),
+            new LoadConstantInstruction(new Register(0), SqlValue.Integer(1)),
+            new EphemeralInsertInstruction(new Cursor(0), new RegisterRange(new Register(0), 1)),
+            new LoadConstantInstruction(new Register(0), SqlValue.Integer(1)),
+            new EphemeralInsertInstruction(new Cursor(0), new RegisterRange(new Register(0), 1)),
+            new LoadConstantInstruction(new Register(0), SqlValue.Null),
+            new EphemeralInsertInstruction(new Cursor(0), new RegisterRange(new Register(0), 1)),
+            new LoadConstantInstruction(new Register(0), SqlValue.Null),
+            new EphemeralInsertInstruction(new Cursor(0), new RegisterRange(new Register(0), 1)),
+            new RewindCursorInstruction(new Cursor(0), new ProgramCounter(15)),
+            new ColumnInstruction(new Cursor(0), ColumnIndex: 0, new Register(1)),
+            new HashDistinctInstruction(new RegisterRange(new Register(1), 1), Collations: [null], HashTableId: 0, DuplicateTarget: new ProgramCounter(14)),
+            new LoadConstantInstruction(new Register(2), SqlValue.Integer(10)),
+            new ResultRowInstruction(new RegisterRange(new Register(2), 1)),
+            new NextInstruction(new Cursor(0), new ProgramCounter(10)),
+            new HaltInstruction(),
+        ];
+
+        var rows = RunHashProgram(instructions, registerCount: 3, cursorCount: 1, hashTableCount: 1);
+        rows.Should().HaveCount(2);
+        rows[0].Should().Be(SqlValue.Integer(10));
+        rows[1].Should().Be(SqlValue.Integer(10));
+    }
+
+    [Test]
+    public void HashClearResetsTableToBuilding()
+    {
+        // HashDistinct lazily creates table 0 in Building, Finalize flips it to Probing,
+        // and Clear must reset it to Building so the second HashDistinct can insert again
+        // (otherwise InsertDistinct throws "can only accept inserts while building").
+        VdbeInstruction[] instructions =
+        [
+            new LoadConstantInstruction(new Register(0), SqlValue.Integer(1)),
+            new HashDistinctInstruction(new RegisterRange(new Register(0), 1), Collations: [null], HashTableId: 0, DuplicateTarget: new ProgramCounter(7)),
+            new HashBuildFinalizeInstruction(HashTableId: 0),
+            new HashClearInstruction(HashTableId: 0),
+            new HashDistinctInstruction(new RegisterRange(new Register(0), 1), Collations: [null], HashTableId: 0, DuplicateTarget: new ProgramCounter(7)),
+            new LoadConstantInstruction(new Register(1), SqlValue.Text("cleared")),
+            new ResultRowInstruction(new RegisterRange(new Register(1), 1)),
+            new HaltInstruction(),
+        ];
+
+        var rows = RunHashProgram(instructions, registerCount: 2, cursorCount: 1, hashTableCount: 1);
+        rows.Should().HaveCount(1);
+        rows[0].Should().Be(SqlValue.Text("cleared"));
+    }
+
+    [Test]
+    public void HashCloseRemovesTheTable()
+    {
+        VdbeInstruction[] instructions =
+        [
+            new HashBuildFinalizeInstruction(HashTableId: 0),
+            new HashCloseInstruction(HashTableId: 0),
+            new LoadConstantInstruction(new Register(0), SqlValue.Integer(1)),
+            new HashProbeInstruction(HashTableId: 0, new RegisterRange(new Register(0), 1), new Register(1), PayloadDestination: null, NotFoundTarget: new ProgramCounter(6)),
+            new LoadConstantInstruction(new Register(0), SqlValue.Text("found")),
+            new ResultRowInstruction(new RegisterRange(new Register(0), 1)),
+            new HaltInstruction(),
+        ];
+
+        RunHashProgram(instructions, registerCount: 2, cursorCount: 1, hashTableCount: 1).Should().BeEmpty();
+    }
+
+    [Test]
+    public void HashMarkMatchedAndUnmatchedScanYieldOnlyUnmatchedRows()
+    {
+        // Build rows (1,a) rowid 1, (2,b) rowid 2, (1,c) rowid 3, track matched bits.
+        // Probe key 1 marks both matches, so the unmatched scan returns only rowid 2.
+        VdbeInstruction[] instructions =
+        [
+            new OpenEphemeralInstruction(new Cursor(0), ColumnCount: 2),
+            new LoadConstantInstruction(new Register(0), SqlValue.Integer(1)),
+            new LoadConstantInstruction(new Register(1), SqlValue.Text("a")),
+            new EphemeralInsertInstruction(new Cursor(0), new RegisterRange(new Register(0), 2)),
+            new LoadConstantInstruction(new Register(0), SqlValue.Integer(2)),
+            new LoadConstantInstruction(new Register(1), SqlValue.Text("b")),
+            new EphemeralInsertInstruction(new Cursor(0), new RegisterRange(new Register(0), 2)),
+            new LoadConstantInstruction(new Register(0), SqlValue.Integer(1)),
+            new LoadConstantInstruction(new Register(1), SqlValue.Text("c")),
+            new EphemeralInsertInstruction(new Cursor(0), new RegisterRange(new Register(0), 2)),
+            new RewindCursorInstruction(new Cursor(0), new ProgramCounter(15)),
+            new ColumnInstruction(new Cursor(0), ColumnIndex: 0, new Register(2)),
+            new ColumnInstruction(new Cursor(0), ColumnIndex: 1, new Register(3)),
+            new HashBuildInstruction(new Cursor(0), new RegisterRange(new Register(2), 1), HashTableId: 0, MemoryBudget: 0, Collations: [null], Payload: new RegisterRange(new Register(3), 1), TrackMatched: true),
+            new NextInstruction(new Cursor(0), new ProgramCounter(11)),
+            new HashBuildFinalizeInstruction(HashTableId: 0),
+            new LoadConstantInstruction(new Register(0), SqlValue.Integer(1)),
+            new HashProbeInstruction(HashTableId: 0, new RegisterRange(new Register(0), 1), new Register(4), PayloadDestination: null, NotFoundTarget: new ProgramCounter(22)),
+            new HashMarkMatchedInstruction(HashTableId: 0),
+            new HashNextInstruction(HashTableId: 0, new Register(4), PayloadDestination: null, ExhaustedTarget: new ProgramCounter(22)),
+            new HashMarkMatchedInstruction(HashTableId: 0),
+            new GotoInstruction(new ProgramCounter(19)),
+            new HashScanUnmatchedInstruction(HashTableId: 0, new Register(5), PayloadDestination: new RegisterRange(new Register(6), 1), ExhaustedTarget: new ProgramCounter(27)),
+            new ResultRowInstruction(new RegisterRange(new Register(5), 2)),
+            new HashNextUnmatchedInstruction(HashTableId: 0, new Register(5), PayloadDestination: new RegisterRange(new Register(6), 1), ExhaustedTarget: new ProgramCounter(27)),
+            new ResultRowInstruction(new RegisterRange(new Register(5), 2)),
+            new GotoInstruction(new ProgramCounter(24)),
+            new HaltInstruction(),
+        ];
+
+        var rows = RunHashProgram(instructions, registerCount: 7, cursorCount: 1, hashTableCount: 1);
+        rows.Should().HaveCount(2);
+        rows[0].Should().Be(SqlValue.Integer(2));
+        rows[1].Should().Be(SqlValue.Text("b"));
+    }
+
+    [Test]
+    public void HashMarkMatchedWithoutCurrentMatchThrows()
+    {
+        // TrackMatched:true requires HashBuild (HashDistinct lazily creates tables without
+        // matched-bit tracking, where MarkCurrentMatched silently no-ops). Build one row,
+        // then mark with no preceding probe/next: the entry index is invalid.
+        VdbeInstruction[] instructions =
+        [
+            new OpenEphemeralInstruction(new Cursor(0), ColumnCount: 1),
+            new LoadConstantInstruction(new Register(0), SqlValue.Integer(1)),
+            new EphemeralInsertInstruction(new Cursor(0), new RegisterRange(new Register(0), 1)),
+            new RewindCursorInstruction(new Cursor(0), new ProgramCounter(7)),
+            new HashBuildInstruction(new Cursor(0), new RegisterRange(new Register(0), 1), HashTableId: 0, MemoryBudget: 0, Collations: [null], Payload: null, TrackMatched: true),
+            new NextInstruction(new Cursor(0), new ProgramCounter(4)),
+            new HashMarkMatchedInstruction(HashTableId: 0),
+            new HaltInstruction(),
+        ];
+
+        var program = new VdbeProgram(registerCount: 1, cursorCount: 1, instructions, hashTableCount: 1);
+        using var statement = new ResumableStatement(program);
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            while (statement.StepResumable() == ResumableStatementStepResult.Row)
+            {
+            }
+        })!.Message.Should().Contain("HashMarkMatched requires a current match from HashProbe or HashNext.");
+    }
+
+    [Test]
+    public void ExplainDescribesHashJoinOpcodes()
+    {
+        var hashBuild = new HashBuildInstruction(new Cursor(2), new RegisterRange(new Register(4), 2), HashTableId: 0, MemoryBudget: 4096, Collations: [null, "BINARY"], Payload: new RegisterRange(new Register(6), 1), TrackMatched: true);
+        var (buildCursor, buildP2, buildP3, buildP4, buildComment) = VdbeExplain.Describe(hashBuild);
+        buildCursor.Should().Be(2);
+        buildP2.Should().Be(4);
+        buildP3.Should().Be(2);
+        buildP4.Should().Be("r[4..5]");
+        buildComment.Should().Be("hash_build c[2] keys r[4..5] -> hash_table[0] budget=4096 payload r[6] track_matched");
+        hashBuild.Opcode.Should().Be(VdbeOpcode.HashBuild);
+
+        var hashDistinct = new HashDistinctInstruction(new RegisterRange(new Register(4), 1), Collations: [null], HashTableId: 1, DuplicateTarget: new ProgramCounter(9));
+        var (distinctP1, distinctP2, distinctP3, distinctP4, distinctComment) = VdbeExplain.Describe(hashDistinct);
+        distinctP1.Should().Be(1);
+        distinctP2.Should().Be(4);
+        distinctP3.Should().Be(1);
+        distinctP4.Should().Be("r[4]");
+        distinctComment.Should().Be("hash_distinct r[4] jmp=9");
+        hashDistinct.Opcode.Should().Be(VdbeOpcode.HashDistinct);
+
+        var hashFinalize = new HashBuildFinalizeInstruction(HashTableId: 2);
+        var (finalizeP1, finalizeP2, finalizeP3, finalizeP4, finalizeComment) = VdbeExplain.Describe(hashFinalize);
+        finalizeP1.Should().Be(2);
+        finalizeP2.Should().Be(0);
+        finalizeP3.Should().Be(0);
+        finalizeP4.Should().BeNull();
+        finalizeComment.Should().Be("hash_build_finalize hash_table[2]");
+        hashFinalize.Opcode.Should().Be(VdbeOpcode.HashBuildFinalize);
+
+        var hashProbe = new HashProbeInstruction(HashTableId: 0, new RegisterRange(new Register(4), 2), new Register(8), PayloadDestination: new RegisterRange(new Register(9), 1), NotFoundTarget: new ProgramCounter(12));
+        var (probeP1, probeP2, probeP3, probeP4, probeComment) = VdbeExplain.Describe(hashProbe);
+        probeP1.Should().Be(0);
+        probeP2.Should().Be(4);
+        probeP3.Should().Be(2);
+        probeP4.Should().Be("r[4..5]");
+        probeComment.Should().Be("r[8]=hash_probe(r[4..5]) goto 12 if not found payload r[9]");
+        hashProbe.Opcode.Should().Be(VdbeOpcode.HashProbe);
+
+        var hashNext = new HashNextInstruction(HashTableId: 0, new Register(8), PayloadDestination: new RegisterRange(new Register(9), 1), ExhaustedTarget: new ProgramCounter(14));
+        var (nextP1, nextP2, nextP3, nextP4, nextComment) = VdbeExplain.Describe(hashNext);
+        nextP1.Should().Be(0);
+        nextP2.Should().Be(8);
+        nextP3.Should().Be(14);
+        nextP4.Should().BeNull();
+        nextComment.Should().Be("r[8]=hash_next goto 14 if exhausted payload r[9]");
+        hashNext.Opcode.Should().Be(VdbeOpcode.HashNext);
+
+        var hashClose = new HashCloseInstruction(HashTableId: 3);
+        var (closeP1, closeP2, closeP3, closeP4, closeComment) = VdbeExplain.Describe(hashClose);
+        closeP1.Should().Be(3);
+        closeP2.Should().Be(0);
+        closeP3.Should().Be(0);
+        closeP4.Should().BeNull();
+        closeComment.Should().Be("hash_close hash_table[3]");
+        hashClose.Opcode.Should().Be(VdbeOpcode.HashClose);
+
+        var hashClear = new HashClearInstruction(HashTableId: 3);
+        var (clearP1, clearP2, clearP3, clearP4, clearComment) = VdbeExplain.Describe(hashClear);
+        clearP1.Should().Be(3);
+        clearP2.Should().Be(0);
+        clearP3.Should().Be(0);
+        clearP4.Should().BeNull();
+        clearComment.Should().Be("hash_clear hash_table[3]");
+        hashClear.Opcode.Should().Be(VdbeOpcode.HashClear);
+
+        var hashMark = new HashMarkMatchedInstruction(HashTableId: 3);
+        var (markP1, markP2, markP3, markP4, markComment) = VdbeExplain.Describe(hashMark);
+        markP1.Should().Be(3);
+        markP2.Should().Be(0);
+        markP3.Should().Be(0);
+        markP4.Should().BeNull();
+        markComment.Should().Be("hash_mark_matched hash_table[3]");
+        hashMark.Opcode.Should().Be(VdbeOpcode.HashMarkMatched);
+
+        var hashReset = new HashResetMatchedInstruction(HashTableId: 3);
+        var (resetP1, resetP2, resetP3, resetP4, resetComment) = VdbeExplain.Describe(hashReset);
+        resetP1.Should().Be(3);
+        resetP2.Should().Be(0);
+        resetP3.Should().Be(0);
+        resetP4.Should().BeNull();
+        resetComment.Should().Be("hash_reset_matched hash_table[3]");
+        hashReset.Opcode.Should().Be(VdbeOpcode.HashResetMatched);
+
+        var hashScanUnmatched = new HashScanUnmatchedInstruction(HashTableId: 0, new Register(8), PayloadDestination: new RegisterRange(new Register(9), 2), ExhaustedTarget: new ProgramCounter(16));
+        var (scanP1, scanP2, scanP3, scanP4, scanComment) = VdbeExplain.Describe(hashScanUnmatched);
+        scanP1.Should().Be(0);
+        scanP2.Should().Be(8);
+        scanP3.Should().Be(16);
+        scanP4.Should().BeNull();
+        scanComment.Should().Be("r[8]=hash_scan_unmatched goto 16 if exhausted payload r[9..10]");
+        hashScanUnmatched.Opcode.Should().Be(VdbeOpcode.HashScanUnmatched);
+
+        var hashNextUnmatched = new HashNextUnmatchedInstruction(HashTableId: 0, new Register(8), PayloadDestination: new RegisterRange(new Register(9), 2), ExhaustedTarget: new ProgramCounter(18));
+        var (nextUnmatchedP1, nextUnmatchedP2, nextUnmatchedP3, nextUnmatchedP4, nextUnmatchedComment) = VdbeExplain.Describe(hashNextUnmatched);
+        nextUnmatchedP1.Should().Be(0);
+        nextUnmatchedP2.Should().Be(8);
+        nextUnmatchedP3.Should().Be(18);
+        nextUnmatchedP4.Should().BeNull();
+        nextUnmatchedComment.Should().Be("r[8]=hash_next_unmatched goto 18 if exhausted payload r[9..10]");
+        hashNextUnmatched.Opcode.Should().Be(VdbeOpcode.HashNextUnmatched);
+    }
+
+    [Test]
+    public void ValidationRejectsMalformedHashJoinBytecode()
+    {
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 2,
+            cursorCount: 1,
+            [
+                new ColumnInstruction(new Cursor(0), ColumnIndex: 0, new Register(0)),
+                new HaltInstruction(),
+            ],
+            hashTableCount: 1))!
+            .Message.Should().Contain("uses cursor 0 before opening it");
+
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 2,
+            cursorCount: 1,
+            [
+                new OpenEphemeralInstruction(new Cursor(0), ColumnCount: 1),
+                new HashBuildInstruction(new Cursor(0), new RegisterRange(new Register(0), 0), HashTableId: 0, MemoryBudget: 0, Collations: [], Payload: null, TrackMatched: false),
+                new HaltInstruction(),
+            ],
+            hashTableCount: 1))!
+            .Message.Should().Contain("HashBuild requires a positive key width");
+
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 2,
+            cursorCount: 1,
+            [
+                new OpenEphemeralInstruction(new Cursor(0), ColumnCount: 1),
+                new HashBuildInstruction(new Cursor(0), new RegisterRange(new Register(0), 1), HashTableId: 9, MemoryBudget: 0, Collations: [null], Payload: null, TrackMatched: false),
+                new HaltInstruction(),
+            ],
+            hashTableCount: 1))!
+            .Message.Should().Contain("references hash table 9, but the program has 1 hash tables");
+
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 2,
+            cursorCount: 1,
+            [
+                new OpenEphemeralInstruction(new Cursor(0), ColumnCount: 1),
+                new HashBuildInstruction(new Cursor(0), new RegisterRange(new Register(0), 1), HashTableId: 0, MemoryBudget: -1, Collations: [null], Payload: null, TrackMatched: false),
+                new HaltInstruction(),
+            ],
+            hashTableCount: 1))!
+            .Message.Should().Contain("HashBuild has a negative memory budget of -1");
+
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 2,
+            cursorCount: 1,
+            [
+                new OpenEphemeralInstruction(new Cursor(0), ColumnCount: 1),
+                new HashBuildInstruction(new Cursor(0), new RegisterRange(new Register(0), 1), HashTableId: 0, MemoryBudget: 0, Collations: [null, null], Payload: null, TrackMatched: false),
+                new HaltInstruction(),
+            ],
+            hashTableCount: 1))!
+            .Message.Should().Contain("declares 2 collations for 1 key columns");
+
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 2,
+            cursorCount: 1,
+            [
+                new OpenEphemeralInstruction(new Cursor(0), ColumnCount: 1),
+                new HashBuildInstruction(new Cursor(0), new RegisterRange(new Register(0), 1), HashTableId: 0, MemoryBudget: 0, Collations: ["CUSTOM"], Payload: null, TrackMatched: false),
+                new HaltInstruction(),
+            ],
+            hashTableCount: 1))!
+            .Message.Should().Contain("uses unsupported collation 'CUSTOM' for key column 0");
+
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 3,
+            cursorCount: 1,
+            [
+                new OpenEphemeralInstruction(new Cursor(0), ColumnCount: 1),
+                new HashBuildInstruction(new Cursor(0), new RegisterRange(new Register(0), 1), HashTableId: 0, MemoryBudget: 0, Collations: [null], Payload: new RegisterRange(new Register(1), 0), TrackMatched: false),
+                new HaltInstruction(),
+            ],
+            hashTableCount: 1))!
+            .Message.Should().Contain("HashBuild payload range must carry at least one register");
+
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 2,
+            cursorCount: 1,
+            [
+                new HashDistinctInstruction(new RegisterRange(new Register(0), 0), Collations: [], HashTableId: 0, DuplicateTarget: new ProgramCounter(1)),
+                new HaltInstruction(),
+            ],
+            hashTableCount: 1))!
+            .Message.Should().Contain("HashDistinct requires a positive key width");
+
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 3,
+            cursorCount: 1,
+            [
+                new HashProbeInstruction(HashTableId: 0, new RegisterRange(new Register(0), 0), new Register(1), PayloadDestination: null, NotFoundTarget: new ProgramCounter(1)),
+                new HaltInstruction(),
+            ],
+            hashTableCount: 1))!
+            .Message.Should().Contain("HashProbe requires a positive key width");
+
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 3,
+            cursorCount: 1,
+            [
+                new HashProbeInstruction(HashTableId: 0, new RegisterRange(new Register(0), 1), new Register(1), PayloadDestination: new RegisterRange(new Register(2), 0), NotFoundTarget: new ProgramCounter(1)),
+                new HaltInstruction(),
+            ],
+            hashTableCount: 1))!
+            .Message.Should().Contain("HashProbe payload range must carry at least one register");
+
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 2,
+            cursorCount: 1,
+            [
+                new HashNextInstruction(HashTableId: 0, new Register(0), PayloadDestination: new RegisterRange(new Register(1), 0), ExhaustedTarget: new ProgramCounter(1)),
+                new HaltInstruction(),
+            ],
+            hashTableCount: 1))!
+            .Message.Should().Contain("HashNext payload range must carry at least one register");
+
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 2,
+            cursorCount: 1,
+            [
+                new HashScanUnmatchedInstruction(HashTableId: 0, new Register(0), PayloadDestination: new RegisterRange(new Register(1), 0), ExhaustedTarget: new ProgramCounter(1)),
+                new HaltInstruction(),
+            ],
+            hashTableCount: 1))!
+            .Message.Should().Contain("HashScanUnmatched payload range must carry at least one register");
+
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 2,
+            cursorCount: 1,
+            [
+                new HashNextUnmatchedInstruction(HashTableId: 0, new Register(0), PayloadDestination: new RegisterRange(new Register(1), 0), ExhaustedTarget: new ProgramCounter(1)),
+                new HaltInstruction(),
+            ],
+            hashTableCount: 1))!
+            .Message.Should().Contain("HashNextUnmatched payload range must carry at least one register");
+
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 1,
+            cursorCount: 1,
+            [
+                new HashBuildFinalizeInstruction(HashTableId: 3),
+                new HaltInstruction(),
+            ],
+            hashTableCount: 1))!
+            .Message.Should().Contain("references hash table 3, but the program has 1 hash tables");
+
+        Assert.Throws<VdbeProgramValidationException>(() => new VdbeProgram(
+            registerCount: 1,
+            cursorCount: 1,
+            [
+                new HashCloseInstruction(HashTableId: -1),
+                new HaltInstruction(),
+            ],
+            hashTableCount: 1))!
+            .Message.Should().Contain("references hash table -1, but the program has 1 hash tables");
+    }
+
+    private static List<SqlValue> RunHashProgram(VdbeInstruction[] instructions, int registerCount, int cursorCount, int hashTableCount)
+    {
+        var program = new VdbeProgram(registerCount: registerCount, cursorCount: cursorCount, instructions, hashTableCount: hashTableCount);
+        using var statement = new ResumableStatement(program);
+
+        var values = new List<SqlValue>();
+        while (statement.StepResumable() == ResumableStatementStepResult.Row)
+        {
+            values.AddRange(statement.CurrentRow!);
+        }
+
+        return values;
+    }
+}

--- a/src/Ahtola.Tests/VdbeProgramTests.cs
+++ b/src/Ahtola.Tests/VdbeProgramTests.cs
@@ -49,7 +49,12 @@ public class VdbeProgramTests
                 "DropColumn=133", "AlterColumn=134", "IndexBuild=135", "AggInverse=136",
                 "BlobRead=137", "BlobWrite=138", "BlobLen=139", "ColumnRange=140",
                 "OpenPseudo=141", "TypeCheck=142", "Once=143", "ResetOnce=144",
-                "ChangeCount=145");
+                "ChangeCount=145", "ResetSorter=146", "AggValue=147", "OpenDup=148",
+                "OpenAutoindex=149", "ColumnHasField=150", "DeferredSeek=151",
+                "SeekEnd=152", "BloomFilter=153", "BloomFilterAdd=154", "HashBuild=155",
+                "HashDistinct=156", "HashBuildFinalize=157", "HashProbe=158",
+                "HashNext=159", "HashClose=160", "HashClear=161", "HashMarkMatched=162",
+                "HashResetMatched=163", "HashScanUnmatched=164", "HashNextUnmatched=165");
 
         var constructors = typeof(VdbeProgram).GetConstructors();
         Type[] legacyParameterTypes =
@@ -63,7 +68,7 @@ public class VdbeProgramTests
             typeof(int),
             typeof(int),
         ];
-        Type[] currentParameterTypes = [.. legacyParameterTypes, typeof(int)];
+        Type[] currentParameterTypes = [.. legacyParameterTypes, typeof(int), typeof(int)];
         constructors.Any(constructor => constructor.GetParameters()
             .Select(static parameter => parameter.ParameterType)
             .SequenceEqual(legacyParameterTypes)).Should().BeTrue();
@@ -99,8 +104,10 @@ public class VdbeProgramTests
             distinctSetCount: 0,
             parameterSlotCount: 0,
             workTableCount: 0,
-            windowBufferCount: 0);
+            windowBufferCount: 0,
+            hashTableCount: 0);
         currentProgram.WindowBufferCount.Should().Be(0);
+        currentProgram.HashTableCount.Should().Be(0);
 
         var legacyInsert = new InsertInstruction(new Cursor(3), VdbeInsertFlags.SkipLastRowid);
         var (legacyCursor, legacyFlags) = legacyInsert;

--- a/src/Ahtola.Tests/VdbeSchemaRuntimeTests.cs
+++ b/src/Ahtola.Tests/VdbeSchemaRuntimeTests.cs
@@ -143,8 +143,28 @@ public sealed class VdbeSchemaRuntimeTests
         ((int)VdbeOpcode.Once).Should().Be(143);
         ((int)VdbeOpcode.ResetOnce).Should().Be(144);
         ((int)VdbeOpcode.ChangeCount).Should().Be(145);
+        ((int)VdbeOpcode.ResetSorter).Should().Be(146);
+        ((int)VdbeOpcode.AggValue).Should().Be(147);
+        ((int)VdbeOpcode.OpenDup).Should().Be(148);
+        ((int)VdbeOpcode.OpenAutoindex).Should().Be(149);
+        ((int)VdbeOpcode.ColumnHasField).Should().Be(150);
+        ((int)VdbeOpcode.DeferredSeek).Should().Be(151);
+        ((int)VdbeOpcode.SeekEnd).Should().Be(152);
+        ((int)VdbeOpcode.BloomFilter).Should().Be(153);
+        ((int)VdbeOpcode.BloomFilterAdd).Should().Be(154);
+        ((int)VdbeOpcode.HashBuild).Should().Be(155);
+        ((int)VdbeOpcode.HashDistinct).Should().Be(156);
+        ((int)VdbeOpcode.HashBuildFinalize).Should().Be(157);
+        ((int)VdbeOpcode.HashProbe).Should().Be(158);
+        ((int)VdbeOpcode.HashNext).Should().Be(159);
+        ((int)VdbeOpcode.HashClose).Should().Be(160);
+        ((int)VdbeOpcode.HashClear).Should().Be(161);
+        ((int)VdbeOpcode.HashMarkMatched).Should().Be(162);
+        ((int)VdbeOpcode.HashResetMatched).Should().Be(163);
+        ((int)VdbeOpcode.HashScanUnmatched).Should().Be(164);
+        ((int)VdbeOpcode.HashNextUnmatched).Should().Be(165);
 
-        Enum.GetValues<VdbeOpcode>().Max(static opcode => (int)opcode).Should().Be(145);
+        Enum.GetValues<VdbeOpcode>().Max(static opcode => (int)opcode).Should().Be(165);
     }
 
     [Test]


### PR DESCRIPTION
Closes the first half of the genuine VDBE/bytecode gaps identified between Ahtola (146 opcodes) and Turso's `Insn` set (pinned reference `turso-src` @ `v0.8.0-pre.7`).

## Changes

**20 new opcodes appended (146–165); existing values untouched.**

| Batch | Opcodes | Work |
| --- | --- | --- |
| Micro-cursor | `ResetSorter`=146, `AggValue`=147, `OpenDup`=148, `OpenAutoindex`=149, `ColumnHasField`=150 | Execution arms in `ResumableStatement`, explain support |
| Deferred-seek | `DeferredSeek`=151, `SeekEnd`=152 | Deferred b-tree rowid resolution |
| Bloom filter | `BloomFilter`=153, `BloomFilterAdd`=154 | New `VdbeBloomFilter` runtime structure |
| Hash join | `HashBuild`=155 … `HashNextUnmatched`=165 | New `VdbeHashTable` runtime, 11 execution arms, program validation, explain |

Supporting changes:
- `VdbeProgram`: primary ctor gains `hashTableCount`; hash-table reference validation (`ValidateHashTable`)
- `CompoundProgramBuilder`: hash-table relocation across compound programs
- New test file `VdbeMicroCursorOpcodeTests.cs` (49 tests)

**Compatibility pin updates (deliberate, additive):**
- `PublicOpcodeValuesAndConstructorRemainCompatible`: snapshot extended to 166 entries (0–165); constructor-shape pin extended with the new `hashTableCount` parameter
- `DdlPrerequisiteOpcodesAreAppendedAfterTheExistingBytecodeTail`: 20 new pins; max opcode 145 → 165

## Verification

Full gate `./build.ps1 test -Framework net10.0` green:
- **7575 passed, 0 failed** (7607 total, 32 skipped)
- Managed closure, packed-closure, and consumer restore/build/run/publish all green on net8.0/net9.0/net10.0

## Notes

- Pure-managed invariant preserved (no native/Rust references); AOT/trim compatibility maintained.
- Pre-existing on baseline, not addressed here: `format-check` fails on ~20 whitespace-only files (recommend a separate formatting-cleanup PR); `ConcurrentMigratorsEfMigrateAsyncShapeRotateTheLock` is load-flaky under the parallel full gate (passes isolated).