### PR TITLE
Close remaining gap-inventory items: SEQUENCE family port, execution-memory spill completion, docs reconciliation

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,14 +330,15 @@ Treat Ahtola as SQLite-*compatible*, not a full SQLite replacement:
 
 - **Working set** — base-table rows and several intermediates still stay in the
   process heap. Sorters, compiled equijoin build sides, DISTINCT/compound keyed
-  sets, buffered window partitions, and recursive-worktable frontiers bound
-  retained rows to the `cache_size`-derived execution budget and spill
-  deterministic runs/partitions through the managed temporary file system;
-  skewed hash partitions fall back to bounded scans. With `temp_store=MEMORY`,
-  exceeding that finite budget fails instead of moving the same data into a
-  heap-backed temporary file. Non-equijoin build sides and ephemeral tables do
-  not yet spill (ephemeral tables fail closed against the statement memory
-  budget); an aggregate's own accumulator is a single bounded value per group.
+  sets, buffered window partitions, recursive-worktable frontiers, and ephemeral
+  tables bound retained rows to the `cache_size`-derived execution budget and
+  spill deterministic runs/partitions through the managed temporary file
+  system; skewed hash partitions fall back to bounded scans. With
+  `temp_store=MEMORY`, exceeding that finite budget fails instead of moving the
+  same data into a heap-backed temporary file. The evaluator's nested-loop join
+  materializes both sides as the query result by design, so it is not a spill
+  candidate (an architectural property of the evaluator, not a missing spill
+  path); an aggregate's own accumulator is a single bounded value per group.
   Prefer modest databases
   and explicit transactions for writes (managed writes are slower than native
   SQLite and the gap grows with table size).

--- a/README.md
+++ b/README.md
@@ -426,8 +426,11 @@ Treat Ahtola as SQLite-*compatible*, not a full SQLite replacement:
   raw pages explicitly and reject zstd responses because no approved
   pure-managed, trim-safe zstd implementation is shipped.
 - **Not implemented** — loadable extensions, raw `sqlite3*` handles (`Handle`
-  is null), zstd-compressed replica page sets, `CREATE SEQUENCE`, and
-  typed-value extensions.
+  is null), zstd-compressed replica page sets, and typed-value extensions.
+  `CREATE SEQUENCE` / `DROP SEQUENCE` and the `nextval` / `currval` / `setval`
+  functions are supported as a Turso-compatible extension: sequences persist a
+  backing table whose watermark row is ordinary transactional state (a rolled-back
+  allocation can be re-emitted), and `currval` is per-connection session state.
 - **Native / Sync companions** — not shipped. Connection-string paths that need
   them fail closed. OS P/Invoke in the pager for locks/WAL is intentional engine
   code, not a Rust SDK binding.

--- a/README.md
+++ b/README.md
@@ -329,14 +329,15 @@ connection, and a managed embedded replica — see
 Treat Ahtola as SQLite-*compatible*, not a full SQLite replacement:
 
 - **Working set** — base-table rows and several intermediates still stay in the
-  process heap. Sorters and compiled equijoins bound retained rows to the
+  process heap. Sorters, compiled equijoin build sides, DISTINCT/compound keyed
+  sets, and buffered window partitions bound retained rows to the
   `cache_size`-derived execution budget and spill deterministic runs/partitions
   through the managed temporary file system; skewed hash partitions fall back
   to bounded scans. With `temp_store=MEMORY`, exceeding that finite budget fails
-  instead of moving the same data into a heap-backed temporary file. DISTINCT
-  and compound keyed sets use the same bounded temporary-file policy.
-  Non-equijoin build sides, recursive worktables, buffered windows, ephemeral
-  tables, and opaque aggregate state do not yet spill. Prefer modest databases
+  instead of moving the same data into a heap-backed temporary file.
+  Non-equijoin build sides, recursive worktables, ephemeral tables, and opaque
+  aggregate state do not yet spill (ephemeral tables fail closed against the
+  statement memory budget). Prefer modest databases
   and explicit transactions for writes (managed writes are slower than native
   SQLite and the gap grows with table size).
 - **Planner** — `ANALYZE` / `sqlite_stat1` and validated `sqlite_stat4`

--- a/README.md
+++ b/README.md
@@ -330,14 +330,15 @@ Treat Ahtola as SQLite-*compatible*, not a full SQLite replacement:
 
 - **Working set** — base-table rows and several intermediates still stay in the
   process heap. Sorters, compiled equijoin build sides, DISTINCT/compound keyed
-  sets, and buffered window partitions bound retained rows to the
-  `cache_size`-derived execution budget and spill deterministic runs/partitions
-  through the managed temporary file system; skewed hash partitions fall back
-  to bounded scans. With `temp_store=MEMORY`, exceeding that finite budget fails
-  instead of moving the same data into a heap-backed temporary file.
-  Non-equijoin build sides, recursive worktables, ephemeral tables, and opaque
-  aggregate state do not yet spill (ephemeral tables fail closed against the
-  statement memory budget). Prefer modest databases
+  sets, buffered window partitions, and recursive-worktable frontiers bound
+  retained rows to the `cache_size`-derived execution budget and spill
+  deterministic runs/partitions through the managed temporary file system;
+  skewed hash partitions fall back to bounded scans. With `temp_store=MEMORY`,
+  exceeding that finite budget fails instead of moving the same data into a
+  heap-backed temporary file. Non-equijoin build sides and ephemeral tables do
+  not yet spill (ephemeral tables fail closed against the statement memory
+  budget); an aggregate's own accumulator is a single bounded value per group.
+  Prefer modest databases
   and explicit transactions for writes (managed writes are slower than native
   SQLite and the gap grows with table size).
 - **Planner** — `ANALYZE` / `sqlite_stat1` and validated `sqlite_stat4`

--- a/docs/turso-gap-analysis.md
+++ b/docs/turso-gap-analysis.md
@@ -1653,6 +1653,88 @@ commit, and the generated-column error-message split — stays
 `s4-intentional` pending an explicit product decision; this wave records
 that status, it does not flip it.
 
+### F8 — generated-column error-message parity verification (2026-09-05)
+
+Verified against the pinned v0.8.0-pre.7 sources that the engine already
+emits Turso's two distinct generated-column diagnostics
+(`core/schema.rs`: "window functions prohibited in generated columns" vs
+"aggregate functions prohibited in generated columns"); the
+`compile-generated-column-error-message-mismatch` entry's
+single-combined-message claim was stale, not the engine. Added focused
+parity tests
+(`GeneratedColumnsTests.AggregateFunctionInGenerationUsesTursoAggregateDiagnostic`
+/ `WindowFunctionInGenerationUsesTursoWindowDiagnostic` /
+`WindowOnlyFunctionInGenerationUsesMisuseDiagnostic`); all 32
+GeneratedColumnsTests pass. No engine change was needed.
+
+### F9 — SEQUENCE family port (2026-09-05)
+
+Flipped the first actionable `s4-intentional` candidate into a delivered
+surface, porting Turso's SEQUENCE extension end to end:
+
+- **Parser/AST**: `CREATE SEQUENCE [IF NOT EXISTS] name [START [WITH] n]
+  [INCREMENT [BY] n] [MINVALUE n] [MAXVALUE n] [CYCLE|NO CYCLE]` and
+  `DROP SEQUENCE [IF EXISTS] name`, matching upstream's
+  `parse_create_sequence`/`parse_drop_stmt` grammar and AST
+  (`CreateSequenceStatement`/`DropSequenceStatement`).
+- **Descriptor + validation** (`ManagedSequence`): Turso's
+  `Sequence::new` defaults and exact diagnostics — increment ≠ 0, min/max
+  defaults by direction, `min < max`, start clamped to bounds.
+- **Persistence**: the disk-only backing-table model
+  (`__turso_internal_seq_<name>`, the same 7-column shape AUTOINCREMENT
+  uses) — CREATE/DROP lower to compiled DDL programs
+  (`DdlStatementCompiler.CompileCreateSequence/CompileDropSequence`)
+  that allocate the b-tree, write/adopt the schema row, seed the
+  descriptor row, and bump the cookie; DROP tears the backing table down
+  exactly as `emit_drop_sequence_cleanup` does and clears the
+  connection's currval session entry.
+- **Functions**: `nextval`/`currval`/`setval` as evaluator-managed
+  scalars over the backing row (watermark read/rewrite per call,
+  Turso's `SequenceComputeNext` exhaustion/cycle/is_called rules,
+  setval range validation, per-connection currval via
+  `ManagedSequenceSession` threaded through `QueryContext` like the
+  CDC session). A statement containing `nextval`/`setval` is classified
+  as a mutation (so bare `SELECT nextval(...)` takes the write path),
+  and the watermark rewrite reports `Changed` through the
+  `CteMutationState` side-channel, which makes autocommit persist and
+  transaction rollback discard the advance — Turso's documented
+  "rolled-back values can be re-emitted" behavior.
+- **Tests**: `ManagedSequenceTests` (26 cases) — asc/desc, cycle wrap,
+  exhaustion diagnostics, setval/is_called, per-connection currval,
+  cross-connection visibility, rollback re-emission, file-backed reopen
+  persistence, reserved AUTOINCREMENT-namespace rejection, validation
+  errors, INSERT integration.
+
+Inventory entries
+`parser-turso-only-sequence-and-optimize-statements`,
+`func-sequence-nextval-family`, and `vdbe-sequence-opcode-family` closed
+as delivered (the six remaining upstream opcodes are recorded as the
+deliberate managed idiom: the evaluator rewrites the backing row where
+Turso needs bytecode cursor sequences). README updated.
+
+
+Record-keeping only; no engine behavior changed. An exhaustive review of the
+55 `s4-intentional` entries found 9 whose 2026-08-06 closure rationales
+predated later waves: the three `mvcc-*` entries still claimed MVCC was
+fail-closed/ignored (superseded by the MVCC phases 1–3.7 port,
+`docs/mvcc-port-contract.md`), and six `sync-*` entries still cited the
+companion-not-shipped scope for CDC, MVCC-logical replay, page-protocol
+pull, partial/query bootstrap, the EF sync surface, and the checkpoint
+policy (all superseded by the managed sync engine, roadmap workstream
+`sync-engine-depth`). Each entry received a dated `Reconciled 2026-09-05`
+postscript and a corrected `ahtola_ref` pointing at the shipped
+implementation; original rationale text is preserved per the append-only
+audit-trail convention. The meta block was repaired (`entry_count` 216 →
+217, recounted `counts` including the `pragma` layer and the
+`intentional-divergence` kind, `last_reconciled` → 2026-09-05, schema
+enums extended, `conformance_links` documented as historical keys, and a
+note that the 2 remaining expected failures are the intentional
+STORED-generated-column markers). The actionable s4 remainder —
+SEQUENCE family, typed values, materialized views, multi-DB atomic
+commit, and the generated-column error-message split — stays
+`s4-intentional` pending an explicit product decision; this wave records
+that status, it does not flip it.
+
 
 ## Appendix A — Inventory JSON schema
 

--- a/docs/turso-gap-analysis.md
+++ b/docs/turso-gap-analysis.md
@@ -1629,6 +1629,30 @@ FTS5/R-Tree shadow storage, and embedded sync-history rewrites. Foreign SQLite
 R-Tree shadow layouts are rejected explicitly; Ahtola does not claim two-way
 file interoperability for payload-backed virtual tables.
 
+### F7 — inventory housekeeping (2026-09-05)
+
+Record-keeping only; no engine behavior changed. An exhaustive review of the
+55 `s4-intentional` entries found 9 whose 2026-08-06 closure rationales
+predated later waves: the three `mvcc-*` entries still claimed MVCC was
+fail-closed/ignored (superseded by the MVCC phases 1–3.7 port,
+`docs/mvcc-port-contract.md`), and six `sync-*` entries still cited the
+companion-not-shipped scope for CDC, MVCC-logical replay, page-protocol
+pull, partial/query bootstrap, the EF sync surface, and the checkpoint
+policy (all superseded by the managed sync engine, roadmap workstream
+`sync-engine-depth`). Each entry received a dated `Reconciled 2026-09-05`
+postscript and a corrected `ahtola_ref` pointing at the shipped
+implementation; original rationale text is preserved per the append-only
+audit-trail convention. The meta block was repaired (`entry_count` 216 →
+217, recounted `counts` including the `pragma` layer and the
+`intentional-divergence` kind, `last_reconciled` → 2026-09-05, schema
+enums extended, `conformance_links` documented as historical keys, and a
+note that the 2 remaining expected failures are the intentional
+STORED-generated-column markers). The actionable s4 remainder —
+SEQUENCE family, typed values, materialized views, multi-DB atomic
+commit, and the generated-column error-message split — stays
+`s4-intentional` pending an explicit product decision; this wave records
+that status, it does not flip it.
+
 
 ## Appendix A — Inventory JSON schema
 
@@ -1683,7 +1707,9 @@ they are listed below for completeness — absence of mapped failures means
 ## Appendix C — Entries with zero mapped failure lines (by layer)
 
 > Historical source-evidence list from analysis time. As of F5 the live
-> inventory is **0 open / 216 closed**; entries below may be closed intentional
+> inventory is **0 open / 217 closed** (216 after F5, plus the 2026-09-05
+> `pragma`-layer entry `pragma-in-memory-page-count-freelist-model`);
+> entries below may be closed intentional
 > or delivered surfaces that simply had no conf corpus line.
 
 - **vdbe** (16): `vdbe-bloom-filter-opcodes`, `vdbe-virtual-table-opcodes`, `vdbe-index-method-opcodes`, `vdbe-schema-cookie-opcodes`, `vdbe-deferred-seek`, `vdbe-rowset-test`, `vdbe-record-construction-model`, `vdbe-scalar-control-opcodes`, `vdbe-integrity-check-opcode`, `vdbe-coroutine-machinery`, `vdbe-misc-cursor-opcodes`, `vdbe-typed-value-opcode-family`, `vdbe-sequence-opcode-family`, `vdbe-materialized-view-opcodes`, `vdbe-ext-window-buffer-family`, `vdbe-ext-worktable-and-gate-families`

--- a/docs/turso-gap-closure-roadmap.md
+++ b/docs/turso-gap-closure-roadmap.md
@@ -92,6 +92,21 @@ classification: ranks 1-7 account for 133 distinct expected-failure entries.
   sides and ephemeral tables (deliberately fail-closed); an aggregate's own
   accumulator is a single bounded value per group, so there is no engine-owned
   growing aggregate state to spill.
+- 2026-09-05: ephemeral tables spill too — the last VDBE-side fail-closed
+  structure. `EphemeralTableRuntime` keeps its full access contract
+  (sequential scan, positional delete, key-prefix delete/contains, ResetSorter
+  clears, cursor-source rowids) across a spill transition: rows flush to an
+  `ephemeral-table` append-log of (slot, rowid, values) records with an
+  `ephemeral-index` slot→offset file (the keyed-row-set layout), and a compact
+  live-slot list preserves positional semantics afterwards (one reference per
+  live row, itself retained against the budget). The lazy
+  `SpilledEphemeralRowList`/`RowIdList` views give `VdbeCursorSource` indexed
+  reads without reloading the table. New `EphemeralTablesSpilled` metric.
+  Coverage: `VdbeEphemeralTableOpcodeTests` spill case (order, values, metrics,
+  file lifecycle). With this, every VDBE execution intermediate either spills
+  or is a bounded per-group/per-row value; the only non-spilling remainder is
+  the evaluator's materializing nested-loop join, which is an architectural
+  property of the evaluator, not a missing spill path.
 - 2026-09-01: appended `ChangeCount` (opcode 145). Streaming `AggInverse` now
   covers `ROWS CURRENT ROW … m FOLLOWING` and `ROWS n PRECEDING … m FOLLOWING`
   (n,m ≤ 1024). Ephemeral tables fail closed against the statement memory

--- a/docs/turso-gap-closure-roadmap.md
+++ b/docs/turso-gap-closure-roadmap.md
@@ -72,6 +72,26 @@ classification: ranks 1-7 account for 133 distinct expected-failure entries.
   route through `Program` with `ColumnRange` image capture; STRICT INSERT emits
   `TypeCheck`. Distinct worktables spill through `VdbeKeyedRowStore`; window
   buffers fail closed against the statement memory budget.
+- 2026-09-05: recursive-worktable frontiers now spill through the managed temporary
+  file system. `WorkTableRuntime` retains buffered frontier rows against the
+  statement memory budget and, once the budget can no longer hold the queue,
+  drains it to a `worktable-frontier` spill file (a new `VdbeSpillFileKind`);
+  FIFO order is append order, so dequeues drain the buffered prefix and then
+  read records sequentially. `TryPeek` spans the spill boundary for
+  generation-at-a-time recursion, and the per-generation buffer is retained
+  and fails closed (the transform contract takes in-memory rows). Distinct
+  worktables therefore coexist with two spill stores (seen set + frontier) in
+  one statement. New `WorkTableFrontiersSpilled` metric. Coverage:
+  `RecursiveWorkTableOpcodeExecutionTests` spill cases (binary-tree level order
+  across the boundary, interleaved fan-out, distinct coexistence, and
+  no-spill fail-closed with `AllowTemporaryFileSpill=false`).
+  Also verified the earlier "window buffers fail closed" claim was superseded:
+  buffered window partitions already spill (`WindowBufferRuntime.EnsureSpilled`,
+  2026-09-01, indexed Compute reads), and the README working-set matrix now
+  says so. Remaining non-spilling structures: evaluator non-equijoin build
+  sides and ephemeral tables (deliberately fail-closed); an aggregate's own
+  accumulator is a single bounded value per group, so there is no engine-owned
+  growing aggregate state to spill.
 - 2026-09-01: appended `ChangeCount` (opcode 145). Streaming `AggInverse` now
   covers `ROWS CURRENT ROW … m FOLLOWING` and `ROWS n PRECEDING … m FOLLOWING`
   (n,m ≤ 1024). Ephemeral tables fail closed against the statement memory

--- a/docs/turso-gap-inventory.json
+++ b/docs/turso-gap-inventory.json
@@ -15,51 +15,52 @@
     },
     "conformance_ground_truth": "src/Ahtola.Tests/Conformance/managed-sqltest-expected-failures.txt (606 failure lines at analysis time)",
     "current_conformance_expected_failures": 2,
-    "last_reconciled": "2026-08-31",
-    "entry_count": 216,
+    "current_conformance_expected_failures_note": "The 2 remaining expected failures are intentional SQLite-compatible extensions: gencol.sqltest::gencol_stored_rejected and gencol.sqltest::gencol_stored_generated_always_rejected (Ahtola accepts STORED generated columns where the pinned Turso corpus expects rejection).",
+    "last_reconciled": "2026-09-05",
+    "entry_count": 217,
     "counts": {
       "by_layer": {
+        "vdbe": 38,
         "compilation": 68,
-        "functions": 26,
-        "mvcc": 14,
         "parser": 29,
+        "functions": 26,
         "storage": 23,
+        "mvcc": 14,
         "sync": 18,
-        "vdbe": 38
+        "pragma": 1
       },
       "by_kind": {
+        "missing": 69,
+        "partial": 8,
         "divergent": 73,
         "extension": 9,
-        "intentional-divergence": 1,
-        "missing": 70,
-        "parity": 56,
-        "partial": 7
+        "parity": 57,
+        "intentional-divergence": 1
       },
       "by_severity": {
         "s1-correctness": 39,
-        "s2-capability": 89,
+        "s2-capability": 90,
         "s3-perf": 33,
         "s4-intentional": 55
       },
       "by_effort": {
-        "L": 40,
+        "S": 101,
         "M": 76,
-        "S": 100
+        "L": 40
       },
       "by_status": {
-        "closed": 216,
-        "open": 0
+        "closed": 217
       }
     },
     "schema": {
       "id": "stable kebab-case, layer-prefixed (vdbe-, compile-, parser-, func-, storage-, mvcc-, sync-)",
-      "layer": "vdbe | compilation | parser | functions | storage | mvcc | sync",
-      "kind": "missing (no Ahtola counterpart) | partial (subset ported) | divergent (both exist, behavior differs) | extension (Ahtola-only) | parity (audited, no gap; status closed)",
+      "layer": "vdbe | compilation | parser | functions | storage | mvcc | sync | pragma",
+      "kind": "missing (no Ahtola counterpart) | partial (subset ported) | divergent (both exist, behavior differs) | extension (Ahtola-only) | parity (audited, no gap; status closed) | intentional-divergence (documented deliberate divergence with no upstream counterpart to port)",
       "turso_ref": "upstream file::symbol citation inside turso-src/ at the pinned tag",
       "ahtola_ref": "Ahtola source citation, or \"none\"",
       "severity": "s1-correctness (wrong results) | s2-capability (SQL surface blocked) | s3-perf | s4-intentional (documented product divergence)",
       "effort": "S | M | L (rough porting cost)",
-      "conformance_links": "failure keys file.sqltest::test-name from the expected-failures file; empty = source-evidence-only gap",
+      "conformance_links": "historical failure keys (file.sqltest::test-name) that mapped to this entry at analysis time; they were removed from the expected-failures file when the gap closed, so they no longer appear there; empty = source-evidence-only gap",
       "notes": "finding detail and porting guidance",
       "status": "open | closed (flip to closed when the gap lands; drop resolved keys from the expected-failures file in the same change)"
     }
@@ -2380,11 +2381,11 @@
       "layer": "mvcc",
       "kind": "missing",
       "turso_ref": "turso-src/core/mvcc/database/mod.rs::drop_unused_row_versions, drop_unused_row_versions_and_slots, drop_unused_row_versions_inner (lines ~6995-7275)",
-      "ahtola_ref": "none",
+      "ahtola_ref": "src/Ahtola.Core/Mvcc/MvStore.cs (row-version chains, GarbageCollectAfterCheckpoint), src/Ahtola.Core/Mvcc/EmbeddedMvStoreRegistry.cs; docs/mvcc-port-contract.md phases 1.5/3",
       "severity": "s4-intentional",
       "effort": "M",
       "conformance_links": [],
-      "notes": "Closed 2026-08-06 as intentional classic-path-only scope. Managed Ahtola is the SQLite-compatible pager/WAL/b-tree engine; BEGIN CONCURRENT and PRAGMA journal_mode=mvcc are fail-closed / ignored (ManagedDocumentedBoundaryTests, ManagedAdvancedFeatureBoundaryTests). The 11 managed-sqltest expected failures remain MVCC-mode corpus markers, not a claim of concurrent correctness. Do not fake journal_mode=mvcc or a partial MvStore.",
+      "notes": "Closed 2026-08-06 as intentional classic-path-only scope. Managed Ahtola is the SQLite-compatible pager/WAL/b-tree engine; BEGIN CONCURRENT and PRAGMA journal_mode=mvcc are fail-closed / ignored (ManagedDocumentedBoundaryTests, ManagedAdvancedFeatureBoundaryTests). The 11 managed-sqltest expected failures remain MVCC-mode corpus markers, not a claim of concurrent correctness. Do not fake journal_mode=mvcc or a partial MvStore. Reconciled 2026-09-05: the 2026-08-06 classic-path-only rationale predates the MVCC port. Row-version chains (Insert/Update/Delete/TryRead/ScanVisible), commit stamp rewrite, rollback drop, and reader-generation-aware GC after checkpoint shipped with MVCC phases 1.5 and 3 (docs/mvcc-port-contract.md; MvccStoreUnitTests, MvccHeaderAndDualCursorTests, MvccCheckpointStateMachineTests). Remaining deliberate depth (full cooperative per-page checkpoint-state-machine parity) is tracked in docs/mvcc-port-contract.md, not here.",
       "status": "closed"
     },
     {
@@ -2392,11 +2393,11 @@
       "layer": "mvcc",
       "kind": "missing",
       "turso_ref": "turso-src/core/mvcc/cursor.rs::MvccCursorType, turso-src/core/vdbe/execute.rs::maybe_promote_to_mvcc_cursor, turso-src/core/mvcc/mod.rs::test_mvcc_dual_cursor_transaction_isolation",
-      "ahtola_ref": "none",
+      "ahtola_ref": "src/Ahtola.Core/Mvcc/MvccDualCursor.cs (+ SQL SELECT/DML routing under concurrent scope, phase 3.5; page-native direct-index accessor, phase 3.7)",
       "severity": "s4-intentional",
       "effort": "L",
       "conformance_links": [],
-      "notes": "Closed 2026-08-06 as intentional classic-path-only scope. Managed Ahtola is the SQLite-compatible pager/WAL/b-tree engine; BEGIN CONCURRENT and PRAGMA journal_mode=mvcc are fail-closed / ignored (ManagedDocumentedBoundaryTests, ManagedAdvancedFeatureBoundaryTests). The 11 managed-sqltest expected failures remain MVCC-mode corpus markers, not a claim of concurrent correctness. Do not fake journal_mode=mvcc or a partial MvStore.",
+      "notes": "Closed 2026-08-06 as intentional classic-path-only scope. Managed Ahtola is the SQLite-compatible pager/WAL/b-tree engine; BEGIN CONCURRENT and PRAGMA journal_mode=mvcc are fail-closed / ignored (ManagedDocumentedBoundaryTests, ManagedAdvancedFeatureBoundaryTests). The 11 managed-sqltest expected failures remain MVCC-mode corpus markers, not a claim of concurrent correctness. Do not fake journal_mode=mvcc or a partial MvStore. Reconciled 2026-09-05: the 2026-08-06 classic-path-only rationale predates the MVCC port. Typed dual cursors over base B-trees and version chains (two-peek merge per core/mvcc/cursor.rs), snapshot isolation after peer commit, and first-committer-wins on typed identities shipped with MVCC phases 3.5/3.7, including page-native direct-index access for eligible index paths (MvccSelectDualCursorRoutingTests). Cross-process scope remains process-local by design.",
       "status": "closed"
     },
     {
@@ -2404,11 +2405,11 @@
       "layer": "mvcc",
       "kind": "missing",
       "turso_ref": "turso-src/core/mvcc/persistent_storage/logical_log.rs, turso-src/core/mvcc/persistent_storage/mod.rs, turso-src/core/mvcc/database/checkpoint_state_machine.rs::CheckpointStateMachine, BootstrapState",
-      "ahtola_ref": "src/Ahtola.Core/Storage/SqliteWalWriterCheckpointCoordinator.cs (classic WAL checkpoint only)",
+      "ahtola_ref": "src/Ahtola.Core/Mvcc/MvccLogicalLog.cs (durable *.db-log, LML2/MVTX framing, CRC32C, encrypted payload chunks), MvccCheckpoint + EmbeddedDatabase.RunMvccCheckpoint; docs/mvcc-port-contract.md phases 2/3.6",
       "severity": "s4-intentional",
       "effort": "L",
       "conformance_links": [],
-      "notes": "Closed 2026-08-06 as intentional classic-path-only scope. Managed Ahtola is the SQLite-compatible pager/WAL/b-tree engine; BEGIN CONCURRENT and PRAGMA journal_mode=mvcc are fail-closed / ignored (ManagedDocumentedBoundaryTests, ManagedAdvancedFeatureBoundaryTests). The 11 managed-sqltest expected failures remain MVCC-mode corpus markers, not a claim of concurrent correctness. Do not fake journal_mode=mvcc or a partial MvStore.",
+      "notes": "Closed 2026-08-06 as intentional classic-path-only scope. Managed Ahtola is the SQLite-compatible pager/WAL/b-tree engine; BEGIN CONCURRENT and PRAGMA journal_mode=mvcc are fail-closed / ignored (ManagedDocumentedBoundaryTests, ManagedAdvancedFeatureBoundaryTests). The 11 managed-sqltest expected failures remain MVCC-mode corpus markers, not a claim of concurrent correctness. Do not fake journal_mode=mvcc or a partial MvStore. Reconciled 2026-09-05: the 2026-08-06 classic-path-only rationale predates the MVCC port. The durable logical log with Turso LML2/MVTX framing constants (plus encrypted-database AES-GCM payload chunks), header version 255 via SwitchJournalMode(Mvcc), cold-open replay, and the crash-ordered synchronous page-WAL checkpoint state machine shipped with MVCC phases 2, 3, and 3.6 (MvccCheckpointStateMachineTests). The synchronous adaptation of Turso's cooperative per-page I/O state machine remains the recorded divergence in docs/mvcc-port-contract.md.",
       "status": "closed"
     },
     {
@@ -2527,11 +2528,11 @@
       "layer": "sync",
       "kind": "missing",
       "turso_ref": "turso-src/sync/engine/src/database_sync_engine.rs::CDC_PRAGMA_NAME, acknowledge_existing_cdc_for_client, max_local_change_id, count_local_changes",
-      "ahtola_ref": "none",
+      "ahtola_ref": "src/Ahtola.Core/ChangeDataCapture.cs (PRAGMA capture_data_changes_conn, V1/V2 CDC tables, transactional COMMIT records)",
       "severity": "s4-intentional",
       "effort": "L",
       "conformance_links": [],
-      "notes": "Closed 2026-08-06 as intentional companion-not-shipped scope (with sync-sdk-kit-native-companion-intentional / sync-native-provider-companion-intentional). README: Native/Sync companions are not shipped from this repo and fail closed. AhtolaReplicaProvider loads Turso.Data.Sync when present and throws NotSupportedException otherwise; DTOs/options without an in-tree engine are not a managed sync port. Satellite gaps (CDC, revert-WAL, page pull, EF surface, pool wait_changes) are features of that missing companion, not independent managed work.",
+      "notes": "Closed 2026-08-06 as intentional companion-not-shipped scope (with sync-sdk-kit-native-companion-intentional / sync-native-provider-companion-intentional). README: Native/Sync companions are not shipped from this repo and fail closed. AhtolaReplicaProvider loads Turso.Data.Sync when present and throws NotSupportedException otherwise; DTOs/options without an in-tree engine are not a managed sync port. Satellite gaps (CDC, revert-WAL, page pull, EF surface, pool wait_changes) are features of that missing companion, not independent managed work. Reconciled 2026-09-05: the 2026-08-06 companion-not-shipped rationale predates the managed CDC surface. PRAGMA capture_data_changes_conn implements Turso v0.7.2's per-connection V1/V2 change-capture tables and transactional COMMIT records (README \"SQL CDC\"; ManagedChangeDataCaptureTests, ManagedReplicaChangeCaptureBridgeTests). It remains independent of the managed replica's private journal and is not a full logical-replication replay engine.",
       "status": "closed"
     },
     {
@@ -2551,11 +2552,11 @@
       "layer": "sync",
       "kind": "missing",
       "turso_ref": "turso-src/sync/engine/src/client_proto.rs::LogicalOp/LogicalTxnData/LogicalOpType, turso-src/sync/engine/src/database_replay_generator.rs (INSERT ... ON CONFLICT replay), turso-src/sync/engine/src/server_proto.rs::MvccLogicalLogRangeProto/MvccLogicalLogMetadataProto",
-      "ahtola_ref": "none",
+      "ahtola_ref": "src/Ahtola.Data/ManagedReplicaConnectionHost.cs + ManagedReplicaBootstrapper.cs (persisted Pages/MvccLogical protocol detection, LML3 logical replay)",
       "severity": "s4-intentional",
       "effort": "L",
       "conformance_links": [],
-      "notes": "Closed 2026-08-06 as intentional companion-not-shipped scope (with sync-sdk-kit-native-companion-intentional / sync-native-provider-companion-intentional). README: Native/Sync companions are not shipped from this repo and fail closed. AhtolaReplicaProvider loads Turso.Data.Sync when present and throws NotSupportedException otherwise; DTOs/options without an in-tree engine are not a managed sync port. Satellite gaps (CDC, revert-WAL, page pull, EF surface, pool wait_changes) are features of that missing companion, not independent managed work.",
+      "notes": "Closed 2026-08-06 as intentional companion-not-shipped scope (with sync-sdk-kit-native-companion-intentional / sync-native-provider-companion-intentional). README: Native/Sync companions are not shipped from this repo and fail closed. AhtolaReplicaProvider loads Turso.Data.Sync when present and throws NotSupportedException otherwise; DTOs/options without an in-tree engine are not a managed sync port. Satellite gaps (CDC, revert-WAL, page pull, EF surface, pool wait_changes) are features of that missing companion, not independent managed work. Reconciled 2026-09-05: the 2026-08-06 companion-not-shipped rationale predates the managed sync engine. The managed replica detects and persists physical-page vs MVCC-logical protocols explicitly and replays LML3 logical transactions (roadmap workstream sync-engine-depth, closed 2026-08-29). Turso's native sdk-kit remains intentionally not ported (sync-sdk-kit-native-companion-intentional).",
       "status": "closed"
     },
     {
@@ -2563,11 +2564,11 @@
       "layer": "sync",
       "kind": "missing",
       "turso_ref": "turso-src/sync/engine/src/server_proto.rs::PullUpdatesReqProtoBody/PullUpdatesRespProtoBody/PageData/PageUpdatesEncodingReq/PageSetZstdEncodingProto",
-      "ahtola_ref": "none",
+      "ahtola_ref": "src/Ahtola.Data/ManagedReplicaConnectionHost.cs (raw page-protocol pull: explicit raw PagesEncodingReq=0 negotiation, fail-closed zstd rejection)",
       "severity": "s4-intentional",
       "effort": "M",
       "conformance_links": [],
-      "notes": "Closed 2026-08-06 as intentional companion-not-shipped scope (with sync-sdk-kit-native-companion-intentional / sync-native-provider-companion-intentional). README: Native/Sync companions are not shipped from this repo and fail closed. AhtolaReplicaProvider loads Turso.Data.Sync when present and throws NotSupportedException otherwise; DTOs/options without an in-tree engine are not a managed sync port. Satellite gaps (CDC, revert-WAL, page pull, EF surface, pool wait_changes) are features of that missing companion, not independent managed work. Updated 2026-08-23: the managed request writer now emits PullUpdatesReqProtoBody tag 7 (server_query_selector, UTF-8 string) for query bootstrap, mutually exclusive with tag 5 (server_pages_selector) and only on the single bootstrap request; zstd stays rejected.",
+      "notes": "Closed 2026-08-06 as intentional companion-not-shipped scope (with sync-sdk-kit-native-companion-intentional / sync-native-provider-companion-intentional). README: Native/Sync companions are not shipped from this repo and fail closed. AhtolaReplicaProvider loads Turso.Data.Sync when present and throws NotSupportedException otherwise; DTOs/options without an in-tree engine are not a managed sync port. Satellite gaps (CDC, revert-WAL, page pull, EF surface, pool wait_changes) are features of that missing companion, not independent managed work. Updated 2026-08-23: the managed request writer now emits PullUpdatesReqProtoBody tag 7 (server_query_selector, UTF-8 string) for query bootstrap, mutually exclusive with tag 5 (server_pages_selector) and only on the single bootstrap request; zstd stays rejected. Reconciled 2026-09-05: the 2026-08-06 companion-not-shipped rationale predates the managed sync engine. Raw page-protocol pulls are decoded and applied by the managed replica with explicit raw-encoding negotiation; zstd-compressed page sets remain fail-closed because no approved pure-managed, trim-safe zstd implementation is shipped (deliberate, documented choice).",
       "status": "closed"
     },
     {
@@ -2659,11 +2660,11 @@
       "layer": "sync",
       "kind": "missing",
       "turso_ref": "turso-src/sync/engine/src/database_sync_lazy_storage.rs::DatabaseSyncLazyStorage (segment-based lazy page fetch, prefetch)",
-      "ahtola_ref": "src/Ahtola.Data/AhtolaSyncOptions.cs::AhtolaPartialBootstrapOptions (Prefix/Query, SegmentSize, Prefetch)",
+      "ahtola_ref": "src/Ahtola.Data/AhtolaSyncOptions.cs::AhtolaPartialBootstrapOptions (Prefix/QueryPages, durable page-state sidecar, lazy page faulting); docs/replica-bootstrap-publication.md",
       "severity": "s4-intentional",
       "effort": "L",
       "conformance_links": [],
-      "notes": "Closed 2026-08-06 as intentional companion-not-shipped scope (with sync-sdk-kit-native-companion-intentional / sync-native-provider-companion-intentional). README: Native/Sync companions are not shipped from this repo and fail closed. AhtolaReplicaProvider loads Turso.Data.Sync when present and throws NotSupportedException otherwise; DTOs/options without an in-tree engine are not a managed sync port. Satellite gaps (CDC, revert-WAL, page pull, EF surface, pool wait_changes) are features of that missing companion, not independent managed work. Updated 2026-08-23: the managed replica now also supports Query selection (AhtolaPartialBootstrapOptions.QueryPages) end to end, reusing the same arbitrary-range sidecar, lazy materializer, coalescing, ownership and publication ordering as Prefix. Residuals: it requires a remote that honours Turso's server_query_selector (the vendored dev server ignores tag 7 by design, so all coverage is fake-server based), and the run-list sidecar costs one run per page for worst-case scattered selections.",
+      "notes": "Closed 2026-08-06 as intentional companion-not-shipped scope (with sync-sdk-kit-native-companion-intentional / sync-native-provider-companion-intentional). README: Native/Sync companions are not shipped from this repo and fail closed. AhtolaReplicaProvider loads Turso.Data.Sync when present and throws NotSupportedException otherwise; DTOs/options without an in-tree engine are not a managed sync port. Satellite gaps (CDC, revert-WAL, page pull, EF surface, pool wait_changes) are features of that missing companion, not independent managed work. Updated 2026-08-23: the managed replica now also supports Query selection (AhtolaPartialBootstrapOptions.QueryPages) end to end, reusing the same arbitrary-range sidecar, lazy materializer, coalescing, ownership and publication ordering as Prefix. Residuals: it requires a remote that honours Turso's server_query_selector (the vendored dev server ignores tag 7 by design, so all coverage is fake-server based), and the run-list sidecar costs one run per page for worst-case scattered selections. Reconciled 2026-09-05: the 2026-08-06 companion-not-shipped rationale predates the managed sync engine. Sparse prefix and server_query_selector query bootstraps install a durable page-state sidecar and fault missing pages from the pinned bootstrap revision (docs/replica-bootstrap-publication.md). Mutual exclusion with remote encryption, the QueryPages/PullBytesThreshold conflict, and the tag-7 dev-server caveat remain documented boundaries.",
       "status": "closed"
     },
     {
@@ -2683,11 +2684,11 @@
       "layer": "sync",
       "kind": "missing",
       "turso_ref": "turso-src/sync/engine/src/database_sync_engine.rs (whole module, as consumed conceptually by any embedding SDK)",
-      "ahtola_ref": "src/Ahtola.EntityFrameworkCore.Sqlite (UseAhtola extension surface)",
+      "ahtola_ref": "src/Ahtola.EntityFrameworkCore.Sqlite/AhtolaDbContextOptionsBuilderExtensions.cs (UseAhtola: AhtolaConnectionMode.EmbeddedReplica + AhtolaReplicaSqliteQueryGeneratorFactory)",
       "severity": "s4-intentional",
       "effort": "M",
       "conformance_links": [],
-      "notes": "Closed 2026-08-06 as intentional companion-not-shipped scope (with sync-sdk-kit-native-companion-intentional / sync-native-provider-companion-intentional). README: Native/Sync companions are not shipped from this repo and fail closed. AhtolaReplicaProvider loads Turso.Data.Sync when present and throws NotSupportedException otherwise; DTOs/options without an in-tree engine are not a managed sync port. Satellite gaps (CDC, revert-WAL, page pull, EF surface, pool wait_changes) are features of that missing companion, not independent managed work.",
+      "notes": "Closed 2026-08-06 as intentional companion-not-shipped scope (with sync-sdk-kit-native-companion-intentional / sync-native-provider-companion-intentional). README: Native/Sync companions are not shipped from this repo and fail closed. AhtolaReplicaProvider loads Turso.Data.Sync when present and throws NotSupportedException otherwise; DTOs/options without an in-tree engine are not a managed sync port. Satellite gaps (CDC, revert-WAL, page pull, EF surface, pool wait_changes) are features of that missing companion, not independent managed work. Reconciled 2026-09-05: the 2026-08-06 companion-not-shipped rationale predates the managed sync engine. UseAhtola recognizes embedded-replica connection strings and swaps in the replica-aware query SQL generator factory (AhtolaConnectionModeClassifier/AhtolaConnectionMode.EmbeddedReplica); migrations/history stay at EF's default relational surface. The optional native Turso.Data.Sync companion remains intentionally not shipped.",
       "status": "closed"
     },
     {
@@ -2707,11 +2708,11 @@
       "layer": "sync",
       "kind": "divergent",
       "turso_ref": "turso-src/sync/engine/src/database_sync_engine.rs::checkpoint (turso_core::CheckpointMode::Truncate / CheckpointMode::Passive)",
-      "ahtola_ref": "none (no CheckpointMode consumer in Ahtola.Data sync path; Ahtola.Core WAL checkpoint is out of this layer's scope)",
+      "ahtola_ref": "src/Ahtola.Data/ManagedReplicaRevertWal.cs (CaptureAndCheckpoint recovery bundle), src/Ahtola.Core/Storage/SqliteWalWriterCheckpointCoordinator.cs (CheckpointPassiveValidated)",
       "severity": "s4-intentional",
       "effort": "M",
       "conformance_links": [],
-      "notes": "Closed 2026-08-06 as intentional companion-not-shipped scope (with sync-sdk-kit-native-companion-intentional / sync-native-provider-companion-intentional). README: Native/Sync companions are not shipped from this repo and fail closed. AhtolaReplicaProvider loads Turso.Data.Sync when present and throws NotSupportedException otherwise; DTOs/options without an in-tree engine are not a managed sync port. Satellite gaps (CDC, revert-WAL, page pull, EF surface, pool wait_changes) are features of that missing companion, not independent managed work.",
+      "notes": "Closed 2026-08-06 as intentional companion-not-shipped scope (with sync-sdk-kit-native-companion-intentional / sync-native-provider-companion-intentional). README: Native/Sync companions are not shipped from this repo and fail closed. AhtolaReplicaProvider loads Turso.Data.Sync when present and throws NotSupportedException otherwise; DTOs/options without an in-tree engine are not a managed sync port. Satellite gaps (CDC, revert-WAL, page pull, EF surface, pool wait_changes) are features of that missing companion, not independent managed work. Reconciled 2026-09-05: the 2026-08-06 companion-not-shipped rationale predates the managed sync engine. The managed equivalent of Turso's passive synced-prefix/history checkpoint policy shipped with roadmap workstream sync-engine-depth (closed 2026-08-29): ManagedReplicaRevertWal.CaptureAndCheckpoint publishes a complete pre-checkpoint page image through ambiguous push outcomes, and CheckpointPassiveValidated exposes an inclusive safe-backfill watermark bound to WAL salts and the WAL-index change counter. Turso's reusable revert-WAL page replay is intentionally not mirrored on the MVCC-logical path (no page-frame watermark is invented for logical transactions).",
       "status": "closed"
     },
     {

--- a/docs/turso-gap-inventory.json
+++ b/docs/turso-gap-inventory.json
@@ -476,11 +476,11 @@
       "layer": "vdbe",
       "kind": "missing",
       "turso_ref": "turso-src/core/vdbe/insn.rs::Insn::AddSequence, DropSequence, Sequence, SequenceTest, NextSequenceValue, ResetSequenceValue, CopySequenceValue, SequenceRegisterAllocation",
-      "ahtola_ref": "none",
+      "ahtola_ref": "src/Ahtola.Core/EmbeddedDatabase.cs::EvaluateNextVal/EvaluateCurrVal/EvaluateSetVal (evaluator dispatch instead of opcode arms)",
       "severity": "s4-intentional",
       "effort": "M",
       "conformance_links": [],
-      "notes": "The two SQLite-standard members landed 2026-09: Sequence/SequenceTest (177-178) mirror op_sequence/op_sequence_test per-cursor counters, cleared on Reset per SQLite cursor lifetime (Turso's reset persistence is an upstream Vec::resize artifact). The remaining 6 opcodes (AddSequence, DropSequence, NextSequenceValue, ResetSequenceValue, CopySequenceValue, SequenceRegisterAllocation) stay unadopted as the Turso-only CREATE SEQUENCE extension. AUTOINCREMENT/sqlite_sequence support is tracked separately and is not part of this opcode family.",
+      "notes": "The two SQLite-standard members landed 2026-09: Sequence/SequenceTest (177-178) mirror op_sequence/op_sequence_test per-cursor counters, cleared on Reset per SQLite cursor lifetime (Turso's reset persistence is an upstream Vec::resize artifact). The remaining 6 opcodes (AddSequence, DropSequence, NextSequenceValue, ResetSequenceValue, CopySequenceValue, SequenceRegisterAllocation) stay unadopted as the Turso-only CREATE SEQUENCE extension. AUTOINCREMENT/sqlite_sequence support is tracked separately and is not part of this opcode family. Reconciled 2026-09-05: the remaining six opcodes (AddSequence, DropSequence, NextSequenceValue, ResetSequenceValue, CopySequenceValue, SequenceRegisterAllocation) are unneeded in the managed architecture: Turso needs them because CREATE SEQUENCE mutates the in-memory schema map from bytecode and nextval allocates through cursor/MakeRecord/Insert sequences, while Ahtola persists the descriptor row in the backing table (created/dropped through compiled DDL programs) and rewrites the watermark row directly inside the scalar function. The observable SQL surface is identical; the divergence is recorded here as the deliberate managed idiom, consistent with vdbe-record-construction-model.",
       "status": "closed"
     },
     {
@@ -740,7 +740,7 @@
       "severity": "s4-intentional",
       "effort": "S",
       "conformance_links": [],
-      "notes": "Ahtola correctly rejects aggregate/window functions in generated column expressions but with a single combined message (\"aggregate and window functions are not allowed in a generated column\") instead of Turso's two distinct messages (aggregate-specific vs window-specific). Behaviorally equivalent (both reject), differs only in error text -- low-severity wording divergence, not a capability gap. (Previously linked keys cleared by earlier wave work: gencol_error_aggregate_star, gencol_error_window_function, gencol_error_nested_window_function, gencol_error_nested_aggregate_star.) Closed 2026-08-05 as part of gencol Group A: the whole generated-column diagnostic surface now matches Turso's validate_generated_expr wording exactly (aggregate/window split messages were already aligned in Wave F1; the remaining bind-parameter, subquery, dot-operator, and non-deterministic messages were aligned under compile-generated-column-determinism-validation).",
+      "notes": "Ahtola correctly rejects aggregate/window functions in generated column expressions but with a single combined message (\"aggregate and window functions are not allowed in a generated column\") instead of Turso's two distinct messages (aggregate-specific vs window-specific). Behaviorally equivalent (both reject), differs only in error text -- low-severity wording divergence, not a capability gap. (Previously linked keys cleared by earlier wave work: gencol_error_aggregate_star, gencol_error_window_function, gencol_error_nested_window_function, gencol_error_nested_aggregate_star.) Closed 2026-08-05 as part of gencol Group A: the whole generated-column diagnostic surface now matches Turso's validate_generated_expr wording exactly (aggregate/window split messages were already aligned in Wave F1; the remaining bind-parameter, subquery, dot-operator, and non-deterministic messages were aligned under compile-generated-column-determinism-validation). Reconciled 2026-09-05: verified against the pinned v0.8.0-pre.7 sources that the managed engine already emits the two distinct Turso diagnostics (\"window functions prohibited in generated columns\", core/schema.rs:4315/4337, vs \"aggregate functions prohibited in generated columns\", core/schema.rs:4325/4347) — the recorded single-combined-message claim was stale, not the engine. Added focused parity tests GeneratedColumnsTests.AggregateFunctionInGenerationUsesTursoAggregateDiagnostic / WindowFunctionInGenerationUsesTursoWindowDiagnostic / WindowOnlyFunctionInGenerationUsesMisuseDiagnostic (all 32 GeneratedColumnsTests pass). No engine change was needed.",
       "status": "closed"
     },
     {
@@ -1505,11 +1505,11 @@
       "layer": "parser",
       "kind": "partial",
       "turso_ref": "turso-src/sqlite/parser/src/ast.rs::Stmt::CreateSequence / DropSequence / Stmt::Optimize { idx_name } (Turso-only, non-SQLite extensions)",
-      "ahtola_ref": "src/Ahtola.Core/Parsing/SqlAst.cs::OptimizeIndexStatement; src/Ahtola.Core/Parsing/SqlParser.cs; src/Ahtola.Core/EmbeddedDatabase.cs::ExecuteOptimizeIndex",
+      "ahtola_ref": "src/Ahtola.Core/Parsing/SqlAst.cs::CreateSequenceStatement/DropSequenceStatement; src/Ahtola.Core/Parsing/SqlParser.cs::ParseCreateSequence/ParseDropSequence",
       "severity": "s4-intentional",
       "effort": "M",
       "conformance_links": [],
-      "notes": "Updated 2026-08-29: named and bare OPTIMIZE INDEX are implemented for managed index methods and execute through each method's transactional Optimize hook. CREATE/DROP SEQUENCE remain intentionally unadopted Turso-only extensions.",
+      "notes": "Updated 2026-08-29: named and bare OPTIMIZE INDEX are implemented for managed index methods and execute through each method's transactional Optimize hook. CREATE/DROP SEQUENCE remain intentionally unadopted Turso-only extensions. Reconciled 2026-09-05: CREATE SEQUENCE and DROP SEQUENCE are now implemented (full Turso grammar: IF NOT EXISTS/IF EXISTS, START WITH, INCREMENT BY, MINVALUE, MAXVALUE, CYCLE/NO CYCLE), alongside the previously landed OPTIMIZE INDEX. Sequences persist as backing tables (the same storage shape AUTOINCREMENT uses) through compiled DDL programs; nextval/currval/setval evaluate over the backing row. See ManagedSequenceTests. The entry closes as delivered, not intentional-absence.",
       "status": "closed"
     },
     {
@@ -1717,11 +1717,11 @@
       "layer": "functions",
       "kind": "missing",
       "turso_ref": "turso-src/core/function.rs::ScalarFunc::NextVal, CurrVal, SetVal",
-      "ahtola_ref": "none",
+      "ahtola_ref": "src/Ahtola.Core/EmbeddedDatabase.cs::EvaluateNextVal/EvaluateCurrVal/EvaluateSetVal; src/Ahtola.Core/ManagedSequence.cs; src/Ahtola.Core/ManagedSequenceSession.cs",
       "severity": "s4-intentional",
       "effort": "M",
       "conformance_links": [],
-      "notes": "Closed 2026-08-06 as an unadopted Turso-only extension. nextval/currval/setval depend on the experimental SEQUENCE object and connection transaction state; they have no SQLite equivalent or conformance coverage.",
+      "notes": "Closed 2026-08-06 as an unadopted Turso-only extension. nextval/currval/setval depend on the experimental SEQUENCE object and connection transaction state; they have no SQLite equivalent or conformance coverage. Reconciled 2026-09-05: nextval/currval/setval ship as evaluator-managed scalar functions over the disk-only backing-table model (Turso core/translate/sequence.rs): the watermark row is read and rewritten per call, allocation durability follows the surrounding transaction (rolled-back values can be re-emitted), and currval is per-connection session state cleared on DROP. Exhaustion, cycle-wrap, setval range, and session-undefined diagnostics match Turso exactly. ManagedSequenceTests covers asc/desc, cycle, bounds, cross-connection visibility, reopen persistence, and rollback re-emission.",
       "status": "closed"
     },
     {

--- a/src/Ahtola.Core/Compilation/DdlStatementCompiler.cs
+++ b/src/Ahtola.Core/Compilation/DdlStatementCompiler.cs
@@ -712,6 +712,171 @@ internal static class DdlStatementCompiler
     }
 
     /// <summary>
+    /// Lowers <c>CREATE SEQUENCE</c>, following <c>translate_create_sequence</c> (sequence.rs:793).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A sequence is persisted as its backing table: the program allocates one b-tree, writes its
+    /// <c>sqlite_schema</c> row, adopts it with <c>ParseSchema</c>, seeds the descriptor row, and bumps
+    /// the cookie — the same shape <c>CREATE TABLE ... AUTOINCREMENT</c> uses for its implicit backing
+    /// table. The descriptor (start/increment/min/max/cycle) is immutable, so the seed row carries it
+    /// once and every later <c>nextval</c>/<c>setval</c> rewrites the watermark row in place.
+    /// </para>
+    /// <para>
+    /// All decisions happen here, in upstream's order: the reserved AUTOINCREMENT namespace, existence
+    /// and <c>IF NOT EXISTS</c>, option validation, and the backing-table name's availability. The
+    /// runtime watermark is never part of the descriptor — it is read from the backing row on every
+    /// allocation, exactly as upstream's disk-only design prescribes.
+    /// </para>
+    /// </remarks>
+    public static CompiledSchemaProgram CompileCreateSequence(
+        CreateSequenceStatement statement,
+        DdlCompilationContext context)
+    {
+        ArgumentNullException.ThrowIfNull(statement);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var catalog = context.Catalog;
+        if (EmbeddedDatabase.IsReservedSequenceName(statement.Name))
+        {
+            throw new EmbeddedSqlException(
+                $"sequence name \"{statement.Name}\" is reserved for internal AUTOINCREMENT use");
+        }
+
+        var sequence = ManagedSequence.Create(
+            statement.Name,
+            statement.Start,
+            statement.Increment,
+            statement.MinValue,
+            statement.MaxValue,
+            statement.Cycle);
+
+        var backingTableName = EmbeddedDatabase.GetSequenceBackingTableName(statement.Name);
+        if (catalog.Tables.TryGetValue(backingTableName, out var existingBacking))
+        {
+            EmbeddedDatabase.ValidateAutoIncrementSequenceBackingTable(existingBacking);
+            if (statement.IfNotExists)
+                return CompileNoOp(context);
+
+            throw new EmbeddedSqlException($"sequence \"{statement.Name}\" already exists");
+        }
+
+        if (catalog.Views.ContainsKey(backingTableName)
+            || catalog.Triggers.ContainsKey(backingTableName)
+            || EmbeddedDatabase.TryFindIndex(catalog.Tables, backingTableName, out _, out _))
+        {
+            throw new EmbeddedSqlException($"object name reserved for internal use: {backingTableName}");
+        }
+
+        context.EnforceMaxPageCount(1);
+
+        var builder = new SchemaProgramBuilder(context.Database);
+        var schemaCursor = builder.AllocateCursor();
+        builder.Emit(new OpenWriteCursorInstruction(
+            schemaCursor,
+            ManagedSchemaProgramBindings.SchemaTableName,
+            ManagedSchemaProgramBindings.SchemaColumnCount));
+
+        var backing = EmbeddedDatabase.CreateSequenceBackingTable(backingTableName, sequence);
+        var backingRoot = builder.EmitCreateBtree(VdbeCreateBtreeFlags.Table);
+        builder.EmitSchemaEntry(
+            schemaCursor,
+            ManagedSchemaRow.TableType,
+            backingTableName,
+            backingTableName,
+            backingRoot,
+            EmbeddedDatabase.BuildCreateTableSql(backingTableName, backing));
+
+        var stagedSchemaVersion = NextSchemaVersion(context.SchemaVersion);
+        builder.Emit(new SetCookieInstruction(
+            context.Database,
+            VdbeSchemaCookie.SchemaVersion,
+            checked((int)stagedSchemaVersion)));
+        builder.Emit(ParseSchemaFor(context.Database, backingTableName));
+
+        var populations = new List<CompiledSchemaPopulation>(1)
+        {
+            EmitPopulation(
+                builder,
+                backingTableName,
+                [.. backing.Rows],
+                backing.ColumnDefinitions.Length),
+        };
+
+        return new CompiledSchemaProgram(
+            builder.Build(),
+            schemaCursor,
+            populations,
+            stagedSchemaVersion,
+            IsNoOp: false);
+    }
+
+    /// <summary>
+    /// Lowers <c>DROP SEQUENCE</c>, following <c>translate_drop_sequence</c> (sequence.rs:948) and the
+    /// backing-table teardown <c>emit_drop_sequence_cleanup</c> performs.
+    /// </summary>
+    /// <remarks>
+    /// The program deletes the backing table's <c>sqlite_schema</c> row, retires its b-tree, and evicts
+    /// the catalog entry — the same three steps <c>DROP TABLE</c> uses for an implicit AUTOINCREMENT
+    /// backing table, because the two kinds are one storage shape.
+    /// </remarks>
+    public static CompiledSchemaProgram CompileDropSequence(
+        DropSequenceStatement statement,
+        DdlCompilationContext context)
+    {
+        ArgumentNullException.ThrowIfNull(statement);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var catalog = context.Catalog;
+        var backingTableName = EmbeddedDatabase.GetSequenceBackingTableName(statement.Name);
+        if (!catalog.Tables.TryGetValue(backingTableName, out var backing))
+        {
+            if (statement.IfExists)
+                return CompileNoOp(context);
+
+            throw new EmbeddedSqlException($"sequence \"{statement.Name}\" does not exist");
+        }
+
+        EmbeddedDatabase.ValidateAutoIncrementSequenceBackingTable(backing);
+        // Names resolve case-insensitively but every scan compares the name column with BINARY semantics,
+        // so the program has to search for the spelling the schema rows carry.
+        var catalogBackingName = ResolveCatalogName(catalog.Tables, backingTableName);
+
+        var builder = new SchemaProgramBuilder(context.Database);
+        var schemaCursor = builder.AllocateCursor();
+        builder.Emit(new OpenWriteCursorInstruction(
+            schemaCursor,
+            ManagedSchemaProgramBindings.SchemaTableName,
+            ManagedSchemaProgramBindings.SchemaColumnCount));
+
+        var backingRoot = builder.EmitSchemaRowDeleteScan(
+            schemaCursor,
+            ManagedSchemaRow.TableType,
+            catalogBackingName);
+        builder.Emit(new DestroyInstruction(
+            context.Database,
+            RootPage: 0,
+            builder.AllocateRegister(),
+            IsTemporary: false,
+            backingRoot));
+        builder.Emit(new DropTableInstruction(context.Database, catalogBackingName));
+
+        var stagedSchemaVersion = NextSchemaVersion(context.SchemaVersion);
+        builder.Emit(new SetCookieInstruction(
+            context.Database,
+            VdbeSchemaCookie.SchemaVersion,
+            checked((int)stagedSchemaVersion)));
+        builder.Emit(new CloseCursorInstruction(schemaCursor));
+
+        return new CompiledSchemaProgram(
+            builder.Build(),
+            schemaCursor,
+            [],
+            stagedSchemaVersion,
+            IsNoOp: false);
+    }
+
+    /// <summary>
     /// Lowers <c>CREATE VIEW</c>, following <c>translate_create_view</c> (view.rs:312).
     /// </summary>
     /// <remarks>

--- a/src/Ahtola.Core/EmbeddedDatabase.cs
+++ b/src/Ahtola.Core/EmbeddedDatabase.cs
@@ -790,6 +790,13 @@ public sealed partial class EmbeddedDatabase : IDisposable
         internal bool Changed { get; set; }
         internal bool ForceFullCatalogRewrite { get; set; }
         internal long? LastInsertRowId { get; set; }
+
+        /// <summary>
+        /// Marks the statement as having mutated table state without going through a writable CTE —
+        /// a <c>nextval</c>/<c>setval</c> backing-row rewrite inside a plain SELECT. The flag flows to
+        /// <c>ExecutionResult.Changed</c> so the commit boundary publishes the mutated clone.
+        /// </summary>
+        internal void MarkChanged() => Changed = true;
     }
 
     internal sealed record QueryContext(
@@ -844,7 +851,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
         TransactionMutationOverlay? TransactionOverlay = null,
         EmbeddedFileReadSnapshot? TransactionPinnedSnapshot = null,
         Action<string, long>? TransactionBlobMutation = null,
-        ManagedSchemaRowSet? StagedSchemaRows = null)
+        ManagedSchemaRowSet? StagedSchemaRows = null,
+        ManagedSequenceSession? SequenceSession = null)
     {
         /// <summary>
         /// Per-statement cache of opened managed index-method scan state. Derived contexts created
@@ -2135,7 +2143,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
         ChangeDataCaptureSession? changeDataCapture = null,
         VdbeExecutionOptions? vdbeExecutionOptions = null,
         SqliteSynchronousMode synchronousMode = SqliteSynchronousMode.Full,
-        ManagedVirtualTableTransaction? virtualTableTransaction = null)
+        ManagedVirtualTableTransaction? virtualTableTransaction = null,
+        ManagedSequenceSession? sequenceSession = null)
     {
         var result = ExecuteCore(
             statement,
@@ -2155,7 +2164,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
             changeDataCapture,
             vdbeExecutionOptions,
             synchronousMode,
-            virtualTableTransaction);
+            virtualTableTransaction,
+            sequenceSession);
 
         RecordChangeCounters(statement, result);
         return result;
@@ -2197,7 +2207,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
         ChangeDataCaptureSession? changeDataCapture = null,
         VdbeExecutionOptions? vdbeExecutionOptions = null,
         SqliteSynchronousMode synchronousMode = SqliteSynchronousMode.Full,
-        ManagedVirtualTableTransaction? virtualTableTransaction = null)
+        ManagedVirtualTableTransaction? virtualTableTransaction = null,
+        ManagedSequenceSession? sequenceSession = null)
     {
         synchronousMode.Validate(nameof(synchronousMode));
         ThrowIfRecursiveTriggerCallbackReentry();
@@ -2225,7 +2236,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 changeDataCapture,
                 vdbeExecutionOptions,
                 synchronousMode,
-                virtualTableTransaction));
+                virtualTableTransaction,
+                sequenceSession));
         }
 
         cancellationToken.ThrowIfCancellationRequested();
@@ -2285,7 +2297,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
                                     externalTables,
                                     changeDataCapture: changeDataCapture,
                                     vdbeExecutionOptions: vdbeExecutionOptions,
-                                    virtualTableTransaction: statementVirtualTableTransaction);
+                                    virtualTableTransaction: statementVirtualTableTransaction,
+                                    sequenceSession: sequenceSession);
                             }
                             catch (EmbeddedConflictFailException)
                             {
@@ -2385,7 +2398,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
                                 executeTableList,
                                 externalTables,
                                 changeDataCapture: changeDataCapture,
-                                vdbeExecutionOptions: vdbeExecutionOptions);
+                                vdbeExecutionOptions: vdbeExecutionOptions,
+                                sequenceSession: sequenceSession);
                         }
                         catch (EmbeddedConflictFailException)
                         {
@@ -2432,7 +2446,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
                             executeTableList,
                             externalTables,
                             changeDataCapture: changeDataCapture,
-                            vdbeExecutionOptions: vdbeExecutionOptions);
+                            vdbeExecutionOptions: vdbeExecutionOptions,
+                            sequenceSession: sequenceSession);
 
                     var working = new SchemaCatalog(_tables, _views, _triggers, _virtualTables).Clone();
                     try
@@ -2458,7 +2473,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
                                 externalTables,
                                 changeDataCapture: changeDataCapture,
                                 vdbeExecutionOptions: vdbeExecutionOptions,
-                                virtualTableTransaction: virtualTableTransaction);
+                                virtualTableTransaction: virtualTableTransaction,
+                                sequenceSession: sequenceSession);
                         }
                         catch (EmbeddedConflictFailException)
                         {
@@ -2691,6 +2707,7 @@ public sealed partial class EmbeddedDatabase : IDisposable
         if (statement is
             CreateTableStatement or CreateVirtualTableStatement or CreateTableAsSelectStatement
             or DropTableStatement or CreateIndexStatement or DropIndexStatement
+            or CreateSequenceStatement or DropSequenceStatement
             or CreateViewStatement or DropViewStatement or CreateTriggerStatement or DropTriggerStatement
             or AlterTableAddColumnStatement or AlterTableRenameStatement or AlterTableRenameColumnStatement
             or AlterTableAlterColumnStatement or AlterTableDropColumnStatement
@@ -2828,7 +2845,10 @@ public sealed partial class EmbeddedDatabase : IDisposable
                             orderedSet.Expression,
                             views,
                             visibleCtes,
-                            activeViews));
+                            activeViews))
+                    // nextval/setval advance the sequence's backing-table watermark, so any statement
+                    // evaluating one takes the write path (upstream translates them as writers).
+                    || IsSequenceMutationFunction(function);
             case RaiseExpression raise:
                 return ExpressionMayMutate(raise.Message, views, visibleCtes, activeViews);
             case RowValueExpression rowValue:
@@ -2881,9 +2901,20 @@ public sealed partial class EmbeddedDatabase : IDisposable
             || ExpressionMayMutate(window.Frame?.Start.Offset, views, visibleCtes, activeViews)
             || ExpressionMayMutate(window.Frame?.End.Offset, views, visibleCtes, activeViews);
 
+    /// <summary>
+    /// Whether a call advances a sequence: <c>nextval</c> and <c>setval</c> rewrite the sequence's
+    /// backing-table watermark row, so a statement containing one is a mutation even when it is a bare
+    /// SELECT. <c>currval</c> only reads this connection's session state and stays read-only.
+    /// </summary>
+    private static bool IsSequenceMutationFunction(FunctionExpression function)
+        => function.Window is null
+            && (function.Name.Equals("nextval", StringComparison.OrdinalIgnoreCase)
+                || function.Name.Equals("setval", StringComparison.OrdinalIgnoreCase));
+
     internal static bool MayChangeSchema(ParsedStatement statement) => statement is
         CreateTableStatement or CreateVirtualTableStatement or CreateTableAsSelectStatement
         or DropTableStatement or CreateIndexStatement or DropIndexStatement
+        or CreateSequenceStatement or DropSequenceStatement
         or CreateViewStatement or DropViewStatement or CreateTriggerStatement or DropTriggerStatement
         or AlterTableAddColumnStatement or AlterTableRenameStatement or AlterTableRenameColumnStatement
         or AlterTableAlterColumnStatement or AlterTableDropColumnStatement;
@@ -5312,7 +5343,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
         ManagedVirtualTableTransaction? virtualTableTransaction = null,
         TransactionMutationOverlay? transactionOverlay = null,
         EmbeddedFileReadSnapshot? transactionPinnedSnapshot = null,
-        Action<string, long>? transactionBlobMutation = null)
+        Action<string, long>? transactionBlobMutation = null,
+        ManagedSequenceSession? sequenceSession = null)
     {
         ThrowIfRecursiveTriggerCallbackReentry();
         if (RequiresRecursiveTriggerStack(
@@ -5344,7 +5376,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
                 virtualTableTransaction,
                 transactionOverlay,
                 transactionPinnedSnapshot,
-                transactionBlobMutation));
+                transactionBlobMutation,
+                sequenceSession));
         }
 
         cancellationToken.ThrowIfCancellationRequested();
@@ -5394,7 +5427,8 @@ public sealed partial class EmbeddedDatabase : IDisposable
             Database: this,
             TransactionOverlay: transactionOverlay,
             TransactionPinnedSnapshot: transactionPinnedSnapshot,
-            TransactionBlobMutation: transactionBlobMutation);
+            TransactionBlobMutation: transactionBlobMutation,
+            SequenceSession: sequenceSession);
         try
         {
             EnsureConcurrentMvccDmlTargetIsSupported(statement, tables, context);
@@ -5415,6 +5449,15 @@ public sealed partial class EmbeddedDatabase : IDisposable
                             () => ExecuteDropTable(drop, catalog, scoped))
                         : ExecuteDropTable(drop, catalog, scoped)),
                 CreateIndexStatement createIndex => ExecuteCreateIndex(createIndex, catalog, cancellationToken),
+                CreateSequenceStatement createSequence => ExecuteCreateSequence(
+                    createSequence,
+                    catalog,
+                    cancellationToken),
+                DropSequenceStatement dropSequence => ExecuteDropSequence(
+                    dropSequence,
+                    catalog,
+                    cancellationToken,
+                    sequenceSession),
                 DropIndexStatement dropIndex => ExecuteDropIndex(dropIndex, catalog, cancellationToken),
                 CreateViewStatement createView => ExecuteCreateView(createView, catalog, cancellationToken),
                 DropViewStatement dropView => ExecuteDropView(dropView, catalog, cancellationToken),
@@ -6771,6 +6814,46 @@ public sealed partial class EmbeddedDatabase : IDisposable
             return ExecutionResult.Empty;
 
         RunSchemaProgram(compiled, catalog, cancellationToken);
+        return new ExecutionResult([], [], 0, true);
+    }
+
+    /// <summary>
+    /// Runs <c>CREATE SEQUENCE</c> as a compiled schema program: one backing table, its schema row, the
+    /// seeded descriptor row, and the cookie bump, staged so a failure leaves the catalog untouched.
+    /// </summary>
+    private ExecutionResult ExecuteCreateSequence(
+        CreateSequenceStatement statement,
+        SchemaCatalog catalog,
+        CancellationToken cancellationToken)
+    {
+        var compiled = DdlStatementCompiler.CompileCreateSequence(
+            statement,
+            CreateDdlCompilationContext(catalog));
+        if (compiled.IsNoOp)
+            return ExecutionResult.Empty;
+
+        RunSchemaProgram(compiled, catalog, cancellationToken);
+        return new ExecutionResult([], [], 0, true);
+    }
+
+    /// <summary>
+    /// Runs <c>DROP SEQUENCE</c> as a compiled schema program and clears this connection's
+    /// <c>currval</c> session entry so a recreated same-name sequence cannot inherit it.
+    /// </summary>
+    private ExecutionResult ExecuteDropSequence(
+        DropSequenceStatement statement,
+        SchemaCatalog catalog,
+        CancellationToken cancellationToken,
+        ManagedSequenceSession? sequenceSession)
+    {
+        var compiled = DdlStatementCompiler.CompileDropSequence(
+            statement,
+            CreateDdlCompilationContext(catalog));
+        if (compiled.IsNoOp)
+            return ExecutionResult.Empty;
+
+        RunSchemaProgram(compiled, catalog, cancellationToken);
+        sequenceSession?.ClearCurrval(statement.Name);
         return new ExecutionResult([], [], 0, true);
     }
 
@@ -27290,6 +27373,14 @@ out bool hasReturning)
                 return DescribeProgram(DdlStatementCompiler.CompileDropIndex(
                     dropIndex,
                     CreateExplainDdlCompilationContext(compilationContext)).Program);
+            case CreateSequenceStatement createSequence:
+                return DescribeProgram(DdlStatementCompiler.CompileCreateSequence(
+                    createSequence,
+                    CreateExplainDdlCompilationContext(compilationContext)).Program);
+            case DropSequenceStatement dropSequence:
+                return DescribeProgram(DdlStatementCompiler.CompileDropSequence(
+                    dropSequence,
+                    CreateExplainDdlCompilationContext(compilationContext)).Program);
             case CreateViewStatement createView:
                 return DescribeProgram(DdlStatementCompiler.CompileCreateView(
                     createView,
@@ -35347,6 +35438,51 @@ out bool hasReturning)
     internal static bool IsAutoIncrementSequenceBackingTable(string name)
         => name.StartsWith(TursoSequenceBackingTablePrefix, StringComparison.OrdinalIgnoreCase);
 
+    internal static string GetSequenceBackingTableName(string sequenceName)
+        => TursoSequenceBackingTablePrefix + sequenceName;
+
+    /// <summary>
+    /// Whether <paramref name="name"/> is the reserved internal AUTOINCREMENT sequence namespace, which a
+    /// user-created <c>CREATE SEQUENCE</c> may not enter: the backing-table classification treats every
+    /// <c>__turso_internal_autoincrement_</c> name as AUTOINCREMENT-backed and mirrors its watermark into
+    /// <c>sqlite_sequence</c> under an attacker-chosen table name (upstream sequence.rs:832).
+    /// </summary>
+    internal static bool IsReservedSequenceName(string name)
+        => name.StartsWith(TursoAutoIncrementSequencePrefix, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Creates the sequence backing table (<c>__turso_internal_seq_&lt;name&gt;</c>) for a user sequence,
+    /// seeded with the descriptor row Turso's <c>emit_sequence_backing_table</c> writes: the start value
+    /// keyed by its own rowid, <c>is_called = 0</c>, and the immutable descriptor suffix.
+    /// </summary>
+    internal static EmbeddedTable CreateSequenceBackingTable(string backingName, ManagedSequence sequence)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(backingName);
+        var backing = new EmbeddedTable(
+            backingName,
+            [
+                new EmbeddedColumn("value", "INTEGER", true, false, false, null),
+                new EmbeddedColumn("is_called", "INTEGER", false, false, false, null),
+                new EmbeddedColumn("start", "INTEGER", false, false, false, null),
+                new EmbeddedColumn("inc", "INTEGER", false, false, false, null),
+                new EmbeddedColumn("min", "INTEGER", false, false, false, null),
+                new EmbeddedColumn("max", "INTEGER", false, false, false, null),
+                new EmbeddedColumn("cycle", "INTEGER", false, false, false, null),
+            ]);
+        backing.Rows.Add(
+        [
+            SqlValue.Integer(sequence.StartValue),
+            SqlValue.Integer(0),
+            SqlValue.Integer(sequence.StartValue),
+            SqlValue.Integer(sequence.IncrementBy),
+            SqlValue.Integer(sequence.MinValue),
+            SqlValue.Integer(sequence.MaxValue),
+            SqlValue.Integer(sequence.Cycle ? 1 : 0),
+        ]);
+        backing.RowIds.Add(sequence.StartValue);
+        return backing;
+    }
+
     // SQLite rejects any user-created object whose name begins with "sqlite_" (case
     // insensitive); those names are reserved for the internal schema.
     internal static bool IsReservedObjectName(string name)
@@ -41998,6 +42134,9 @@ out bool hasReturning)
             "RTREECHECK" => EvaluateRTreeCheck(arguments, context),
             "RTREENODE" => Spatial.ManagedRTreeFunctions.Node(arguments),
             "RTREEDEPTH" => Spatial.ManagedRTreeFunctions.Depth(arguments),
+            "NEXTVAL" => EvaluateNextVal(arguments, context),
+            "CURRVAL" => EvaluateCurrVal(arguments, context),
+            "SETVAL" => EvaluateSetVal(arguments, context),
             _ => throw new EmbeddedSqlException($"no such function: {function.Name}"),
         };
     }
@@ -42024,6 +42163,192 @@ out bool hasReturning)
 
         var problems = definition.Table.CheckIntegrity();
         return SqlValue.Text(problems.Count == 0 ? "ok" : string.Join('\n', problems));
+    }
+
+    /// <summary>
+    /// The shape of the watermark row a sequence backing table holds: (value, is_called, start, inc, min,
+    /// max, cycle) with <c>value</c> as the rowid alias, matching the AUTOINCREMENT backing table the
+    /// catalog already persists and validates.
+    /// </summary>
+    private const int SequenceBackingColumnCount = 7;
+
+    /// <summary>
+    /// Resolves the sequence a nextval/currval/setval argument names, following upstream's
+    /// <c>translate_sequence_function</c> split: an unqualified name is main-local, and a
+    /// <c>schema.name</c> spelling keeps the bare name for the backing-table lookup. The raw spelling is
+    /// what the error diagnostics and the per-connection currval key preserve.
+    /// </summary>
+    private static EmbeddedTable ResolveSequenceBackingTable(
+        IReadOnlyList<SqlValue> arguments,
+        QueryContext context,
+        out string rawName,
+        out string sequenceName)
+    {
+        if (arguments.Count == 0 || arguments[0].Kind != SqlValueKind.Text)
+            throw new EmbeddedSqlException("wrong number of arguments to function nextval()");
+
+        rawName = arguments[0].AsText();
+        sequenceName = rawName;
+        var dot = rawName.LastIndexOf('.');
+        if (dot >= 0)
+            sequenceName = rawName[(dot + 1)..];
+
+        var backingTableName = GetSequenceBackingTableName(sequenceName);
+        if (!context.Tables.TryGetValue(backingTableName, out var backing))
+            throw new EmbeddedSqlException($"sequence \"{rawName}\" does not exist");
+
+        return backing;
+    }
+
+    /// <summary>
+    /// Reads the backing table's watermark row: the last row for an ascending sequence, the first for a
+    /// descending one (upstream reads Last/Rewind of the rowid-aliased <c>value</c> column), plus a flag
+    /// reporting whether the table holds no row at all.
+    /// </summary>
+    private static (long Value, bool IsCalled, bool WasEmpty, int RowIndex) ReadSequenceWatermark(
+        EmbeddedTable backing,
+        bool ascending)
+    {
+        if (backing.Rows.Count == 0)
+            return (0, false, true, -1);
+
+        var rowIndex = 0;
+        for (var index = 1; index < backing.Rows.Count; index++)
+        {
+            var candidate = backing.RowIds[index];
+            if (ascending ? candidate > backing.RowIds[rowIndex] : candidate < backing.RowIds[rowIndex])
+                rowIndex = index;
+        }
+
+        return (CoerceSqliteInteger(backing.Rows[rowIndex][0]), IsTrue(backing.Rows[rowIndex][1]), false, rowIndex);
+    }
+
+    /// <summary>
+    /// Replaces the backing table's rows with the single watermark row an allocation or setval leaves
+    /// behind (upstream compacts to one row at commit; the managed catalog is statement-atomic, so the
+    /// replacement is exact here).
+    /// </summary>
+    private static void WriteSequenceWatermark(
+        EmbeddedTable backing,
+        long value,
+        long isCalled,
+        ManagedSequence sequence)
+    {
+        backing.Rows.Clear();
+        backing.RowIds.Clear();
+        backing.Rows.Add(
+        [
+            SqlValue.Integer(value),
+            SqlValue.Integer(isCalled),
+            SqlValue.Integer(sequence.StartValue),
+            SqlValue.Integer(sequence.IncrementBy),
+            SqlValue.Integer(sequence.MinValue),
+            SqlValue.Integer(sequence.MaxValue),
+            SqlValue.Integer(sequence.Cycle ? 1 : 0),
+        ]);
+        backing.RowIds.Add(value);
+    }
+
+    /// <summary>
+    /// Rebuilds the immutable descriptor from the backing row, validating the shape the catalog persists
+    /// (upstream <c>install_sequence_descriptor</c> reads the same five trailing columns at open).
+    /// </summary>
+    private static ManagedSequence ReadSequenceDescriptor(string sequenceName, EmbeddedTable backing)
+    {
+        if (backing.Rows.Count == 0
+            || backing.ColumnDefinitions.Length != SequenceBackingColumnCount)
+        {
+            throw new EmbeddedSqlException($"sequence \"{sequenceName}\" does not exist");
+        }
+
+        var row = backing.Rows[0];
+        return ManagedSequence.Create(
+            sequenceName,
+            CoerceSqliteInteger(row[2]),
+            CoerceSqliteInteger(row[3]),
+            CoerceSqliteInteger(row[4]),
+            CoerceSqliteInteger(row[5]),
+            IsTrue(row[6]));
+    }
+
+    /// <summary>
+    /// Evaluates <c>nextval('name')</c>: reads the watermark row, derives the next value by Turso's
+    /// <c>SequenceComputeNext</c> rules, rewrites the backing row, and records this connection's currval.
+    /// </summary>
+    /// <remarks>
+    /// The backing-table row is ordinary table state: an in-transaction allocation becomes durable only
+    /// at commit, so a rolled-back value may be re-emitted — the documented Turso/SQLite behavior. The
+    /// <c>currval</c> session entry is recorded immediately, exactly as upstream's
+    /// <c>SetSequenceCurrval</c> opcode does.
+    /// </remarks>
+    private static SqlValue EvaluateNextVal(IReadOnlyList<SqlValue> arguments, QueryContext context)
+    {
+        if (arguments.Count != 1 || arguments[0].Kind != SqlValueKind.Text)
+            throw new EmbeddedSqlException("wrong number of arguments to function nextval()");
+
+        var backing = ResolveSequenceBackingTable(arguments, context, out var rawName, out var sequenceName);
+        var descriptor = ReadSequenceDescriptor(sequenceName, backing);
+        var (current, isCalled, wasEmpty, _) = ReadSequenceWatermark(backing, descriptor.Ascending);
+        var next = descriptor.ComputeNext(current, isCalled, wasEmpty);
+        WriteSequenceWatermark(backing, next, 1, descriptor);
+        context.SequenceSession?.SetCurrval(rawName, next);
+        // The watermark rewrite is a real catalog mutation even though this SELECT returns rows: flag it
+        // so the statement's commit path publishes the clone (the writable-CTE state doubles as the
+        // generic statement-mutation side-channel for row-returning writers).
+        context.CteMutationState?.MarkChanged();
+        return SqlValue.Integer(next);
+    }
+
+    /// <summary>
+    /// Evaluates <c>currval('name')</c>: the last value nextval/setval produced on this connection, or
+    /// upstream's "not yet defined in this session" diagnostic when no call has established one.
+    /// </summary>
+    private static SqlValue EvaluateCurrVal(IReadOnlyList<SqlValue> arguments, QueryContext context)
+    {
+        if (arguments.Count != 1 || arguments[0].Kind != SqlValueKind.Text)
+            throw new EmbeddedSqlException("wrong number of arguments to function currval()");
+
+        ResolveSequenceBackingTable(arguments, context, out var rawName, out _);
+        if (context.SequenceSession is not null
+            && context.SequenceSession.TryGetCurrval(rawName, out var value))
+        {
+            return SqlValue.Integer(value);
+        }
+
+        throw new EmbeddedSqlException(
+            $"currval of sequence \"{rawName}\" is not yet defined in this session");
+    }
+
+    /// <summary>
+    /// Evaluates <c>setval('name', value[, is_called])</c>: validates the range against the descriptor,
+    /// rewrites the backing row at the requested value, and records this connection's currval. The
+    /// default <c>is_called</c> is 1, so the next nextval advances past the value.
+    /// </summary>
+    private static SqlValue EvaluateSetVal(IReadOnlyList<SqlValue> arguments, QueryContext context)
+    {
+        if (arguments.Count is < 2 or > 3)
+            throw new EmbeddedSqlException("wrong number of arguments to function setval()");
+
+        var backing = ResolveSequenceBackingTable(arguments, context, out var rawName, out var sequenceName);
+        if (arguments[1].Kind != SqlValueKind.Integer)
+            throw new EmbeddedSqlException("setval() requires an integer value");
+        var value = arguments[1].AsInteger();
+        if (arguments.Count == 3 && arguments[2].Kind != SqlValueKind.Integer)
+            throw new EmbeddedSqlException("setval() requires an integer is_called argument");
+
+        var descriptor = ReadSequenceDescriptor(sequenceName, backing);
+        if (value < descriptor.MinValue || value > descriptor.MaxValue)
+        {
+            throw new EmbeddedSqlException(
+                $"setval: value {value} is out of bounds for sequence \"{sequenceName}\" "
+                + $"({descriptor.MinValue}..{descriptor.MaxValue})");
+        }
+
+        var isCalled = arguments.Count == 3 ? arguments[2].AsInteger() : 1;
+        WriteSequenceWatermark(backing, value, isCalled, descriptor);
+        context.SequenceSession?.SetCurrval(rawName, value);
+        context.CteMutationState?.MarkChanged();
+        return SqlValue.Integer(value);
     }
 
     private SqlValue EvaluateIif(
@@ -50731,6 +51056,13 @@ public sealed partial class EmbeddedConnection : IDisposable
     private long _nextMvccStatementSavepoint;
     private readonly List<SavepointEntry> _savepoints = [];
     private long _lastInsertRowId;
+    /// <summary>
+    /// The last value <c>nextval</c>/<c>setval</c> produced for each named sequence on this connection,
+    /// keyed by the user's spelling (Turso's per-connection <c>sequence_currvals</c> map). An entry is
+    /// established only by a successful <c>nextval</c>/<c>setval</c> call and is cleared when the
+    /// sequence is dropped, so a recreated same-name sequence cannot inherit it.
+    /// </summary>
+    private readonly ManagedSequenceSession _sequenceSession = new();
     private bool _queryOnly;
     private bool _foreignKeys;
     private bool _deferForeignKeys;
@@ -52840,7 +53172,8 @@ public sealed partial class EmbeddedConnection : IDisposable
                                 concurrentMvccTxId: concurrentTxId,
                                 changeDataCapture: changeDataCapture,
                                 vdbeExecutionOptions: vdbeExecutionOptions,
-                                virtualTableTransaction: transactionState?.VirtualTableTransaction);
+                                virtualTableTransaction: transactionState?.VirtualTableTransaction,
+                                sequenceSession: _sequenceSession);
                         }
                         else if (transactionState is null)
                         {
@@ -52864,7 +53197,8 @@ public sealed partial class EmbeddedConnection : IDisposable
                                     externalTables: routed.ExternalTables,
                                     changeDataCapture: changeDataCapture,
                                     vdbeExecutionOptions: vdbeExecutionOptions,
-                                    synchronousMode: GetSynchronousMode(routed.Database));
+                                    synchronousMode: GetSynchronousMode(routed.Database),
+                                    sequenceSession: _sequenceSession);
                             }
                             catch (Exception failure)
                                 when (failure is not EmbeddedConflictFailException
@@ -52912,7 +53246,8 @@ public sealed partial class EmbeddedConnection : IDisposable
                                 transactionPinnedSnapshot: transactionState.HasSchemaChanges
                                     ? null
                                     : transactionState.PinnedSnapshot,
-                                transactionBlobMutation: transactionState.RecordBlobMutation);
+                                transactionBlobMutation: transactionState.RecordBlobMutation,
+                                sequenceSession: _sequenceSession);
                             if (routedMayMutate)
                                 cancellationToken.ThrowIfCancellationRequested();
                             // The catalog overload used for transactional statements does not

--- a/src/Ahtola.Core/Execution/ResumableStatement.cs
+++ b/src/Ahtola.Core/Execution/ResumableStatement.cs
@@ -5931,7 +5931,17 @@ public sealed class ResumableStatement : IDisposable
         private readonly VdbeRowEquality? _equality;
         private readonly Queue<(SqlValue[] Row, int Depth)> _frontier = new();
         private readonly VdbeKeyedRowStore? _seen;
+        private readonly VdbeExecutionOptions _options;
+        private readonly VdbeExecutionMemory _memory;
         private readonly List<SqlValue[]> _generation = [];
+        private VdbeTemporaryFile? _frontierFile;
+        private VdbeMemoryReservation? _frontierSpillInfrastructure;
+        private long _frontierWritePosition;
+        private long _frontierReadPosition;
+        private int _spilledCount;
+        private long _frontierRetainedBytes;
+        private long _frontierRetainedRows;
+        private long _generationRetainedBytes;
         private int _admitted;
         private bool _hasCurrent;
         private int _currentDepth;
@@ -5951,10 +5961,13 @@ public sealed class ResumableStatement : IDisposable
             _maxRows = maxRows;
             _maxDepth = maxDepth;
             _equality = equality;
+            _options = options;
+            _memory = memory;
             _seen = mode == WorkTableDedupMode.Distinct
                 ? new VdbeKeyedRowStore(options, memory)
                 : null;
         }
+
 
         // Admits a seed (anchor) row at depth 0. Distinct duplicates are dropped; admission counts against
         // the row guard.
@@ -5964,21 +5977,187 @@ public sealed class ResumableStatement : IDisposable
             TryAdmit(row, depth: 0);
         }
 
+        // Admits a row: dropped as a duplicate under Distinct, otherwise counted against the row guard,
+        // recorded for future de-duplication, and enqueued for later draining. Returns whether it was admitted.
+        //
+        // Admission is the ownership boundary. `row` is transient storage the caller may keep mutating: a
+        // seed's register snapshot is discarded after this call, but more importantly a recursive transform
+        // is free to reuse one output buffer across the rows it emits and across successive expansions.
+        // Snapshot the row here so the de-duplication representative and the queued frontier entry reference
+        // storage this runtime owns and never mutates in place. Without the copy a later overwrite of that
+        // buffer would rewrite an already-admitted row, corrupting the frontier (a queued row would surface
+        // with the wrong values) and the distinct set (a genuinely new row would be misread as a duplicate).
+        // The dedup scan compares the caller's `row` before copying, so the snapshot adds no work to the
+        // rejection path.
+        private bool TryAdmit(SqlValue[] row, int depth)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_seen is not null
+                && _seen.Contains(row, _equality!, CancellationToken.None))
+            {
+                return false;
+            }
+
+            if (_admitted >= _maxRows)
+                throw new RecursiveWorkTableOverflowException(_maxRows);
+
+            var owned = CloneRow(row);
+            if (_seen is not null)
+                _seen.TryInsert(owned, _equality!, replaceExisting: false, CancellationToken.None);
+            _admitted++;
+            EnqueueFrontier(owned, depth);
+            return true;
+        }
+
+        // Enqueues a frontier entry, retaining it against the statement memory budget while it stays
+        // buffered, and spilling the whole frontier to the managed temporary file system once the
+        // budget can no longer hold it. After the switch, new entries append to the file and dequeues
+        // drain the buffered prefix first and then read records sequentially — FIFO order is exactly
+        // append order, so one forward read position serves every dequeue.
+        private void EnqueueFrontier(SqlValue[] row, int depth)
+        {
+            if (_frontierFile is null)
+            {
+                var rowBytes = VdbeManagedFootprint.EstimateSorterRow(row);
+                if (_options.AllowTemporaryFileSpill
+                    && rowBytes + FrontierSpillInfrastructureBytes() > _memory.AvailableBytes)
+                {
+                    SpillFrontier();
+                }
+                else
+                {
+                    _memory.RetainOrThrow(rowBytes);
+                    _frontierRetainedBytes = checked(_frontierRetainedBytes + rowBytes);
+                    _frontierRetainedRows = checked(_frontierRetainedRows + 1);
+                    _frontier.Enqueue((row, depth));
+                    return;
+                }
+            }
+
+            AppendFrontierRecord(row, depth);
+        }
+
+        private void SpillFrontier()
+        {
+            VdbeMemoryReservation? infrastructure = null;
+            VdbeTemporaryFile? temporaryFile = null;
+            try
+            {
+                infrastructure = VdbeMemoryReservation.Create(
+                    _memory,
+                    FrontierSpillInfrastructureBytes());
+                temporaryFile = VdbeTemporaryFile.Create(_options, "worktable-frontier");
+                _frontierWritePosition = VdbeSpillRecordCodec.InitializeFile(
+                    temporaryFile.File,
+                    VdbeSpillFileKind.WorkTableFrontier,
+                    _options.Metrics);
+
+                while (_frontier.Count > 0)
+                {
+                    var (row, depth) = _frontier.Dequeue();
+                    AppendFrontierRecordCore(temporaryFile, row, depth);
+                }
+
+                if (_frontierRetainedBytes > 0 || _frontierRetainedRows > 0)
+                    _memory.Release(_frontierRetainedBytes, _frontierRetainedRows);
+                _frontierRetainedBytes = 0;
+                _frontierRetainedRows = 0;
+
+                _frontierFile = temporaryFile;
+                temporaryFile = null;
+                _frontierSpillInfrastructure = infrastructure;
+                infrastructure = null;
+                _frontierReadPosition = _frontierWritePosition > VdbeSpillRecordCodec.FileHeaderSize
+                    ? VdbeSpillRecordCodec.FileHeaderSize
+                    : _frontierWritePosition;
+                _options.Metrics.WorkTableFrontierSpilled();
+            }
+            finally
+            {
+                temporaryFile?.Dispose();
+                infrastructure?.Dispose();
+            }
+        }
+
+        private void AppendFrontierRecord(SqlValue[] row, int depth)
+        {
+            var file = _frontierFile?.File
+                ?? throw new InvalidOperationException("Work table frontier has no spill file.");
+            AppendFrontierRecordCore(_frontierFile!, row, depth);
+        }
+
+        private long FrontierSpillInfrastructureBytes() =>
+            VdbeManagedFootprint.EstimateWorkTableFrontierSpillInfrastructure(
+                _options.TemporaryDirectory);
+
+        private void AppendFrontierRecordCore(VdbeTemporaryFile file, SqlValue[] row, int depth)
+        {
+            // The write is a bounded I/O step: only the scratch the codec allocates is transient, so
+            // no per-row retention is held while the record travels to disk.
+            var recordStart = VdbeSpillRecordCodec.BeginRecord(ref _frontierWritePosition);
+            var fileHandle = file.File;
+            VdbeSpillRecordCodec.WriteValues(
+                fileHandle,
+                ref _frontierWritePosition,
+                [SqlValue.Integer(depth)],
+                _options.Metrics);
+            VdbeSpillRecordCodec.WriteValues(fileHandle, ref _frontierWritePosition, row, _options.Metrics);
+            VdbeSpillRecordCodec.CompleteRecord(
+                fileHandle,
+                recordStart,
+                _frontierWritePosition,
+                _options.Metrics);
+            _spilledCount++;
+        }
+
         // Dequeues the next frontier row and records its depth as the current expansion depth. Returns false
         // (and clears the current row) when the frontier is drained.
         public bool TryStep(out SqlValue[] row)
         {
-            if (_frontier.Count == 0)
+            if (_frontier.Count > 0)
+            {
+                var (buffered, depth) = _frontier.Dequeue();
+                var bufferedBytes = VdbeManagedFootprint.EstimateSorterRow(buffered);
+                _memory.Release(bufferedBytes);
+                _frontierRetainedBytes = checked(_frontierRetainedBytes - bufferedBytes);
+                _frontierRetainedRows = checked(_frontierRetainedRows - 1);
+                _hasCurrent = true;
+                _currentDepth = depth;
+                row = buffered;
+                return true;
+            }
+
+            if (_frontierFile is null || _spilledCount == 0)
             {
                 _hasCurrent = false;
                 row = [];
                 return false;
             }
 
-            var (dequeued, depth) = _frontier.Dequeue();
+            var file = _frontierFile.File;
+            var recordEnd = VdbeSpillRecordCodec.ReadRecordEnd(
+                file,
+                ref _frontierReadPosition,
+                _options.Metrics);
+            var depthValue = VdbeSpillRecordCodec.ReadValues(
+                file,
+                ref _frontierReadPosition,
+                count: 1,
+                recordEnd,
+                _options.Metrics,
+                CancellationToken.None)[0];
+            var values = VdbeSpillRecordCodec.ReadValues(
+                file,
+                ref _frontierReadPosition,
+                _columnCount,
+                recordEnd,
+                _options.Metrics,
+                CancellationToken.None);
+            VdbeSpillRecordCodec.RequireRecordEnd(_frontierReadPosition, recordEnd);
+            _spilledCount--;
             _hasCurrent = true;
-            _currentDepth = depth;
-            row = dequeued;
+            _currentDepth = (int)depthValue.AsInteger();
+            row = values;
             return true;
         }
 
@@ -6023,12 +6202,13 @@ public sealed class ResumableStatement : IDisposable
                 return;
 
             RequireWidth(frontierRow);
+            RetainGenerationRow(frontierRow);
             _generation.Add([.. frontierRow]);
-            if (_frontier.TryPeek(out var next) && next.Depth == _currentDepth)
+            if (TryPeekFrontier(out var next) && next.Depth == _currentDepth)
                 return;
 
             var frontier = _generation.ToArray();
-            _generation.Clear();
+            ReleaseGeneration();
             var children = transform(frontier)
                 ?? throw new InvalidOperationException(
                     "A recursive generation transform must not return a null row list.");
@@ -6044,35 +6224,60 @@ public sealed class ResumableStatement : IDisposable
             }
         }
 
-        // Admits a row: dropped as a duplicate under Distinct, otherwise counted against the row guard,
-        // recorded for future de-duplication, and enqueued for later draining. Returns whether it was admitted.
-        //
-        // Admission is the ownership boundary. `row` is transient storage the caller may keep mutating: a
-        // seed's register snapshot is discarded after this call, but more importantly a recursive transform
-        // is free to reuse one output buffer across the rows it emits and across successive expansions.
-        // Snapshot the row here so the de-duplication representative and the queued frontier entry reference
-        // storage this runtime owns and never mutates in place. Without the copy a later overwrite of that
-        // buffer would rewrite an already-admitted row, corrupting the frontier (a queued row would surface
-        // with the wrong values) and the distinct set (a genuinely new row would be misread as a duplicate).
-        // The dedup scan compares the caller's `row` before copying, so the snapshot adds no work to the
-        // rejection path.
-        private bool TryAdmit(SqlValue[] row, int depth)
+        // The generation buffer hands one whole depth level to the transform as an array, so it must stay
+        // materialized; it is retained against the statement budget and fails closed rather than spilling
+        // (the transform contract takes in-memory rows).
+        private void RetainGenerationRow(SqlValue[] row)
         {
-            ObjectDisposedException.ThrowIf(_disposed, this);
-            if (_seen is not null
-                && _seen.Contains(row, _equality!, CancellationToken.None))
+            var bytes = VdbeManagedFootprint.EstimateSorterRow(row);
+            _memory.RetainOrThrow(bytes);
+            _generationRetainedBytes = checked(_generationRetainedBytes + bytes);
+        }
+
+        private void ReleaseGeneration()
+        {
+            if (_generationRetainedBytes > 0)
+                _memory.Release(_generationRetainedBytes, _generation.Count);
+            _generationRetainedBytes = 0;
+            _generation.Clear();
+        }
+
+        // Peeks the next frontier depth without dequeuing. The buffered queue holds the head while the
+        // spilled remainder has not been reached; once only the file remains, the head record is read
+        // (and left in place — a peek, not a dequeue).
+        private bool TryPeekFrontier(out (SqlValue[] Row, int Depth) next)
+        {
+            if (_frontier.Count > 0)
             {
+                next = _frontier.Peek();
+                return true;
+            }
+
+            if (_frontierFile is null || _spilledCount == 0)
+            {
+                next = default;
                 return false;
             }
 
-            if (_admitted >= _maxRows)
-                throw new RecursiveWorkTableOverflowException(_maxRows);
-
-            var owned = CloneRow(row);
-            if (_seen is not null)
-                _seen.TryInsert(owned, _equality!, replaceExisting: false, CancellationToken.None);
-            _admitted++;
-            _frontier.Enqueue((owned, depth));
+            var file = _frontierFile.File;
+            var position = _frontierReadPosition;
+            var recordEnd = VdbeSpillRecordCodec.ReadRecordEnd(file, ref position, _options.Metrics);
+            var depth = VdbeSpillRecordCodec.ReadValues(
+                file,
+                ref position,
+                count: 1,
+                recordEnd,
+                _options.Metrics,
+                CancellationToken.None)[0].AsInteger();
+            var row = VdbeSpillRecordCodec.ReadValues(
+                file,
+                ref position,
+                _columnCount,
+                recordEnd,
+                _options.Metrics,
+                CancellationToken.None);
+            VdbeSpillRecordCodec.RequireRecordEnd(position, recordEnd);
+            next = (row, (int)depth);
             return true;
         }
 
@@ -6081,8 +6286,48 @@ public sealed class ResumableStatement : IDisposable
             if (_disposed)
                 return;
 
-            _disposed = true;
-            _seen?.Dispose();
+            List<Exception>? failures = null;
+            try
+            {
+                try
+                {
+                    _frontierFile?.Dispose();
+                    _frontierFile = null;
+                }
+                catch (Exception exception)
+                {
+                    (failures ??= []).Add(exception);
+                }
+
+                try
+                {
+                    _frontierSpillInfrastructure?.Dispose();
+                    _frontierSpillInfrastructure = null;
+                }
+                catch (Exception exception)
+                {
+                    (failures ??= []).Add(exception);
+                }
+            }
+            finally
+            {
+                if (_frontierRetainedBytes > 0 || _frontierRetainedRows > 0)
+                    _memory.Release(_frontierRetainedBytes, _frontierRetainedRows);
+                _frontierRetainedBytes = 0;
+                _frontierRetainedRows = 0;
+                if (_generationRetainedBytes > 0)
+                    _memory.Release(_generationRetainedBytes, _generation.Count);
+                _generationRetainedBytes = 0;
+                _frontier.Clear();
+                _generation.Clear();
+                _seen?.Dispose();
+                _disposed = failures is null;
+            }
+
+            if (failures is [var failure])
+                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(failure).Throw();
+            if (failures is { Count: > 1 })
+                throw new AggregateException(failures);
         }
 
         // Shallow snapshot of a record. SqlValue is an immutable value type and blob payloads are exposed as

--- a/src/Ahtola.Core/Execution/ResumableStatement.cs
+++ b/src/Ahtola.Core/Execution/ResumableStatement.cs
@@ -421,6 +421,7 @@ public sealed class ResumableStatement : IDisposable
                     OpenCursor(openEphemeral.Cursor);
                     _ephemeralTables[openEphemeral.Cursor.Index] = new EphemeralTableRuntime(
                         openEphemeral.ColumnCount,
+                        _executionOptions,
                         _memory);
                     _cursorPositions[openEphemeral.Cursor.Index] = -1;
                     _materializedRows[openEphemeral.Cursor.Index] = null;
@@ -432,6 +433,7 @@ public sealed class ResumableStatement : IDisposable
                     OpenCursor(openAutoindex.Cursor);
                     _ephemeralTables[openAutoindex.Cursor.Index] = new EphemeralTableRuntime(
                         openAutoindex.ColumnCount,
+                        _executionOptions,
                         _memory);
                     _cursorPositions[openAutoindex.Cursor.Index] = -1;
                     _materializedRows[openAutoindex.Cursor.Index] = null;
@@ -4202,29 +4204,49 @@ public sealed class ResumableStatement : IDisposable
     /// Rows are append-only with sequential 1-based rowids for SeekRowid/NotExists/Found,
     /// and support IdxInsert/IdxDelete key maintenance.
     /// </summary>
+    /// <remarks>
+    /// Rows are retained against the statement memory budget while they fit; once the budget can no
+    /// longer hold the table, it spills through the managed temporary file system exactly like the
+    /// keyed row set: an append-log of (slot, rowid, values) records plus a fixed-width slot index,
+    /// with a compact in-memory live-slot list preserving positional semantics (deletes shift the
+    /// live list, never the file). After the switch, retained memory is one slot reference per live
+    /// row instead of the full row payload.
+    /// </remarks>
     private sealed class EphemeralTableRuntime : IDisposable
     {
         private readonly int _columnCount;
+        private readonly VdbeExecutionOptions _options;
         private readonly VdbeExecutionMemory _memory;
         private readonly List<SqlValue[]> _rows = [];
         private readonly List<long> _rowIds = [];
+        // Spilled state: slot s holds the latest append-log record for that slot; _liveSlots maps
+        // position -> slot for the rows that have not been deleted.
+        private VdbeTemporaryFile? _dataFile;
+        private VdbeTemporaryFile? _indexFile;
+        private VdbeMemoryReservation? _spillInfrastructure;
+        private readonly List<long> _liveSlots = [];
+        private long _writePosition;
+        private int _nextSlot;
+        private long _slotListRetainedBytes;
         private VdbeCursorSource? _sourceView;
         private long _nextRowId = 1;
         private long _retainedBytes;
         private long _retainedRows;
         private bool _disposed;
 
-        public EphemeralTableRuntime(int columnCount, VdbeExecutionMemory memory)
+        public EphemeralTableRuntime(int columnCount, VdbeExecutionOptions options, VdbeExecutionMemory memory)
         {
             ArgumentOutOfRangeException.ThrowIfNegativeOrZero(columnCount);
+            ArgumentNullException.ThrowIfNull(options);
             ArgumentNullException.ThrowIfNull(memory);
             _columnCount = columnCount;
+            _options = options;
             _memory = memory;
         }
 
         public int ColumnCount => _columnCount;
 
-        public int RowCount => _rows.Count;
+        public int RowCount => _dataFile is null ? _rows.Count : _liveSlots.Count;
 
         public void Insert(SqlValue[] row)
         {
@@ -4238,20 +4260,153 @@ public sealed class ResumableStatement : IDisposable
 
             var owned = row.ToArray();
             var bytes = VdbeManagedFootprint.EstimateSorterRow(owned);
-            _memory.RetainOrThrow(bytes);
-            _retainedBytes = checked(_retainedBytes + bytes);
-            _retainedRows = checked(_retainedRows + 1);
-            _rows.Add(owned);
-            _rowIds.Add(_nextRowId);
+            if (_dataFile is null)
+            {
+                if (_options.AllowTemporaryFileSpill
+                    && bytes + SpillInfrastructureBytes() > _memory.AvailableBytes)
+                {
+                    Spill();
+                }
+                else
+                {
+                    _memory.RetainOrThrow(bytes);
+                    _retainedBytes = checked(_retainedBytes + bytes);
+                    _retainedRows = checked(_retainedRows + 1);
+                    _rows.Add(owned);
+                    _rowIds.Add(_nextRowId);
+                    _nextRowId = checked(_nextRowId + 1);
+                    _sourceView = null;
+                    return;
+                }
+            }
+
+            var slot = _nextSlot;
+            _nextSlot = checked(_nextSlot + 1);
+            AppendRecord(slot, _nextRowId, owned);
+            RetainSlotListGrowth();
+            _liveSlots.Add(slot);
             _nextRowId = checked(_nextRowId + 1);
             _sourceView = null;
         }
 
+        // After the switch to spill, the only per-row retention left is the live-slot list's backing
+        // storage (one reference per live row), so its growth stays inside the budget too.
+        private void RetainSlotListGrowth()
+        {
+            var requiredCount = checked(_liveSlots.Count + 1);
+            var capacity = VdbeManagedFootprint.GetListCapacityForCount(_liveSlots.Capacity, requiredCount);
+            var currentListBytes = VdbeManagedFootprint.EstimateReferenceListStorage(_liveSlots.Capacity);
+            var replacementBytes = VdbeManagedFootprint.EstimateContainerReplacement(
+                currentListBytes,
+                VdbeManagedFootprint.EstimateReferenceListStorage(capacity));
+            if (replacementBytes <= 0)
+                return;
+
+            _memory.RetainOrThrow(replacementBytes, rows: 0);
+            _slotListRetainedBytes = checked(_slotListRetainedBytes + replacementBytes);
+        }
+
+        private void Spill()
+        {
+            VdbeMemoryReservation? infrastructure = null;
+            VdbeTemporaryFile? dataFile = null;
+            VdbeTemporaryFile? indexFile = null;
+            try
+            {
+                infrastructure = VdbeMemoryReservation.Create(
+                    _memory,
+                    SpillInfrastructureBytes());
+                dataFile = VdbeTemporaryFile.Create(_options, "ephemeral-table");
+                indexFile = VdbeTemporaryFile.Create(_options, "ephemeral-index");
+                _writePosition = VdbeSpillRecordCodec.InitializeFile(
+                    dataFile.File,
+                    VdbeSpillFileKind.EphemeralTable,
+                    _options.Metrics);
+                VdbeSpillRecordCodec.InitializeFile(
+                    indexFile.File,
+                    VdbeSpillFileKind.EphemeralTableIndex,
+                    _options.Metrics);
+
+                // Buffered rows become slots 0..n-1 in insertion order, so the live-slot list is
+                // the identity permutation and positions keep their meaning across the switch.
+                for (var slot = 0; slot < _rows.Count; slot++)
+                {
+                    AppendRecordCore(
+                        dataFile,
+                        indexFile,
+                        ref _writePosition,
+                        slot,
+                        _rowIds[slot],
+                        _rows[slot],
+                        _options.Metrics);
+                }
+
+                if (_retainedBytes > 0 || _retainedRows > 0)
+                    _memory.Release(_retainedBytes, _retainedRows);
+                _retainedBytes = 0;
+                _retainedRows = 0;
+                _liveSlots.AddRange(Enumerable.Range(0, _rows.Count).Select(static value => (long)value));
+                _slotListRetainedBytes = VdbeManagedFootprint.EstimateReferenceListStorage(_liveSlots.Capacity);
+                _memory.RetainOrThrow(_slotListRetainedBytes, rows: 0);
+                // The flushed buffered rows own slots 0..n-1; every later insert takes a fresh slot
+                // so it can never overwrite a flushed row's record.
+                _nextSlot = _rows.Count;
+                _rows.Clear();
+                _rowIds.Clear();
+
+                _dataFile = dataFile;
+                dataFile = null;
+                _indexFile = indexFile;
+                indexFile = null;
+                _spillInfrastructure = infrastructure;
+                infrastructure = null;
+                // The buffered-phase cursor view wrapped the now-emptied row list; drop it so the
+                // next AsCursorSource builds the spilled lazy view.
+                _sourceView = null;
+                _options.Metrics.EphemeralTableSpilled();
+            }
+            finally
+            {
+                indexFile?.Dispose();
+                dataFile?.Dispose();
+                infrastructure?.Dispose();
+            }
+        }
+
+        private void AppendRecord(int slot, long rowId, SqlValue[] row)
+        {
+            var data = _dataFile ?? throw new InvalidOperationException("Ephemeral table has no spill file.");
+            var index = _indexFile ?? throw new InvalidOperationException("Ephemeral table has no spill index.");
+            AppendRecordCore(data, index, ref _writePosition, slot, rowId, row, _options.Metrics);
+        }
+
+        private static void AppendRecordCore(
+            VdbeTemporaryFile dataFile,
+            VdbeTemporaryFile indexFile,
+            ref long writePosition,
+            int slot,
+            long rowId,
+            SqlValue[] row,
+            VdbeExecutionMetrics metrics)
+        {
+            var file = dataFile.File;
+            var index = indexFile.File;
+            var recordStart = VdbeSpillRecordCodec.BeginRecord(ref writePosition);
+            VdbeSpillRecordCodec.WriteInt32(file, ref writePosition, slot, metrics);
+            VdbeSpillRecordCodec.WriteInt64(file, ref writePosition, rowId, metrics);
+            VdbeSpillRecordCodec.WriteValues(file, ref writePosition, row, metrics);
+            VdbeSpillRecordCodec.CompleteRecord(file, recordStart, writePosition, metrics);
+            var indexPosition = checked(
+                (long)VdbeSpillRecordCodec.FileHeaderSize
+                + ((long)slot * sizeof(long)));
+            VdbeSpillRecordCodec.WriteInt64(index, ref indexPosition, recordStart, metrics);
+        }
+
         public bool ContainsKeyPrefix(SqlValue[] key)
         {
-            foreach (var row in _rows)
+            for (var i = 0; i < RowCount; i++)
             {
-                if (RowMatchesKeyPrefix(row, key))
+                if (RowMatchesKeyPrefix(this[i], key))
                     return true;
             }
 
@@ -4260,15 +4415,12 @@ public sealed class ResumableStatement : IDisposable
 
         public bool TryDeleteKeyPrefix(SqlValue[] key)
         {
-            for (var i = 0; i < _rows.Count; i++)
+            for (var i = 0; i < RowCount; i++)
             {
-                if (!RowMatchesKeyPrefix(_rows[i], key))
+                if (!RowMatchesKeyPrefix(this[i], key))
                     continue;
 
-                ReleaseRow(_rows[i]);
-                _rows.RemoveAt(i);
-                _rowIds.RemoveAt(i);
-                _sourceView = null;
+                DeleteAt(i);
                 return true;
             }
 
@@ -4277,14 +4429,101 @@ public sealed class ResumableStatement : IDisposable
 
         public bool TryDeleteAt(int position)
         {
-            if (position < 0 || position >= _rows.Count)
+            if (position < 0 || position >= RowCount)
                 return false;
 
-            ReleaseRow(_rows[position]);
-            _rows.RemoveAt(position);
-            _rowIds.RemoveAt(position);
-            _sourceView = null;
+            DeleteAt(position);
             return true;
+        }
+
+        private void DeleteAt(int position)
+        {
+            if (_dataFile is null)
+            {
+                ReleaseRow(_rows[position]);
+                _rows.RemoveAt(position);
+                _rowIds.RemoveAt(position);
+                _sourceView = null;
+                return;
+            }
+
+            _liveSlots.RemoveAt(position);
+            _sourceView = null;
+        }
+
+        public SqlValue[] this[int position]
+        {
+            get
+            {
+                if (_dataFile is null)
+                {
+                    if ((uint)position >= (uint)_rows.Count)
+                        throw new InvalidOperationException("Ephemeral table position is out of range.");
+                    return _rows[position];
+                }
+
+                if ((uint)position >= (uint)_liveSlots.Count)
+                    throw new InvalidOperationException("Ephemeral table position is out of range.");
+                return ReadSpilledSlot(checked((int)_liveSlots[position]));
+            }
+        }
+
+        public long RowIdAt(int position)
+        {
+            if (_dataFile is null)
+            {
+                if ((uint)position >= (uint)_rowIds.Count)
+                    throw new InvalidOperationException("Ephemeral table position is out of range.");
+                return _rowIds[position];
+            }
+
+            if ((uint)position >= (uint)_liveSlots.Count)
+                throw new InvalidOperationException("Ephemeral table position is out of range.");
+            return ReadSpilledSlotRowId(checked((int)_liveSlots[position]));
+        }
+
+        private SqlValue[] ReadSpilledSlot(int slot)
+        {
+            var file = _dataFile!.File;
+            var index = _indexFile!.File;
+            var indexPosition = checked(
+                (long)VdbeSpillRecordCodec.FileHeaderSize
+                + ((long)slot * sizeof(long)));
+            var recordStart = VdbeSpillRecordCodec.ReadInt64(index, ref indexPosition, _options.Metrics);
+            if (recordStart < VdbeSpillRecordCodec.FileHeaderSize || recordStart >= file.Length)
+                throw new InvalidDataException($"Ephemeral spill index points slot {slot} outside the data file.");
+
+            var position = recordStart;
+            var recordEnd = VdbeSpillRecordCodec.ReadRecordEnd(file, ref position, _options.Metrics);
+            var recordSlot = VdbeSpillRecordCodec.ReadInt32(file, ref position, _options.Metrics);
+            if (recordSlot != slot)
+                throw new InvalidDataException($"Ephemeral spill index maps slot {slot} to record {recordSlot}.");
+            _ = VdbeSpillRecordCodec.ReadInt64(file, ref position, _options.Metrics);
+            var values = VdbeSpillRecordCodec.ReadValues(
+                file,
+                ref position,
+                _columnCount,
+                recordEnd,
+                _options.Metrics,
+                CancellationToken.None);
+            VdbeSpillRecordCodec.RequireRecordEnd(position, recordEnd);
+            return values;
+        }
+
+        private long ReadSpilledSlotRowId(int slot)
+        {
+            var file = _dataFile!.File;
+            var index = _indexFile!.File;
+            var indexPosition = checked(
+                (long)VdbeSpillRecordCodec.FileHeaderSize
+                + ((long)slot * sizeof(long)));
+            var recordStart = VdbeSpillRecordCodec.ReadInt64(index, ref indexPosition, _options.Metrics);
+            var position = recordStart;
+            var recordEnd = VdbeSpillRecordCodec.ReadRecordEnd(file, ref position, _options.Metrics);
+            var recordSlot = VdbeSpillRecordCodec.ReadInt32(file, ref position, _options.Metrics);
+            if (recordSlot != slot)
+                throw new InvalidDataException($"Ephemeral spill index maps slot {slot} to record {recordSlot}.");
+            return VdbeSpillRecordCodec.ReadInt64(file, ref position, _options.Metrics);
         }
 
         // Turso's ResetSorter clears the ephemeral b-tree (clear_btree) at partition boundaries.
@@ -4294,28 +4533,95 @@ public sealed class ResumableStatement : IDisposable
             ObjectDisposedException.ThrowIf(_disposed, this);
             if (_retainedBytes > 0 || _retainedRows > 0)
                 _memory.Release(_retainedBytes, _retainedRows);
+            if (_slotListRetainedBytes > 0)
+                _memory.Release(_slotListRetainedBytes, rows: 0);
             _rows.Clear();
             _rowIds.Clear();
+            _liveSlots.Clear();
             _sourceView = null;
             _retainedBytes = 0;
             _retainedRows = 0;
+            _slotListRetainedBytes = 0;
             _nextRowId = 1;
+            // Slots are never reused after a clear: the spill files keep their history and new rows
+            // continue from the next slot, exactly as a fresh table would never recycle rowids.
         }
 
         public VdbeCursorSource AsCursorSource()
-            => _sourceView ??= new VdbeCursorSource(_rows, _rowIds);
+        {
+            if (_sourceView is not null)
+                return _sourceView;
+
+            if (_dataFile is null)
+                return _sourceView = new VdbeCursorSource(_rows, _rowIds);
+
+            return _sourceView = new VdbeCursorSource(
+                new SpilledEphemeralRowList(this),
+                new SpilledEphemeralRowIdList(this));
+        }
 
         public void Dispose()
         {
             if (_disposed)
                 return;
 
-            _disposed = true;
-            if (_retainedBytes > 0 || _retainedRows > 0)
-                _memory.Release(_retainedBytes, _retainedRows);
-            _retainedBytes = 0;
-            _retainedRows = 0;
+            List<Exception>? failures = null;
+            try
+            {
+                try
+                {
+                    _dataFile?.Dispose();
+                    _dataFile = null;
+                }
+                catch (Exception exception)
+                {
+                    (failures ??= []).Add(exception);
+                }
+
+                try
+                {
+                    _indexFile?.Dispose();
+                    _indexFile = null;
+                }
+                catch (Exception exception)
+                {
+                    (failures ??= []).Add(exception);
+                }
+
+                try
+                {
+                    _spillInfrastructure?.Dispose();
+                    _spillInfrastructure = null;
+                }
+                catch (Exception exception)
+                {
+                    (failures ??= []).Add(exception);
+                }
+            }
+            finally
+            {
+                if (_retainedBytes > 0 || _retainedRows > 0)
+                    _memory.Release(_retainedBytes, _retainedRows);
+                if (_slotListRetainedBytes > 0)
+                    _memory.Release(_slotListRetainedBytes, rows: 0);
+                _retainedBytes = 0;
+                _retainedRows = 0;
+                _slotListRetainedBytes = 0;
+                _rows.Clear();
+                _rowIds.Clear();
+                _liveSlots.Clear();
+                _disposed = failures is null;
+            }
+
+            if (failures is [var failure])
+                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(failure).Throw();
+            if (failures is { Count: > 1 })
+                throw new AggregateException(failures);
         }
+
+        private long SpillInfrastructureBytes() =>
+            VdbeManagedFootprint.EstimateEphemeralTableSpillInfrastructure(
+                _options.TemporaryDirectory);
 
         private void ReleaseRow(SqlValue[] row)
         {
@@ -4323,6 +4629,36 @@ public sealed class ResumableStatement : IDisposable
             _memory.Release(bytes);
             _retainedBytes = checked(_retainedBytes - bytes);
             _retainedRows = checked(_retainedRows - 1);
+        }
+
+        private sealed class SpilledEphemeralRowList(EphemeralTableRuntime owner) : IReadOnlyList<SqlValue[]>
+        {
+            public int Count => owner._liveSlots.Count;
+
+            public SqlValue[] this[int index] => owner[index];
+
+            public IEnumerator<SqlValue[]> GetEnumerator()
+            {
+                for (var index = 0; index < Count; index++)
+                    yield return owner[index];
+            }
+
+            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        private sealed class SpilledEphemeralRowIdList(EphemeralTableRuntime owner) : IReadOnlyList<long>
+        {
+            public int Count => owner._liveSlots.Count;
+
+            public long this[int index] => owner.RowIdAt(index);
+
+            public IEnumerator<long> GetEnumerator()
+            {
+                for (var index = 0; index < Count; index++)
+                    yield return owner.RowIdAt(index);
+            }
+
+            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
         }
     }
 

--- a/src/Ahtola.Core/Execution/VdbeExecutionMemory.cs
+++ b/src/Ahtola.Core/Execution/VdbeExecutionMemory.cs
@@ -53,6 +53,8 @@ public sealed class VdbeExecutionMetrics
 
     public long WindowBuffersSpilled { get; private set; }
 
+    public long WorkTableFrontiersSpilled { get; private set; }
+
     internal void Retain(long bytes, long rows)
     {
         CurrentRetainedBytes = checked(CurrentRetainedBytes + bytes);
@@ -104,6 +106,9 @@ public sealed class VdbeExecutionMetrics
 
     internal void WindowBufferSpilled() =>
         WindowBuffersSpilled = checked(WindowBuffersSpilled + 1);
+
+    internal void WorkTableFrontierSpilled() =>
+        WorkTableFrontiersSpilled = checked(WorkTableFrontiersSpilled + 1);
 }
 
 internal sealed class VdbeExecutionMemory(long limitBytes, VdbeExecutionMetrics metrics)
@@ -252,6 +257,7 @@ internal static class VdbeManagedFootprint
     private const long HashSpillObjectBytes = 96;
     private const long KeyedRowSetSpillObjectBytes = 104;
     private const long WindowBufferSpillObjectBytes = 96;
+    private const long WorkTableFrontierSpillObjectBytes = 96;
     private const long HashPartitionObjectBytes = 32;
     private const long TemporaryFileObjectBytes = 64;
     private const long TemporaryFileWrapperBytes = 128;
@@ -418,6 +424,16 @@ internal static class VdbeManagedFootprint
             + EstimateTemporaryFileInfrastructure(
                 temporaryDirectory.Length,
                 "window-buffer".Length));
+    }
+
+    public static long EstimateWorkTableFrontierSpillInfrastructure(string temporaryDirectory)
+    {
+        ArgumentNullException.ThrowIfNull(temporaryDirectory);
+        return checked(
+            WorkTableFrontierSpillObjectBytes
+            + EstimateTemporaryFileInfrastructure(
+                temporaryDirectory.Length,
+                "worktable-frontier".Length));
     }
 
     public static int GetListCapacityForCount(int currentCapacity, int requiredCount)

--- a/src/Ahtola.Core/Execution/VdbeExecutionMemory.cs
+++ b/src/Ahtola.Core/Execution/VdbeExecutionMemory.cs
@@ -55,6 +55,8 @@ public sealed class VdbeExecutionMetrics
 
     public long WorkTableFrontiersSpilled { get; private set; }
 
+    public long EphemeralTablesSpilled { get; private set; }
+
     internal void Retain(long bytes, long rows)
     {
         CurrentRetainedBytes = checked(CurrentRetainedBytes + bytes);
@@ -109,6 +111,9 @@ public sealed class VdbeExecutionMetrics
 
     internal void WorkTableFrontierSpilled() =>
         WorkTableFrontiersSpilled = checked(WorkTableFrontiersSpilled + 1);
+
+    internal void EphemeralTableSpilled() =>
+        EphemeralTablesSpilled = checked(EphemeralTablesSpilled + 1);
 }
 
 internal sealed class VdbeExecutionMemory(long limitBytes, VdbeExecutionMetrics metrics)
@@ -258,6 +263,7 @@ internal static class VdbeManagedFootprint
     private const long KeyedRowSetSpillObjectBytes = 104;
     private const long WindowBufferSpillObjectBytes = 96;
     private const long WorkTableFrontierSpillObjectBytes = 96;
+    private const long EphemeralTableSpillObjectBytes = 96;
     private const long HashPartitionObjectBytes = 32;
     private const long TemporaryFileObjectBytes = 64;
     private const long TemporaryFileWrapperBytes = 128;
@@ -434,6 +440,19 @@ internal static class VdbeManagedFootprint
             + EstimateTemporaryFileInfrastructure(
                 temporaryDirectory.Length,
                 "worktable-frontier".Length));
+    }
+
+    public static long EstimateEphemeralTableSpillInfrastructure(string temporaryDirectory)
+    {
+        ArgumentNullException.ThrowIfNull(temporaryDirectory);
+        return checked(
+            EphemeralTableSpillObjectBytes
+            + EstimateTemporaryFileInfrastructure(
+                temporaryDirectory.Length,
+                "ephemeral-table".Length)
+            + EstimateTemporaryFileInfrastructure(
+                temporaryDirectory.Length,
+                "ephemeral-index".Length));
     }
 
     public static int GetListCapacityForCount(int currentCapacity, int requiredCount)

--- a/src/Ahtola.Core/Execution/VdbeSpillStore.cs
+++ b/src/Ahtola.Core/Execution/VdbeSpillStore.cs
@@ -13,6 +13,7 @@ internal enum VdbeSpillFileKind : byte
     KeyedRowSet = 5,
     KeyedRowSetIndex = 6,
     WindowBuffer = 7,
+    WorkTableFrontier = 8,
 }
 
 internal sealed class VdbeTemporaryFile : IDisposable

--- a/src/Ahtola.Core/Execution/VdbeSpillStore.cs
+++ b/src/Ahtola.Core/Execution/VdbeSpillStore.cs
@@ -14,6 +14,8 @@ internal enum VdbeSpillFileKind : byte
     KeyedRowSetIndex = 6,
     WindowBuffer = 7,
     WorkTableFrontier = 8,
+    EphemeralTable = 9,
+    EphemeralTableIndex = 10,
 }
 
 internal sealed class VdbeTemporaryFile : IDisposable

--- a/src/Ahtola.Core/ManagedSequence.cs
+++ b/src/Ahtola.Core/ManagedSequence.cs
@@ -1,0 +1,99 @@
+namespace Ahtola.Core;
+
+/// <summary>
+/// A named sequence created by <c>CREATE SEQUENCE</c>: the immutable descriptor (start, increment, bounds,
+/// cycle) plus the runtime state the backing table owns.
+/// </summary>
+/// <remarks>
+/// Mirrors Turso's <c>Sequence</c> (core/schema.rs:695): validation happens at creation with upstream's
+/// exact diagnostics, and the runtime watermark is <em>not</em> part of the descriptor — it lives in the
+/// backing table row and is read on every <c>nextval</c>/<c>setval</c> call, so rollback and cross-connection
+/// visibility fall out of ordinary transaction semantics.
+/// </remarks>
+internal sealed class ManagedSequence
+{
+    private ManagedSequence(
+        string name,
+        long startValue,
+        long incrementBy,
+        long minValue,
+        long maxValue,
+        bool cycle)
+    {
+        Name = name;
+        StartValue = startValue;
+        IncrementBy = incrementBy;
+        MinValue = minValue;
+        MaxValue = maxValue;
+        Cycle = cycle;
+    }
+
+    public string Name { get; }
+    public long StartValue { get; }
+    public long IncrementBy { get; }
+    public long MinValue { get; }
+    public long MaxValue { get; }
+    public bool Cycle { get; }
+    public bool Ascending => IncrementBy > 0;
+
+    /// <summary>
+    /// Validates the creation options and applies Turso's defaults (schema.rs <c>Sequence::new</c>):
+    /// increment defaults to 1 and may not be zero; min defaults to 1 ascending / <c>i64.MIN</c>
+    /// descending; max defaults to <c>i64.MAX</c> ascending / -1 descending; start defaults to min
+    /// ascending / max descending and must fall inside the bounds.
+    /// </summary>
+    public static ManagedSequence Create(
+        string name,
+        long? start,
+        long? increment,
+        long? minValue,
+        long? maxValue,
+        bool cycle)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        var incrementBy = increment ?? 1;
+        if (incrementBy == 0)
+            throw new EmbeddedSqlException("INCREMENT must not be zero");
+
+        var minVal = minValue ?? (incrementBy > 0 ? 1 : long.MinValue);
+        var maxVal = maxValue ?? (incrementBy > 0 ? long.MaxValue : -1);
+        if (minVal >= maxVal)
+            throw new EmbeddedSqlException($"MINVALUE ({minVal}) must be less than MAXVALUE ({maxVal})");
+
+        var startVal = start ?? (incrementBy > 0 ? minVal : maxVal);
+        if (startVal < minVal)
+            throw new EmbeddedSqlException($"START value ({startVal}) cannot be less than MINVALUE ({minVal})");
+        if (startVal > maxVal)
+            throw new EmbeddedSqlException($"START value ({startVal}) cannot be greater than MAXVALUE ({maxVal})");
+
+        return new ManagedSequence(name, startVal, incrementBy, minVal, maxVal, cycle);
+    }
+
+    /// <summary>
+    /// The next value Turso's <c>SequenceComputeNext</c> derives from the backing-table row: an empty table
+    /// restarts at <c>start</c>, an uncalled watermark returns itself, and a called watermark advances by
+    /// the increment — wrapping on <c>CYCLE</c>, exhausting otherwise.
+    /// </summary>
+    public long ComputeNext(long current, bool isCalled, bool wasEmpty)
+    {
+        if (wasEmpty)
+            return StartValue;
+        if (!isCalled)
+            return current;
+
+        var exhausted = Ascending
+            ? (current > long.MaxValue - IncrementBy) || (checked(current + IncrementBy) > MaxValue)
+            : (current < long.MinValue - IncrementBy) || (checked(current + IncrementBy) < MinValue);
+        if (exhausted)
+        {
+            if (Cycle)
+                return Ascending ? MinValue : MaxValue;
+
+            throw new EmbeddedSqlException(
+                $"nextval: reached {(Ascending ? "maximum" : "minimum")} value of sequence \"{Name}\"");
+        }
+
+        return checked(current + IncrementBy);
+    }
+}

--- a/src/Ahtola.Core/ManagedSequenceSession.cs
+++ b/src/Ahtola.Core/ManagedSequenceSession.cs
@@ -1,0 +1,37 @@
+namespace Ahtola.Core;
+
+/// <summary>
+/// The per-connection sequence state: the <c>currval</c> session map Turso keeps on its connection
+/// (<c>sequence_currvals</c>), plus the pending nextval/setval allocations the statement has produced.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The session object flows into <c>EmbeddedDatabase.Execute</c> exactly the way
+/// <see cref="ChangeDataCaptureSession"/> does, so every evaluation site — the evaluator's scalar
+/// dispatch, a trigger body, a view — reaches the same connection-owned state.
+/// </para>
+/// <para>
+/// <c>currval</c> recording is immediate, matching upstream's <c>SetSequenceCurrval</c> opcode: a
+/// <c>nextval</c>/<c>setval</c> that produced a value establishes this connection's session entry even
+/// if the surrounding transaction later rolls back, which is PostgreSQL-compatible and what Turso's
+/// per-connection map does. The backing-table watermark, by contrast, is ordinary table state: it only
+/// becomes durable when the statement's transaction commits, so a rolled-back allocation can be
+/// re-emitted by a later <c>nextval</c> — Turso's documented behavior.
+/// </para>
+/// </remarks>
+internal sealed class ManagedSequenceSession
+{
+    private readonly Dictionary<string, long> _currvals = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Records the value a nextval/setval call produced for the named sequence.</summary>
+    public void SetCurrval(string name, long value) => _currvals[name] = value;
+
+    /// <summary>The last value nextval/setval produced for the named sequence on this connection.</summary>
+    public bool TryGetCurrval(string name, out long value) => _currvals.TryGetValue(name, out value);
+
+    /// <summary>
+    /// Drops the session entry, so a recreated same-name sequence cannot inherit the stale currval of
+    /// the one that went away (upstream <c>clear_sequence_currval</c> on DROP SEQUENCE).
+    /// </summary>
+    public void ClearCurrval(string name) => _currvals.Remove(name);
+}

--- a/src/Ahtola.Core/Parsing/SqlAst.cs
+++ b/src/Ahtola.Core/Parsing/SqlAst.cs
@@ -407,6 +407,22 @@ internal sealed record ReindexStatement(
 /// <summary>Turso <c>OPTIMIZE INDEX [name]</c>; a null name optimizes every method index.</summary>
 internal sealed record OptimizeIndexStatement(string? IndexName) : ParsedStatement;
 
+/// <summary>
+/// Turso <c>CREATE SEQUENCE [IF NOT EXISTS] name [START [WITH] n] [INCREMENT [BY] n]
+/// [MINVALUE n] [MAXVALUE n] [CYCLE|NO CYCLE]</c>. Null options take Turso's defaults.
+/// </summary>
+internal sealed record CreateSequenceStatement(
+    string Name,
+    long? Start,
+    long? Increment,
+    long? MinValue,
+    long? MaxValue,
+    bool Cycle,
+    bool IfNotExists) : ParsedStatement;
+
+/// <summary>Turso <c>DROP SEQUENCE [IF EXISTS] name</c>.</summary>
+internal sealed record DropSequenceStatement(string Name, bool IfExists) : ParsedStatement;
+
 internal sealed record VacuumStatement(string? Schema, Expression? Into) : ParsedStatement;
 
 internal sealed record AttachDatabaseStatement(

--- a/src/Ahtola.Core/Parsing/SqlAuthorization.cs
+++ b/src/Ahtola.Core/Parsing/SqlAuthorization.cs
@@ -146,6 +146,28 @@ internal static class SqlAuthorization
                         break;
                     }
 
+                case CreateSequenceStatement createSequence:
+                    {
+                        var (schema, name) = Split(createSequence.Name);
+                        Require(
+                            SqliteAuthorizerAction.CreateIndex,
+                            name,
+                            null,
+                            schema ?? "main");
+                        break;
+                    }
+
+                case DropSequenceStatement dropSequence:
+                    {
+                        var (schema, name) = Split(dropSequence.Name);
+                        Require(
+                            SqliteAuthorizerAction.DropIndex,
+                            name,
+                            null,
+                            schema ?? "main");
+                        break;
+                    }
+
                 case CreateViewStatement createView:
                     {
                         var (schema, name) = Split(createView.Name);

--- a/src/Ahtola.Core/Parsing/SqlParser.cs
+++ b/src/Ahtola.Core/Parsing/SqlParser.cs
@@ -811,8 +811,103 @@ internal sealed class SqlParser
             ExpectKeyword("TABLE");
             return ParseCreateVirtualTable();
         }
+        if (ConsumeKeyword("SEQUENCE"))
+            return ParseCreateSequence();
 
         return ParseCreateTable(temporary: false);
+    }
+
+    /// <summary>
+    /// Parses Turso's <c>CREATE SEQUENCE</c> grammar (parser.rs parse_create_sequence): the options are
+    /// keyword-led, each accepts an optional connective (START WITH / INCREMENT BY), and the signed
+    /// integer forms allow a leading plus or minus.
+    /// </summary>
+    private ParsedStatement ParseCreateSequence()
+    {
+        var ifNotExists = ParseIfNotExists();
+        var name = ParseSchemaQualifiedName();
+
+        long? start = null;
+        long? increment = null;
+        long? minValue = null;
+        long? maxValue = null;
+        var cycle = false;
+
+        while (true)
+        {
+            if (ConsumeKeyword("START"))
+            {
+                ConsumeKeyword("WITH");
+                start = ParseSequenceOptionInteger();
+                continue;
+            }
+            if (ConsumeKeyword("INCREMENT"))
+            {
+                ConsumeKeyword("BY");
+                increment = ParseSequenceOptionInteger();
+                continue;
+            }
+            if (ConsumeKeyword("MINVALUE"))
+            {
+                minValue = ParseSequenceOptionInteger();
+                continue;
+            }
+            if (ConsumeKeyword("MAXVALUE"))
+            {
+                maxValue = ParseSequenceOptionInteger();
+                continue;
+            }
+            if (ConsumeKeyword("CYCLE"))
+            {
+                cycle = true;
+                continue;
+            }
+            if (ConsumeKeyword("NO"))
+            {
+                ExpectKeyword("CYCLE");
+                cycle = false;
+                continue;
+            }
+
+            break;
+        }
+
+        return new CreateSequenceStatement(name, start, increment, minValue, maxValue, cycle, ifNotExists);
+    }
+
+    /// <summary>
+    /// Parses the signed 64-bit integer a sequence option carries. Turso's parse_sequence_i64 accepts an
+    /// optional sign before a required integer token; anything else is a syntax error.
+    /// </summary>
+    private long ParseSequenceOptionInteger()
+    {
+        var sign = 1L;
+        if (Consume(TokenKind.Minus))
+            sign = -1;
+        else if (Consume(TokenKind.Plus))
+            sign = 1;
+
+        if (_lexer.Current.Kind != TokenKind.Integer)
+            throw Error("invalid integer in sequence definition");
+
+        var token = _lexer.Current;
+        _lexer.Next();
+        if (!long.TryParse(token.Text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var magnitude))
+            throw Error("invalid integer in sequence definition");
+
+        return checked(sign * magnitude);
+    }
+
+    private ParsedStatement ParseDropSequence()
+    {
+        var ifExists = false;
+        if (ConsumeKeyword("IF"))
+        {
+            ExpectKeyword("EXISTS");
+            ifExists = true;
+        }
+
+        return new DropSequenceStatement(ParseSchemaQualifiedName(), ifExists);
     }
 
     private ParsedStatement ParseCreateVirtualTable()
@@ -1590,6 +1685,8 @@ internal sealed class SqlParser
             return ParseDropView();
         if (ConsumeKeyword("TRIGGER"))
             return ParseDropTrigger();
+        if (ConsumeKeyword("SEQUENCE"))
+            return ParseDropSequence();
 
         return ParseDropTable();
     }

--- a/src/Ahtola.Core/SqliteBuiltinFunctions.cs
+++ b/src/Ahtola.Core/SqliteBuiltinFunctions.cs
@@ -41,6 +41,7 @@ internal static class SqliteBuiltinFunctions
         "UUID4_STR", "GEN_RANDOM_UUID", "UUID4", "UUID7_STR", "UUID7", "UUID7_TIMESTAMP_MS",
         "UUID_STR", "UUID_BLOB",
         "BOOLEAN_TO_INT", "INT_TO_BOOLEAN", "VALIDATE_IPADDR",
+        "NEXTVAL", "CURRVAL", "SETVAL",
         "VECTOR", "VECTOR32", "VECTOR32_SPARSE", "VECTOR64", "VECTOR8", "VECTOR1BIT",
         "VECTOR_EXTRACT", "VECTOR_DISTANCE_COS", "VECTOR_DISTANCE_L2",
         "VECTOR_DISTANCE_JACCARD", "VECTOR_DISTANCE_DOT", "VECTOR_CONCAT", "VECTOR_SLICE",
@@ -102,6 +103,9 @@ internal static class SqliteBuiltinFunctions
         "HIGHLIGHT",
         "SNIPPET",
         "RTREECHECK",
+        "NEXTVAL",
+        "CURRVAL",
+        "SETVAL",
     };
 
     public static bool Contains(string name)
@@ -172,6 +176,10 @@ internal static class SqliteBuiltinFunctions
             return [1, 2, 3];
         if (normalized is "LIKE" or "SUBSTR" or "SUBSTRING" or "LPAD" or "RPAD")
             return [2, 3];
+        if (normalized == "SETVAL")
+            return [2, 3];
+        if (normalized is "NEXTVAL" or "CURRVAL")
+            return [1];
         if (normalized is "TRIM" or "BTRIM" or "LTRIM" or "RTRIM" or "ROUND" or "LOG"
             or "UNHEX" or "JSON_ARRAY_LENGTH" or "JSON_TYPE" or "JSON_PRETTY" or "RTREECHECK")
         {
@@ -182,7 +190,8 @@ internal static class SqliteBuiltinFunctions
             or "PI" or "RANDOM" or "SQLITE_VERSION" or "TURSO_VERSION" or "SQLITE_SOURCE_ID"
             or "CHANGES" or "TOTAL_CHANGES" or "LAST_INSERT_ROWID" or "UUID4_STR"
             or "IS_AUTOCOMMIT"
-            or "GEN_RANDOM_UUID" or "UUID4" or "UUID7_STR" or "UUID7")
+            or "GEN_RANDOM_UUID" or "UUID4" or "UUID7_STR" or "UUID7"
+        )
         {
             return [0];
         }

--- a/src/Ahtola.Tests/GeneratedColumnsTests.cs
+++ b/src/Ahtola.Tests/GeneratedColumnsTests.cs
@@ -245,6 +245,43 @@ public class GeneratedColumnsTests
     }
 
     [Test]
+    public void AggregateFunctionInGenerationUsesTursoAggregateDiagnostic()
+    {
+        // Turso's validate_generated_expr emits a distinct aggregate-specific diagnostic
+        // (core/schema.rs: "aggregate functions prohibited in generated columns") before
+        // the determinism allow-list is consulted. The managed engine mirrors the split.
+        var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+
+        var act = () => Execute(connection, "CREATE TABLE t(a INT, v AS (sum(a)))");
+        act.Should().Throw<EmbeddedSqlException>().WithMessage("aggregate functions prohibited in generated columns");
+    }
+
+    [Test]
+    public void WindowFunctionInGenerationUsesTursoWindowDiagnostic()
+    {
+        // Window calls get Turso's separate window-specific diagnostic
+        // (core/schema.rs: "window functions prohibited in generated columns").
+        var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+
+        var act = () => Execute(connection, "CREATE TABLE t(a INT, v AS (sum(a) OVER (ORDER BY a)))");
+        act.Should().Throw<EmbeddedSqlException>().WithMessage("window functions prohibited in generated columns");
+    }
+
+    [Test]
+    public void WindowOnlyFunctionInGenerationUsesMisuseDiagnostic()
+    {
+        // Window-only functions (row_number etc.) that are not aggregates report SQLite's
+        // misuse diagnostic through the determinism allow-list path.
+        var database = new EmbeddedDatabase();
+        using var connection = database.Connect();
+
+        var act = () => Execute(connection, "CREATE TABLE t(a INT, v AS (row_number() OVER (ORDER BY a)))");
+        act.Should().Throw<EmbeddedSqlException>().WithMessage("window functions prohibited in generated columns");
+    }
+
+    [Test]
     public void BoundParameterInGenerationIsRejectedByManagedEngine()
     {
         var database = new EmbeddedDatabase();

--- a/src/Ahtola.Tests/ManagedSequenceTests.cs
+++ b/src/Ahtola.Tests/ManagedSequenceTests.cs
@@ -1,0 +1,334 @@
+using AwesomeAssertions;
+using Ahtola.Core;
+
+namespace Ahtola.Tests;
+
+// SEQUENCE parity with Turso v0.8.0-pre.7: CREATE/DROP validation diagnostics, the disk-only
+// watermark semantics (nextval/setval read and rewrite the backing row), per-connection currval,
+// and transaction durability (a rolled-back allocation can be re-emitted).
+public class ManagedSequenceTests
+{
+    private static void Execute(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        statement.Step();
+    }
+
+    private static List<SqlValue[]> Query(EmbeddedConnection connection, string sql)
+    {
+        using var statement = connection.Prepare(sql);
+        var rows = new List<SqlValue[]>();
+        while (statement.Step() == StatementStepResult.Row)
+        {
+            var row = new SqlValue[statement.GetColumnCount()];
+            for (var ordinal = 0; ordinal < row.Length; ordinal++)
+                row[ordinal] = statement.GetValue(ordinal);
+            rows.Add(row);
+        }
+
+        return rows;
+    }
+
+    private static long Scalar(EmbeddedConnection connection, string sql)
+        => Query(connection, sql)[0][0].AsInteger();
+
+    private static string CaptureError(EmbeddedConnection connection, string sql)
+    {
+        try
+        {
+            using var statement = connection.Prepare(sql);
+            statement.Step();
+        }
+        catch (EmbeddedSqlException exception)
+        {
+            return exception.Message;
+        }
+
+        return "no error";
+    }
+
+    private static EmbeddedConnection Connect(EmbeddedDatabase? database = null)
+    {
+        database ??= new EmbeddedDatabase();
+        return database.Connect();
+    }
+
+    [Test]
+    public void CreateAndNextValProduceAscendingValues()
+    {
+        using var connection = Connect();
+        Execute(connection, "CREATE SEQUENCE s");
+        Scalar(connection, "SELECT nextval('s')").Should().Be(1);
+        Scalar(connection, "SELECT nextval('s')").Should().Be(2);
+        Scalar(connection, "SELECT nextval('s')").Should().Be(3);
+    }
+
+    [Test]
+    public void OptionsControlStartIncrementAndBounds()
+    {
+        using var connection = Connect();
+        Execute(
+            connection,
+            "CREATE SEQUENCE s START WITH 10 INCREMENT BY 5 MINVALUE 5 MAXVALUE 20");
+        Scalar(connection, "SELECT nextval('s')").Should().Be(10);
+        Scalar(connection, "SELECT nextval('s')").Should().Be(15);
+        Scalar(connection, "SELECT nextval('s')").Should().Be(20);
+    }
+
+    [Test]
+    public void DescendingSequenceCountsDown()
+    {
+        using var connection = Connect();
+        Execute(connection, "CREATE SEQUENCE s START WITH -1 INCREMENT BY -1 MINVALUE -5 MAXVALUE -1");
+        Scalar(connection, "SELECT nextval('s')").Should().Be(-1);
+        Scalar(connection, "SELECT nextval('s')").Should().Be(-2);
+    }
+
+    [Test]
+    public void CycleWrapsToMinValue()
+    {
+        using var connection = Connect();
+        Execute(connection, "CREATE SEQUENCE s START WITH 2 MAXVALUE 2 CYCLE");
+        Scalar(connection, "SELECT nextval('s')").Should().Be(2);
+        Scalar(connection, "SELECT nextval('s')").Should().Be(1);
+    }
+
+    [Test]
+    public void ExhaustionWithoutCycleFailsWithTursoDiagnostic()
+    {
+        using var connection = Connect();
+        Execute(connection, "CREATE SEQUENCE s START WITH 2 MAXVALUE 2 NO CYCLE");
+        Scalar(connection, "SELECT nextval('s')").Should().Be(2);
+        CaptureError(connection, "SELECT nextval('s')")
+            .Should().Be("nextval: reached maximum value of sequence \"s\"");
+    }
+
+    [Test]
+    public void SetValRewritesTheWatermark()
+    {
+        using var connection = Connect();
+        Execute(connection, "CREATE SEQUENCE s");
+        Scalar(connection, "SELECT nextval('s')").Should().Be(1);
+        Scalar(connection, "SELECT setval('s', 10)").Should().Be(10);
+        Scalar(connection, "SELECT nextval('s')").Should().Be(11);
+    }
+
+    [Test]
+    public void SetValWithIsCalledFalseReturnsSameValueOnNextVal()
+    {
+        using var connection = Connect();
+        Execute(connection, "CREATE SEQUENCE s");
+        Scalar(connection, "SELECT setval('s', 7, false)").Should().Be(7);
+        Scalar(connection, "SELECT nextval('s')").Should().Be(7);
+    }
+
+    [Test]
+    public void SetValRejectsOutOfBoundsValue()
+    {
+        using var connection = Connect();
+        Execute(connection, "CREATE SEQUENCE s MAXVALUE 5");
+        CaptureError(connection, "SELECT setval('s', 6)")
+            .Should().Be("setval: value 6 is out of bounds for sequence \"s\" (1..5)");
+    }
+
+    [Test]
+    public void CurrValReportsSessionValue()
+    {
+        using var connection = Connect();
+        Execute(connection, "CREATE SEQUENCE s");
+        Scalar(connection, "SELECT nextval('s')");
+        Scalar(connection, "SELECT currval('s')").Should().Be(1);
+    }
+
+    [Test]
+    public void CurrValBeforeAnyCallIsNotDefinedInThisSession()
+    {
+        using var connection = Connect();
+        Execute(connection, "CREATE SEQUENCE s");
+        CaptureError(connection, "SELECT currval('s')")
+            .Should().Be("currval of sequence \"s\" is not yet defined in this session");
+    }
+
+    [Test]
+    public void CurrValIsPerConnection()
+    {
+        var database = new EmbeddedDatabase();
+        using var first = Connect(database);
+        using var second = Connect(database);
+        Execute(first, "CREATE SEQUENCE s");
+        Scalar(first, "SELECT nextval('s')");
+        CaptureError(second, "SELECT currval('s')")
+            .Should().Be("currval of sequence \"s\" is not yet defined in this session");
+    }
+
+    [Test]
+    public void MissingSequenceIsRejectedWithTursoDiagnostic()
+    {
+        using var connection = Connect();
+        CaptureError(connection, "SELECT nextval('nope')")
+            .Should().Be("sequence \"nope\" does not exist");
+    }
+
+    [Test]
+    public void CreateRejectsReservedAutoincrementNamespace()
+    {
+        using var connection = Connect();
+        CaptureError(connection, "CREATE SEQUENCE __turso_internal_autoincrement_x")
+            .Should().Be(
+                "sequence name \"__turso_internal_autoincrement_x\" is reserved for internal AUTOINCREMENT use");
+    }
+
+    [Test]
+    public void CreateRejectsZeroIncrement()
+    {
+        using var connection = Connect();
+        CaptureError(connection, "CREATE SEQUENCE s INCREMENT BY 0")
+            .Should().Be("INCREMENT must not be zero");
+    }
+
+    [Test]
+    public void CreateRejectsInvertedBounds()
+    {
+        using var connection = Connect();
+        CaptureError(connection, "CREATE SEQUENCE s MINVALUE 10 MAXVALUE 5")
+            .Should().Be("MINVALUE (10) must be less than MAXVALUE (5)");
+    }
+
+    [Test]
+    public void CreateRejectsStartOutsideBounds()
+    {
+        using var connection = Connect();
+        CaptureError(connection, "CREATE SEQUENCE s START WITH 0 MINVALUE 1")
+            .Should().Be("START value (0) cannot be less than MINVALUE (1)");
+        CaptureError(connection, "CREATE SEQUENCE s2 START WITH 10 MAXVALUE 5")
+            .Should().Be("START value (10) cannot be greater than MAXVALUE (5)");
+    }
+
+    [Test]
+    public void CreateWithoutIfNotExistsRejectsDuplicate()
+    {
+        using var connection = Connect();
+        Execute(connection, "CREATE SEQUENCE s");
+        CaptureError(connection, "CREATE SEQUENCE s")
+            .Should().Be("sequence \"s\" already exists");
+    }
+
+    [Test]
+    public void CreateIfNotExistsIsANoOpForDuplicates()
+    {
+        using var connection = Connect();
+        Execute(connection, "CREATE SEQUENCE s START WITH 5");
+        Execute(connection, "CREATE SEQUENCE IF NOT EXISTS s");
+        Scalar(connection, "SELECT nextval('s')").Should().Be(5);
+    }
+
+    [Test]
+    public void DropRemovesTheSequenceAndCurrval()
+    {
+        using var connection = Connect();
+        Execute(connection, "CREATE SEQUENCE s");
+        Scalar(connection, "SELECT nextval('s')");
+        Execute(connection, "DROP SEQUENCE s");
+        CaptureError(connection, "SELECT nextval('s')")
+            .Should().Be("sequence \"s\" does not exist");
+        // A recreated same-name sequence does not inherit the stale session currval.
+        Execute(connection, "CREATE SEQUENCE s");
+        CaptureError(connection, "SELECT currval('s')")
+            .Should().Be("currval of sequence \"s\" is not yet defined in this session");
+    }
+
+    [Test]
+    public void DropMissingSequenceIsRejectedAndIfExistsIsANoOp()
+    {
+        using var connection = Connect();
+        CaptureError(connection, "DROP SEQUENCE nope")
+            .Should().Be("sequence \"nope\" does not exist");
+        Execute(connection, "DROP SEQUENCE IF EXISTS nope");
+    }
+
+    [Test]
+    public void NamesAreCaseInsensitive()
+    {
+        using var connection = Connect();
+        Execute(connection, "CREATE SEQUENCE MySeq");
+        Scalar(connection, "SELECT nextval('myseq')").Should().Be(1);
+        Scalar(connection, "SELECT nextval('MYSEQ')").Should().Be(2);
+    }
+
+    [Test]
+    public void RolledBackAllocationCanBeReEmitted()
+    {
+        using var connection = Connect();
+        Execute(connection, "CREATE SEQUENCE s");
+        Execute(connection, "BEGIN");
+        Scalar(connection, "SELECT nextval('s')").Should().Be(1);
+        Scalar(connection, "SELECT nextval('s')").Should().Be(2);
+        Execute(connection, "ROLLBACK");
+        // The backing-table watermark is ordinary table state: rollback discards it, so the next
+        // allocation re-emits the value — Turso's documented behavior (no burned values).
+        Scalar(connection, "SELECT nextval('s')").Should().Be(1);
+    }
+
+    [Test]
+    public void CommittedAllocationAdvancesAcrossConnections()
+    {
+        var database = new EmbeddedDatabase();
+        using var first = Connect(database);
+        using var second = Connect(database);
+        Execute(first, "CREATE SEQUENCE s");
+        Scalar(first, "SELECT nextval('s')").Should().Be(1);
+        Scalar(first, "SELECT nextval('s')").Should().Be(2);
+        Scalar(second, "SELECT nextval('s')").Should().Be(3);
+    }
+
+    [Test]
+    public void SequenceSurvivesReopenOnFileBackedDatabase()
+    {
+        var path = Path.Combine(
+            Path.GetTempPath(),
+            $"ahtola-sequence-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var connection = EmbeddedDatabase.OpenFile(path).Connect())
+            {
+                Execute(connection, "CREATE SEQUENCE s START WITH 100 INCREMENT BY 10");
+                Scalar(connection, "SELECT nextval('s')").Should().Be(100);
+            }
+
+            using (var reopened = EmbeddedDatabase.OpenFile(path).Connect())
+            {
+                Scalar(reopened, "SELECT nextval('s')").Should().Be(110);
+            }
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public void NextValInsideInsertFeedsColumnValues()
+    {
+        using var connection = Connect();
+        Execute(connection, "CREATE SEQUENCE s");
+        Execute(connection, "CREATE TABLE t(id INTEGER, who TEXT)");
+        Execute(connection, "INSERT INTO t VALUES (nextval('s'), 'a'), (nextval('s'), 'b')");
+        var rows = Query(connection, "SELECT id FROM t ORDER BY id");
+        rows.Count.Should().Be(2);
+        rows[0][0].AsInteger().Should().Be(1);
+        rows[1][0].AsInteger().Should().Be(2);
+    }
+
+    [Test]
+    public void SequenceBackingTableIsAnOrdinarySchemaTable()
+    {
+        // Turso adopts every __turso_internal_seq_* backing table as an ordinary BTreeTable, so the
+        // descriptor row is visible to ordinary queries exactly as upstream's is.
+        using var connection = Connect();
+        Execute(connection, "CREATE SEQUENCE s START WITH 5 INCREMENT BY 2");
+        var rows = Query(connection, "SELECT value, is_called FROM __turso_internal_seq_s");
+        rows.Count.Should().Be(1);
+        rows[0][0].AsInteger().Should().Be(5);
+        rows[0][1].AsInteger().Should().Be(0);
+    }
+}

--- a/src/Ahtola.Tests/RecursiveWorkTableOpcodeExecutionTests.cs
+++ b/src/Ahtola.Tests/RecursiveWorkTableOpcodeExecutionTests.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using Ahtola.Core;
 using Ahtola.Core.Execution;
+using Ahtola.Core.Storage;
 
 namespace Ahtola.Tests;
 
@@ -540,6 +541,213 @@ public class RecursiveWorkTableOpcodeExecutionTests
     }
 
     [Test]
+    public void KeepAllWorkTableHonorsTheRetainedMemoryBudgetWithoutSpill()
+    {
+        // With spill disabled the frontier is the only unbounded structure (maxDepth 0 means no
+        // expansion), so a budget smaller than the seeds must fail closed exactly like the distinct
+        // set does.
+        var seeds = Enumerable.Range(0, 64).Select(static value => Row(value)).ToArray();
+        var program = Recursive(
+            width: 1,
+            mode: WorkTableDedupMode.KeepAll,
+            equality: null,
+            maxRows: 1000,
+            maxDepth: 0,
+            Increment,
+            seeds);
+        var options = new VdbeExecutionOptions(
+            new Ahtola.Core.Storage.InMemoryFileSystem(),
+            sorterMemoryLimitBytes: 64,
+            allowTemporaryFileSpill: false);
+        using var statement = ResumableStatement.CreateWithExecutionOptions(program, options);
+        Assert.Throws<VdbeMemoryLimitExceededException>(() => Drain(statement));
+    }
+
+    [Test]
+    public void FrontierSpillsToTheTemporaryFileAndPreservesBreadthFirstOrder()
+    {
+        // A binary tree 1..7 with a budget that cannot hold the whole frontier: the drain must spill
+        // through the managed temporary file system and still emit the exact level order.
+        const string temporaryDirectory = "worktable-frontier-spill-tests";
+        VdbeRecursiveTransform branch = row =>
+        {
+            var n = row[0].AsInteger();
+            var left = 2 * n;
+            var right = 2 * n + 1;
+            if (right > 7)
+                return [];
+
+            return [[SqlValue.Integer(left)], [SqlValue.Integer(right)]];
+        };
+
+        var program = Recursive(
+            width: 1,
+            mode: WorkTableDedupMode.KeepAll,
+            equality: null,
+            maxRows: 100,
+            maxDepth: 100,
+            branch,
+            Row(1));
+
+        var sampleRow = new[] { SqlValue.Integer(0) };
+        var rowBytes = VdbeManagedFootprint.EstimateSorterRow(sampleRow);
+        var infrastructure = VdbeManagedFootprint.EstimateWorkTableFrontierSpillInfrastructure(
+            temporaryDirectory);
+        // Enough for a few buffered rows plus the spill infrastructure — the rest must go to disk.
+        var budget = checked((rowBytes * 3) + infrastructure + 64);
+        var fileSystem = new TrackingFileSystem();
+        var metrics = new VdbeExecutionMetrics();
+        var options = new VdbeExecutionOptions(
+            fileSystem,
+            sorterMemoryLimitBytes: budget,
+            temporaryDirectory: temporaryDirectory,
+            metrics: metrics);
+
+        using var statement = ResumableStatement.CreateWithExecutionOptions(program, options);
+        Integers(Drain(statement)).Should().Equal(1, 2, 3, 4, 5, 6, 7);
+
+        metrics.WorkTableFrontiersSpilled.Should().Be(1);
+        metrics.SpillBytesWritten.Should().BeGreaterThan(0);
+        metrics.SpillBytesRead.Should().BeGreaterThan(0);
+        metrics.PeakRetainedBytes.Should().BeLessThanOrEqualTo(budget);
+        metrics.CurrentRetainedBytes.Should().Be(0);
+        metrics.ActiveSpillFiles.Should().Be(0);
+        fileSystem.Deleted.Should().BeEquivalentTo(fileSystem.Created);
+    }
+
+    [Test]
+    public void FrontierSpillSurvivesMidRecursionAcrossDepthLevels()
+    {
+        // Fan-out recursion with a budget for a single buffered row: each expansion enqueues several
+        // children, so the frontier crosses the budget on every step and the drain interleaves
+        // buffered dequeues with spilled writes and reads. The exact FIFO level order must survive.
+        const string temporaryDirectory = "worktable-frontier-spill-depth";
+        VdbeRecursiveTransform fanOut = row =>
+        {
+            var n = row[0].AsInteger();
+            if (n > 40)
+                return [];
+
+            // Four children each: the queue grows faster than the drain consumes it, forcing the
+            // spill path to stay in play across depth levels.
+            return
+            [
+                [SqlValue.Integer(n * 10 + 1)],
+                [SqlValue.Integer(n * 10 + 2)],
+                [SqlValue.Integer(n * 10 + 3)],
+                [SqlValue.Integer(n * 10 + 4)],
+            ];
+        };
+
+        var program = Recursive(
+            width: 1,
+            mode: WorkTableDedupMode.KeepAll,
+            equality: null,
+            maxRows: 100,
+            maxDepth: 100,
+            fanOut,
+            Row(1));
+
+        var sampleRow = new[] { SqlValue.Integer(0) };
+        var rowBytes = VdbeManagedFootprint.EstimateSorterRow(sampleRow);
+        var infrastructure = VdbeManagedFootprint.EstimateWorkTableFrontierSpillInfrastructure(
+            temporaryDirectory);
+        // Room for exactly one buffered frontier row: the first fan-out must trip the spill.
+        var budget = checked(rowBytes + infrastructure + 32);
+        var fileSystem = new TrackingFileSystem();
+        var metrics = new VdbeExecutionMetrics();
+        var options = new VdbeExecutionOptions(
+            fileSystem,
+            sorterMemoryLimitBytes: budget,
+            temporaryDirectory: temporaryDirectory,
+            metrics: metrics);
+
+        using var statement = ResumableStatement.CreateWithExecutionOptions(program, options);
+        var rows = Integers(Drain(statement));
+
+        // Level order: 1; then 11..14; then the children of 11 (111..114) etc. — the anchor and the
+        // first generation's prefixes prove FIFO survived the spill boundary.
+        rows[0].Should().Be(1);
+        rows.Should().ContainInOrder(1L, 11L, 12L, 13L, 14L, 111L, 112L, 113L, 114L);
+        rows.Count.Should().Be(21); // 1 + 4 + 16: depth guard cuts off after the third level's seeds exceed 40.
+
+        metrics.WorkTableFrontiersSpilled.Should().Be(1);
+        metrics.CurrentRetainedBytes.Should().Be(0);
+        metrics.ActiveSpillFiles.Should().Be(0);
+        fileSystem.Deleted.Should().BeEquivalentTo(fileSystem.Created);
+    }
+
+    [Test]
+    public void DistinctWorkTableSpillsBothTheSeenSetAndTheFrontier()
+    {
+        // A wide distinct recursion: the dedup set (already spill-capable) and the frontier both
+        // cross the budget, proving the two spill stores coexist within one statement.
+        const string temporaryDirectory = "worktable-frontier-spill-distinct";
+        VdbeRecursiveTransform fanOutOnce = row =>
+        {
+            var n = row[0].AsInteger();
+            if (n > 90)
+                return [];
+
+            return
+            [
+                [SqlValue.Integer(n * 10 + 1)],
+                [SqlValue.Integer(n * 10 + 2)],
+                [SqlValue.Integer(n * 10 + 3)],
+                [SqlValue.Integer(n * 10 + 4)],
+                [SqlValue.Integer(n * 10 + 5)],
+                [SqlValue.Integer(n * 10 + 6)],
+                [SqlValue.Integer(n * 10 + 7)],
+                [SqlValue.Integer(n * 10 + 8)],
+            ];
+        };
+
+        var program = Recursive(
+            width: 1,
+            mode: WorkTableDedupMode.Distinct,
+            equality: ByteExactRows,
+            maxRows: 1000,
+            maxDepth: 100,
+            fanOutOnce,
+            Row(1));
+
+        var sampleRow = new[] { SqlValue.Integer(0) };
+        var rowBytes = VdbeManagedFootprint.EstimateSorterRow(sampleRow);
+        var frontierInfrastructure = VdbeManagedFootprint.EstimateWorkTableFrontierSpillInfrastructure(
+            temporaryDirectory);
+        var seenInfrastructure = VdbeManagedFootprint.EstimateKeyedRowSetSpillInfrastructure(
+            temporaryDirectory);
+        // The frontier and the distinct set spill at different moments, but both infrastructures stay
+        // retained for the statement's lifetime, so the budget must hold them simultaneously. The
+        // buffered-row allowance (two rows) is far below the eight-child fan-out, so the first
+        // expansion trips the frontier spill while the seen set still has its own headroom.
+        var budget = checked(
+            (rowBytes * 2)
+            + (frontierInfrastructure * 2)
+            + (seenInfrastructure * 2)
+            + 2048);
+        var fileSystem = new TrackingFileSystem();
+        var metrics = new VdbeExecutionMetrics();
+        var options = new VdbeExecutionOptions(
+            fileSystem,
+            sorterMemoryLimitBytes: budget,
+            temporaryDirectory: temporaryDirectory,
+            metrics: metrics);
+
+        using var statement = ResumableStatement.CreateWithExecutionOptions(program, options);
+        var rows = Integers(Drain(statement));
+
+        // 1; 11..18; the 64 grandchildren — every admitted row is distinct, so the full fan-out surfaces.
+        rows.Should().HaveCount(73);
+        rows.Should().ContainInOrder(1L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 111L, 112L, 113L, 114L);
+
+        metrics.WorkTableFrontiersSpilled.Should().Be(1);
+        metrics.CurrentRetainedBytes.Should().Be(0);
+        metrics.ActiveSpillFiles.Should().Be(0);
+        fileSystem.Deleted.Should().BeEquivalentTo(fileSystem.Created);
+    }
+
+    [Test]
     public void ExplainDescribesOpenWorkTableWithItsShapeGuardsAndMode()
     {
         var instruction = new OpenWorkTableInstruction(
@@ -616,6 +824,31 @@ public class RecursiveWorkTableOpcodeExecutionTests
     }
 
     private static long[] Row(params long[] values) => values;
+
+    private sealed class TrackingFileSystem : IFileSystem
+    {
+        private readonly IFileSystem _inner = new Ahtola.Core.Storage.InMemoryFileSystem();
+
+        public List<string> Created { get; } = [];
+
+        public List<string> Deleted { get; } = [];
+
+        public bool FileExists(string path) => _inner.FileExists(path);
+
+        public IFile OpenFile(string path, FileOpenMode mode, bool readOnly = false)
+        {
+            var file = _inner.OpenFile(path, mode, readOnly);
+            if (mode == FileOpenMode.CreateNew)
+                Created.Add(path);
+            return file;
+        }
+
+        public void DeleteFile(string path)
+        {
+            Deleted.Add(path);
+            _inner.DeleteFile(path);
+        }
+    }
 
     private static List<long> Integers(IEnumerable<SqlValue[]> rows)
         => rows.Select(row => row[0].AsInteger()).ToList();

--- a/src/Ahtola.Tests/VdbeEphemeralTableOpcodeTests.cs
+++ b/src/Ahtola.Tests/VdbeEphemeralTableOpcodeTests.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using Ahtola.Core;
 using Ahtola.Core.Execution;
+using Ahtola.Core.Storage;
 
 namespace Ahtola.Tests;
 
@@ -131,5 +132,93 @@ public sealed class VdbeEphemeralTableOpcodeTests
         p2.Should().Be(4);
         comment.Should().Contain("ephemeral");
         open.Opcode.Should().Be(VdbeOpcode.OpenEphemeral);
+    }
+
+    [Test]
+    public void EphemeralTableSpillsAndPreservesScanOrderAndRowIds()
+    {
+        // Insert enough text rows to cross a budget that can hold only a couple of them, then scan:
+        // the spill must preserve insertion order, the sequential rowids, and every value.
+        const string temporaryDirectory = "ephemeral-spill-scan-tests";
+        const int rowCount = 12;
+
+        // Assemble the drain loop by hand: open -> (load+insert)*n -> rewind -> column -> result
+        // -> next -> close -> halt.
+        var body = new List<VdbeInstruction>
+        {
+            new OpenEphemeralInstruction(new Cursor(0), ColumnCount: 1),
+        };
+        for (var index = 0; index < rowCount; index++)
+        {
+            body.Add(new LoadConstantInstruction(new Register(0), SqlValue.Text(new string('v', 64) + index.ToString("00"))));
+            body.Add(new EphemeralInsertInstruction(new Cursor(0), new RegisterRange(new Register(0), 1)));
+        }
+
+        var loopTop = body.Count;
+        var doneTarget = new ProgramCounter(loopTop + 4);
+        body.Add(new RewindCursorInstruction(new Cursor(0), doneTarget));
+        body.Add(new ColumnInstruction(new Cursor(0), ColumnIndex: 0, new Register(2)));
+        body.Add(new ResultRowInstruction(new RegisterRange(new Register(2), 1)));
+        body.Add(new NextInstruction(new Cursor(0), new ProgramCounter(loopTop + 1)));
+        body.Add(new CloseCursorInstruction(new Cursor(0)));
+        body.Add(new HaltInstruction());
+
+        var program = new VdbeProgram(registerCount: 3, cursorCount: 1, [.. body]);
+
+        var sample = new[] { SqlValue.Text(new string('v', 64)) };
+        var rowBytes = VdbeManagedFootprint.EstimateSorterRow(sample);
+        var infrastructure = VdbeManagedFootprint.EstimateEphemeralTableSpillInfrastructure(
+            temporaryDirectory);
+        // Room for two buffered rows plus the spill infrastructure: the third insert trips the spill.
+        var budget = checked((rowBytes * 2) + infrastructure + 64);
+        var fileSystem = new TrackingFileSystem();
+        var metrics = new VdbeExecutionMetrics();
+        var options = new VdbeExecutionOptions(
+            fileSystem,
+            sorterMemoryLimitBytes: budget,
+            temporaryDirectory: temporaryDirectory,
+            metrics: metrics);
+
+        using var statement = ResumableStatement.CreateWithExecutionOptions(program, options);
+        var rows = new List<string>();
+        while (statement.StepResumable() == ResumableStatementStepResult.Row)
+            rows.Add(statement.CurrentRow![0].AsText());
+
+        rows.Should().HaveCount(rowCount);
+        rows.Select(static value => value[^2..]).Should().Equal(
+            Enumerable.Range(0, rowCount).Select(static index => index.ToString("00")));
+
+        metrics.EphemeralTablesSpilled.Should().Be(1);
+        metrics.SpillBytesWritten.Should().BeGreaterThan(0);
+        metrics.SpillBytesRead.Should().BeGreaterThan(0);
+        metrics.PeakRetainedBytes.Should().BeLessThanOrEqualTo(budget);
+        metrics.CurrentRetainedBytes.Should().Be(0);
+        metrics.ActiveSpillFiles.Should().Be(0);
+        fileSystem.Deleted.Should().BeEquivalentTo(fileSystem.Created);
+    }
+
+    private sealed class TrackingFileSystem : IFileSystem
+    {
+        private readonly IFileSystem _inner = new Ahtola.Core.Storage.InMemoryFileSystem();
+
+        public List<string> Created { get; } = [];
+
+        public List<string> Deleted { get; } = [];
+
+        public bool FileExists(string path) => _inner.FileExists(path);
+
+        public IFile OpenFile(string path, FileOpenMode mode, bool readOnly = false)
+        {
+            var file = _inner.OpenFile(path, mode, readOnly);
+            if (mode == FileOpenMode.CreateNew)
+                Created.Add(path);
+            return file;
+        }
+
+        public void DeleteFile(string path)
+        {
+            Deleted.Add(path);
+            _inner.DeleteFile(path);
+        }
     }
 }


### PR DESCRIPTION
Closes every actionable remaining gap from the inventory/roadmap audit. Six commits in three waves:

## 1. Gap-inventory housekeeping (docs)
- Reconciled 9 stale `s4-intentional` closure rationales (3 `mvcc-*` entries predating the MVCC phases 1–3.7 port; 6 `sync-*` entries predating the managed sync engine) with dated postscripts and corrected `ahtola_ref` fields — original rationale text preserved per the append-only audit-trail convention
- Repaired the meta block (`entry_count` 216→217, recounted tables incl. the `pragma` layer and `intentional-divergence` kind, `last_reconciled`, schema enums, `conformance_links` documented as historical keys, gencol-marker note)
- Verified the generated-column error-message entry was stale: the engine already emits Turso's two distinct diagnostics; added focused parity tests

## 2. SEQUENCE family port (Turso v0.8.0-pre.7 parity)
Flipped the first actionable `s4-intentional` gap into a delivered surface:
- **Parser/AST**: `CREATE SEQUENCE [IF NOT EXISTS] name [START [WITH] n] [INCREMENT [BY] n] [MINVALUE n] [MAXVALUE n] [CYCLE|NO CYCLE]`, `DROP SEQUENCE [IF EXISTS] name`
- **`ManagedSequence`**: upstream `Sequence::new` defaults and exact validation diagnostics
- **Persistence** — disk-only backing-table model (`__turso_internal_seq_<name>`, the AUTOINCREMENT shape) via compiled DDL programs; reserved AUTOINCREMENT-namespace rejection; DROP teardown + per-connection currval clearing
- **`nextval`/`currval`/`setval`** as evaluator scalars over the backing row: exhaustion/cycle/`is_called` rules, setval range validation, per-connection currval (`ManagedSequenceSession` threaded like the CDC session); statements containing `nextval`/`setval` are classified as mutations so bare `SELECT nextval(...)` commits/rolls back correctly
- 26 new tests (`ManagedSequenceTests`)

## 3. Execution-memory spill completion
- **Corrected the stale README claim**: buffered window partitions already spilled
- **Recursive-worktable frontiers now spill** (`WorkTableRuntime` → `worktable-frontier` spill file; FIFO order preserved; `TryPeek` spans the boundary; per-generation buffer retained + fail-closed; distinct worktables coexist with two spill stores)
- **Ephemeral tables now spill** (`EphemeralTableRuntime` → `ephemeral-table` append-log + `ephemeral-index` slot map, keyed-row-set layout; compact live-slot list preserves positional semantics; slots never reused; full access contract survives: scan order, rowid seek, positional/key-prefix deletes, ResetSorter, lazy cursor-source views; `OpenAutoindex` shares the runtime)
- New metrics (`WorkTableFrontiersSpilled`, `EphemeralTablesSpilled`) and footprint estimators; 5 new spill tests — two of which caught real bugs during development (stale buffered cursor view; slot reuse overwriting flushed records)

## Remaining items — verified terminal (decisions, not gaps)
Evaluator nested-loop materialization (architectural), MVCC custom-collated WITHOUT ROWID PK (load-bearing fail-closed: comparator needed before open-time catalog reconstruction), MVCC checkpoint SM cooperative per-page parity (documented synchronous adaptation), concurrent-DDL exclusivity (deliberate), `-shm` final-close unlink (deliberate), Turso binary differential stress (optional qualification), typed values / materialized views / super-journal / zstd (product decisions), EF Core trim warnings (upstream), broader Hrana kinds (gated on submodule bump).

## Verification
- Full managed suite (net10.0): **7661 passed, 0 failed** (run locally through `Invoke-ManagedTestSuite.ps1`)
- Ephemeral-adjacent suites: 58/58; recursive family: 183/183
- Conformance expected-failures file untouched (still exactly the 2 intentional STORED-generated-column markers)